### PR TITLE
Release: 0.9.17 note check-off

### DIFF
--- a/docs/releases/0.9.17.md
+++ b/docs/releases/0.9.17.md
@@ -28,10 +28,12 @@ the fix.
 
 ## Release status
 
-- [ ] Signed + notarized build (releaseId `0.9.17-beta.1`); artifact
+- [x] Signed + notarized build (releaseId `0.9.17-beta.1`); artifact
       validation PASS incl. the exact-secret gate.
-- [ ] Uploaded to R2, all objects verified.
-- [ ] Feed verified on BOTH hosts (www.videorc.com + legacy Vercel).
+- [x] Uploaded to R2, all objects verified.
+- [x] Feed verified 2026-07-07 on BOTH hosts: www.videorc.com and the
+      legacy Vercel feed each serve `version: 0.9.17`; `/api/changelog`
+      serves the entry.
 - [ ] Owner by-eye: (1) first-ever grant → calm badge, no red stack;
       (2) export a support bundle → app.version + health.version both
       0.9.17, schemaVersion 2; (3) Cam Link preview → no start-stretch;


### PR DESCRIPTION
Checks off the 0.9.17 release note now that the release is shipped and verified.

**0.9.17 is already live** — the release built from the pushed version bump
(`7bf56201`), was signed + notarized (Apple: Accepted), passed artifact
validation incl. the exact-secret gate, uploaded to R2, and both feed hosts
(`www.videorc.com` + the legacy Vercel feed) serve `version: 0.9.17`. This is
purely the `docs/releases/0.9.17.md` bookkeeping check-off, which couldn't push
directly once `main` began requiring PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release checklist to show completed verification steps for the 0.9.17-beta.1 release.
  * Added a verification date and clarified the feed status, including the version served on the primary and legacy feeds and the changelog endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->