### PR TITLE
Release skill: announce each release on Discord

### DIFF
--- a/.claude/skills/videorc-release/SKILL.md
+++ b/.claude/skills/videorc-release/SKILL.md
@@ -74,8 +74,25 @@ If admin still shows an old version (it sat on "0.9.0 beta 1" for three
 releases), that env is pinned to a versioned key — fix the env + redeploy,
 never hand-edit per release.
 
-### 6. Commit the release note
-Update `docs/releases/<version>.md` (check off build/upload/verify), commit + push.
+### 6. Announce on Discord
+After the feed is verified, post a short "what's new" to the Videorc Discord:
+
+```sh
+set -a; . ~/.videorc-release.env; set +a   # loads VIDEORC_DISCORD_RELEASE_WEBHOOK
+pnpm release:notify:discord -- --dry-run    # preview the message first
+pnpm release:notify:discord                 # posts the newest changelog entry
+```
+
+It posts the release title + up to 4 changelog highlights (short — full notes
+live on the site). The webhook URL is a **post-anywhere credential and the repo
+is PUBLIC**, so it is NEVER committed — it lives in `~/.videorc-release.env` as
+`VIDEORC_DISCORD_RELEASE_WEBHOOK` (gitignored, already sourced by the build).
+The script refuses to run without it and never echoes the URL. Pass a releaseId
+to re-announce an older one: `pnpm release:notify:discord 0.9.17-beta.1`.
+
+### 7. Commit the release note
+Update `docs/releases/<version>.md` (check off build/upload/verify/announce),
+commit + push (via a PR — `main` is branch-protected since 2026-07-07).
 
 ## Gotchas (each cost real debugging)
 

--- a/docs/releases/release-runbook.md
+++ b/docs/releases/release-runbook.md
@@ -95,6 +95,15 @@ Newsletter: `pnpm changelog:email <releaseId>` renders the entry to
 email-ready HTML + plaintext under `dist/changelog/email/` (sending is manual —
 no ESP is wired yet).
 
+Discord announcement: after the feed is verified, `pnpm release:notify:discord`
+posts a short "what's new" (release title + up to 4 changelog highlights) to the
+Videorc Discord channel. `-- --dry-run` previews without posting; a releaseId
+argument re-announces an older release. The webhook is a post-anywhere
+credential and this repo is PUBLIC, so it is **never committed** — it lives in
+`~/.videorc-release.env` as `VIDEORC_DISCORD_RELEASE_WEBHOOK` (gitignored,
+already sourced by the build); the script refuses to run without it and never
+echoes the URL.
+
 ## Verify (always follow the redirect to R2)
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "changelog:build": "node scripts/build-changelog.mjs",
     "changelog:check": "node scripts/build-changelog.mjs --check",
     "changelog:email": "node scripts/changelog-email.mjs",
+    "release:notify:discord": "node scripts/notify-discord-release.mjs",
     "ffmpeg:build:macos": "bash scripts/build-ffmpeg-macos.sh",
     "ffmpeg:fetch:windows": "node scripts/fetch-ffmpeg-windows.mjs",
     "package:backend": "cargo build --release -p videorc-backend",

--- a/scripts/lib/discord-release-message.test.mjs
+++ b/scripts/lib/discord-release-message.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { buildDiscordReleaseMessage } from '../notify-discord-release.mjs'
+
+describe('buildDiscordReleaseMessage', () => {
+  it('drops the -beta suffix and renders a short titled bullet list', () => {
+    const message = buildDiscordReleaseMessage({
+      version: '0.9.17-beta.1',
+      title: 'A calmer permission grant, a steadier preview',
+      highlights: ['Grant no longer errors', 'Preview no longer stretches']
+    })
+    assert.match(message, /🚀 \*\*Videorc 0\.9\.17 — A calmer permission grant/)
+    assert.ok(!message.includes('beta'))
+    assert.match(message, /• Grant no longer errors/)
+    assert.match(message, /• Preview no longer stretches/)
+    assert.match(message, /Update from Settings/)
+  })
+
+  it('caps at 4 highlights and adds an "and more" line', () => {
+    const message = buildDiscordReleaseMessage({
+      version: '1.0.0',
+      title: 'Big one',
+      highlights: ['a', 'b', 'c', 'd', 'e', 'f']
+    })
+    assert.equal((message.match(/^• /gm) ?? []).length, 4)
+    assert.match(message, /…and more\./)
+  })
+
+  it('strips inline markdown emphasis and links from highlights', () => {
+    const message = buildDiscordReleaseMessage({
+      version: '1.2.3',
+      title: 'T',
+      highlights: ['See **bold** and [the page](https://videorc.com/x) and `code`']
+    })
+    assert.match(message, /• See bold and the page and code$/m)
+    assert.ok(!message.includes('https://videorc.com/x'))
+  })
+})

--- a/scripts/notify-discord-release.mjs
+++ b/scripts/notify-discord-release.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Post a short release announcement to the Videorc Discord channel.
+//
+// Runs at the END of the release process (after the feed is verified) so
+// followers see what the update brings. The message is intentionally SHORT:
+// the release title + up to a few highlights from the changelog entry — the
+// full notes live on the website.
+//
+//   node scripts/notify-discord-release.mjs [releaseId] [--dry-run]
+//
+// - releaseId defaults to the newest changelog entry (the one just shipped).
+// - --dry-run prints the exact payload without posting.
+//
+// SECURITY: the webhook URL is a post-anywhere credential and this repo is
+// public — it is NEVER hardcoded here. It is read from the env var
+// VIDEORC_DISCORD_RELEASE_WEBHOOK, which lives in ~/.videorc-release.env
+// (gitignored, already sourced by the release build). The script refuses to
+// run without it and never echoes the URL.
+
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { loadChangelogEntries } from './lib/changelog.mjs'
+
+const WEBHOOK_ENV = 'VIDEORC_DISCORD_RELEASE_WEBHOOK'
+const MAX_HIGHLIGHTS = 4
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+
+/** Strip inline markdown emphasis/links so a highlight reads clean in Discord. */
+function stripInline(text) {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[*_`]/g, '')
+    .trim()
+}
+
+/** Build the short Discord message from a changelog entry. */
+export function buildDiscordReleaseMessage(entry) {
+  const version = entry.version.replace(/-beta\.\d+$/, '')
+  const highlights = entry.highlights
+    .slice(0, MAX_HIGHLIGHTS)
+    .map((item) => `• ${stripInline(item)}`)
+  const lines = [`🚀 **Videorc ${version} — ${entry.title}**`, '', ...highlights]
+  if (entry.highlights.length > MAX_HIGHLIGHTS) {
+    lines.push('', '…and more.')
+  }
+  lines.push('', 'Update from Settings → About, or it applies on next launch.')
+  return lines.join('\n')
+}
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const dryRun = argv.includes('--dry-run')
+  const releaseId = argv.find((arg) => !arg.startsWith('--'))
+
+  const entries = await loadChangelogEntries(join(repoRoot, 'changelog'))
+  const entry = releaseId
+    ? entries.find((candidate) => candidate.version === releaseId)
+    : entries[0]
+  if (!entry) {
+    console.error(`No changelog entry found${releaseId ? ` for ${releaseId}` : ''}.`)
+    process.exit(1)
+  }
+
+  const content = buildDiscordReleaseMessage(entry)
+
+  if (dryRun) {
+    console.log('--- Discord release message (dry run, not posted) ---')
+    console.log(content)
+    return
+  }
+
+  const webhook = process.env[WEBHOOK_ENV]?.trim()
+  if (!webhook) {
+    console.error(
+      `${WEBHOOK_ENV} is not set. Add it to ~/.videorc-release.env (never commit it) and source that file, or pass --dry-run.`
+    )
+    process.exit(1)
+  }
+
+  const response = await fetch(webhook, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    // flags:4 = SUPPRESS_EMBEDS — keep it a plain text post, no link unfurls.
+    body: JSON.stringify({ content, flags: 4, allowed_mentions: { parse: [] } })
+  })
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    // Never surface the webhook URL in the error.
+    console.error(
+      `Discord webhook POST failed: ${response.status} ${response.statusText} ${detail}`
+    )
+    process.exit(1)
+  }
+
+  console.log(`Posted ${entry.version} release announcement to Discord.`)
+}
+
+// Only run when invoked directly (not when imported by the unit test).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
Adds a post-release Discord announcement step to the release flow.

- `pnpm release:notify:discord` posts the release title + up to 4 changelog
  highlights (short — full notes live on the site) to the Videorc channel.
  `-- --dry-run` previews; a releaseId argument re-announces an older release.
- **The webhook is a post-anywhere credential and this repo is public**, so it
  is never committed — read from `VIDEORC_DISCORD_RELEASE_WEBHOOK` in
  `~/.videorc-release.env` (gitignored, already sourced by the build). The
  script refuses to run without it and never echoes the URL.
- Message builder is unit-tested (beta-suffix drop, 4-highlight cap,
  inline-markdown strip). Skill (`step 6`) + runbook document it.

Already used: the 0.9.17 announcement was posted to Discord with this tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)