### PR TITLE
Fix Scene margin preview commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
@@ -374,6 +374,7 @@ export function LayoutTab(): ReactElement {
                     suffix="px"
                     value={layout.cameraMargin}
                     onChange={(cameraMargin) => patchLayout({ cameraMargin })}
+                    onCommit={(cameraMargin) => applyLayoutPatch({ cameraMargin })}
                   />
                 </>
               ) : null}

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -355,7 +355,7 @@ fn camera_transform(
         }
     };
 
-    sanitize_transform(SceneTransform {
+    sanitize_transform_unsnapped(SceneTransform {
         x,
         y,
         width: camera_width / output_width,
@@ -909,6 +909,26 @@ mod tests {
         assert!((preview_camera.height - recording_camera.height).abs() < 0.0001);
         assert!((preview_camera.x - recording_camera.x).abs() < 0.0001);
         assert!((preview_camera.y - recording_camera.y).abs() < 0.0001);
+    }
+
+    #[test]
+    fn camera_margin_below_snap_threshold_stays_visible() {
+        let mut params = base_params();
+        params.layout.camera_corner = CameraCorner::BottomRight;
+        params.layout.camera_margin = 18;
+
+        let scene = scene_from_capture_config(params);
+        let camera = scene
+            .sources
+            .iter()
+            .find(|source| source.kind == SceneSourceKind::Camera)
+            .expect("camera source present");
+
+        let right_margin = 1.0 - (camera.transform.x + camera.transform.width);
+        let bottom_margin = 1.0 - (camera.transform.y + camera.transform.height);
+
+        assert!((right_margin - (18.0 / 1280.0)).abs() < 0.0001);
+        assert!((bottom_margin - (18.0 / 720.0)).abs() < 0.0001);
     }
 
     #[test]

--- a/scripts/smoke-preview-scene-commit-app.mjs
+++ b/scripts/smoke-preview-scene-commit-app.mjs
@@ -71,6 +71,50 @@ try {
   )
   assertCameraShapeCommit({ compositor: shapeCompositor, surface: shapeSurface, highRevision })
 
+  const marginValue = 18
+  await smokeCommand(smoke, 'open-layout-tab')
+  const marginInputResult = await smokeCommand(smoke, 'eval-js', {
+    code: `
+      const camera = document.querySelector('[data-videorc-stage-source="source:camera"]')
+      camera?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }))
+      camera?.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }))
+      camera?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+      const input = document.querySelector('input[aria-label="Margin value"]')
+      if (!input) return { ok: false, reason: 'margin input missing' }
+
+      input.focus()
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setter?.call(input, '${marginValue}')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        code: 'Enter',
+        bubbles: true,
+        cancelable: true
+      }))
+      input.blur()
+      await sleep(${settleMs})
+      return { ok: true, value: input.value }
+    `
+  })
+  if (marginInputResult?.ok === false) {
+    throw new Error(`Margin input was not available: ${JSON.stringify(marginInputResult)}`)
+  }
+  const marginCompositor = await waitForCompositorCameraMargin(
+    ws,
+    marginValue,
+    shapeCompositor.sceneRevision
+  )
+  const marginSurface = await waitForSurfaceRevision(smoke, marginCompositor.sceneRevision)
+  const marginScene = await request(ws, timeoutMs, 'scene.get')
+  assertCameraMarginCommit({
+    compositor: marginCompositor,
+    surface: marginSurface,
+    scene: marginScene,
+    margin: marginValue
+  })
+
   const shapedScene = await request(ws, timeoutMs, 'scene.get')
   const source =
     shapedScene.sources.find((candidate) => candidate.visible) ?? shapedScene.sources[0]
@@ -102,7 +146,7 @@ try {
   assertCommitResult({ commit, compositor, surface, scene, sourceId: source.id, nextX })
 
   console.log(
-    `Preview scene commit smoke OK - stale revision ${highRevision} advanced through camera shape ${shapeCompositor.sceneRevision} and transform ${commit.sceneRevision}, surface ${surface.sceneRevision}.`
+    `Preview scene commit smoke OK - stale revision ${highRevision} advanced through camera shape ${shapeCompositor.sceneRevision}, margin ${marginCompositor.sceneRevision}, and transform ${commit.sceneRevision}, surface ${surface.sceneRevision}.`
   )
 } finally {
   try {
@@ -168,6 +212,29 @@ async function waitForCompositorCameraShape(connection, shape, minRevision) {
   )
 }
 
+async function waitForCompositorCameraMargin(connection, margin, minRevision) {
+  let last = null
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    last = await request(connection, timeoutMs, 'compositor.status')
+    const camera = last.sceneSources?.find((source) => source.kind === 'camera')
+    if (
+      last.sceneRevision > minRevision &&
+      last.frameSceneRevision === last.sceneRevision &&
+      last.sceneLayout?.cameraMargin === margin &&
+      camera
+    ) {
+      return last
+    }
+    await sleep(100)
+  }
+  throw new Error(
+    `Timed out waiting for compositor camera margin ${margin} after revision ${minRevision}. Last status: ${JSON.stringify(
+      last
+    )}`
+  )
+}
+
 async function waitForSurfaceRevision(smoke, revision) {
   let last = null
   const deadline = Date.now() + timeoutMs
@@ -202,6 +269,50 @@ async function waitForSurfaceCameraShape(smoke, shape, revision) {
   )
 }
 
+function assertCameraMarginCommit({ compositor, surface, scene, margin }) {
+  if (compositor.sceneLayout?.cameraMargin !== margin) {
+    throw new Error(
+      `Compositor layout did not commit margin ${margin}: ${JSON.stringify(compositor)}`
+    )
+  }
+  if (surface.sceneRevision !== compositor.sceneRevision) {
+    throw new Error(
+      `Preview surface revision ${surface.sceneRevision} did not match margin commit ${compositor.sceneRevision}.`
+    )
+  }
+  if (surface.surfaceStatus?.state !== 'live') {
+    throw new Error(`Preview surface is not live after margin commit: ${JSON.stringify(surface)}`)
+  }
+
+  const camera = scene.sources.find((source) => source.kind === 'camera')
+  if (!camera) {
+    throw new Error(`Committed scene lost camera source: ${JSON.stringify(scene)}`)
+  }
+  const output =
+    scene.outputs?.find((candidate) => candidate.kind === 'recording') ?? scene.outputs?.[0]
+  if (!output?.width || !output?.height) {
+    throw new Error(`Committed scene has no recording output dimensions: ${JSON.stringify(scene)}`)
+  }
+
+  const rightMargin = 1 - (Number(camera.transform?.x ?? 0) + Number(camera.transform?.width ?? 0))
+  const bottomMargin =
+    1 - (Number(camera.transform?.y ?? 0) + Number(camera.transform?.height ?? 0))
+  const scale = Math.min(output.width / 1280, output.height / 720)
+  const scaledMargin = Math.max(1, Math.round(margin * scale))
+  const expectedRightMargin = scaledMargin / output.width
+  const expectedBottomMargin = scaledMargin / output.height
+  if (Math.abs(rightMargin - expectedRightMargin) > 0.0001) {
+    throw new Error(
+      `Committed camera right margin ${rightMargin}, expected ${expectedRightMargin}: ${JSON.stringify(camera.transform)}`
+    )
+  }
+  if (Math.abs(bottomMargin - expectedBottomMargin) > 0.0001) {
+    throw new Error(
+      `Committed camera bottom margin ${bottomMargin}, expected ${expectedBottomMargin}: ${JSON.stringify(camera.transform)}`
+    )
+  }
+}
+
 function assertCameraShapeCommit({ compositor, surface, highRevision }) {
   if (compositor.sceneRevision <= highRevision) {
     throw new Error(
@@ -216,7 +327,9 @@ function assertCameraShapeCommit({ compositor, surface, highRevision }) {
     throw new Error(`Compositor camera source stayed ${camera?.shape}: ${JSON.stringify(camera)}`)
   }
   if (surface.cameraShape !== 'circle' || surface.sourceShapes?.['source:camera'] !== 'circle') {
-    throw new Error(`Preview surface camera shape did not commit circle: ${JSON.stringify(surface)}`)
+    throw new Error(
+      `Preview surface camera shape did not commit circle: ${JSON.stringify(surface)}`
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- Commit Margin slider changes through `applyLayoutPatch` so the detached/native preview receives a new backend-owned scene revision immediately.
- Keep preset camera margins unsnapped so sub-threshold margins like `18px` do not stick the camera to the right/bottom canvas edge.
- Extend the preview scene commit smoke to drive the real Margin input at `18px` and assert compositor, surface, and scene geometry.

## Verification
- `cargo test -p videorc-backend camera_margin_below_snap_threshold_stays_visible`
- `PATH=/opt/homebrew/bin:$PATH pnpm smoke:preview-scene-commit`
- `PATH=/opt/homebrew/bin:$PATH pnpm --filter @videorc/desktop test`
- `PATH=/opt/homebrew/bin:$PATH pnpm typecheck`
- `PATH=/opt/homebrew/bin:$PATH pnpm lint`
- `PATH=/opt/homebrew/bin:$PATH pnpm format:check`
- `cargo fmt --check --all`
- `cargo test -p videorc-backend`
- `cargo clippy -p videorc-backend -- -D warnings`
- `PATH=/opt/homebrew/bin:$PATH pnpm smoke:recording-studio`
- `PATH=/opt/homebrew/bin:$PATH pnpm smoke:recording-studio:devices` ran; the final source-complete device step failed once on native preview perf (`25.70fps`, threshold `27.00fps`) after the full repeated gate load.
- `PATH=/opt/homebrew/bin:$PATH VIDEORC_NATIVE_PREVIEW_SOURCE_COMPLETE_SCENE=1 VIDEORC_NATIVE_PREVIEW_LAYOUT_STRESS_UPDATES=4 pnpm smoke:recording-native-preview` passed on isolated rerun of that exact failing device step (`29.29fps`).
