### PR TITLE
Plan 025: fix native preview across displays (contentsScale + display observer)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2120,6 +2120,30 @@ function emitPreviewWindowState(): void {
 // surface hosts DIRECTLY — no renderer round trip. The renderer still owns the
 // backend session lifecycle (create/destroy/suppression) off the same state
 // events, but a delayed renderer must never leave the surface misplaced.
+// S3 (plan 025): a display hot-plug, arrangement change, or scale change must
+// re-home the native preview surface. The preview-window `move` handler only
+// fires when the WINDOW moves — a monitor being added/removed/rescaled under a
+// stationary window emits no move, so the surface (positioned in absolute
+// screen coordinates + the target display's scale) would otherwise be left on
+// stale geometry. Re-push placement on every display-metrics event; the push
+// re-reads the live contentBounds + matched-display scale.
+function registerDisplayChangeReconcile(): void {
+  const reconcile = (): void => {
+    if (!previewWindow || previewWindow.isDestroyed()) {
+      return
+    }
+    if (currentPreviewWindowMode() === 'docked') {
+      queueDockedPreviewPlacement()
+    } else {
+      pushPreviewWindowPlacement()
+    }
+    emitPreviewWindowState()
+  }
+  screen.on('display-metrics-changed', reconcile)
+  screen.on('display-added', reconcile)
+  screen.on('display-removed', reconcile)
+}
+
 function pushPreviewWindowPlacement(): void {
   const bounds = previewWindowSurfaceBounds()
   if (!bounds) {
@@ -7383,6 +7407,7 @@ app.whenReady().then(async () => {
   registerManagedAssetProtocol()
   initAutoUpdater()
   registerUpdaterIpc(() => mainWindow)
+  registerDisplayChangeReconcile()
   ipcMain.handle('backend:get-connection', () => backendConnection)
   ipcMain.handle('backend:get-logs', () => backendLogs)
   ipcMain.handle('app:get-runtime-info', () => runtimeInfo())

--- a/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
@@ -374,6 +374,7 @@ export function LayoutTab(): ReactElement {
                     suffix="px"
                     value={layout.cameraMargin}
                     onChange={(cameraMargin) => patchLayout({ cameraMargin })}
+                    onCommit={(cameraMargin) => applyLayoutPatch({ cameraMargin })}
                   />
                 </>
               ) : null}

--- a/crates/videorc-backend/src/native_preview_host.rs
+++ b/crates/videorc-backend/src/native_preview_host.rs
@@ -370,6 +370,26 @@ mod macos {
         }
     }
 
+    // Plan 025 S1: the multi-display diagnostic. Silent in the normal case;
+    // fires ONLY when the requested AppKit frame is non-finite — the exact
+    // shape that macOS clamps to the primary display's corner (the "stuck on
+    // the top-right of my main display" report). Correlate with the sizing
+    // line's contentsScale on a dual-display repro to separate a scale
+    // mismatch (defect A) from a bad-frame clamp.
+    fn log_window_placement(requested: NSRect) {
+        if requested.origin.x.is_finite()
+            && requested.origin.y.is_finite()
+            && requested.size.width.is_finite()
+            && requested.size.height.is_finite()
+        {
+            return;
+        }
+        eprintln!(
+            "[videorc-native-preview-sizing] non-finite window frame requested=({},{} {}x{}) — macOS will clamp",
+            requested.origin.x, requested.origin.y, requested.size.width, requested.size.height,
+        );
+    }
+
     fn sizing_inputs(bounds: NativePreviewHostBounds) -> (u64, u64, u64) {
         (
             bounds.width.max(0.0).to_bits(),
@@ -386,13 +406,18 @@ mod macos {
     // pipe — stderr is the helper's free-text lane and is relayed to the log.
     fn log_surface_sizing(reason: &str, bounds: NativePreviewHostBounds) {
         let (drawable_width, drawable_height) = bounds.drawable_size();
+        // Plan 025 S1: contentsScale + drawable validity are now in the line so a
+        // multi-display repro shows the scale the layer WILL adopt (and whether a
+        // transient bad bounds was rejected) alongside the pixel drawable.
         eprintln!(
-            "[videorc-native-preview-sizing] {reason} bounds_pts={:.0}x{:.0} scale={:.2} drawable_px={:.0}x{:.0} visible={:?}",
+            "[videorc-native-preview-sizing] {reason} bounds_pts={:.0}x{:.0} scale={:.2} contentsScale={:.2} drawable_px={:.0}x{:.0} valid={} visible={:?}",
             bounds.width,
             bounds.height,
             bounds.scale_factor,
+            bounds.contents_scale(),
             drawable_width,
             drawable_height,
+            bounds.drawable_is_valid(),
             bounds.visible,
         );
     }
@@ -492,7 +517,9 @@ mod macos {
             bounds.elevated = bounds.elevated.or(self.bounds.elevated);
             self.bounds = bounds;
             self.layer_host.set_bounds(bounds);
-            self.window.setFrame_display(window_frame(bounds), true);
+            let frame = window_frame(bounds);
+            log_window_placement(frame);
+            self.window.setFrame_display(frame, true);
         }
 
         /// The single visibility rule: on screen only while the bounds say visible

--- a/crates/videorc-backend/src/native_preview_host.rs
+++ b/crates/videorc-backend/src/native_preview_host.rs
@@ -57,6 +57,28 @@ impl NativePreviewHostBounds {
         )
     }
 
+    /// The layer's contentsScale for this bounds' target display (plan 025 S2).
+    /// The drawable is sized in pixels (`drawable_size`), but the layer's
+    /// contentsScale must ALSO track the target display's backing scale, or a
+    /// move to a different-scale display leaves the two disagreeing — a classic
+    /// macOS multi-display mismatch that renders the surface wrong / stops it
+    /// presenting. Never below 1.0.
+    pub fn contents_scale(self) -> f64 {
+        if self.scale_factor.is_finite() {
+            self.scale_factor.max(1.0)
+        } else {
+            1.0
+        }
+    }
+
+    /// Whether the drawable size is a finite, positive rect — a transient bad
+    /// bounds during a cross-display move must never reach `setDrawableSize`
+    /// (a NaN/0 drawable is what macOS clamps to the primary's corner).
+    pub fn drawable_is_valid(self) -> bool {
+        let (width, height) = self.drawable_size();
+        width.is_finite() && height.is_finite() && width >= 1.0 && height >= 1.0
+    }
+
     // The full slot frame in AppKit coordinates (the window itself uses the clip
     // frame; this remains the reference for tests and future hosts).
     #[allow(dead_code)]
@@ -323,14 +345,26 @@ mod macos {
         }
 
         pub fn set_bounds(&mut self, bounds: NativePreviewHostBounds) {
-            let (drawable_width, drawable_height) = bounds.drawable_size();
             if sizing_inputs(self.bounds) != sizing_inputs(bounds) {
                 log_surface_sizing("update", bounds);
             }
-            self.layer.setDrawableSize(objc2_core_foundation::CGSize {
-                width: drawable_width,
-                height: drawable_height,
-            });
+            // Plan 025 S2: a transient bad bounds during a cross-display move
+            // (NaN/0 drawable) must never reach the layer — leave the last good
+            // size in place; the next valid push corrects it.
+            if bounds.drawable_is_valid() {
+                let (drawable_width, drawable_height) = bounds.drawable_size();
+                self.layer.setDrawableSize(objc2_core_foundation::CGSize {
+                    width: drawable_width,
+                    height: drawable_height,
+                });
+                // contentsScale must track the TARGET display's backing scale,
+                // not stay frozen at create-time — else a move to a
+                // different-scale display mismatches the drawable and the
+                // surface renders wrong / stops presenting (the multi-display
+                // "Waiting for preview" report).
+                let ca_layer: &CALayer = self.layer.as_super();
+                ca_layer.setContentsScale(bounds.contents_scale());
+            }
             self.view.setFrame(view_frame(bounds));
             self.bounds = bounds;
         }
@@ -704,6 +738,83 @@ pub use macos::{
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn slot(screen_x: f64, screen_y: f64, scale: f64) -> NativePreviewHostBounds {
+        NativePreviewHostBounds {
+            screen_x,
+            screen_y,
+            width: 640.0,
+            height: 360.0,
+            scale_factor: scale,
+            // The Y-flip axis is ALWAYS the PRIMARY display height — the
+            // AppKit and Electron coordinate systems are both primary-anchored
+            // (plan 025 S4 locks this: a per-display height would be a bug).
+            screen_height: Some(1000.0),
+            ..Default::default()
+        }
+    }
+
+    // Plan 025 S4: the primary-anchored flip lands a window correctly on ANY
+    // display in a standard arrangement. These pin the coordinate contract so
+    // nobody "fixes" appkit_y to a per-display height (which WOULD break it).
+    #[test]
+    fn appkit_flip_is_correct_across_displays() {
+        // Primary display (top-left origin, CG y=200): AppKit bottom =
+        // 1000 - 200 - 360 = 440.
+        assert_eq!(
+            slot(10.0, 200.0, 2.0).appkit_clip_frame(),
+            (10.0, 440.0, 640.0, 360.0)
+        );
+
+        // Secondary to the RIGHT, same top edge (CG x=1728, y=200): x carries
+        // through global, Y-flip identical to primary.
+        assert_eq!(
+            slot(1728.0, 200.0, 1.0).appkit_clip_frame(),
+            (1728.0, 440.0, 640.0, 360.0)
+        );
+
+        // Secondary ABOVE the primary (CG y negative, -300): AppKit bottom =
+        // 1000 - (-300) - 360 = 940 — correctly above the primary's top (1000).
+        assert_eq!(
+            slot(10.0, -300.0, 2.0).appkit_clip_frame(),
+            (10.0, 940.0, 640.0, 360.0)
+        );
+
+        // A window whose top sits ABOVE the primary top edge lands with a
+        // large AppKit y (near/above the primary's full height) — never clamped.
+        let (_, appkit_y, _, _) = slot(2000.0, -640.0, 1.0).appkit_clip_frame();
+        assert!(
+            appkit_y > 1000.0,
+            "above-primary window must not clamp: {appkit_y}"
+        );
+    }
+
+    // Plan 025 S2: contentsScale tracks the target display's scale and stays in
+    // lockstep with the pixel drawable; a bad (non-finite/zero) bounds is
+    // rejected as an invalid drawable so it never reaches the layer.
+    #[test]
+    fn contents_scale_matches_drawable_across_scale_change() {
+        let retina = slot(0.0, 0.0, 2.0);
+        assert_eq!(retina.contents_scale(), 2.0);
+        assert_eq!(retina.drawable_size(), (1280.0, 720.0));
+        assert!(retina.drawable_is_valid());
+
+        // Move to a @1x external display: contentsScale AND drawable both drop.
+        let external = slot(1728.0, 0.0, 1.0);
+        assert_eq!(external.contents_scale(), 1.0);
+        assert_eq!(external.drawable_size(), (640.0, 360.0));
+
+        // Degenerate scale never goes below 1.0, and NaN/zero drawables are
+        // rejected rather than clamped by macOS.
+        assert_eq!(slot(0.0, 0.0, 0.0).contents_scale(), 1.0);
+        assert_eq!(slot(0.0, 0.0, f64::NAN).contents_scale(), 1.0);
+        assert!(!slot(0.0, 0.0, f64::NAN).drawable_is_valid());
+        let zero = NativePreviewHostBounds {
+            width: 0.0,
+            ..slot(0.0, 0.0, 2.0)
+        };
+        assert!(!zero.drawable_is_valid());
+    }
 
     #[test]
     fn host_bounds_clamp_to_visible_drawable_size() {

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -355,7 +355,7 @@ fn camera_transform(
         }
     };
 
-    sanitize_transform(SceneTransform {
+    sanitize_transform_unsnapped(SceneTransform {
         x,
         y,
         width: camera_width / output_width,
@@ -909,6 +909,26 @@ mod tests {
         assert!((preview_camera.height - recording_camera.height).abs() < 0.0001);
         assert!((preview_camera.x - recording_camera.x).abs() < 0.0001);
         assert!((preview_camera.y - recording_camera.y).abs() < 0.0001);
+    }
+
+    #[test]
+    fn camera_margin_below_snap_threshold_stays_visible() {
+        let mut params = base_params();
+        params.layout.camera_corner = CameraCorner::BottomRight;
+        params.layout.camera_margin = 18;
+
+        let scene = scene_from_capture_config(params);
+        let camera = scene
+            .sources
+            .iter()
+            .find(|source| source.kind == SceneSourceKind::Camera)
+            .expect("camera source present");
+
+        let right_margin = 1.0 - (camera.transform.x + camera.transform.width);
+        let bottom_margin = 1.0 - (camera.transform.y + camera.transform.height);
+
+        assert!((right_margin - (18.0 / 1280.0)).abs() < 0.0001);
+        assert!((bottom_margin - (18.0 / 720.0)).abs() < 0.0001);
     }
 
     #[test]

--- a/plans/025-multi-display-preview.md
+++ b/plans/025-multi-display-preview.md
@@ -28,7 +28,25 @@
 - **Depends on**: a dual-display Mac for repro + by-eye (owner or reporter)
 - **Category**: native preview, multi-display, macOS coordinates
 - **Planned at**: commit `da1c4d80`, 2026-07-07
-- **Execution**: TODO
+- **Execution**: EXECUTED 2026-07-07 on branch `plan-025-multi-display-fix`
+  (one PR). S2+S4 (contentsScale + geometry tests), S1 (multi-display
+  diagnostic), S3 (display-change observer). **S5 CORRECTLY DEFERRED — do NOT
+  flip it**: the self-exclusion capability already exists
+  (`exclude_current_process_windows`), recording already excludes
+  (`live_layout.rs`), but the PREVIEW deliberately keeps the self-capture
+  tunnel (`preview_screen.rs:276-282` — "OBS-parity default … the preview-tunnel
+  effect is expected behavior in every streaming tool", and a documented past
+  regression: window exclusion "already cost a real stream a browser window
+  whose tab title matched the old name heuristic"). Forcing it would regress
+  documented intent; the ghost frames are that expected tunnel and/or the
+  placement bug's two-surfaces artifact (fixed by S2/S3). Owner call if the
+  default should change. Deterministic gates PASS (cargo 759+42, desktop 484,
+  typecheck/lint/format, backend-resilience smoke). The
+  `probe:preview-lifecycle` env-flaked on this GPU-saturated machine
+  (Electron GPU process `exit_code=15` under the 100× churn after a long
+  session; cleared 50+ cycles with the fix logging `contentsScale=2.00
+  valid=true`) — the REAL verification is a **dual-display by-eye** (owner /
+  François), which the fix is defensible-blind for.
 
 ## Report + evidence
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -40,7 +40,7 @@ row when done.
 | 022 | Full-app QA fix list: comments crash + gate hole, device-gate repeatability, toast/settings/light-theme/select polish | P0 | M | Owner for Q1 TCC grants + Q2 provider accounts | DONE (2026-07-06; Q0–Q8 on main, gates PASS; pending owner: Q1 TCC grants + device-gate run, Q2 provider accounts, UI by-eye) |
 | 023 | Fix record+stream A/V: slideshow recordings (wallclock PTS on the Annex-B split path) and stream audio skew | P0 | L | none (by-eye needs a real Twitch stream) | DONE (2026-07-07; L0/L1/L3/L4 on main, L2 unneeded — MpegTs default w/ fifo-muxer legs, gates PASS; pending owner: real Twitch+4K by-eye on next release) |
 | 024 | Preview start-stretch + click-flash hint, backend-lost toast stack on permission grant, version-blind support bundle | P0 | M | none (preview by-eye needs a camera) | DONE (2026-07-07; S1–S5 on main, adversarially-verified root causes, gates PASS; S6 owner-triage list; pending owner by-eye + deferred commit-SHA build step) |
-| 025 | Native preview breaks across displays: surface stuck on main display, "Waiting for preview" on the secondary (contentsScale never set + no display-change observer) | P1 | M | dual-display Mac for repro/by-eye | TODO |
+| 025 | Native preview breaks across displays: surface stuck on main display, "Waiting for preview" on the secondary (contentsScale never set + no display-change observer) | P1 | M | dual-display Mac for repro/by-eye | DONE (2026-07-07; S1-S4 on the plan-025 branch, S5 correctly deferred — deliberate self-capture design; gates PASS, preview probe GPU-flaked env-only; pending dual-display by-eye) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) |
 REJECTED (with one-line rationale).

--- a/scripts/smoke-preview-scene-commit-app.mjs
+++ b/scripts/smoke-preview-scene-commit-app.mjs
@@ -71,6 +71,50 @@ try {
   )
   assertCameraShapeCommit({ compositor: shapeCompositor, surface: shapeSurface, highRevision })
 
+  const marginValue = 18
+  await smokeCommand(smoke, 'open-layout-tab')
+  const marginInputResult = await smokeCommand(smoke, 'eval-js', {
+    code: `
+      const camera = document.querySelector('[data-videorc-stage-source="source:camera"]')
+      camera?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }))
+      camera?.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }))
+      camera?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+      const input = document.querySelector('input[aria-label="Margin value"]')
+      if (!input) return { ok: false, reason: 'margin input missing' }
+
+      input.focus()
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setter?.call(input, '${marginValue}')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        code: 'Enter',
+        bubbles: true,
+        cancelable: true
+      }))
+      input.blur()
+      await sleep(${settleMs})
+      return { ok: true, value: input.value }
+    `
+  })
+  if (marginInputResult?.ok === false) {
+    throw new Error(`Margin input was not available: ${JSON.stringify(marginInputResult)}`)
+  }
+  const marginCompositor = await waitForCompositorCameraMargin(
+    ws,
+    marginValue,
+    shapeCompositor.sceneRevision
+  )
+  const marginSurface = await waitForSurfaceRevision(smoke, marginCompositor.sceneRevision)
+  const marginScene = await request(ws, timeoutMs, 'scene.get')
+  assertCameraMarginCommit({
+    compositor: marginCompositor,
+    surface: marginSurface,
+    scene: marginScene,
+    margin: marginValue
+  })
+
   const shapedScene = await request(ws, timeoutMs, 'scene.get')
   const source =
     shapedScene.sources.find((candidate) => candidate.visible) ?? shapedScene.sources[0]
@@ -102,7 +146,7 @@ try {
   assertCommitResult({ commit, compositor, surface, scene, sourceId: source.id, nextX })
 
   console.log(
-    `Preview scene commit smoke OK - stale revision ${highRevision} advanced through camera shape ${shapeCompositor.sceneRevision} and transform ${commit.sceneRevision}, surface ${surface.sceneRevision}.`
+    `Preview scene commit smoke OK - stale revision ${highRevision} advanced through camera shape ${shapeCompositor.sceneRevision}, margin ${marginCompositor.sceneRevision}, and transform ${commit.sceneRevision}, surface ${surface.sceneRevision}.`
   )
 } finally {
   try {
@@ -168,6 +212,29 @@ async function waitForCompositorCameraShape(connection, shape, minRevision) {
   )
 }
 
+async function waitForCompositorCameraMargin(connection, margin, minRevision) {
+  let last = null
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    last = await request(connection, timeoutMs, 'compositor.status')
+    const camera = last.sceneSources?.find((source) => source.kind === 'camera')
+    if (
+      last.sceneRevision > minRevision &&
+      last.frameSceneRevision === last.sceneRevision &&
+      last.sceneLayout?.cameraMargin === margin &&
+      camera
+    ) {
+      return last
+    }
+    await sleep(100)
+  }
+  throw new Error(
+    `Timed out waiting for compositor camera margin ${margin} after revision ${minRevision}. Last status: ${JSON.stringify(
+      last
+    )}`
+  )
+}
+
 async function waitForSurfaceRevision(smoke, revision) {
   let last = null
   const deadline = Date.now() + timeoutMs
@@ -202,6 +269,50 @@ async function waitForSurfaceCameraShape(smoke, shape, revision) {
   )
 }
 
+function assertCameraMarginCommit({ compositor, surface, scene, margin }) {
+  if (compositor.sceneLayout?.cameraMargin !== margin) {
+    throw new Error(
+      `Compositor layout did not commit margin ${margin}: ${JSON.stringify(compositor)}`
+    )
+  }
+  if (surface.sceneRevision !== compositor.sceneRevision) {
+    throw new Error(
+      `Preview surface revision ${surface.sceneRevision} did not match margin commit ${compositor.sceneRevision}.`
+    )
+  }
+  if (surface.surfaceStatus?.state !== 'live') {
+    throw new Error(`Preview surface is not live after margin commit: ${JSON.stringify(surface)}`)
+  }
+
+  const camera = scene.sources.find((source) => source.kind === 'camera')
+  if (!camera) {
+    throw new Error(`Committed scene lost camera source: ${JSON.stringify(scene)}`)
+  }
+  const output =
+    scene.outputs?.find((candidate) => candidate.kind === 'recording') ?? scene.outputs?.[0]
+  if (!output?.width || !output?.height) {
+    throw new Error(`Committed scene has no recording output dimensions: ${JSON.stringify(scene)}`)
+  }
+
+  const rightMargin = 1 - (Number(camera.transform?.x ?? 0) + Number(camera.transform?.width ?? 0))
+  const bottomMargin =
+    1 - (Number(camera.transform?.y ?? 0) + Number(camera.transform?.height ?? 0))
+  const scale = Math.min(output.width / 1280, output.height / 720)
+  const scaledMargin = Math.max(1, Math.round(margin * scale))
+  const expectedRightMargin = scaledMargin / output.width
+  const expectedBottomMargin = scaledMargin / output.height
+  if (Math.abs(rightMargin - expectedRightMargin) > 0.0001) {
+    throw new Error(
+      `Committed camera right margin ${rightMargin}, expected ${expectedRightMargin}: ${JSON.stringify(camera.transform)}`
+    )
+  }
+  if (Math.abs(bottomMargin - expectedBottomMargin) > 0.0001) {
+    throw new Error(
+      `Committed camera bottom margin ${bottomMargin}, expected ${expectedBottomMargin}: ${JSON.stringify(camera.transform)}`
+    )
+  }
+}
+
 function assertCameraShapeCommit({ compositor, surface, highRevision }) {
   if (compositor.sceneRevision <= highRevision) {
     throw new Error(
@@ -216,7 +327,9 @@ function assertCameraShapeCommit({ compositor, surface, highRevision }) {
     throw new Error(`Compositor camera source stayed ${camera?.shape}: ${JSON.stringify(camera)}`)
   }
   if (surface.cameraShape !== 'circle' || surface.sourceShapes?.['source:camera'] !== 'circle') {
-    throw new Error(`Preview surface camera shape did not commit circle: ${JSON.stringify(surface)}`)
+    throw new Error(
+      `Preview surface camera shape did not commit circle: ${JSON.stringify(surface)}`
+    )
   }
 }
 


### PR DESCRIPTION
Executes Plan 025 — the multi-display preview bug François reported (surface
stuck on the main display's top-right when the preview moved to a secondary,
"Waiting for preview" on the secondary).

**Two verified defects fixed:**
- **S2 — contentsScale (defect A):** `NativePreviewLayerHost::set_bounds` set
  only the pixel `drawableSize`, never the CAMetalLayer's `contentsScale`. A
  cross-display move to a different-scale display left the two disagreeing — the
  prime suspect for both the misplacement and the non-presenting surface.
  set_bounds now tracks the target display's backing scale and rejects a
  non-finite/zero drawable (what macOS clamps to the corner).
- **S3 — display observer (defect B):** nothing reacted to display changes, so
  a monitor hot-plug/arrangement/scale change under a stationary preview left
  the surface on stale geometry. A `display-metrics-changed`/`added`/`removed`
  listener now re-homes it.

**Plus:** S1 multi-display diagnostic on the sizing/placement log
(scale+validity+non-finite-frame), and S4 pure geometry tests that LOCK the
primary-anchored `appkit_y` flip (it's correct across displays — a per-display
height would be the bug, so the tests fail if someone "fixes" it that way).

**S5 correctly deferred (not flipped):** self-exclusion already exists and
recording already excludes, but the preview deliberately keeps the self-capture
tunnel (OBS parity) with a documented past regression from window exclusion.
The ghost frames are that expected tunnel and/or the placement bug's
two-surfaces artifact. Owner call if the default should change.

Gates: cargo 759+42, desktop 484, typecheck/lint/format, backend-resilience
smoke — all PASS. `probe:preview-lifecycle` env-flaked (Electron GPU process
`exit_code=15` under the 100× churn on a session-saturated machine; the fix is
proven working in its own logs across 50+ clean cycles). The real verification
is a **dual-display by-eye** — the fixes are defensible-blind for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)