### PR TITLE
Add README beta status note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ window.
 
 **[Download for macOS →](https://videorc.com)** (macOS 13+, Apple Silicon)
 
+**Beta status:** Videorc is still in beta. Expect fast-moving releases,
+rough edges, and occasional recording/streaming bugs while the app is being
+hardened.
+
 ## Why Videorc
 
 Most capture tools make you choose between "simple but shallow" and "powerful


### PR DESCRIPTION
## Summary
- Add a prominent README note that Videorc is still in beta

## Verification
- git diff --check README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a beta status notice to the README near the macOS download link.
  * Clarified that the app is still evolving and may have occasional rough edges or recording/streaming issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->