### PR TITLE
Release: 0.9.18 — multi-display preview fix (Plan 025) + release-preflight unblock

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.18-beta.1.md
+++ b/changelog/0.9.18-beta.1.md
@@ -1,0 +1,24 @@
+---
+version: 0.9.18-beta.1
+date: 2026-07-07
+channel: beta
+title: The preview follows you to a second display
+summary: Move the detached preview onto a second monitor and it stays put and keeps rendering — and it now reacts when you plug in, unplug, or rearrange displays.
+highlights:
+  - The detached preview no longer gets stranded on your main display when you move it to a second monitor.
+  - The preview keeps rendering at the right scale across monitors with different resolutions (a Retina laptop next to an external screen).
+  - Plugging in, unplugging, or rearranging monitors now re-homes the preview instead of leaving it on stale geometry.
+---
+
+## The preview follows you to a second display
+
+If you moved the detached preview window onto a second monitor, its live video
+could get stranded on your main display while the window showed "Waiting for
+preview." The native preview surface now tracks the display you move it to —
+including the correct scale when your monitors have different resolutions (say
+a Retina laptop beside a 1080p external), so it keeps rendering wherever you
+put it.
+
+Videorc also watches for display changes now: plug in a monitor, unplug one, or
+rearrange your arrangement, and the preview re-homes itself instead of sitting
+on outdated geometry.

--- a/docs/releases/0.9.18.md
+++ b/docs/releases/0.9.18.md
@@ -23,11 +23,12 @@ secondary).
 
 ## Release status
 
-- [ ] Signed + notarized build (releaseId `0.9.18-beta.1`); artifact
+- [x] Signed + notarized build (releaseId `0.9.18-beta.1`); artifact
       validation PASS incl. the exact-secret gate.
-- [ ] Uploaded to R2, all objects verified.
-- [ ] Feed verified on BOTH hosts (www.videorc.com + legacy Vercel).
-- [ ] Discord announced (`pnpm release:notify:discord`).
+- [x] Uploaded to R2, all objects verified.
+- [x] Feed verified on BOTH hosts (www.videorc.com + legacy Vercel — both
+      serve `version: 0.9.18`; www zip resolves HTTP 200).
+- [x] Discord announced (`pnpm release:notify:discord`).
 - [ ] Owner / François by-eye on a **dual-display** Mac: drag the detached
       preview to a second monitor (ideally a different scale factor) — it
       follows and keeps rendering, no stranded surface; hot-plug a monitor
@@ -37,3 +38,9 @@ secondary).
 
 - The fixes address two verified defects and are defensible-blind, but the
   real confirmation is a dual-display by-eye (the executor had one display).
+- Release tooling: `release:preflight:macos` was unblocked. It had hard-failed
+  on missing `CSC_LINK`/`CSC_KEY_PASSWORD`/`APPLE_TEAM_ID` even though the
+  documented `pnpm dist:desktop:release` path signs from the keychain
+  "Developer ID Application" identity and bakes `APPLE_TEAM_ID` inline. The
+  gate now accepts either keychain signing or a CSC certificate and no longer
+  requires the baked team id in the ambient env (unit tests updated).

--- a/docs/releases/0.9.18.md
+++ b/docs/releases/0.9.18.md
@@ -1,0 +1,39 @@
+# Videorc 0.9.18 Beta 1
+
+Videorc 0.9.18 ships the **Plan 025** multi-display preview fix (François's
+Discord report: the detached preview stuck on the main display when moved to a
+secondary).
+
+## Scope
+
+- **contentsScale on cross-display move** (`native_preview_host.rs`) — the
+  CAMetalLayer's `contentsScale` now tracks the target display's backing
+  scale on every bounds update (it previously set only the pixel
+  `drawableSize`), and a non-finite/zero drawable is rejected rather than
+  pushed to the layer (what macOS clamps to the primary's corner).
+- **Display-change observer** (`index.ts`) — a `display-metrics-changed` /
+  `display-added` / `display-removed` listener re-homes the preview surface
+  on monitor hot-plug / arrangement / scale changes.
+- **Diagnostic + geometry tests** — the sizing log carries contentsScale +
+  validity; pure multi-display tests lock the primary-anchored `appkit_y`
+  flip (it is correct — a per-display height would be the bug).
+- S5 (self-capture exclusion) deliberately NOT changed — the preview's
+  self-capture tunnel is documented OBS-parity behavior with a prior
+  window-exclusion regression; owner call.
+
+## Release status
+
+- [ ] Signed + notarized build (releaseId `0.9.18-beta.1`); artifact
+      validation PASS incl. the exact-secret gate.
+- [ ] Uploaded to R2, all objects verified.
+- [ ] Feed verified on BOTH hosts (www.videorc.com + legacy Vercel).
+- [ ] Discord announced (`pnpm release:notify:discord`).
+- [ ] Owner / François by-eye on a **dual-display** Mac: drag the detached
+      preview to a second monitor (ideally a different scale factor) — it
+      follows and keeps rendering, no stranded surface; hot-plug a monitor
+      and it re-homes.
+
+## Notes
+
+- The fixes address two verified defects and are defensible-blind, but the
+  real confirmation is a dual-display by-eye (the executor had one display).

--- a/scripts/lib/macos-release-preflight.mjs
+++ b/scripts/lib/macos-release-preflight.mjs
@@ -1,10 +1,8 @@
-export const REQUIRED_RELEASE_ENV_VARS = [
-  'CSC_LINK',
-  'CSC_KEY_PASSWORD',
-  'APPLE_ID',
-  'APPLE_APP_SPECIFIC_PASSWORD',
-  'APPLE_TEAM_ID'
-]
+// Notarization credentials that must come from the environment. APPLE_TEAM_ID
+// is intentionally NOT here: the `dist:release` script bakes it inline
+// (APPLE_TEAM_ID=C2PA37RB58 electron-builder …), so requiring it in the ambient
+// env would falsely fail the documented `pnpm dist:desktop:release` path.
+export const REQUIRED_RELEASE_ENV_VARS = ['APPLE_ID', 'APPLE_APP_SPECIFIC_PASSWORD']
 
 export const REQUIRED_RELEASE_TOOLS = [
   { id: 'codesign', label: 'codesign' },
@@ -28,7 +26,8 @@ export function evaluateMacosReleasePreflight({
   platform = 'darwin',
   env = {},
   tools = {},
-  paths = {}
+  paths = {},
+  signing = {}
 } = {}) {
   const checks = []
 
@@ -48,6 +47,27 @@ export function evaluateMacosReleasePreflight({
       detail: present ? 'present' : 'missing'
     })
   }
+
+  // Signing can come from either the keychain "Developer ID Application"
+  // identity (the primary path — electron-builder auto-detects it) or an
+  // exported CSC_LINK/CSC_KEY_PASSWORD certificate. Require at least one; never
+  // echo the certificate value.
+  const hasKeychainIdentity = signing.keychainIdentity === true
+  const hasCscCertificate =
+    typeof env.CSC_LINK === 'string' &&
+    env.CSC_LINK.trim().length > 0 &&
+    typeof env.CSC_KEY_PASSWORD === 'string' &&
+    env.CSC_KEY_PASSWORD.trim().length > 0
+  checks.push({
+    type: 'signing',
+    label: 'Developer ID Application',
+    ok: hasKeychainIdentity || hasCscCertificate,
+    detail: hasKeychainIdentity
+      ? 'keychain identity'
+      : hasCscCertificate
+        ? 'CSC_LINK certificate'
+        : 'no keychain identity and no CSC_LINK certificate'
+  })
 
   for (const tool of REQUIRED_RELEASE_TOOLS) {
     checks.push({

--- a/scripts/lib/macos-release-preflight.test.mjs
+++ b/scripts/lib/macos-release-preflight.test.mjs
@@ -9,11 +9,8 @@ import {
 
 function completeEnv(overrides = {}) {
   return {
-    CSC_LINK: 'secret-certificate-link',
-    CSC_KEY_PASSWORD: 'secret-cert-password',
     APPLE_ID: 'creator@example.test',
     APPLE_APP_SPECIFIC_PASSWORD: 'secret-apple-password',
-    APPLE_TEAM_ID: 'TEAMID1234',
     ...overrides
   }
 }
@@ -30,12 +27,18 @@ const completePaths = {
   releaseOutputDir: true
 }
 
+// The primary signing path: electron-builder auto-detects the keychain
+// "Developer ID Application" identity. dist:release bakes APPLE_TEAM_ID, so the
+// ambient env never needs the certificate or team id.
+const keychainSigning = { keychainIdentity: true }
+
 describe('evaluateMacosReleasePreflight', () => {
-  it('passes when every macOS release prerequisite is present', () => {
+  it('passes with keychain signing and only the notarization env vars present', () => {
     const result = evaluateMacosReleasePreflight({
       env: completeEnv(),
       tools: completeTools,
-      paths: completePaths
+      paths: completePaths,
+      signing: keychainSigning
     })
 
     assert.equal(result.ok, true)
@@ -45,13 +48,25 @@ describe('evaluateMacosReleasePreflight', () => {
     )
   })
 
-  it('fails with named missing prerequisites without printing secret values', () => {
-    const env = completeEnv({
-      APPLE_ID: '',
-      CSC_LINK: 'never-print-this-certificate'
-    })
+  it('does not require APPLE_TEAM_ID in the ambient env (dist:release bakes it)', () => {
     const result = evaluateMacosReleasePreflight({
-      env,
+      env: completeEnv(),
+      tools: completeTools,
+      paths: completePaths,
+      signing: keychainSigning
+    })
+
+    assert.equal(result.ok, true)
+    assert.doesNotMatch(formatMacosReleasePreflightReport(result), /APPLE_TEAM_ID/)
+  })
+
+  it('fails with named missing prerequisites without printing secret values', () => {
+    const result = evaluateMacosReleasePreflight({
+      env: completeEnv({
+        APPLE_ID: '',
+        CSC_LINK: 'never-print-this-certificate',
+        CSC_KEY_PASSWORD: 'never-print-this-password'
+      }),
       tools: {
         ...completeTools,
         notarytool: false
@@ -59,7 +74,8 @@ describe('evaluateMacosReleasePreflight', () => {
       paths: {
         ...completePaths,
         releaseOutputDir: false
-      }
+      },
+      signing: { keychainIdentity: false }
     })
     const report = formatMacosReleasePreflightReport(result)
 
@@ -69,14 +85,16 @@ describe('evaluateMacosReleasePreflight', () => {
     assert.match(report, /tool: xcrun notarytool \(missing\)/)
     assert.match(report, /path: apps\/desktop\/release \(missing or not writable\)/)
     assert.doesNotMatch(report, /never-print-this-certificate/)
+    assert.doesNotMatch(report, /never-print-this-password/)
   })
 
-  it('requires every signing and notarization environment variable', () => {
+  it('requires every notarization environment variable', () => {
     for (const name of REQUIRED_RELEASE_ENV_VARS) {
       const result = evaluateMacosReleasePreflight({
         env: completeEnv({ [name]: '   ' }),
         tools: completeTools,
-        paths: completePaths
+        paths: completePaths,
+        signing: keychainSigning
       })
 
       assert.equal(result.ok, false, `${name} should be required`)
@@ -92,10 +110,63 @@ describe('evaluateMacosReleasePreflight', () => {
       platform: 'linux',
       env: completeEnv(),
       tools: completeTools,
-      paths: completePaths
+      paths: completePaths,
+      signing: keychainSigning
     })
 
     assert.equal(result.ok, false)
     assert.match(formatMacosReleasePreflightReport(result), /platform: macOS host \(got linux\)/)
+  })
+})
+
+describe('evaluateMacosReleasePreflight signing', () => {
+  const base = {
+    env: completeEnv(),
+    tools: completeTools,
+    paths: completePaths
+  }
+
+  it('accepts a keychain Developer ID identity with no CSC certificate', () => {
+    const result = evaluateMacosReleasePreflight({ ...base, signing: { keychainIdentity: true } })
+
+    assert.equal(result.ok, true)
+    assert.match(
+      formatMacosReleasePreflightReport(result),
+      /signing: Developer ID Application \(keychain identity\)/
+    )
+  })
+
+  it('accepts a CSC_LINK certificate when no keychain identity is present', () => {
+    const result = evaluateMacosReleasePreflight({
+      ...base,
+      env: completeEnv({ CSC_LINK: 'cert', CSC_KEY_PASSWORD: 'pw' }),
+      signing: { keychainIdentity: false }
+    })
+
+    assert.equal(result.ok, true)
+    assert.match(
+      formatMacosReleasePreflightReport(result),
+      /signing: Developer ID Application \(CSC_LINK certificate\)/
+    )
+  })
+
+  it('requires the CSC key password alongside CSC_LINK', () => {
+    const result = evaluateMacosReleasePreflight({
+      ...base,
+      env: completeEnv({ CSC_LINK: 'cert' }),
+      signing: { keychainIdentity: false }
+    })
+
+    assert.equal(result.ok, false)
+  })
+
+  it('fails when neither a keychain identity nor a CSC certificate is available', () => {
+    const result = evaluateMacosReleasePreflight({ ...base, signing: { keychainIdentity: false } })
+
+    assert.equal(result.ok, false)
+    assert.match(
+      formatMacosReleasePreflightReport(result),
+      /signing: Developer ID Application \(no keychain identity and no CSC_LINK certificate\)/
+    )
   })
 })

--- a/scripts/preflight-macos-release.mjs
+++ b/scripts/preflight-macos-release.mjs
@@ -27,12 +27,16 @@ async function main() {
     ),
     releaseOutputDir: await canWriteDirectory(releaseDir)
   }
+  const signing = {
+    keychainIdentity: hasDeveloperIdIdentity()
+  }
 
   const result = evaluateMacosReleasePreflight({
     platform: process.platform,
     env: process.env,
     tools,
-    paths
+    paths,
+    signing
   })
 
   const report = formatMacosReleasePreflightReport(result)
@@ -59,6 +63,19 @@ function commandExists(command) {
 function xcrunToolExists(tool) {
   const result = spawnSync('xcrun', ['--find', tool], { stdio: 'ignore' })
   return result.status === 0
+}
+
+// True when the keychain holds a "Developer ID Application" codesigning
+// identity — the primary signing path electron-builder auto-detects. Output is
+// inspected but never logged (identity hashes are not printed).
+function hasDeveloperIdIdentity() {
+  const result = spawnSync('security', ['find-identity', '-v', '-p', 'codesigning'], {
+    encoding: 'utf8'
+  })
+  if (result.status !== 0 || typeof result.stdout !== 'string') {
+    return false
+  }
+  return /Developer ID Application:/.test(result.stdout)
 }
 
 async function canWriteDirectory(directory) {


### PR DESCRIPTION
Cuts **0.9.18-beta.1**, carrying the **Plan 025** multi-display native-preview fix (already merged to main via #5) as a shipped release, plus a release-tooling fix discovered while cutting it.

## What ships to users
- **Detached preview follows across displays** — the CAMetalLayer `contentsScale` now tracks the target display's backing scale on every bounds update (Defect A), so moving the detached preview to a second monitor no longer strands the surface on the main display or leaves it stuck at "Waiting for preview." Non-finite/zero drawables are rejected instead of clamped to the corner.
- **Display-change observer** — a `display-metrics-changed` / `display-added` / `display-removed` listener re-homes the preview on monitor hot-plug / arrangement / scale changes (Defect B).
- (Both were verified present on this branch; the primary-anchored `appkit_y` flip is intentionally unchanged and pinned by tests.)

## Release-tooling fix (in this PR)
`release:preflight:macos` hard-failed on missing `CSC_LINK`/`CSC_KEY_PASSWORD`/`APPLE_TEAM_ID` even though the documented `pnpm dist:desktop:release` path signs from the keychain "Developer ID Application" identity and bakes `APPLE_TEAM_ID` inline. The gate blocked the very command the runbook says to run. Now it:
- requires only `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` from the env,
- adds a signing-capability check that passes on either a keychain Developer ID identity or `CSC_LINK`+`CSC_KEY_PASSWORD` (never echoing the cert), and
- drops `APPLE_TEAM_ID` from the required env.

Unit tests updated (9/9 green); the real `release:preflight:macos` now PASSES on the keychain path.

## Release verification (done)
- Signed + notarized + stapled; `release:validate:macos` PASS (codesign / Gatekeeper / staple / entitlements / bundled OAuth secret).
- Uploaded to R2, all objects verified (dmg, sha256, versioned + stable `release.json`, `latest-mac.yml`, feed zip + blockmap, `changelog.json`).
- Both feed hosts serve `version: 0.9.18` (www.videorc.com — zip resolves 200 — and legacy `videorc-web.vercel.app`).
- Discord announcement posted.

## Still open (owner-only)
- Dual-display by-eye on a real two-monitor Mac (drag the detached preview to a second monitor at a different scale factor; hot-plug a monitor). The executor has a single display, so this is defensible-blind but unconfirmed by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)