### PR TITLE
Fix Twitch comments for manual streams

### DIFF
--- a/apps/desktop/src/renderer/src/components/comments-reader.tsx
+++ b/apps/desktop/src/renderer/src/components/comments-reader.tsx
@@ -13,7 +13,7 @@ import type {
 } from '@/lib/backend'
 import { AvatarCircle } from '@/lib/chat-avatar'
 import { CHAT_SEND_MAX_CHARS, validateChatDraft, type ChatSendFailure } from '@/lib/chat-send'
-import { sortMessagesChronological } from '@/lib/live-chat-view'
+import { liveChatEmptyMessage, sortMessagesChronological } from '@/lib/live-chat-view'
 import { viewerChipDetail, viewerChipLabel, viewerSampleStale } from '@/lib/viewer-count-view'
 import { cn } from '@/lib/utils'
 
@@ -276,7 +276,9 @@ function OffAir({ providers }: { providers: LiveChatProviderState[] }): ReactEle
               <ProviderPill key={provider.platform} provider={provider} />
             ))}
           </div>
-          <p className="text-sm text-subtle">Waiting for comments…</p>
+          <p className="text-sm text-subtle">
+            {liveChatEmptyMessage({ providers }, 'Start a livestream to see comments here.')}
+          </p>
         </>
       ) : (
         <p className="text-sm text-subtle">Start a livestream to see comments here.</p>

--- a/apps/desktop/src/renderer/src/components/live-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/live-chat-panel.tsx
@@ -16,6 +16,7 @@ import {
   LIVE_CHAT_PLATFORMS,
   MAX_RENDERED_LIVE_CHAT_MESSAGES,
   filterMessagesByPlatform,
+  liveChatEmptyMessage,
   nextUnreadCount,
   shouldAutoscroll,
   visibleMessages
@@ -255,9 +256,7 @@ export function LiveChatPanel({
             ))
           ) : (
             <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted-foreground">
-              {hasProviders
-                ? 'No comments yet. Comments appear here once you go live.'
-                : 'Connect a YouTube or Twitch account to read live comments.'}
+              {liveChatEmptyMessage(snapshot)}
             </div>
           )}
         </div>

--- a/apps/desktop/src/renderer/src/lib/live-chat-view.test.ts
+++ b/apps/desktop/src/renderer/src/lib/live-chat-view.test.ts
@@ -8,6 +8,7 @@ import {
   applyLiveChatProviderStatus,
   emptyLiveChatSnapshot,
   filterMessagesByPlatform,
+  liveChatEmptyMessage,
   nextUnreadCount,
   shouldAutoscroll,
   sortMessagesChronological,
@@ -115,5 +116,47 @@ describe('live-chat-view', () => {
     )
     expect(visibleMessages(messages, 2).map((m) => m.id)).toEqual(['m3', 'm4'])
     expect(visibleMessages(messages, 10)).toHaveLength(5)
+  })
+
+  it('uses actionable provider messages for the empty state', () => {
+    expect(liveChatEmptyMessage({ providers: [] })).toBe(
+      'Connect YouTube or Twitch to read live comments.'
+    )
+    expect(
+      liveChatEmptyMessage({
+        providers: [
+          {
+            platform: 'twitch',
+            state: 'disabled',
+            message: 'Connect Twitch to read live comments.',
+            capabilities: ['not-connected']
+          }
+        ]
+      })
+    ).toBe('Connect Twitch to read live comments.')
+    expect(
+      liveChatEmptyMessage({
+        providers: [
+          {
+            platform: 'twitch',
+            state: 'disabled',
+            message: 'Reconnect Twitch to enable live comments.',
+            capabilities: ['needs-reconnect']
+          }
+        ]
+      })
+    ).toBe('Reconnect Twitch to enable live comments.')
+    expect(
+      liveChatEmptyMessage({
+        providers: [
+          {
+            platform: 'twitch',
+            state: 'connected',
+            message: 'Twitch live chat connected.',
+            capabilities: ['available']
+          }
+        ]
+      })
+    ).toBe('No comments yet. Comments appear here once you go live.')
   })
 })

--- a/apps/desktop/src/renderer/src/lib/live-chat-view.ts
+++ b/apps/desktop/src/renderer/src/lib/live-chat-view.ts
@@ -5,6 +5,7 @@
 
 import type {
   LiveChatMessage,
+  LiveChatProviderConnectionState,
   LiveChatProviderState,
   LiveChatSnapshot,
   StreamPlatform
@@ -109,6 +110,38 @@ export function shouldAutoscroll(paused: boolean): boolean {
 
 /** Max rows rendered in the feed at once (windowed/virtualized tail). */
 export const MAX_RENDERED_LIVE_CHAT_MESSAGES = 200
+
+function providerStatePriority(
+  state: LiveChatProviderConnectionState,
+  capabilities: string[]
+): number {
+  if (state === 'failed') return 0
+  if (capabilities.includes('needs-reconnect')) return 1
+  if (capabilities.includes('not-connected')) return 2
+  if (state === 'unsupported' || capabilities.includes('unsupported')) return 3
+  return 4
+}
+
+function providerNeedsAction(provider: LiveChatProviderState): boolean {
+  return providerStatePriority(provider.state, provider.capabilities) < 4
+}
+
+export function liveChatEmptyMessage(
+  snapshot: Pick<LiveChatSnapshot, 'providers'>,
+  noProviderMessage = 'Connect YouTube or Twitch to read live comments.'
+): string {
+  if (snapshot.providers.length === 0) {
+    return noProviderMessage
+  }
+  const provider = snapshot.providers
+    .filter(providerNeedsAction)
+    .sort(
+      (left, right) =>
+        providerStatePriority(left.state, left.capabilities) -
+        providerStatePriority(right.state, right.capabilities)
+    )[0]
+  return provider?.message ?? 'No comments yet. Comments appear here once you go live.'
+}
 
 /**
  * Apply a batch of incoming messages in a single pass (event batching): dedupe against the

--- a/crates/videorc-backend/src/live_chat.rs
+++ b/crates/videorc-backend/src/live_chat.rs
@@ -239,7 +239,7 @@ pub fn chat_capability(
             TWITCH_CHAT_SCOPE,
             "Twitch live comments are ready.",
             "Reconnect Twitch to enable live comments.",
-            "Connect a Twitch account to read live comments.",
+            "Connect Twitch to read live comments.",
         ),
         StreamPlatform::X => ChatCapability {
             platform,
@@ -596,9 +596,14 @@ impl LiveChatCoordinator {
 /// Provider rows for a starting session, derived from current chat capabilities. The
 /// connectors (slices 4-5) drive each row to connecting → connected/failed; platforms with
 /// no native path stay `unsupported`.
-fn session_provider_rows(accounts: &[PlatformAccount]) -> Vec<LiveChatProviderState> {
+fn session_provider_rows(
+    accounts: &[PlatformAccount],
+    platforms: &[StreamPlatform],
+) -> Vec<LiveChatProviderState> {
+    let requested: HashSet<StreamPlatform> = platforms.iter().copied().collect();
     chat_capabilities(accounts)
         .into_iter()
+        .filter(|capability| requested.is_empty() || requested.contains(&capability.platform))
         .map(provider_state_from_capability)
         .collect()
 }
@@ -609,6 +614,9 @@ fn session_provider_rows(accounts: &[PlatformAccount]) -> Vec<LiveChatProviderSt
 #[serde(rename_all = "camelCase")]
 pub struct LiveChatStartParams {
     pub session_id: String,
+    /// Platforms this session should show. Empty preserves the legacy full readiness surface.
+    #[serde(default)]
+    pub platforms: Vec<StreamPlatform>,
     #[serde(default)]
     pub fake: Option<FakeChatConfig>,
     #[serde(default)]
@@ -648,7 +656,7 @@ fn default_fake_interval_ms() -> u64 {
 /// emit the initial snapshot. Returns the snapshot for the command response.
 pub async fn start_live_chat(state: &AppState, params: LiveChatStartParams) -> LiveChatSnapshot {
     let accounts = state.database.list_platform_accounts().unwrap_or_default();
-    let providers = session_provider_rows(&accounts);
+    let providers = session_provider_rows(&accounts, &params.platforms);
     {
         let mut coordinator = state.live_chat.lock().await;
         coordinator.start_session(params.session_id.clone(), providers);

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -1244,6 +1244,14 @@ fn twitch_chat_config(
     target: &crate::streaming::StreamTargetSettings,
 ) -> Result<twitch_chat::TwitchChatConfig> {
     let credential = twitch_account_credentials(state, target.account_id.as_deref())?;
+    if !credential
+        .account
+        .scopes
+        .iter()
+        .any(|scope| scope == live_chat::TWITCH_CHAT_SCOPE)
+    {
+        anyhow::bail!("Reconnect Twitch to enable live comments.");
+    }
     let access_ref = credential
         .token_secret_ref
         .as_deref()
@@ -1277,33 +1285,53 @@ async fn spawn_session_live_chat(
         .collect();
     let mut params = live_chat::LiveChatStartParams {
         session_id: session_id.to_string(),
+        platforms: Vec::new(),
         fake: None,
         youtube: None,
         twitch: None,
     };
     for target in &streaming.targets {
-        if !enabled.contains(target.id.as_str())
-            || target.auth_mode != crate::streaming::StreamAuthMode::Oauth
-        {
+        if !enabled.contains(target.id.as_str()) {
             continue;
         }
         match target.platform {
-            StreamPlatform::Youtube => match youtube_chat_config(state, target).await {
-                Ok(config) => params.youtube = Some(config),
-                Err(error) => {
-                    state.emit_log("warn", format!("YouTube live chat unavailable: {error}"))
+            StreamPlatform::Youtube => {
+                if target.auth_mode != crate::streaming::StreamAuthMode::Oauth {
+                    continue;
                 }
-            },
+                if !params.platforms.contains(&StreamPlatform::Youtube) {
+                    params.platforms.push(StreamPlatform::Youtube);
+                }
+                match youtube_chat_config(state, target).await {
+                    Ok(config) => params.youtube = Some(config),
+                    Err(error) => {
+                        state.emit_log("warn", format!("YouTube live chat unavailable: {error}"))
+                    }
+                }
+            }
             StreamPlatform::Twitch => match twitch_chat_config(state, target) {
-                Ok(config) => params.twitch = Some(config),
+                Ok(config) => {
+                    if !params.platforms.contains(&StreamPlatform::Twitch) {
+                        params.platforms.push(StreamPlatform::Twitch);
+                    }
+                    params.twitch = Some(config);
+                }
                 Err(error) => {
+                    if !params.platforms.contains(&StreamPlatform::Twitch) {
+                        params.platforms.push(StreamPlatform::Twitch);
+                    }
                     state.emit_log("warn", format!("Twitch live chat unavailable: {error}"))
                 }
             },
-            _ => {}
+            StreamPlatform::X => {
+                if !params.platforms.contains(&StreamPlatform::X) {
+                    params.platforms.push(StreamPlatform::X);
+                }
+            }
+            StreamPlatform::Custom => {}
         }
     }
-    if params.youtube.is_some() || params.twitch.is_some() {
+    if !params.platforms.is_empty() {
         live_chat::start_live_chat(state, params).await;
     }
 }
@@ -3463,6 +3491,117 @@ mod tests {
             updated_at: "2026-06-23T10:00:00Z".to_string(),
             status,
         }
+    }
+
+    fn streaming_with_enabled_target(
+        platform: StreamPlatform,
+        auth_mode: crate::streaming::StreamAuthMode,
+    ) -> crate::streaming::StreamingSettings {
+        let mut targets = crate::streaming::default_stream_targets();
+        for target in &mut targets {
+            target.enabled = target.platform == platform;
+            if target.platform == platform {
+                target.auth_mode = auth_mode;
+                target.stream_key_present = true;
+                target.stream_key_secret_ref = Some(format!(
+                    "stream-target:{}:manual-stream-key",
+                    crate::streaming::stream_platform_id(platform)
+                ));
+            }
+        }
+        let enabled_target_ids = targets
+            .iter()
+            .filter(|target| target.enabled)
+            .map(|target| target.id.clone())
+            .collect::<Vec<_>>();
+        crate::streaming::StreamingSettings {
+            enabled: true,
+            mode: crate::streaming::StreamMode::Single,
+            targets,
+            selected_target_id: Some(crate::streaming::stream_platform_id(platform).to_string()),
+            default_output_preset: protocol::VideoPreset::StreamSafe1080p30,
+            default_bitrate_kbps: 6_000,
+            enabled_target_ids,
+        }
+    }
+
+    fn upsert_twitch_account(state: &AppState, scopes: Vec<String>) {
+        state
+            .database
+            .upsert_platform_account(UpsertPlatformAccount {
+                platform: StreamPlatform::Twitch,
+                account_id: "twitch-channel-1".to_string(),
+                account_label: "Twitch Channel".to_string(),
+                account_handle: Some("twitch_channel".to_string()),
+                avatar_url: None,
+                scopes,
+                token_secret_ref: None,
+                refresh_token_secret_ref: None,
+                stream_key_secret_ref: None,
+                expires_at: None,
+                status: PlatformAccountStatus::Connected,
+            })
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn manual_twitch_stream_starts_status_only_chat_session_without_oauth_account() {
+        let state = test_state();
+        let streaming = streaming_with_enabled_target(
+            StreamPlatform::Twitch,
+            crate::streaming::StreamAuthMode::ManualRtmp,
+        );
+
+        spawn_session_live_chat(&state, "manual-twitch-session", &streaming).await;
+
+        let snapshot = live_chat::current_status(&state).await;
+        assert_eq!(
+            snapshot.session_id.as_deref(),
+            Some("manual-twitch-session")
+        );
+        assert_eq!(snapshot.providers.len(), 1);
+        let twitch = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.platform == StreamPlatform::Twitch)
+            .expect("twitch provider row");
+        assert_eq!(
+            twitch.state,
+            live_chat::LiveChatProviderConnectionState::Disabled
+        );
+        assert!(twitch.message.contains("Connect Twitch"));
+    }
+
+    #[tokio::test]
+    async fn manual_twitch_stream_surfaces_reconnect_when_account_lacks_chat_scope() {
+        let state = test_state();
+        upsert_twitch_account(
+            &state,
+            vec![
+                "channel:manage:broadcast".to_string(),
+                "channel:read:stream_key".to_string(),
+            ],
+        );
+        let streaming = streaming_with_enabled_target(
+            StreamPlatform::Twitch,
+            crate::streaming::StreamAuthMode::ManualRtmp,
+        );
+
+        spawn_session_live_chat(&state, "stale-twitch-session", &streaming).await;
+
+        let snapshot = live_chat::current_status(&state).await;
+        assert_eq!(snapshot.session_id.as_deref(), Some("stale-twitch-session"));
+        assert_eq!(snapshot.providers.len(), 1);
+        let twitch = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.platform == StreamPlatform::Twitch)
+            .expect("twitch provider row");
+        assert_eq!(
+            twitch.state,
+            live_chat::LiveChatProviderConnectionState::Disabled
+        );
+        assert!(twitch.message.contains("Reconnect Twitch"));
     }
 
     #[test]

--- a/crates/videorc-backend/src/twitch_chat.rs
+++ b/crates/videorc-backend/src/twitch_chat.rs
@@ -710,6 +710,19 @@ pub async fn run_twitch_chat_connector(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use axum::extract::State;
+    use axum::extract::ws::{Message as AxumMessage, WebSocketUpgrade};
+    use axum::response::IntoResponse;
+    use axum::routing::{get, post};
+    use axum::{Json, Router};
+    use tokio::sync::{Mutex, broadcast, oneshot};
+
+    use crate::live_chat::{
+        LiveChatProviderConnectionState, LiveChatProviderState, current_status,
+    };
+    use crate::storage::Database;
 
     fn chat_message_frame() -> String {
         json!({
@@ -741,6 +754,176 @@ mod tests {
             }
         })
         .to_string()
+    }
+
+    #[derive(Clone)]
+    struct MockTwitchServerState {
+        subscriptions: Arc<Mutex<Vec<Value>>>,
+    }
+
+    async fn mock_eventsub_ws(ws: WebSocketUpgrade) -> impl IntoResponse {
+        ws.on_upgrade(|mut socket| async move {
+            let welcome = json!({
+                "metadata": { "message_type": "session_welcome" },
+                "payload": { "session": { "id": "socket-session-1" } }
+            })
+            .to_string();
+            let _ = socket.send(AxumMessage::Text(welcome.into())).await;
+            sleep(Duration::from_millis(100)).await;
+            let _ = socket
+                .send(AxumMessage::Text(chat_message_frame().into()))
+                .await;
+            sleep(Duration::from_millis(100)).await;
+        })
+    }
+
+    async fn mock_subscriptions(
+        State(state): State<MockTwitchServerState>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        state.subscriptions.lock().await.push(body);
+        Json(json!({ "data": [] }))
+    }
+
+    async fn mock_users() -> Json<Value> {
+        Json(json!({
+            "data": [
+                { "id": "987", "profile_image_url": "https://static-cdn.jtvnw.net/viewer.png" }
+            ]
+        }))
+    }
+
+    async fn spawn_mock_twitch_server()
+    -> (String, String, Arc<Mutex<Vec<Value>>>, oneshot::Sender<()>) {
+        let subscriptions = Arc::new(Mutex::new(Vec::new()));
+        let state = MockTwitchServerState {
+            subscriptions: subscriptions.clone(),
+        };
+        let app = Router::new()
+            .route("/eventsub", get(mock_eventsub_ws))
+            .route("/helix/eventsub/subscriptions", post(mock_subscriptions))
+            .route("/helix/users", get(mock_users))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("mock twitch listener");
+        let addr = listener.local_addr().expect("mock twitch addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+        (
+            format!("http://{addr}"),
+            format!("ws://{addr}/eventsub"),
+            subscriptions,
+            shutdown_tx,
+        )
+    }
+
+    fn test_state() -> AppState {
+        let (events, _) = broadcast::channel(16);
+        AppState::new(
+            "test-token".to_string(),
+            1234,
+            events,
+            Database::open_in_memory_for_tests(),
+        )
+    }
+
+    fn twitch_provider_row() -> LiveChatProviderState {
+        LiveChatProviderState {
+            platform: StreamPlatform::Twitch,
+            target_id: Some("twitch".to_string()),
+            account_id: Some("broadcaster-1".to_string()),
+            account_label: Some("Twitch Channel".to_string()),
+            state: LiveChatProviderConnectionState::Connecting,
+            message: "Connecting to Twitch live chat…".to_string(),
+            last_connected_at: None,
+            last_message_at: None,
+            last_error: None,
+            capabilities: vec!["available".to_string()],
+        }
+    }
+
+    async fn wait_for_twitch_message(state: &AppState) -> crate::live_chat::LiveChatSnapshot {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshot = current_status(state).await;
+            if snapshot
+                .messages
+                .iter()
+                .any(|message| message.id == "twitch:chat-1")
+            {
+                return snapshot;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("timed out waiting for mocked Twitch chat message: {snapshot:?}");
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn eventsub_session_subscribes_and_delivers_chat_message() {
+        let (api_base_url, eventsub_ws_url, subscriptions, shutdown) =
+            spawn_mock_twitch_server().await;
+        let state = test_state();
+        {
+            let mut coordinator = state.live_chat.lock().await;
+            coordinator.start_session("session-1".to_string(), vec![twitch_provider_row()]);
+        }
+
+        let connector = tokio::spawn(run_twitch_chat_connector(
+            state.clone(),
+            "session-1".to_string(),
+            TwitchChatConfig {
+                access_token: "token-1".to_string(),
+                client_id: "client-1".to_string(),
+                broadcaster_user_id: "broadcaster-1".to_string(),
+                user_id: "user-1".to_string(),
+                target_id: Some("twitch".to_string()),
+                eventsub_ws_url: Some(eventsub_ws_url),
+                api_base_url: Some(api_base_url),
+            },
+        ));
+
+        let snapshot = wait_for_twitch_message(&state).await;
+        connector.abort();
+        let _ = shutdown.send(());
+
+        let twitch = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.platform == StreamPlatform::Twitch)
+            .expect("twitch provider");
+        assert_eq!(twitch.state, LiveChatProviderConnectionState::Connected);
+        assert_eq!(snapshot.messages.len(), 1);
+        let message = &snapshot.messages[0];
+        assert_eq!(message.id, "twitch:chat-1");
+        assert_eq!(message.message_text, "hi Kappa");
+        assert_eq!(
+            message.author_avatar_url.as_deref(),
+            Some("https://static-cdn.jtvnw.net/viewer.png")
+        );
+
+        let subscription_types = subscriptions
+            .lock()
+            .await
+            .iter()
+            .filter_map(|body| body["type"].as_str().map(ToOwned::to_owned))
+            .collect::<Vec<_>>();
+        for subscription_type in CHAT_SUBSCRIPTION_TYPES {
+            assert!(
+                subscription_types
+                    .iter()
+                    .any(|submitted| submitted == subscription_type),
+                "missing mocked subscription type {subscription_type}: {subscription_types:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- start a live-chat session for enabled Twitch targets even when the stream uses manual RTMP, so the comments UI shows a Twitch provider row instead of staying blank
- require the Twitch `user:read:chat` scope before starting EventSub and surface explicit connect/reconnect provider messages in the panel and detached comments window
- add regression coverage for manual Twitch session startup, scope-missing status, empty-state copy, and a mocked Twitch EventSub message delivery path

## Verification
- `cargo fmt --check --all`
- `cargo test -p videorc-backend`
- `cargo test -p videorc-backend live_chat -- --nocapture`
- `cargo test -p videorc-backend twitch_chat -- --nocapture`
- `cargo clippy -p videorc-backend -- -D warnings`
- `PATH=/opt/homebrew/bin:$PATH pnpm typecheck`
- `PATH=/opt/homebrew/bin:$PATH pnpm lint`
- `PATH=/opt/homebrew/bin:$PATH pnpm format:check`
- `PATH=/opt/homebrew/bin:$PATH pnpm --filter @videorc/desktop test`
- `PATH=/opt/homebrew/bin:$PATH pnpm --filter @videorc/desktop test -- live-chat-view live-chat-surface`
- `PATH=/opt/homebrew/bin:$PATH pnpm smoke:live-chat-fake-providers`
- `PATH=/opt/homebrew/bin:$PATH pnpm probe:comments-window`
- `PATH=/opt/homebrew/bin:$PATH pnpm audit:js` (passed high-severity gate; pnpm reported one moderate advisory)
- `PATH=/opt/homebrew/bin:$PATH pnpm test:scripts`
- `PATH=/opt/homebrew/bin:$PATH pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live chat now shows clearer empty-state messages based on whether streaming accounts are connected.
  * Live chat sessions can now be started for only the selected streaming platforms.
  * Twitch live comments now require the correct chat permission and will prompt users to reconnect if needed.

* **Bug Fixes**
  * Improved live chat status handling so provider messages better reflect connection issues and missing comments.
  * Twitch comments now load more reliably during session startup and display author avatars when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->