### PR TITLE
Fix live layout switching for static screen sources

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -263,6 +263,8 @@ const NATIVE_PREVIEW_COMPOSITOR_POLL_INTERVAL_MS = 1000 / 60
 const NATIVE_PREVIEW_COMPOSITOR_TIMING_SAMPLE_LIMIT = 900
 const NATIVE_PREVIEW_SCENE_FRAME_WAIT_TIMEOUT_MS = 750
 const NATIVE_PREVIEW_SCENE_FRAME_WAIT_INTERVAL_MS = 33
+const LIVE_LAYOUT_PROOF_WAIT_TIMEOUT_MS = 5000
+const LIVE_LAYOUT_PROOF_WAIT_INTERVAL_MS = 100
 
 function recordNativePreviewTimingSample(samples: number[], value: number): void {
   if (!Number.isFinite(value)) {
@@ -317,6 +319,53 @@ async function waitForRenderedCompositorSceneRevision(
   }
 
   return initialStatus
+}
+
+async function waitForLiveLayoutProof(
+  activeClient: BackendClient,
+  status: LiveLayoutApplyStatus
+): Promise<CompositorStatus> {
+  const deadline = Date.now() + LIVE_LAYOUT_PROOF_WAIT_TIMEOUT_MS
+  let lastCompositorStatus: CompositorStatus | null = null
+  let lastDiagnostics: DiagnosticStats | null = null
+  let lastError: unknown = null
+
+  while (Date.now() < deadline) {
+    try {
+      const [compositorStatus, diagnostics] = await Promise.all([
+        activeClient.request<CompositorStatus>('compositor.status'),
+        activeClient.request<DiagnosticStats>('diagnostics.stats')
+      ])
+      lastCompositorStatus = compositorStatus
+      lastDiagnostics = diagnostics
+      if (
+        compositorStatusHasRenderedSceneRevision(compositorStatus, status.sceneRevision) &&
+        typeof diagnostics.activeSceneRevision === 'number' &&
+        diagnostics.activeSceneRevision >= status.sceneRevision
+      ) {
+        return compositorStatus
+      }
+    } catch (error) {
+      lastError = error
+    }
+    await sleep(LIVE_LAYOUT_PROOF_WAIT_INTERVAL_MS)
+  }
+
+  const renderedRevision =
+    lastCompositorStatus?.frameSceneRevision == null
+      ? 'none'
+      : lastCompositorStatus.frameSceneRevision.toString()
+  const activeRevision =
+    lastDiagnostics?.activeSceneRevision == null
+      ? 'none'
+      : lastDiagnostics.activeSceneRevision.toString()
+  const errorDetail =
+    lastError instanceof Error && lastError.message ? ` Last error: ${lastError.message}` : ''
+  throw new Error(
+    `Live layout switch did not reach the active recording/streaming output within ${Math.round(
+      LIVE_LAYOUT_PROOF_WAIT_TIMEOUT_MS / 1000
+    )}s (target revision ${status.sceneRevision}, rendered revision ${renderedRevision}, active revision ${activeRevision}).${errorDetail}`
+  )
 }
 
 export type StudioContextValue = {
@@ -2907,13 +2956,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         return
       }
 
-      const compositorStatus = await client
-        .request<CompositorStatus>('compositor.status')
-        .catch(() => null)
-      if (
-        typeof compositorStatus?.sceneRevision === 'number' &&
-        compositorStatus.sceneRevision >= status.sceneRevision
-      ) {
+      const compositorStatus = await waitForLiveLayoutProof(client, status)
+      if (typeof compositorStatus.sceneRevision === 'number') {
         nativePreviewCommittedSceneRef.current = {
           sceneId: status.scene.id,
           sceneRevision: compositorStatus.sceneRevision,

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -143,7 +143,7 @@ pub fn camera_status_is_live(status: &PreviewCameraStatus) -> bool {
 
 #[cfg(test)]
 pub fn screen_status_is_live(status: &PreviewScreenStatus) -> bool {
-    status.state == PreviewScreenState::Live && fresh_frame_age(status.frame_age_ms)
+    status.state == PreviewScreenState::Live && screen_has_frame_evidence(status, None)
 }
 
 fn fresh_frame_age(frame_age_ms: Option<u64>) -> bool {
@@ -154,8 +154,11 @@ fn camera_frame_info_is_live(frame_info: Option<PreviewCameraFrameInfo>) -> bool
     frame_info.is_some_and(|frame| frame.frame_age_ms <= SOURCE_FRESH_FRAME_MAX_AGE_MS)
 }
 
-fn screen_frame_info_is_live(frame_info: Option<PreviewScreenFrameInfo>) -> bool {
-    frame_info.is_some_and(|frame| frame.frame_age_ms <= SOURCE_FRESH_FRAME_MAX_AGE_MS)
+fn screen_has_frame_evidence(
+    status: &PreviewScreenStatus,
+    frame_info: Option<PreviewScreenFrameInfo>,
+) -> bool {
+    frame_info.is_some() || status.sequence.is_some() || status.frames_captured > 0
 }
 
 #[cfg(test)]
@@ -202,9 +205,7 @@ fn target_screen_is_live(
     frame_info: Option<PreviewScreenFrameInfo>,
     target_sources: Option<&SourceSelection>,
 ) -> bool {
-    if status.state != PreviewScreenState::Live
-        || !(fresh_frame_age(status.frame_age_ms) || screen_frame_info_is_live(frame_info))
-    {
+    if status.state != PreviewScreenState::Live || !screen_has_frame_evidence(status, frame_info) {
         return false;
     }
     match target_sources.and_then(selected_screen_source_id) {
@@ -258,13 +259,36 @@ async fn source_liveness(
     state: &AppState,
     target_sources: Option<&SourceSelection>,
 ) -> SourceLiveness {
+    source_readiness(state, target_sources).await.live
+}
+
+#[derive(Debug, Clone)]
+struct SourceReadiness {
+    live: SourceLiveness,
+    camera_status: PreviewCameraStatus,
+    screen_status: PreviewScreenStatus,
+    camera_frame: Option<PreviewCameraFrameInfo>,
+    screen_frame: Option<PreviewScreenFrameInfo>,
+}
+
+async fn source_readiness(
+    state: &AppState,
+    target_sources: Option<&SourceSelection>,
+) -> SourceReadiness {
     let camera = preview_camera_status(state).await;
     let screen = preview_screen_status(state).await;
     let camera_frame = preview_camera_latest_frame_info(state).await;
     let screen_frame = preview_screen_latest_frame_info(state).await;
-    SourceLiveness {
+    let live = SourceLiveness {
         camera: target_camera_is_live(&camera, camera_frame, target_sources),
         screen: target_screen_is_live(&screen, screen_frame, target_sources),
+    };
+    SourceReadiness {
+        live,
+        camera_status: camera,
+        screen_status: screen,
+        camera_frame,
+        screen_frame,
     }
 }
 
@@ -452,19 +476,127 @@ async fn wait_for_sources_ready(
 ) -> Result<()> {
     let started = Instant::now();
     loop {
-        let live = source_liveness(state, target_sources).await;
-        if missing_sources(needs, live).is_empty() {
+        let readiness = source_readiness(state, target_sources).await;
+        if missing_sources(needs, readiness.live).is_empty() {
             return Ok(());
         }
         if started.elapsed() >= WARM_SOURCE_START_TIMEOUT {
-            let still_missing = missing_sources(needs, live).join(" + ");
+            let still_missing =
+                missing_readiness_messages(needs, &readiness, target_sources).join("; ");
             bail!(
-                "Live {action_label} blocked: {still_missing} produced no fresh frames within {}s. The previous layout is still live.",
+                "Live {action_label} blocked: {still_missing} within {}s. The previous layout is still live.",
                 WARM_SOURCE_START_TIMEOUT.as_secs()
             );
         }
         sleep(WARM_SOURCE_POLL).await;
     }
+}
+
+fn missing_readiness_messages(
+    needs: SceneSourceNeeds,
+    readiness: &SourceReadiness,
+    target_sources: Option<&SourceSelection>,
+) -> Vec<String> {
+    let mut messages = Vec::new();
+    if needs.camera && !readiness.live.camera {
+        messages.push(format!(
+            "camera produced no fresh frames ({})",
+            camera_readiness_detail(readiness, target_sources)
+        ));
+    }
+    if needs.screen && !readiness.live.screen {
+        messages.push(format!(
+            "screen/window produced no initial frame for the selected source ({})",
+            screen_readiness_detail(readiness, target_sources)
+        ));
+    }
+    messages
+}
+
+fn camera_readiness_detail(
+    readiness: &SourceReadiness,
+    target_sources: Option<&SourceSelection>,
+) -> String {
+    let status = &readiness.camera_status;
+    let frame_age_ms = readiness
+        .camera_frame
+        .map(|frame| frame.frame_age_ms)
+        .or(status.frame_age_ms);
+    format!(
+        "state: {}, target: {}, current: {}, frames captured: {}, latest sequence: {}, latest frame age: {}",
+        camera_state_label(&status.state),
+        target_sources
+            .and_then(|sources| sources.camera_id.as_deref())
+            .unwrap_or("none"),
+        status.camera_id.as_deref().unwrap_or("none"),
+        status.frames_captured,
+        format_optional_u64(
+            readiness
+                .camera_frame
+                .map(|frame| frame.sequence)
+                .or(status.sequence)
+        ),
+        format_age_ms(frame_age_ms)
+    )
+}
+
+fn screen_readiness_detail(
+    readiness: &SourceReadiness,
+    target_sources: Option<&SourceSelection>,
+) -> String {
+    let status = &readiness.screen_status;
+    let frame_age_ms = readiness
+        .screen_frame
+        .map(|frame| frame.frame_age_ms)
+        .or(status.frame_age_ms);
+    format!(
+        "state: {}, target: {}, current: {}, frames captured: {}, latest sequence: {}, latest frame age: {}",
+        screen_state_label(&status.state),
+        target_sources
+            .and_then(selected_screen_source_id)
+            .unwrap_or("none"),
+        status.source_id.as_deref().unwrap_or("none"),
+        status.frames_captured,
+        format_optional_u64(
+            readiness
+                .screen_frame
+                .map(|frame| frame.sequence)
+                .or(status.sequence)
+        ),
+        format_age_ms(frame_age_ms)
+    )
+}
+
+fn camera_state_label(state: &PreviewCameraState) -> &'static str {
+    match state {
+        PreviewCameraState::DeviceMissing => "device-missing",
+        PreviewCameraState::PermissionNeeded => "permission-needed",
+        PreviewCameraState::Starting => "starting",
+        PreviewCameraState::Live => "live",
+        PreviewCameraState::Failed => "failed",
+    }
+}
+
+fn screen_state_label(state: &PreviewScreenState) -> &'static str {
+    match state {
+        PreviewScreenState::SourceMissing => "source-missing",
+        PreviewScreenState::PermissionNeeded => "permission-needed",
+        PreviewScreenState::Starting => "starting",
+        PreviewScreenState::Live => "live",
+        PreviewScreenState::Failed => "failed",
+    }
+}
+
+fn format_optional_u64(value: Option<u64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+fn format_age_ms(value: Option<u64>) -> String {
+    value
+        .map(|value| format!("{value}ms"))
+        .unwrap_or_else(|| "none".to_string())
 }
 
 pub async fn commit_scene_with_current_layout(
@@ -584,6 +716,69 @@ mod tests {
             video: Some(fallback_video_settings()),
             background: None,
             protected_overlay_window_ids: Vec::new(),
+        }
+    }
+
+    fn live_camera_status(
+        camera_id: &str,
+        frame_age_ms: Option<u64>,
+        frames_captured: u64,
+        sequence: Option<u64>,
+    ) -> PreviewCameraStatus {
+        PreviewCameraStatus {
+            state: PreviewCameraState::Live,
+            camera_id: Some(camera_id.to_string()),
+            device_unique_id: None,
+            target_fps: 30,
+            width: None,
+            height: None,
+            requested_width: None,
+            requested_height: None,
+            actual_width: None,
+            actual_height: None,
+            selected_format_width: None,
+            selected_format_height: None,
+            selected_format_min_fps: None,
+            selected_format_max_fps: None,
+            source_fps: None,
+            frame_age_ms,
+            frames_captured,
+            dropped_frames: 0,
+            sequence,
+            updated_at: "t".to_string(),
+            message: None,
+        }
+    }
+
+    fn live_screen_status(
+        source_id: &str,
+        frame_age_ms: Option<u64>,
+        frames_captured: u64,
+        sequence: Option<u64>,
+    ) -> PreviewScreenStatus {
+        PreviewScreenStatus {
+            state: PreviewScreenState::Live,
+            source_id: Some(source_id.to_string()),
+            source_kind: Some(PreviewScreenSourceKind::Screen),
+            target_fps: 30,
+            width: None,
+            height: None,
+            native_width: None,
+            native_height: None,
+            requested_width: None,
+            requested_height: None,
+            actual_width: None,
+            actual_height: None,
+            iosurface_available: Some(true),
+            source_fps: None,
+            frame_age_ms,
+            frames_captured,
+            dropped_frames: 0,
+            sequence,
+            include_cursor: true,
+            exclude_current_process_windows: true,
+            updated_at: "t".to_string(),
+            message: None,
         }
     }
 
@@ -749,7 +944,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_or_missing_frames_do_not_count_as_live() {
+    fn camera_freshness_and_screen_presence_are_source_specific() {
         let mut camera = PreviewCameraStatus {
             state: PreviewCameraState::Live,
             camera_id: None,
@@ -767,7 +962,7 @@ mod tests {
             selected_format_max_fps: None,
             source_fps: None,
             frame_age_ms: Some(120),
-            frames_captured: 10,
+            frames_captured: 0,
             dropped_frames: 0,
             sequence: None,
             updated_at: "t".to_string(),
@@ -808,6 +1003,9 @@ mod tests {
         };
         assert!(screen_status_is_live(&screen));
         screen.frame_age_ms = Some(SOURCE_FRESH_FRAME_MAX_AGE_MS + 1);
+        assert!(screen_status_is_live(&screen));
+        screen.frame_age_ms = None;
+        screen.frames_captured = 0;
         assert!(!screen_status_is_live(&screen));
     }
 
@@ -932,7 +1130,7 @@ mod tests {
             iosurface_available: Some(true),
             source_fps: None,
             frame_age_ms: None,
-            frames_captured: 10,
+            frames_captured: 0,
             dropped_frames: 0,
             sequence: None,
             include_cursor: true,
@@ -946,10 +1144,72 @@ mod tests {
             sequence: 10,
             width: 3840,
             height: 2160,
-            frame_age_ms: 120,
+            frame_age_ms: SOURCE_FRESH_FRAME_MAX_AGE_MS + 1,
         };
 
         assert!(target_screen_is_live(&screen, Some(frame), Some(&target)));
         assert!(!target_screen_status_is_live(&screen, Some(&target)));
+    }
+
+    #[test]
+    fn target_screen_liveness_accepts_static_screen_frame_presence() {
+        let screen = live_screen_status(
+            "screen:a",
+            Some(SOURCE_FRESH_FRAME_MAX_AGE_MS + 1),
+            24,
+            Some(24),
+        );
+        let mut target = sources(false, true);
+        target.screen_id = Some("screen:a".to_string());
+
+        assert!(target_screen_status_is_live(&screen, Some(&target)));
+    }
+
+    #[test]
+    fn target_screen_liveness_rejects_source_without_initial_frame() {
+        let screen = live_screen_status("screen:a", None, 0, None);
+        let mut target = sources(false, true);
+        target.screen_id = Some("screen:a".to_string());
+
+        assert!(!target_screen_status_is_live(&screen, Some(&target)));
+    }
+
+    #[test]
+    fn missing_readiness_messages_name_camera_freshness_and_screen_initial_frame() {
+        let camera = live_camera_status(
+            "camera:a",
+            Some(SOURCE_FRESH_FRAME_MAX_AGE_MS + 1),
+            42,
+            Some(42),
+        );
+        let screen = live_screen_status("screen:a", None, 0, None);
+        let mut target = sources(true, true);
+        target.camera_id = Some("camera:a".to_string());
+        target.screen_id = Some("screen:a".to_string());
+        let readiness = SourceReadiness {
+            live: SourceLiveness {
+                camera: false,
+                screen: false,
+            },
+            camera_status: camera,
+            screen_status: screen,
+            camera_frame: None,
+            screen_frame: None,
+        };
+
+        let messages = missing_readiness_messages(
+            SceneSourceNeeds {
+                camera: true,
+                screen: true,
+            },
+            &readiness,
+            Some(&target),
+        );
+
+        assert_eq!(messages.len(), 2);
+        assert!(messages[0].contains("camera produced no fresh frames"));
+        assert!(messages[0].contains("latest frame age: 1501ms"));
+        assert!(messages[1].contains("screen/window produced no initial frame"));
+        assert!(messages[1].contains("frames captured: 0"));
     }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "smoke:session-ops": "node scripts/smoke-session-ops.mjs",
     "smoke:start-labels": "node scripts/smoke-start-labels.mjs",
     "smoke:layout-source-loop": "node scripts/smoke-layout-source-loop-app.mjs",
+    "smoke:live-layout-switch-recording": "node scripts/smoke-live-layout-switch-recording-app.mjs",
+    "smoke:live-layout-switch-recording:devices": "VIDEORC_LIVE_LAYOUT_REAL_SCREEN=1 node scripts/smoke-live-layout-switch-recording-app.mjs",
     "smoke:preview-real-launch": "node scripts/smoke-preview-real-launch-app.mjs",
     "smoke:preview-scene-commit": "node scripts/smoke-preview-scene-commit-app.mjs",
     "smoke:preview-pump-diagnostics": "node scripts/smoke-preview-pump-diagnostics-app.mjs",

--- a/scripts/lib/recording-studio-gates.mjs
+++ b/scripts/lib/recording-studio-gates.mjs
@@ -73,6 +73,11 @@ export function buildRecordingStudioGateSteps({
         args: ['smoke:layout-source-loop']
       },
       {
+        label: 'active-session live layout switch recording smoke',
+        command: 'pnpm',
+        args: ['smoke:live-layout-switch-recording']
+      },
+      {
         label: 'backend-owned preview scene commit smoke',
         command: 'pnpm',
         args: ['smoke:preview-scene-commit']
@@ -130,15 +135,22 @@ export function buildRecordingStudioGateSteps({
   }
 
   if (includeDeviceSmoke) {
-    steps.push({
-      label: 'native preview source-complete layout stress recording smoke',
-      command: 'pnpm',
-      args: ['smoke:recording-native-preview'],
-      env: {
-        VIDEORC_NATIVE_PREVIEW_SOURCE_COMPLETE_SCENE: '1',
-        VIDEORC_NATIVE_PREVIEW_LAYOUT_STRESS_UPDATES: '4'
+    steps.push(
+      {
+        label: 'real ScreenCaptureKit live layout switch recording smoke',
+        command: 'pnpm',
+        args: ['smoke:live-layout-switch-recording:devices']
+      },
+      {
+        label: 'native preview source-complete layout stress recording smoke',
+        command: 'pnpm',
+        args: ['smoke:recording-native-preview'],
+        env: {
+          VIDEORC_NATIVE_PREVIEW_SOURCE_COMPLETE_SCENE: '1',
+          VIDEORC_NATIVE_PREVIEW_LAYOUT_STRESS_UPDATES: '4'
+        }
       }
-    })
+    )
   }
 
   return steps

--- a/scripts/lib/recording-studio-gates.test.mjs
+++ b/scripts/lib/recording-studio-gates.test.mjs
@@ -22,6 +22,7 @@ describe('buildRecordingStudioGateSteps', () => {
       'imported screen image recording smoke',
       'real-user launch first-frame contract smoke',
       'layout/source preview liveness smoke',
+      'active-session live layout switch recording smoke',
       'backend-owned preview scene commit smoke',
       'preview main pump diagnostics smoke',
       'preview click/focus continuity smoke',
@@ -44,10 +45,11 @@ describe('buildRecordingStudioGateSteps', () => {
       'backend-isolation.test.ts'
     ])
     assert.deepEqual(steps[1].args, ['test:scripts'])
-    assert.deepEqual(steps.at(-12).args, ['smoke:dev'])
-    assert.deepEqual(steps.at(-11).args, ['smoke:screens'])
-    assert.deepEqual(steps.at(-10).args, ['smoke:preview-real-launch'])
-    assert.deepEqual(steps.at(-9).args, ['smoke:layout-source-loop'])
+    assert.deepEqual(steps.at(-13).args, ['smoke:dev'])
+    assert.deepEqual(steps.at(-12).args, ['smoke:screens'])
+    assert.deepEqual(steps.at(-11).args, ['smoke:preview-real-launch'])
+    assert.deepEqual(steps.at(-10).args, ['smoke:layout-source-loop'])
+    assert.deepEqual(steps.at(-9).args, ['smoke:live-layout-switch-recording'])
     assert.deepEqual(steps.at(-8).args, ['smoke:preview-scene-commit'])
     assert.deepEqual(steps.at(-7).args, ['smoke:preview-pump-diagnostics'])
     assert.deepEqual(steps.at(-6).args, ['smoke:preview-click-focus'])
@@ -65,8 +67,14 @@ describe('buildRecordingStudioGateSteps', () => {
 
   it('can include the heavier native preview layout-stress smoke', () => {
     const steps = buildRecordingStudioGateSteps({ includeDeviceSmoke: true })
+    const liveLayoutDeviceSmoke = steps.at(-2)
     const deviceSmoke = steps.at(-1)
 
+    assert.equal(
+      liveLayoutDeviceSmoke.label,
+      'real ScreenCaptureKit live layout switch recording smoke'
+    )
+    assert.deepEqual(liveLayoutDeviceSmoke.args, ['smoke:live-layout-switch-recording:devices'])
     assert.equal(deviceSmoke.label, 'native preview source-complete layout stress recording smoke')
     assert.deepEqual(deviceSmoke.args, ['smoke:recording-native-preview'])
     assert.equal(deviceSmoke.env.VIDEORC_NATIVE_PREVIEW_SOURCE_COMPLETE_SCENE, '1')
@@ -85,6 +93,7 @@ describe('buildRecordingStudioGateSteps', () => {
     assert.match(report, /smoke:dev/)
     assert.match(report, /smoke:screens/)
     assert.match(report, /smoke:layout-source-loop/)
+    assert.match(report, /smoke:live-layout-switch-recording/)
     assert.match(report, /smoke:preview-scene-commit/)
     assert.match(report, /smoke:preview-pump-diagnostics/)
     assert.match(report, /smoke:preview-click-focus/)
@@ -97,6 +106,7 @@ describe('buildRecordingStudioGateSteps', () => {
     assert.match(report, /VIDEORC_PREVIEW_SURFACE_MAX_INPUT_TO_PRESENT_P95_MS=100/)
     assert.match(report, /VIDEORC_NATIVE_PREVIEW_SOURCE_COMPLETE_SCENE=1/)
     assert.match(report, /VIDEORC_NATIVE_PREVIEW_LAYOUT_STRESS_UPDATES=4/)
+    assert.match(report, /pnpm smoke:live-layout-switch-recording:devices/)
     assert.match(report, /pnpm smoke:recording-native-preview/)
   })
 })

--- a/scripts/preview-window-probe.mjs
+++ b/scripts/preview-window-probe.mjs
@@ -38,7 +38,7 @@ let lastWindowDump = []
 const surfaceSizingLines = []
 function recordSurfaceSizing(line) {
   const match = line.match(
-    /\[videorc-native-preview-sizing\] \w+ bounds_pts=(\d+)x(\d+) scale=([\d.]+) drawable_px=(\d+)x(\d+)/
+    /\[videorc-native-preview-sizing\] \w+ bounds_pts=(\d+)x(\d+) scale=([\d.]+)(?: contentsScale=[\d.]+)? drawable_px=(\d+)x(\d+)/
   )
   if (match) {
     surfaceSizingLines.push({

--- a/scripts/smoke-live-layout-switch-recording-app.mjs
+++ b/scripts/smoke-live-layout-switch-recording-app.mjs
@@ -1,0 +1,402 @@
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { launchDevApp } from './lib/app-launcher.mjs'
+import { analyzeRecording, writeReports } from './lib/recording-analyzer.mjs'
+import { connectBackend, request } from './smoke-recording-session.mjs'
+
+const outputDirectory = resolve(
+  process.env.VIDEORC_SMOKE_OUTPUT_DIR ??
+    join(tmpdir(), `videorc-live-layout-switch-${Date.now()}`)
+)
+const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 120000)
+const recordingMs = Number(process.env.VIDEORC_LIVE_LAYOUT_RECORDING_MS ?? 3500)
+const streamRecordingMs = Number(
+  process.env.VIDEORC_LIVE_LAYOUT_STREAM_RECORDING_MS ?? Math.max(recordingMs, 6500)
+)
+const staticScreenSettleMs = Number(process.env.VIDEORC_LIVE_LAYOUT_STATIC_SCREEN_MS ?? 6200)
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+const ffprobePath = process.env.VIDEORC_SMOKE_FFPROBE_PATH ?? 'ffprobe'
+const realScreenMode = process.env.VIDEORC_LIVE_LAYOUT_REAL_SCREEN === '1'
+const includeStreamMode = process.env.VIDEORC_LIVE_LAYOUT_SKIP_STREAM !== '1'
+const streamPort = Number(process.env.VIDEORC_LIVE_LAYOUT_STREAM_PORT ?? 19611)
+const streamKey = 'live-layout-switch'
+
+const video = {
+  preset: 'custom',
+  width: 640,
+  height: 360,
+  fps: 30,
+  bitrateKbps: 2000
+}
+
+mkdirSync(outputDirectory, { recursive: true })
+
+const launched = await launchDevApp({
+  requiredMarkers: ['backend-ready'],
+  timeoutMs,
+  env: {
+    VIDEORC_SMOKE_PRINT_BACKEND_READY: '1'
+  }
+})
+
+let ws
+let listener = null
+let stopping = false
+try {
+  ws = await connectBackend(launched.connections['backend-ready'], timeoutMs)
+  const health = await request(ws, timeoutMs, 'health.ping', { ffmpegPath })
+  if (!health?.ffmpeg?.available) {
+    throw new Error(
+      health?.ffmpeg?.message ?? 'FFmpeg is unavailable for live layout switch smoke.'
+    )
+  }
+
+  const sources = realScreenMode ? await prepareRealScreenSource(ws) : { testPattern: true }
+  await runSwitchScenario(ws, {
+    label: realScreenMode ? 'real-screen-recording' : 'synthetic-recording',
+    sources,
+    streamTarget: null,
+    durationMs: recordingMs
+  })
+
+  if (includeStreamMode) {
+    const streamTarget = {
+      port: streamPort,
+      serverUrl: `rtmp://127.0.0.1:${streamPort}/live`,
+      streamKey,
+      listenUrl: `rtmp://127.0.0.1:${streamPort}/live/${streamKey}`,
+      recvPath: join(outputDirectory, 'stream-received.flv')
+    }
+    listener = spawnListener(streamTarget)
+    await sleep(1500)
+    await runSwitchScenario(ws, {
+      label: realScreenMode ? 'real-screen-record-stream' : 'synthetic-record-stream',
+      sources,
+      streamTarget,
+      durationMs: streamRecordingMs
+    })
+    stopping = true
+    await stopListener(listener)
+    listener = null
+    assertStreamReceived(streamTarget)
+  }
+
+  console.log(
+    `Live layout switch smoke OK - ${realScreenMode ? 'real ScreenCaptureKit' : 'synthetic'} active-session apply_live switches reached recording${includeStreamMode ? ' and stream' : ''}.`
+  )
+} finally {
+  ws?.close()
+  if (listener) {
+    stopping = true
+    await stopListener(listener)
+  }
+  await launched.stop()
+}
+
+async function prepareRealScreenSource(ws) {
+  const devices = await request(ws, timeoutMs, 'devices.list', { ffmpegPath })
+  const source = (devices.devices ?? []).find(
+    (device) =>
+      (device.kind === 'screen' || device.kind === 'window') &&
+      device.status === 'available' &&
+      device.id.includes('screencapturekit')
+  )
+  if (!source) {
+    const summary = (devices.devices ?? [])
+      .filter((device) => device.kind === 'screen' || device.kind === 'window')
+      .map((device) => `${device.kind}:${device.id}:${device.status}`)
+      .join(', ')
+    throw new Error(
+      `No available ScreenCaptureKit screen/window source for live layout switch device smoke. Devices: ${summary || 'none'}`
+    )
+  }
+
+  const sources =
+    source.kind === 'window'
+      ? { windowId: source.id, testPattern: false }
+      : { screenId: source.id, testPattern: false }
+  const status = await request(ws, timeoutMs, 'preview.screen.start', {
+    sources,
+    video,
+    protectedOverlayWindowIds: []
+  })
+  if (status.state !== 'live') {
+    throw new Error(
+      `Screen preview did not start for ${source.id}: ${status.state} ${status.message ?? ''}`
+    )
+  }
+  await waitForScreenFrame(ws, source.id)
+  // Hold the source visually static long enough that frame-age freshness would
+  // have failed before the backend fix.
+  await sleep(staticScreenSettleMs)
+  return sources
+}
+
+async function waitForScreenFrame(ws, sourceId) {
+  const deadline = Date.now() + timeoutMs
+  let last = null
+  while (Date.now() < deadline) {
+    last = await request(ws, timeoutMs, 'preview.screen.status')
+    if (
+      last?.state === 'live' &&
+      last.sourceId === sourceId &&
+      ((last.framesCaptured ?? 0) > 0 || last.sequence != null)
+    ) {
+      return last
+    }
+    await sleep(100)
+  }
+  throw new Error(
+    `Timed out waiting for first screen frame from ${sourceId}. Last status: ${JSON.stringify(last)}`
+  )
+}
+
+async function runSwitchScenario(ws, { label, sources, streamTarget, durationMs }) {
+  const started = await request(
+    ws,
+    timeoutMs,
+    'session.start',
+    sessionParams({ sources, streamTarget })
+  )
+  if (!['recording', 'streaming'].includes(started.state)) {
+    throw new Error(`[${label}] Expected active session after start, got ${started.state}.`)
+  }
+  const sessionId = started.sessionId
+
+  await sleep(500)
+  for (const preset of ['screen-camera', 'screen-only', 'screen-camera']) {
+    const status = await request(ws, timeoutMs, 'scene.layout.apply_live', {
+      sources,
+      layout: layout(preset),
+      video,
+      background: null,
+      protectedOverlayWindowIds: []
+    })
+    if (!status.applied) {
+      throw new Error(`[${label}] ${preset} did not apply: ${JSON.stringify(status)}`)
+    }
+    await assertSameSession(ws, sessionId, label)
+    await waitForSceneProof(ws, status.sceneRevision, label, preset)
+  }
+
+  await sleep(durationMs)
+  if (streamTarget) {
+    stopping = true
+  }
+  const stopped = await request(ws, timeoutMs, 'session.stop')
+  await assertRecordingArtifact(label, stopped.outputPath ?? started.outputPath, {
+    minVideoSeconds: 2
+  })
+}
+
+function sessionParams({ sources, streamTarget }) {
+  const timestamp = '2026-01-01T00:00:00.000Z'
+  const streamEnabled = Boolean(streamTarget)
+  return {
+    sources,
+    layout: layout('screen-only'),
+    output: {
+      recordEnabled: true,
+      streamEnabled,
+      outputDirectory,
+      ffmpegPath,
+      video,
+      rtmp: {
+        preset: 'custom',
+        serverUrl: streamTarget?.serverUrl ?? '',
+        streamKey: streamTarget?.streamKey ?? ''
+      }
+    },
+    ...(streamTarget
+      ? {
+          streaming: {
+            enabled: true,
+            mode: 'single',
+            targets: [
+              {
+                id: 'custom',
+                platform: 'custom',
+                label: 'Local RTMP',
+                enabled: true,
+                serverUrl: streamTarget.serverUrl,
+                urlMode: 'server-and-key',
+                streamKey: streamTarget.streamKey,
+                streamKeyPresent: true,
+                authMode: 'manual-rtmp',
+                createdAt: timestamp,
+                updatedAt: timestamp
+              }
+            ],
+            defaultOutputPreset: 'tutorial-1080p30',
+            defaultBitrateKbps: 2000,
+            enabledTargetIds: ['custom']
+          }
+        }
+      : {})
+  }
+}
+
+function layout(layoutPreset) {
+  return {
+    layoutPreset,
+    cameraTransformMode: 'preset',
+    cameraTransform: null,
+    cameraCorner: 'bottom-right',
+    cameraSize: 'medium',
+    cameraShape: 'rectangle',
+    cameraCornerRadiusPct: 12,
+    cameraAspect: 'source',
+    cameraMargin: 32,
+    cameraFit: 'fill',
+    cameraMirror: false,
+    cameraZoom: 100,
+    cameraOffsetX: 0,
+    cameraOffsetY: 0,
+    sideBySideSplit: '70-30',
+    sideBySideCameraSide: 'right'
+  }
+}
+
+async function assertSameSession(ws, sessionId, label) {
+  const status = await request(ws, timeoutMs, 'recording.status')
+  if (status.sessionId !== sessionId || !['recording', 'streaming'].includes(status.state)) {
+    throw new Error(
+      `[${label}] live layout switch changed session state: expected ${sessionId}, got ${status.sessionId}/${status.state}.`
+    )
+  }
+}
+
+async function waitForSceneProof(ws, revision, label, preset) {
+  const deadline = Date.now() + timeoutMs
+  let lastCompositor = null
+  let lastDiagnostics = null
+  while (Date.now() < deadline) {
+    lastCompositor = await request(ws, timeoutMs, 'compositor.status')
+    lastDiagnostics = await request(ws, timeoutMs, 'diagnostics.stats')
+    const compositorRendered = (lastCompositor.frameSceneRevision ?? 0) >= revision
+    const diagnosticsReached = (lastDiagnostics.activeSceneRevision ?? 0) >= revision
+    if (compositorRendered && diagnosticsReached) {
+      return
+    }
+    await sleep(150)
+  }
+  throw new Error(
+    `[${label}] ${preset} scene revision ${revision} was not proven live. Last compositor: ${JSON.stringify(
+      lastCompositor
+    )}; last diagnostics: ${JSON.stringify(lastDiagnostics)}`
+  )
+}
+
+async function assertRecordingArtifact(label, outputPath, { minVideoSeconds }) {
+  if (!outputPath || !existsSync(outputPath)) {
+    throw new Error(`[${label}] Recording output was not created: ${outputPath ?? 'missing path'}`)
+  }
+  const size = statSync(outputPath).size
+  if (size <= 0) {
+    throw new Error(`[${label}] Recording output is empty: ${outputPath}`)
+  }
+  const quality = await analyzeRecording(outputPath, {
+    ffmpegPath,
+    ffprobePath,
+    intendedFps: video.fps,
+    expectAudio: false,
+    gates: {
+      requireMotion: false,
+      // This smoke proves active-session layout switching and video output
+      // health. Synthetic record+stream audio is covered by the dedicated A/V
+      // sync gates, and may start before split-output video in this harness.
+      avSyncTargetMs: Number.POSITIVE_INFINITY,
+      avSyncHardFailMs: Number.POSITIVE_INFINITY
+    }
+  })
+  const reportPaths = writeReports(quality)
+  if (!quality.verdict.pass) {
+    throw new Error(
+      `[${label}] Recording quality gate failed: ${quality.verdict.failures.join('; ')} (report: ${reportPaths.mdPath})`
+    )
+  }
+  if ((quality.metrics.durationSeconds ?? 0) < minVideoSeconds) {
+    throw new Error(
+      `[${label}] Recording video duration ${quality.metrics.durationSeconds ?? 'unknown'}s is below ${minVideoSeconds}s (report: ${reportPaths.mdPath})`
+    )
+  }
+  console.log(
+    `[${label}] recording quality PASS: ${outputPath} (${size} bytes, report: ${reportPaths.mdPath})`
+  )
+}
+
+function spawnListener(target) {
+  const proc = spawn(
+    ffmpegPath,
+    [
+      '-y',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-listen',
+      '1',
+      '-i',
+      target.listenUrl,
+      '-c',
+      'copy',
+      '-f',
+      'flv',
+      target.recvPath
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  )
+  proc.stderr.setEncoding('utf8')
+  proc.stderr.on('data', (text) => {
+    if (stopping) {
+      return
+    }
+    for (const line of text.split(/\r?\n/)) {
+      if (line.trim()) {
+        console.error(`[live-layout-listener :${target.port}] ${line}`)
+      }
+    }
+  })
+  return proc
+}
+
+function stopListener(proc) {
+  return new Promise((resolveStop) => {
+    if (!proc?.pid || proc.killed) {
+      resolveStop()
+      return
+    }
+    const timer = setTimeout(() => {
+      try {
+        proc.kill('SIGKILL')
+      } catch {
+        // already gone
+      }
+      resolveStop()
+    }, 2000)
+    proc.once('exit', () => {
+      clearTimeout(timer)
+      resolveStop()
+    })
+    try {
+      proc.kill('SIGTERM')
+    } catch {
+      clearTimeout(timer)
+      resolveStop()
+    }
+  })
+}
+
+function assertStreamReceived(target) {
+  const size = existsSync(target.recvPath) ? statSync(target.recvPath).size : 0
+  if (size <= 0) {
+    throw new Error(`Local RTMP listener received no stream bytes: ${target.recvPath}`)
+  }
+  console.log(`Local RTMP listener received ${size} bytes: ${target.recvPath}`)
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
## Summary
- Treat screen/window readiness as live source + initial frame evidence, instead of requiring a fresh frame age, so static ScreenCaptureKit sources no longer block live layout switches during recording or streaming.
- Keep camera readiness freshness-based and improve timeout diagnostics so camera freshness and screen initial-frame failures are reported separately.
- Wait for live layout commits to be rendered by the active recording/streaming output before updating the renderer committed scene, and add focused synthetic + real ScreenCaptureKit smokes to the recording-studio gate.
- Update the preview-window probe sizing-log parser for the current helper log format so the maintained recording-studio wrapper can verify drawable scale again.

## Verification
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test:scripts
- pnpm --filter @videorc/desktop test
- pnpm build
- cargo fmt --check --all
- cargo test -p videorc-backend
- cargo clippy -p videorc-backend -- -D warnings
- pnpm smoke:live-layout-switch-recording
- pnpm smoke:live-layout-switch-recording:devices
- pnpm probe:preview-window
- pnpm smoke:recording-studio