### PR TITLE
Release: 0.9.19-beta.1 prep

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.19-beta.1.md
+++ b/changelog/0.9.19-beta.1.md
@@ -1,0 +1,25 @@
+---
+version: 0.9.19-beta.1
+date: 2026-07-07
+channel: beta
+title: Scene switching stays live while recording
+summary: Switch scenes while recording or streaming without the layout getting blocked when a screen or window source has not visibly changed yet.
+highlights:
+  - Scene changes stay available while recording and live streaming, even when a screen or window source is momentarily static.
+  - Videorc can commit a valid scene switch without waiting for a visible change on an unchanged screen source.
+  - Manual Twitch streams can read Twitch live comments once the connected account has the chat permission.
+---
+
+## Scene switching stays live while recording
+
+Scene changes are part of a live workflow, so they need to keep working while
+Videorc is recording or streaming. This release fixes the path that could block
+a layout switch when a screen or window source was valid but had not visibly
+changed yet. Videorc now treats the unchanged source as usable and can commit
+the new scene without interrupting the live session.
+
+## Twitch comments for manual streams
+
+Manual Twitch streams also get the live-comments path they were missing. Once
+Twitch is reconnected with chat access, comments from manual streams can appear
+in the comments panel and reader alongside the rest of the stream controls.


### PR DESCRIPTION
## Summary
- bump desktop app version to 0.9.19
- add public changelog entry for 0.9.19-beta.1

## Verification
- pnpm changelog:check
- pnpm --filter @videorc/desktop test
- cargo test -p videorc-backend
- pnpm smoke:live-layout-switch-recording
- pnpm smoke:recording-studio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Manual Twitch streams now support live comments once chat access is restored, so comments can appear in the comments panel alongside stream controls.

- **Bug Fixes**
  - Scene switching now continues to work during recording or streaming even when a source is technically valid but hasn’t visibly updated yet, reducing blocked scene changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->