### PR TITLE
Silence automatic source fallback warnings

### DIFF
--- a/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
@@ -120,8 +120,6 @@ export function SourcesTab(): ReactElement {
     openPreviewPermissions,
     revealPermissionTarget,
     runtimeInfo,
-    sourceFallbackNotices,
-    dismissSourceFallbackNotices,
     wsStatus,
     diagnosticStats
   } = useStudio()
@@ -169,8 +167,6 @@ export function SourcesTab(): ReactElement {
     buildCameraSources(captureConfig.sources, cameras, cameraId)
 
   const applyCaptureSource = (captureId: string | undefined): void => {
-    // A manual pick acknowledges any automatic fallback (Q3, plan 022).
-    dismissSourceFallbackNotices()
     const sources = captureSourcesForDevice(captureId)
     if (isSessionActive) {
       void switchSourceDeviceLive('capture', sources)
@@ -180,7 +176,6 @@ export function SourcesTab(): ReactElement {
   }
 
   const applyCameraSource = (cameraId: string | undefined): void => {
-    dismissSourceFallbackNotices()
     const sources = cameraSourcesForDevice(cameraId)
     if (isSessionActive) {
       void switchSourceDeviceLive('camera', sources)
@@ -248,25 +243,6 @@ export function SourcesTab(): ReactElement {
             <AlertTitle>{warning}</AlertTitle>
           </Alert>
         ))}
-        {/* Durable record of automatic source swaps (Q3, plan 022): the toast
-            is transient; this stays until dismissed or a source is re-picked. */}
-        {sourceFallbackNotices.length > 0 ? (
-          <Alert variant="warning">
-            <Warning weight="fill" />
-            <AlertTitle>Videorc changed a capture source automatically.</AlertTitle>
-            <AlertDescription className="flex flex-col gap-2 pt-2">
-              {sourceFallbackNotices.map((notice) => (
-                <span key={notice}>{notice}</span>
-              ))}
-              <div>
-                <Button size="sm" variant="outline" onClick={dismissSourceFallbackNotices}>
-                  <Check data-icon="inline-start" />
-                  Got it
-                </Button>
-              </div>
-            </AlertDescription>
-          </Alert>
-        ) : null}
         {hasCapturePermissionRequired ? (
           <Alert variant="warning">
             <Warning weight="fill" />

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -37,7 +37,7 @@ import {
   reconcileSourceSelection,
   rtmpDefaults,
   smokePreviewCompositorCaptureConfig,
-  sourceSelectionChangeMessages,
+  sourceSelectionChangeEvents,
   STORAGE_KEYS,
   streamOutputVideoSettings,
   videoProfileCompatibility,
@@ -66,6 +66,7 @@ import type {
   SessionStorageTotals,
   AiQuotaStatus,
   AiWorkflowResult,
+  AutomaticSourceFallbackEvent,
   AudioMeterResult,
   BackendConnection,
   BackendHealth,
@@ -128,6 +129,7 @@ import type {
   StreamTargetRuntime,
   StreamTargetSettings,
   StreamTargetsSnapshot,
+  SupportBundleExportParams,
   SupportBundleExportResult,
   SystemPermissionPane,
   TwitchCategory,
@@ -213,6 +215,13 @@ function premiumUpgradeToastOptions(description?: string) {
       onClick: openPremiumUpgradePage
     }
   }
+}
+
+function sourceFallbackActiveSessionMessage(state: RecordingStatus['state']): string {
+  if (state === 'streaming') {
+    return 'Source changed while streaming. Check the output before continuing.'
+  }
+  return 'Source changed while recording. Check the output before continuing.'
 }
 
 const NATIVE_PREVIEW_SURFACE_PRESENT_REPORT_INTERVAL_MS = 250
@@ -384,9 +393,6 @@ export type StudioContextValue = {
   recording: RecordingStatus
   logs: BackendLogEvent[]
   healthEvents: HealthEvent[]
-  /** Durable record of automatic source swaps (Q3); cleared by dismissal or a manual re-pick. */
-  sourceFallbackNotices: string[]
-  dismissSourceFallbackNotices: () => void
   streamHealth: StreamHealth | null
   streamTargets: StreamTargetRuntime[]
   diagnosticStats: DiagnosticStats
@@ -905,10 +911,6 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const [recording, setRecording] = useState<RecordingStatus>({ state: 'idle', message: 'Ready.' })
   const [logs, setLogs] = useState<BackendLogEvent[]>([])
   const [healthEvents, setHealthEvents] = useState<HealthEvent[]>([])
-  // Q3 (plan 022): the durable record of automatic source swaps. The toast is
-  // transient; this feeds a dismissible Sources-tab notice that persists until
-  // the user re-picks a source (acknowledgement) or dismisses it.
-  const [sourceFallbackNotices, setSourceFallbackNotices] = useState<string[]>([])
   const [streamHealth, setStreamHealth] = useState<StreamHealth | null>(null)
   const [streamTargets, setStreamTargets] = useState<StreamTargetRuntime[]>([])
   const [diagnosticStats, setDiagnosticStats] = useState<DiagnosticStats>(idleDiagnosticStats)
@@ -1314,7 +1316,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     null
   )
   const nativePreviewSurfacePresentReportLastSentAtRef = useRef(0)
-  const sourceReconciliationMessages = useRef<string[]>([])
+  const automaticSourceFallbacks = useRef<AutomaticSourceFallbackEvent[]>([])
   const toastedFailedTargets = useRef<Set<string>>(new Set())
   const platformLifecycleRun = useRef(0)
   const [previewRefreshNonce, setPreviewRefreshNonce] = useState(0)
@@ -2267,31 +2269,30 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         return current
       }
 
-      sourceReconciliationMessages.current.push(
-        ...sourceSelectionChangeMessages(current.sources, nextSources)
-      )
+      const fallbackEvents = sourceSelectionChangeEvents(current.sources, nextSources)
+      if (fallbackEvents.length > 0) {
+        const occurredAt = new Date().toISOString()
+        const sessionState = recordingRef.current.state
+        const enrichedEvents = fallbackEvents.map((event) => ({
+          ...event,
+          occurredAt,
+          sessionState
+        }))
+        automaticSourceFallbacks.current = [
+          ...automaticSourceFallbacks.current,
+          ...enrichedEvents
+        ].slice(-50)
+
+        if (isActiveRecordingState(sessionState)) {
+          toast.warning(sourceFallbackActiveSessionMessage(sessionState), {
+            duration: 10_000,
+            id: 'source-reconciliation:active-session'
+          })
+        }
+      }
       return { ...current, sources: nextSources }
     })
   }, [deviceList])
-
-  useEffect(() => {
-    const messages = sourceReconciliationMessages.current.splice(0)
-    for (const message of new Set(messages)) {
-      // FX9: these fire during churny moments (backend restart, window
-      // closed) — the default 4s toast expired unseen by-eye. A source
-      // swap changes what gets recorded; give it time to be read.
-      // Q3 (plan 022): keyed by message so repeated reconciliation of the
-      // same source UPDATES one toast instead of stacking a covering pile.
-      toast.warning(message, { duration: 10_000, id: `source-reconciliation:${message}` })
-    }
-    if (messages.length > 0) {
-      setSourceFallbackNotices((current) => [...new Set([...current, ...messages])])
-    }
-  }, [captureConfig.sources])
-
-  const dismissSourceFallbackNotices = useCallback(() => {
-    setSourceFallbackNotices([])
-  }, [])
 
   useEffect(() => {
     if (!connection) {
@@ -4068,15 +4069,19 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     try {
       setLastError(null)
       setSupportBundleExportPending(true)
+      const params: SupportBundleExportParams = {
+        ffmpegPath: settings.ffmpegPath.trim() || undefined,
+        // S2 (plan 024): the backend only knows its crate version (stuck at
+        // 0.9.0); forward the real Electron app version so the bundle
+        // identifies the shipped build. Absent → backend degrades to crate.
+        appVersion: runtimeInfo?.version,
+        rendererDiagnostics: {
+          automaticSourceFallbacks: automaticSourceFallbacks.current
+        }
+      }
       const result = await client.request<SupportBundleExportResult>(
         'diagnostics.supportBundle.export',
-        {
-          ffmpegPath: settings.ffmpegPath.trim() || undefined,
-          // S2 (plan 024): the backend only knows its crate version (stuck at
-          // 0.9.0); forward the real Electron app version so the bundle
-          // identifies the shipped build. Absent → backend degrades to crate.
-          appVersion: runtimeInfo?.version
-        }
+        params
       )
       const reveal = window.videorc?.revealPath
       toast.success('Support bundle exported.', {
@@ -5765,8 +5770,6 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       recording,
       logs,
       healthEvents,
-      sourceFallbackNotices,
-      dismissSourceFallbackNotices,
       streamHealth,
       streamTargets,
       diagnosticStats,
@@ -5940,8 +5943,6 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       recording,
       logs,
       healthEvents,
-      sourceFallbackNotices,
-      dismissSourceFallbackNotices,
       streamHealth,
       streamTargets,
       diagnosticStats,

--- a/apps/desktop/src/renderer/src/lib/capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.test.ts
@@ -34,7 +34,7 @@ import {
   resetAudioSyncCalibration,
   smokePreviewCompositorCaptureConfig,
   streamOutputVideoForTarget,
-  sourceSelectionChangeMessages,
+  sourceSelectionChangeEvents,
   streamOutputVideoSettings,
   streamOutputVideosForTargets,
   videoProfileCompatibility,
@@ -59,8 +59,8 @@ describe('reconcileSourceSelection', () => {
   // The renderer mounts with an empty deviceList placeholder and the
   // reconcile effect fires before the backend's first devices.list answer.
   // Remembered selections must survive that pre-snapshot tick: clearing them
-  // toasts 'Capture source "…" is unavailable, so it was cleared.' for
-  // devices that are actually present (startup-toast bug, 2026-06-13).
+  // used to announce a missing source for devices that were actually present
+  // one snapshot later (startup-toast bug, 2026-06-13).
   it('leaves remembered selections untouched before the first device snapshot', () => {
     const remembered: SourceSelection = {
       screenId: 'screen:1',
@@ -74,7 +74,7 @@ describe('reconcileSourceSelection', () => {
     const next = reconcileSourceSelection(remembered, [])
 
     expect(next).toEqual(remembered)
-    expect(sourceSelectionChangeMessages(remembered, next)).toEqual([])
+    expect(sourceSelectionChangeEvents(remembered, next)).toEqual([])
   })
 
   // F-013: with Screen Recording denied the only enumerable capture device is
@@ -98,9 +98,9 @@ describe('reconcileSourceSelection', () => {
   })
 
   // FX9 (0.9.8 sweep): a selected window vanishing from the next device
-  // snapshot fell back to the default display SILENTLY by eye. The message
-  // machinery must produce the fallback notice for exactly this path.
-  it('window vanishes → falls back to the default display AND says so', () => {
+  // snapshot must still fall back to the default display. Plan 027 keeps the
+  // explanation as diagnostics evidence instead of a startup warning.
+  it('window vanishes → falls back to the default display and records diagnostics evidence', () => {
     const remembered: SourceSelection = {
       windowId: 'window:screencapturekit:42',
       windowName: 'cmux - ~/projects/videorc'
@@ -118,8 +118,16 @@ describe('reconcileSourceSelection', () => {
 
     expect(next.screenId).toBe('screen:screencapturekit:1')
     expect(next.windowId).toBeUndefined()
-    expect(sourceSelectionChangeMessages(remembered, next)).toEqual([
-      'Capture source "cmux - ~/projects/videorc" is unavailable, so Videorc selected "Display 1".'
+    expect(sourceSelectionChangeEvents(remembered, next)).toEqual([
+      {
+        kind: 'automatic-source-fallback',
+        sourceKind: 'capture',
+        reason: 'unavailable-selected',
+        previousId: 'window:screencapturekit:42',
+        previousName: 'cmux - ~/projects/videorc',
+        nextId: 'screen:screencapturekit:1',
+        nextName: 'Display 1'
+      }
     ])
   })
 
@@ -218,7 +226,7 @@ describe('reconcileSourceSelection', () => {
     expect(next.screenName).toBe('Capture screen 1')
     expect(next.windowId).toBeUndefined()
     expect(next.windowName).toBeUndefined()
-    expect(sourceSelectionChangeMessages(remembered, next)).toEqual([])
+    expect(sourceSelectionChangeEvents(remembered, next)).toEqual([])
   })
 
   it('selects the avfoundation screen fallback when ScreenCaptureKit only reports status rows', () => {

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -1,5 +1,7 @@
 import type {
   AudioSettings,
+  AutomaticSourceFallbackEvent,
+  AutomaticSourceFallbackSourceKind,
   CameraTransform,
   CameraTransformMode,
   Device,
@@ -1390,43 +1392,43 @@ export function reconcileSourceSelection(
   return nextSources
 }
 
-export function sourceSelectionChangeMessages(
+export function sourceSelectionChangeEvents(
   previous: SourceSelection,
   next: SourceSelection
-): string[] {
-  const messages = [
-    sourceChangeMessage(
-      'Capture source',
+): AutomaticSourceFallbackEvent[] {
+  const events = [
+    sourceChangeEvent(
+      'capture',
       previous.windowId ?? previous.screenId,
       previous.windowName ?? previous.screenName,
       next.windowId ?? next.screenId,
       next.windowName ?? next.screenName
     ),
-    sourceChangeMessage(
-      'Camera',
+    sourceChangeEvent(
+      'camera',
       previous.cameraId,
       previous.cameraName,
       next.cameraId,
       next.cameraName
     ),
-    sourceChangeMessage(
-      'Microphone',
+    sourceChangeEvent(
+      'microphone',
       previous.microphoneId,
       previous.microphoneName,
       next.microphoneId,
       next.microphoneName
     )
   ]
-  return messages.filter((message): message is string => Boolean(message))
+  return events.filter((event): event is AutomaticSourceFallbackEvent => Boolean(event))
 }
 
-function sourceChangeMessage(
-  label: string,
+function sourceChangeEvent(
+  sourceKind: AutomaticSourceFallbackSourceKind,
   previousId: string | undefined,
   previousName: string | undefined,
   nextId: string | undefined,
   nextName: string | undefined
-): string | undefined {
+): AutomaticSourceFallbackEvent | undefined {
   if (!previousId && !previousName) {
     return undefined
   }
@@ -1434,16 +1436,22 @@ function sourceChangeMessage(
     return undefined
   }
 
-  const previousLabel = previousName ?? previousId ?? 'saved source'
+  const event = {
+    kind: 'automatic-source-fallback' as const,
+    sourceKind,
+    previousId,
+    previousName,
+    nextId,
+    nextName
+  }
   if (!nextId && !nextName) {
-    return `${label} "${previousLabel}" is unavailable, so it was cleared.`
+    return { ...event, reason: 'unavailable-cleared' }
   }
 
-  const nextLabel = nextName ?? nextId ?? 'another available source'
   if (previousName && previousName === nextName && previousId !== nextId) {
-    return `${label} "${nextLabel}" was restored by name because its system ID changed.`
+    return { ...event, reason: 'restored-by-name' }
   }
-  return `${label} "${previousLabel}" is unavailable, so Videorc selected "${nextLabel}".`
+  return { ...event, reason: 'unavailable-selected' }
 }
 
 export function startButtonLabel(recordEnabled: boolean, streamEnabled: boolean): string {

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -39,6 +39,13 @@ export interface SupportBundleExportResult {
   redactionSummary: SupportBundleRedactionSummary
 }
 
+export interface SupportBundleExportParams {
+  outputDirectory?: string
+  ffmpegPath?: string
+  appVersion?: string
+  rendererDiagnostics?: RendererDiagnosticsSnapshot
+}
+
 export type FeatureId = 'local-recording' | 'livestreaming' | 'multistreaming' | 'cloud-ai'
 export type EntitlementState = 'enabled' | 'disabled' | 'developer-override'
 export type EntitlementTier = 'basic' | 'premium' | 'developer'
@@ -130,6 +137,28 @@ export interface RecordingStatus {
   pipeline?: RecordingPipelineStatus
   durationMs?: number
   message?: string
+}
+
+export type AutomaticSourceFallbackSourceKind = 'capture' | 'camera' | 'microphone'
+export type AutomaticSourceFallbackReason =
+  | 'unavailable-selected'
+  | 'unavailable-cleared'
+  | 'restored-by-name'
+
+export interface AutomaticSourceFallbackEvent {
+  kind: 'automatic-source-fallback'
+  sourceKind: AutomaticSourceFallbackSourceKind
+  reason: AutomaticSourceFallbackReason
+  previousId?: string
+  previousName?: string
+  nextId?: string
+  nextName?: string
+  sessionState?: RecordingState
+  occurredAt?: string
+}
+
+export interface RendererDiagnosticsSnapshot {
+  automaticSourceFallbacks: AutomaticSourceFallbackEvent[]
 }
 
 export type AudioTrackSource = 'microphone' | 'test-tone'

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -3344,6 +3344,7 @@ async fn export_support_bundle_for_state(
     support_bundle::export_support_bundle(support_bundle::SupportBundleExportInput {
         output_directory: params.output_directory.map(PathBuf::from),
         app_version: params.app_version,
+        renderer_diagnostics: params.renderer_diagnostics,
         database_path: state.database.path().clone(),
         health: backend_health(state, ffmpeg_path).await,
         devices: devices::list_devices(ffmpeg_path).await,

--- a/crates/videorc-backend/src/support_bundle.rs
+++ b/crates/videorc-backend/src/support_bundle.rs
@@ -29,6 +29,8 @@ pub struct SupportBundleExportParams {
     /// decoupled from the shipped app version (plan 024 S2).
     #[serde(default)]
     pub app_version: Option<String>,
+    #[serde(default)]
+    pub renderer_diagnostics: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -45,6 +47,7 @@ pub struct SupportBundleExportInput {
     /// The Electron app version (plan 024 S2); a missing/empty value degrades
     /// to the backend crate version rather than an empty string.
     pub app_version: Option<String>,
+    pub renderer_diagnostics: Option<Value>,
     pub database_path: PathBuf,
     pub health: BackendHealth,
     pub devices: DeviceList,
@@ -68,6 +71,8 @@ pub struct SupportBundle {
     pub entitlements: Value,
     pub recording: Value,
     pub diagnostics: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub renderer_diagnostics: Option<Value>,
     pub logs: Value,
     pub sessions: Vec<SupportBundleSessionSummary>,
     pub redaction_summary: SupportBundleRedactionSummary,
@@ -188,12 +193,16 @@ pub fn build_support_bundle(input: SupportBundleExportInput) -> Result<SupportBu
     let mut entitlements = serde_json::to_value(input.entitlements)?;
     let mut recording = serde_json::to_value(input.recording)?;
     let mut diagnostics = serde_json::to_value(input.diagnostics)?;
+    let mut renderer_diagnostics = input.renderer_diagnostics;
     let mut logs = serde_json::to_value(input.logs)?;
 
     redact_value(&mut health, &mut redaction_summary);
     redact_value(&mut entitlements, &mut redaction_summary);
     redact_value(&mut recording, &mut redaction_summary);
     redact_value(&mut diagnostics, &mut redaction_summary);
+    if let Some(value) = renderer_diagnostics.as_mut() {
+        redact_value(value, &mut redaction_summary);
+    }
     redact_value(&mut logs, &mut redaction_summary);
 
     let (sessions, session_redactions) = redact_sessions(input.sessions);
@@ -214,6 +223,7 @@ pub fn build_support_bundle(input: SupportBundleExportInput) -> Result<SupportBu
         entitlements,
         recording,
         diagnostics,
+        renderer_diagnostics,
         logs,
         sessions,
         redaction_summary,
@@ -380,6 +390,7 @@ fn included_sections() -> Vec<String> {
         "entitlements",
         "recording",
         "diagnostics",
+        "rendererDiagnostics",
         "logs",
         "sessions",
     ]
@@ -649,6 +660,19 @@ mod tests {
             output_directory: Some(directory.clone()),
             // Plan 024 S2: the renderer forwards the Electron app version.
             app_version: Some("0.9.16".to_string()),
+            renderer_diagnostics: Some(json!({
+                "automaticSourceFallbacks": [
+                    {
+                        "kind": "automatic-source-fallback",
+                        "sourceKind": "camera",
+                        "reason": "unavailable-selected",
+                        "previousName": "Cam Link 4K",
+                        "nextName": "MacBook Pro Camera",
+                        "occurredAt": "2026-07-07T21:01:33Z"
+                    }
+                ],
+                "debugUrl": "https://user:password@example.test/support"
+            })),
             database_path: directory.join("videorc.sqlite3"),
             health: BackendHealth {
                 status: "ok".to_string(),
@@ -709,6 +733,10 @@ mod tests {
         assert!(text.contains(DATABASE_PATH_REDACTION));
         assert!(!text.contains("plain-key"));
         assert!(!text.contains("sk-test"));
+        assert!(!text.contains("password@example"));
+        assert!(text.contains("\"rendererDiagnostics\""));
+        assert!(text.contains("Cam Link 4K"));
+        assert!(text.contains("MacBook Pro Camera"));
         assert!(!text.contains("videorc.sqlite3"));
         assert!(text.contains("\"lastAudioMeter\""));
         assert!(text.contains("\"no-frames\""));
@@ -716,6 +744,11 @@ mod tests {
             result
                 .included_sections
                 .contains(&"diagnostics".to_string())
+        );
+        assert!(
+            result
+                .included_sections
+                .contains(&"rendererDiagnostics".to_string())
         );
         assert!(result.included_sections.contains(&"devices".to_string()));
         assert!(
@@ -742,6 +775,7 @@ mod tests {
         SupportBundleExportInput {
             output_directory: None,
             app_version,
+            renderer_diagnostics: None,
             database_path: std::path::PathBuf::from("/tmp/videorc.sqlite3"),
             health: BackendHealth {
                 status: "ok".to_string(),

--- a/plans/027-silent-product-source-fallbacks.md
+++ b/plans/027-silent-product-source-fallbacks.md
@@ -1,0 +1,210 @@
+# Plan 027: Make automatic source fallbacks silent product-wide
+
+> **Executor instructions**: This is a product polish and trust slice, not a
+> dev-mode preference. Do not weaken source reconciliation. The app should still
+> recover when a saved display, camera, or microphone is gone; it just must not
+> announce successful recovery as warning UI. Keep the explanation in
+> diagnostics/support evidence so support can ask for a bundle when someone has
+> a real problem.
+>
+> **Drift check (run first)**: `git status --short --branch`; inspect
+> `apps/desktop/src/renderer/src/lib/capture.ts`,
+> `apps/desktop/src/renderer/src/hooks/use-studio.tsx`,
+> `apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx`,
+> `apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx`, and the
+> support-bundle export path around `diagnostics.supportBundle.export`. If the
+> source reconciliation messages moved since `5910ad4e`, re-map the current
+> equivalent before editing.
+
+## Status
+
+- **Priority**: P1 - startup currently looks like the app failed even when it
+  recovered correctly.
+- **Effort**: S-M.
+- **Depends on**: Plan 018 support bundle diagnostics.
+- **Category**: product polish, capture source selection, diagnostics.
+- **Planned at**: commit `5910ad4e`, 2026-07-07.
+- **Execution**: DONE 2026-07-07 on branch `codex/silent-source-fallbacks`.
+  Startup/idle automatic fallback UI was removed product-wide; fallback
+  selection remains intact; renderer fallback events are exported through the
+  redacted support bundle. Gates passed: `pnpm --filter @videorc/desktop test`,
+  `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test:scripts`,
+  `cargo test -p videorc-backend support_bundle`, `cargo fmt --check --all`.
+  `pnpm smoke:recording-studio` was not run because the final code slice only
+  removes source-fallback notification UI and adds diagnostics/support-bundle
+  evidence; it does not change capture/session params, preview, recording
+  output, encoding, or audio paths.
+
+## Why this matters
+
+When Videorc starts and a remembered device is unavailable, it currently shows
+large warning toasts such as:
+
+- `Capture source "Display 2" is unavailable, so Videorc selected "Display 1".`
+- `Camera "Cam Link 4K" is unavailable, so Videorc selected "MacBook Pro Camera".`
+- `Microphone "Shure MV7+" is unavailable, so Videorc selected "Fallback - MacBook Pro Microphone".`
+
+Those messages are technically accurate but product-hostile. They describe an
+implementation detail after the app has already self-healed. A normal launch
+should feel calm: show the sources currently in use, warn only when the user has
+an action to take, and keep the forensic trail in diagnostics.
+
+## Current behavior
+
+- `reconcileSourceSelection` in `capture.ts` correctly chooses a renderable
+  fallback when remembered sources are missing.
+- `sourceSelectionChangeMessages` builds user-facing strings for each automatic
+  fallback.
+- `use-studio.tsx` collects those messages in `sourceReconciliationMessages`,
+  shows each one as a 10 second `toast.warning`, and stores them in
+  `sourceFallbackNotices`.
+- `sources-tab.tsx` renders the same messages again as a persistent yellow
+  alert: `Videorc changed a capture source automatically.`
+- Diagnostics/support export exists, but the automatic fallback history is not
+  clearly owned as diagnostic evidence.
+
+## Product rule
+
+Automatic source recovery is not a warning.
+
+User-facing UI should only warn when there is an actionable problem:
+
+- no usable capture source exists
+- camera, microphone, or screen permissions are missing
+- the user explicitly picked a device and that action failed
+- a source disappears during an active recording or stream and the recorded/live
+  output may have changed
+
+Startup and idle-session fallback should be silent product-wide. No dev-only
+flag, no startup warning stack, no persistent yellow fallback alert.
+
+## Slices
+
+### S1 - Remove automatic fallback toasts
+
+In `use-studio.tsx`, stop calling `toast.warning` for automatic reconciliation
+messages produced while applying `reconcileSourceSelection`.
+
+Keep the source selection state update exactly as-is. The app must still pick
+the best available display/camera/microphone. Only the notification behavior
+changes.
+
+**Done when**: launching with missing saved devices produces no source-fallback
+toast, and the selected source state still resolves to available devices.
+
+### S2 - Remove the persistent Sources-tab fallback alert
+
+Remove the public `sourceFallbackNotices` alert from `sources-tab.tsx`, along
+with now-unused context values and dismiss callbacks if they no longer serve a
+diagnostic purpose.
+
+The Sources tab should show the current selected devices inline. It should not
+keep a yellow "Videorc changed a capture source automatically" banner after a
+successful self-heal.
+
+**Done when**: the Sources tab shows the actual current capture/camera/mic
+selection, with no automatic fallback alert for a recovered startup.
+
+### S3 - Preserve fallback history as diagnostics
+
+Keep an internal, redacted event record for automatic source fallback, for
+example:
+
+```json
+{
+  "kind": "automatic-source-fallback",
+  "sourceKind": "camera",
+  "previousName": "Cam Link 4K",
+  "nextName": "MacBook Pro Camera",
+  "sessionState": "idle",
+  "occurredAt": "2026-07-07T21:01:33.000Z"
+}
+```
+
+Route this into diagnostics/support bundle evidence rather than normal UI. The
+executor should verify the current support-bundle ownership first; if the
+backend export does not know renderer-only reconciliation events, pass a
+redacted recent-event snapshot through the export request or add the nearest
+existing diagnostics channel.
+
+**Done when**: a support bundle can answer "why did Videorc pick this source?"
+without showing startup warnings to every user.
+
+### S4 - Keep actionable warnings, rewrite any remaining fallback copy
+
+Inventory remaining warning paths around devices and source switching. Keep
+warnings for failures the user can act on, but make them shorter and calmer:
+
+- Good: `Camera permission needed.`
+- Good: `No microphone is available.`
+- Good: `Source changed while recording. Check the output before continuing.`
+- Avoid: `"X" is unavailable, so Videorc selected "Y".`
+
+If an active recording/stream source swap still needs a warning, make it
+session-scoped and high-signal. Do not reuse startup fallback copy.
+
+**Done when**: all product-visible source warnings are either permission/no
+device/manual-action/live-session warnings, not automatic-startup fallback
+notices.
+
+### S5 - Add regression coverage
+
+Keep existing tests that prove `reconcileSourceSelection` falls back correctly.
+Add or update focused tests proving the product contract:
+
+- automatic fallback still changes the selection to an available device
+- idle/startup fallback does not enqueue a toast
+- the Sources tab does not render the automatic fallback alert
+- diagnostics/support evidence contains the fallback event
+
+Use the smallest available test layer. If a hook-level toast test is awkward,
+extract a pure helper that classifies reconciliation events into
+`diagnostic-only` vs `user-visible`.
+
+**Done when**: a future change cannot reintroduce startup warning stacks without
+breaking tests.
+
+### S6 - By-eye acceptance
+
+Manually launch with stale saved devices:
+
+- saved screen/display unavailable
+- saved camera unavailable
+- saved microphone unavailable
+
+Expected product behavior:
+
+- no startup fallback toasts
+- no persistent fallback alert on Sources
+- current selected devices are visible inline
+- start/preview behavior still uses available devices
+- support bundle or diagnostics contains the automatic fallback history
+
+## Verification
+
+Minimum deterministic gates:
+
+```sh
+pnpm --filter @videorc/desktop test
+pnpm typecheck
+pnpm lint
+```
+
+Because this touches capture source selection UI, run the relevant recording
+studio gate before handoff unless the final code slice proves it only removed UI
+notifications and did not alter capture/session params:
+
+```sh
+pnpm smoke:recording-studio
+```
+
+If the full recording-studio smoke is blocked locally, state the exact blocker
+and run the closest focused source/preview smoke plus the desktop tests above.
+
+## Non-negotiables
+
+- Do not make this dev-only. The quieter behavior is the product behavior.
+- Do not remove automatic fallback selection.
+- Do not hide permission, no-device, manual-action, or live-session failures.
+- Do not lose support evidence; fallback explanations belong in diagnostics.
+- Do not show large yellow startup stacks for successful recovery.

--- a/plans/README.md
+++ b/plans/README.md
@@ -41,6 +41,7 @@ row when done.
 | 023 | Fix record+stream A/V: slideshow recordings (wallclock PTS on the Annex-B split path) and stream audio skew | P0 | L | none (by-eye needs a real Twitch stream) | DONE (2026-07-07; L0/L1/L3/L4 on main, L2 unneeded — MpegTs default w/ fifo-muxer legs, gates PASS; pending owner: real Twitch+4K by-eye on next release) |
 | 024 | Preview start-stretch + click-flash hint, backend-lost toast stack on permission grant, version-blind support bundle | P0 | M | none (preview by-eye needs a camera) | DONE (2026-07-07; S1–S5 on main, adversarially-verified root causes, gates PASS; S6 owner-triage list; pending owner by-eye + deferred commit-SHA build step) |
 | 025 | Native preview breaks across displays: surface stuck on main display, "Waiting for preview" on the secondary (contentsScale never set + no display-change observer) | P1 | M | dual-display Mac for repro/by-eye | DONE (2026-07-07; S1-S4 on the plan-025 branch, S5 correctly deferred — deliberate self-capture design; gates PASS, preview probe GPU-flaked env-only; pending dual-display by-eye) |
+| 027 | Make automatic source fallbacks silent product-wide; keep the explanation in diagnostics/support bundles | P1 | S-M | 018 | DONE (2026-07-07; startup/source fallback warning UI removed product-wide, recovery preserved, support-bundle diagnostics added; gates PASS) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) |
 REJECTED (with one-line rationale).


### PR DESCRIPTION
## Summary
- remove startup/idle automatic source fallback toasts and the persistent Sources-tab fallback alert
- keep automatic fallback selection intact while recording structured fallback events for diagnostics
- include renderer fallback diagnostics in redacted support bundles and document Plan 027 as complete

## Verification
- PATH="/opt/homebrew/bin:$PATH" pnpm --filter @videorc/desktop test
- PATH="/opt/homebrew/bin:$PATH" pnpm typecheck
- PATH="/opt/homebrew/bin:$PATH" pnpm lint
- PATH="/opt/homebrew/bin:$PATH" pnpm format:check
- PATH="/opt/homebrew/bin:$PATH" pnpm test:scripts
- cargo test -p videorc-backend support_bundle
- cargo fmt --check --all

`pnpm smoke:recording-studio` was not run: the final code path removes notification UI and adds diagnostics/support-bundle evidence without changing capture/session params, preview, recording output, encoding, or audio paths.