### PR TITLE
Add native X Livestream API integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -585,6 +586,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -2153,6 +2163,7 @@ dependencies = [
  "dispatch2",
  "ed25519-dalek",
  "futures-util",
+ "hmac",
  "image",
  "libc",
  "objc2",
@@ -2173,6 +2184,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "thiserror",
  "tokio",

--- a/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
@@ -67,6 +67,7 @@ import type {
 } from '@/lib/backend'
 import {
   isStreamTargetReady,
+  oauthUnavailableReason,
   streamOutputVideoForTarget,
   streamOutputVideoSettings,
   videoProfileCompatibility
@@ -585,7 +586,8 @@ function DestinationCard({
   const ready = isStreamTargetReady(target)
   const fullUrl = target.urlMode === 'full-url'
   const nativeDestination = target.platform !== 'custom'
-  const oauthMode = nativeDestination && target.authMode === 'oauth'
+  const oauthUnavailableMessage = oauthUnavailableReason(target.platform)
+  const oauthMode = nativeDestination && target.authMode === 'oauth' && !oauthUnavailableMessage
   // While a session is live the runtime status (on air / stopped / skipped) takes
   // over the badge; otherwise it reflects the saved-credential readiness.
   const savedStatusBadge = target.status ? streamTargetStatusBadge(target.status.state) : null
@@ -614,6 +616,11 @@ function DestinationCard({
   useEffect(() => {
     setFullUrlDraft(target.serverUrl)
   }, [target.id, target.serverUrl])
+  useEffect(() => {
+    if (target.authMode === 'oauth' && oauthUnavailableMessage) {
+      onPatch(target.id, { authMode: 'manual-rtmp' })
+    }
+  }, [oauthUnavailableMessage, onPatch, target.authMode, target.id])
 
   const credentialLabel = fullUrl ? 'RTMP URL' : 'stream key'
 
@@ -770,19 +777,28 @@ function DestinationCard({
           {nativeDestination ? (
             <Field>
               <FieldLabel>Auth mode</FieldLabel>
-              <ToggleGroup
-                className="w-full"
-                disabled={disabled}
-                type="single"
-                value={target.authMode}
-                variant="outline"
-                onValueChange={(value) =>
-                  value && onPatch(target.id, { authMode: value as StreamAuthMode })
-                }
-              >
-                <ToggleGroupItem value="oauth">OAuth</ToggleGroupItem>
-                <ToggleGroupItem value="manual-rtmp">Manual RTMP</ToggleGroupItem>
-              </ToggleGroup>
+              {oauthUnavailableMessage ? (
+                <div className="flex flex-col gap-2 rounded-row border bg-muted/30 px-3 py-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+                  <span>{oauthUnavailableMessage}</span>
+                  <Badge className="w-fit" variant="outline">
+                    Manual RTMP
+                  </Badge>
+                </div>
+              ) : (
+                <ToggleGroup
+                  className="w-full"
+                  disabled={disabled}
+                  type="single"
+                  value={target.authMode}
+                  variant="outline"
+                  onValueChange={(value) =>
+                    value && onPatch(target.id, { authMode: value as StreamAuthMode })
+                  }
+                >
+                  <ToggleGroupItem value="oauth">OAuth</ToggleGroupItem>
+                  <ToggleGroupItem value="manual-rtmp">Manual RTMP</ToggleGroupItem>
+                </ToggleGroup>
+              )}
             </Field>
           ) : null}
 

--- a/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
@@ -1208,7 +1208,13 @@ function OAuthAccountPanel({
               className="w-fit"
               variant={xNativeCapability?.nativeAvailable ? 'success' : 'warning'}
             >
-              {xNativeCapability?.nativeAvailable ? 'Native ready' : 'Partner API required'}
+              {xNativeCapability?.nativeAvailable
+                ? 'X API ready'
+                : xNativeCapability?.state === 'missing-credentials'
+                  ? 'Credentials needed'
+                  : xNativeCapability?.state === 'account-mismatch'
+                    ? 'Account mismatch'
+                    : 'X API check needed'}
             </Badge>
             <Button
               disabled={disabled || xNativeCapabilityLoading}
@@ -1257,8 +1263,8 @@ function OAuthAccountPanel({
                 Switch to Manual RTMP
               </Button>
               <span className="text-xs text-muted-foreground">
-                Going live on X works today via Media Studio Producer: create an RTMP source at
-                studio.x.com, then paste its RTMP URL and stream key here in Manual RTMP mode.
+                Manual RTMP is still available as an explicit fallback: create an RTMP source in X
+                Producer, then paste its URL and stream key here in Manual RTMP mode.
               </span>
             </div>
           ) : null}

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -22,6 +22,7 @@ import {
   buildCameraSources,
   areEnabledStreamTargetsStartReady,
   defaultSettings,
+  isPlatformOAuthAvailable,
   legacyStreamKeyMigrationCandidates,
   loadCaptureConfig,
   loadJson,
@@ -31,6 +32,7 @@ import {
   patchStreamTargetForEdit,
   persistableCaptureConfig,
   previewDeviceRefreshSignature,
+  oauthUnavailableReason,
   preparedXActivationTargets,
   preparedXCompletionTargets,
   preparedYouTubeActivationTargets,
@@ -1966,6 +1968,14 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   const refreshYouTubeChannels = useCallback(
     async (accountId?: string, options: { background?: boolean } = {}) => {
+      const unavailable = oauthUnavailableReason('youtube')
+      if (unavailable) {
+        setYoutubeChannels([])
+        if (!options.background) {
+          toast.warning(unavailable)
+        }
+        return
+      }
       if (!client) {
         setYoutubeChannels([])
         return
@@ -1998,6 +2008,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   const selectYouTubeChannel = useCallback(
     async (channelId: string, accountId?: string) => {
+      const unavailable = oauthUnavailableReason('youtube')
+      if (unavailable) {
+        toast.warning(unavailable)
+        return
+      }
       if (!client || wsStatus !== 'connected') {
         toast.error('Backend socket is not connected.')
         return
@@ -2056,7 +2071,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   useEffect(() => {
     const account = platformAccounts.find((item) => item.platform === 'youtube')
-    if (!account || !shouldAutoRefreshYouTubeChannels(account, platformAccountValidations)) {
+    if (
+      !isPlatformOAuthAvailable('youtube') ||
+      !account ||
+      !shouldAutoRefreshYouTubeChannels(account, platformAccountValidations)
+    ) {
       setYoutubeChannels([])
       return
     }
@@ -4418,6 +4437,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   const connectPlatformAccount = useCallback(
     async (platform: PlatformAccount['platform']) => {
+      const unavailable = oauthUnavailableReason(platform)
+      if (unavailable) {
+        toast.warning(unavailable)
+        return
+      }
       if (!client || wsStatus !== 'connected') {
         toast.error('Backend socket is not connected.')
         return
@@ -5021,6 +5045,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           let unhealthy: StreamTargetSettings | null = null
           let unhealthyMessage: string | null = null
           for (const target of enabledOauthTargets) {
+            const unavailable = oauthUnavailableReason(target.platform)
+            if (unavailable) {
+              unhealthy = target
+              unhealthyMessage = unavailable
+              break
+            }
             if (target.platform === 'x') {
               const capability = await client.request<XNativeLiveCapability>(
                 'streamTargets.x.capability',
@@ -5112,6 +5142,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     )) {
       try {
         if (target.platform === 'youtube') {
+          const unavailable = oauthUnavailableReason(target.platform)
+          if (unavailable) {
+            throw new Error(unavailable)
+          }
           const prepared = await client.request<PreparedYouTubeBroadcast>(
             'streamTargets.youtube.prepare',
             {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -31,6 +31,8 @@ import {
   patchStreamTargetForEdit,
   persistableCaptureConfig,
   previewDeviceRefreshSignature,
+  preparedXActivationTargets,
+  preparedXCompletionTargets,
   preparedYouTubeActivationTargets,
   preparedYouTubeCompletionTargets,
   readyStreamTargetLabels,
@@ -105,6 +107,7 @@ import type {
   PreviewLiveStatus,
   PlatformAccount,
   PlatformAccountValidation,
+  PreparedXStreamSource,
   PreparedTwitchBroadcast,
   PreparedYouTubeBroadcast,
   OAuthCompleteParams,
@@ -137,6 +140,9 @@ import type {
   VideoSettings,
   VideorcAccountSnapshot,
   XNativeLiveCapability,
+  XEndResult,
+  XLiveChatStartParams,
+  XPublishResult,
   YouTubeBroadcastTransitionResult,
   YouTubeChannel,
   YouTubeStreamStatusResult,
@@ -4770,6 +4776,107 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     [client]
   )
 
+  const activatePreparedXBroadcasts = useCallback(
+    async (streamingForStart: StreamingSettings, runId: number, sessionId?: string) => {
+      if (!client) {
+        return
+      }
+
+      const xTargets = preparedXActivationTargets(streamingForStart)
+
+      for (const target of xTargets) {
+        const sourceId = target.platformStreamId
+        const region = target.platformBroadcastId
+        if (!sourceId || !region) {
+          continue
+        }
+        if (platformLifecycleRun.current !== runId) {
+          return
+        }
+
+        try {
+          setCaptureConfig((current) =>
+            bridgeStreamingToLegacy({
+              ...current,
+              streaming: patchPreparedStreamTarget(current.streaming, target.id, {
+                status: {
+                  state: 'connecting',
+                  message: 'Waiting for X ingest.'
+                }
+              })
+            })
+          )
+
+          const result = await client.request<XPublishResult>('streamTargets.x.publish', {
+            accountId: target.accountId,
+            sourceId,
+            region,
+            isLowLatency: true,
+            shouldNotTweet: false,
+            locale: 'en',
+            chatOption: 2
+          })
+
+          if (platformLifecycleRun.current !== runId) {
+            return
+          }
+
+          setCaptureConfig((current) =>
+            bridgeStreamingToLegacy({
+              ...current,
+              streaming: patchPreparedStreamTarget(current.streaming, target.id, {
+                accountId: result.accountId,
+                platformBroadcastId: result.broadcastId,
+                platformStreamId: result.mediaKey,
+                status: {
+                  state: result.tweetError ? 'warning' : 'live',
+                  message: result.tweetError
+                    ? `X broadcast is live, but the announcement post failed: ${result.tweetError}`
+                    : `X broadcast is live: ${result.shareUrl}`,
+                  redactedUrl: result.shareUrl
+                }
+              })
+            })
+          )
+
+          if (sessionId) {
+            try {
+              const params: XLiveChatStartParams = {
+                sessionId,
+                broadcastId: result.broadcastId,
+                mediaKey: result.mediaKey,
+                targetId: target.id
+              }
+              await client.request<LiveChatSnapshot>('liveChat.x.start', params)
+            } catch (chatError) {
+              const chatMessage = chatError instanceof Error ? chatError.message : String(chatError)
+              toast.warning(`X comments need review for ${target.label}.`, {
+                description: chatMessage
+              })
+            }
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          setCaptureConfig((current) =>
+            bridgeStreamingToLegacy({
+              ...current,
+              streaming: patchPreparedStreamTarget(current.streaming, target.id, {
+                status: {
+                  state: 'warning',
+                  message: `X go-live needs review: ${message}`
+                }
+              })
+            })
+          )
+          toast.warning(`Could not publish ${target.label} on X.`, {
+            description: message
+          })
+        }
+      }
+    },
+    [client]
+  )
+
   const completePreparedPlatformBroadcasts = useCallback(
     async (streamingForCleanup: StreamingSettings = captureConfig.streaming) => {
       if (!client) {
@@ -4832,6 +4939,58 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           })
         }
       }
+
+      const xTargets = preparedXCompletionTargets(streamingForCleanup)
+      for (const target of xTargets) {
+        const broadcastId = target.platformBroadcastId
+        if (!broadcastId) {
+          continue
+        }
+        try {
+          setCaptureConfig((current) =>
+            bridgeStreamingToLegacy({
+              ...current,
+              streaming: patchPreparedStreamTarget(current.streaming, target.id, {
+                status: {
+                  state: 'connecting',
+                  message: 'Ending X broadcast.'
+                }
+              })
+            })
+          )
+          const result = await client.request<XEndResult>('streamTargets.x.end', {
+            accountId: target.accountId,
+            broadcastId
+          })
+          setCaptureConfig((current) =>
+            bridgeStreamingToLegacy({
+              ...current,
+              streaming: patchPreparedStreamTarget(current.streaming, target.id, {
+                status: {
+                  state: 'stopped',
+                  message: result.message
+                }
+              })
+            })
+          )
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          setCaptureConfig((current) =>
+            bridgeStreamingToLegacy({
+              ...current,
+              streaming: patchPreparedStreamTarget(current.streaming, target.id, {
+                status: {
+                  state: 'warning',
+                  message: `X cleanup needs review: ${message}`
+                }
+              })
+            })
+          )
+          toast.warning(`Could not end ${target.label} on X.`, {
+            description: message
+          })
+        }
+      }
     },
     [captureConfig.streaming, client]
   )
@@ -4859,12 +5018,35 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         )
         if (enabledOauthTargets.length) {
           const validations = await validatePlatformAccountsForClient(client)
-          const unhealthy = enabledOauthTargets.find((target) => {
+          let unhealthy: StreamTargetSettings | null = null
+          let unhealthyMessage: string | null = null
+          for (const target of enabledOauthTargets) {
+            if (target.platform === 'x') {
+              const capability = await client.request<XNativeLiveCapability>(
+                'streamTargets.x.capability',
+                {
+                  accountId: target.accountId
+                }
+              )
+              if (!capability.nativeAvailable) {
+                unhealthy = target
+                unhealthyMessage = capability.message
+                break
+              }
+              continue
+            }
             const validation = validations.find((item) => item.platform === target.platform)
-            return !validation || !['valid', 'refreshed'].includes(validation.state)
-          })
+            if (!validation || !['valid', 'refreshed'].includes(validation.state)) {
+              unhealthy = target
+              unhealthyMessage = `Reconnect ${target.label} before starting an OAuth livestream.`
+              break
+            }
+          }
           if (unhealthy) {
-            throw new Error(`Reconnect ${unhealthy.label} before starting an OAuth livestream.`)
+            throw new Error(
+              unhealthyMessage ??
+                `Reconnect ${unhealthy.label} before starting an OAuth livestream.`
+            )
           }
         }
         const optimisticRecording = isActiveRecordingState(recordingRef.current.state)
@@ -4885,6 +5067,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         applyRecordingStatus(status)
         await refreshSessions(client)
         await activatePreparedYouTubeBroadcasts(streamingForStart, lifecycleRunId)
+        await activatePreparedXBroadcasts(
+          streamingForStart,
+          lifecycleRunId,
+          status.sessionId ?? recordingRef.current.sessionId
+        )
       } catch (error) {
         if (streamingOverride && streamingForStart) {
           await completePreparedPlatformBroadcasts(streamingForStart)
@@ -4899,6 +5086,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     },
     [
       activatePreparedYouTubeBroadcasts,
+      activatePreparedXBroadcasts,
       applyRecordingStatus,
       captureConfig.streaming,
       client,
@@ -4965,7 +5153,24 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             }
           })
         } else if (target.platform === 'x') {
-          await client.request('streamTargets.x.prepare', { accountId: target.accountId })
+          const prepared = await client.request<PreparedXStreamSource>('streamTargets.x.prepare', {
+            accountId: target.accountId
+          })
+          nextStreaming = patchPreparedStreamTarget(nextStreaming, target.id, {
+            accountId: prepared.accountId,
+            accountLabel: prepared.accountLabel,
+            serverUrl: prepared.serverUrl,
+            streamKeySecretRef: prepared.streamKeySecretRef,
+            streamKeyPresent: true,
+            platformBroadcastId: prepared.region,
+            platformStreamId: prepared.sourceId,
+            status: {
+              state: 'ready',
+              message: prepared.isStreamActive
+                ? 'X source prepared; ingest is already active.'
+                : 'X source prepared.'
+            }
+          })
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -143,6 +143,17 @@ const STREAM_PLATFORM_LABELS: Record<StreamPlatform, string> = {
   custom: 'Custom RTMP'
 }
 
+export const YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE =
+  'YouTube OAuth is temporarily unavailable while Videorc awaits Google approval. Use Manual RTMP for YouTube for now.'
+
+export function oauthUnavailableReason(platform: StreamPlatform): string | null {
+  return platform === 'youtube' ? YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE : null
+}
+
+export function isPlatformOAuthAvailable(platform: StreamPlatform): boolean {
+  return platform !== 'custom' && !oauthUnavailableReason(platform)
+}
+
 function isStreamPlatform(value: unknown): value is StreamPlatform {
   return typeof value === 'string' && (STREAM_PLATFORM_ORDER as readonly string[]).includes(value)
 }
@@ -853,6 +864,10 @@ function normalizeStreamTarget(
     typeof saved.streamKeySecretRef === 'string' ? saved.streamKeySecretRef : undefined
   const serverUrl =
     typeof saved.serverUrl === 'string' && saved.serverUrl.trim() ? saved.serverUrl : base.serverUrl
+  const savedAuthMode = saved.authMode === 'oauth' ? 'oauth' : 'manual-rtmp'
+  const authMode =
+    savedAuthMode === 'oauth' && isPlatformOAuthAvailable(base.platform) ? 'oauth' : 'manual-rtmp'
+  const oauthUnavailable = savedAuthMode === 'oauth' && authMode !== 'oauth'
   return {
     // id, platform, status keep the built-in identity from base.
     ...base,
@@ -860,16 +875,24 @@ function normalizeStreamTarget(
     enabled: typeof saved.enabled === 'boolean' ? saved.enabled : false,
     serverUrl,
     urlMode: saved.urlMode === 'full-url' ? 'full-url' : 'server-and-key',
-    streamKey,
-    streamKeySecretRef,
-    streamKeyPresent: streamKey.length > 0 || Boolean(streamKeySecretRef),
-    authMode: saved.authMode === 'oauth' ? 'oauth' : 'manual-rtmp',
-    accountId: typeof saved.accountId === 'string' ? saved.accountId : undefined,
-    accountLabel: typeof saved.accountLabel === 'string' ? saved.accountLabel : undefined,
+    streamKey: oauthUnavailable ? '' : streamKey,
+    streamKeySecretRef: oauthUnavailable ? undefined : streamKeySecretRef,
+    streamKeyPresent: !oauthUnavailable && (streamKey.length > 0 || Boolean(streamKeySecretRef)),
+    authMode,
+    accountId:
+      authMode === 'oauth' && typeof saved.accountId === 'string' ? saved.accountId : undefined,
+    accountLabel:
+      authMode === 'oauth' && typeof saved.accountLabel === 'string'
+        ? saved.accountLabel
+        : undefined,
     platformBroadcastId:
-      typeof saved.platformBroadcastId === 'string' ? saved.platformBroadcastId : undefined,
+      authMode === 'oauth' && typeof saved.platformBroadcastId === 'string'
+        ? saved.platformBroadcastId
+        : undefined,
     platformStreamId:
-      typeof saved.platformStreamId === 'string' ? saved.platformStreamId : undefined,
+      authMode === 'oauth' && typeof saved.platformStreamId === 'string'
+        ? saved.platformStreamId
+        : undefined,
     outputPreset:
       typeof saved.outputPreset === 'string' && saved.outputPreset in videoPresets
         ? saved.outputPreset
@@ -974,12 +997,15 @@ export function isStreamTargetReady(target: StreamTargetSettings): boolean {
 }
 
 export function isStreamTargetStartReady(target: StreamTargetSettings): boolean {
-  return target.authMode === 'oauth' || isStreamTargetReady(target)
+  if (target.authMode === 'oauth') {
+    return isPlatformOAuthAvailable(target.platform)
+  }
+  return isStreamTargetReady(target)
 }
 
 export function readyStreamTargetLabels(streaming: StreamingSettings): string[] {
   return streaming.targets
-    .filter((target) => target.enabled && isStreamTargetReady(target))
+    .filter((target) => target.enabled && isStreamTargetStartReady(target))
     .map((target) => target.label)
 }
 
@@ -994,8 +1020,8 @@ export function areEnabledStreamTargetsStartReady(streaming: StreamingSettings):
 export function bridgeStreamingToLegacy(config: CaptureConfig): CaptureConfig {
   const { streaming } = config
   const primary = streaming.enabled
-    ? (streaming.targets.find((target) => target.enabled && isStreamTargetReady(target)) ??
-      streaming.targets.find((target) => target.enabled))
+    ? (streaming.targets.find((target) => target.enabled && isStreamTargetStartReady(target)) ??
+      streaming.targets.find((target) => target.enabled && !isUnavailableOAuthTarget(target)))
     : undefined
 
   if (primary) {
@@ -1064,7 +1090,8 @@ export function applyStoredManualStreamKeyResult(
 
 export function persistableCaptureConfig(config: CaptureConfig): CaptureConfig {
   const { testPattern: _testPattern, ...sources } = config.sources
-  const targets = config.streaming.targets.map((target) => {
+  const targets = config.streaming.targets.map((item) => {
+    const target = removeUnavailableOAuthState(item)
     if (!target.streamKeySecretRef && target.authMode !== 'oauth') {
       return target
     }
@@ -1083,8 +1110,33 @@ export function persistableCaptureConfig(config: CaptureConfig): CaptureConfig {
     streaming,
     rtmpServerUrl:
       primary?.urlMode === 'full-url' && primary.streamKeySecretRef ? '' : config.rtmpServerUrl,
-    streamKey: primary?.authMode === 'oauth' || primary?.streamKeySecretRef ? '' : config.streamKey
+    streamKey:
+      primary?.authMode === 'oauth' || primary?.streamKeySecretRef
+        ? ''
+        : (primary?.streamKey ?? config.streamKey)
   }
+}
+
+function removeUnavailableOAuthState(target: StreamTargetSettings): StreamTargetSettings {
+  if (!isUnavailableOAuthTarget(target)) {
+    return target
+  }
+  return {
+    ...target,
+    authMode: 'manual-rtmp',
+    streamKey: '',
+    streamKeySecretRef: undefined,
+    streamKeyPresent: false,
+    accountId: undefined,
+    accountLabel: undefined,
+    platformBroadcastId: undefined,
+    platformStreamId: undefined,
+    status: { state: 'not-configured' }
+  }
+}
+
+function isUnavailableOAuthTarget(target: StreamTargetSettings): boolean {
+  return target.authMode === 'oauth' && !isPlatformOAuthAvailable(target.platform)
 }
 
 export function patchStreamTargetForEdit(
@@ -1092,18 +1144,27 @@ export function patchStreamTargetForEdit(
   patch: Partial<StreamTargetSettings>,
   now: string = new Date().toISOString()
 ): StreamTargetSettings {
-  const next: StreamTargetSettings = { ...target, ...patch, updatedAt: now }
+  const { authMode: requestedAuthMode, ...restPatch } = patch
+  const next: StreamTargetSettings = {
+    ...target,
+    ...restPatch,
+    ...(requestedAuthMode &&
+    (requestedAuthMode !== 'oauth' || isPlatformOAuthAvailable(target.platform))
+      ? { authMode: requestedAuthMode }
+      : {}),
+    updatedAt: now
+  }
   if (typeof patch.streamKey === 'string') {
     next.streamKeyPresent = patch.streamKey.trim().length > 0
   }
-  if (patch.authMode && patch.authMode !== target.authMode) {
+  if (requestedAuthMode && next.authMode !== target.authMode) {
     next.streamKey = ''
     next.streamKeySecretRef = undefined
     next.streamKeyPresent = false
     next.platformBroadcastId = undefined
     next.platformStreamId = undefined
     next.status = { state: 'not-configured' }
-    if (patch.authMode === 'oauth') {
+    if (next.authMode === 'oauth') {
       next.accountId = target.accountId
       next.accountLabel = target.accountLabel
     } else {
@@ -1123,7 +1184,7 @@ export function patchStreamTargetForEdit(
     next.streamKeyPresent = false
     next.status = { state: 'not-configured' }
   }
-  return next
+  return removeUnavailableOAuthState(next)
 }
 
 export function patchPreparedStreamTarget(
@@ -1148,6 +1209,7 @@ export function preparedYouTubeActivationTargets(
       target.enabled &&
       target.authMode === 'oauth' &&
       target.platform === 'youtube' &&
+      isPlatformOAuthAvailable(target.platform) &&
       Boolean(target.platformBroadcastId) &&
       Boolean(target.platformStreamId)
   )
@@ -1161,6 +1223,7 @@ export function preparedYouTubeCompletionTargets(
       target.enabled &&
       target.authMode === 'oauth' &&
       target.platform === 'youtube' &&
+      isPlatformOAuthAvailable(target.platform) &&
       target.status?.state === 'live' &&
       Boolean(target.platformBroadcastId)
   )

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -1166,6 +1166,29 @@ export function preparedYouTubeCompletionTargets(
   )
 }
 
+export function preparedXActivationTargets(streaming: StreamingSettings): StreamTargetSettings[] {
+  return streaming.targets.filter(
+    (target) =>
+      target.enabled &&
+      target.authMode === 'oauth' &&
+      target.platform === 'x' &&
+      Boolean(target.platformStreamId) &&
+      Boolean(target.platformBroadcastId) &&
+      target.status?.state === 'ready'
+  )
+}
+
+export function preparedXCompletionTargets(streaming: StreamingSettings): StreamTargetSettings[] {
+  return streaming.targets.filter(
+    (target) =>
+      target.enabled &&
+      target.authMode === 'oauth' &&
+      target.platform === 'x' &&
+      target.status?.state === 'live' &&
+      Boolean(target.platformBroadcastId)
+  )
+}
+
 function findRememberedSource(
   sourceId: string | undefined,
   sourceName: string | undefined,

--- a/apps/desktop/src/renderer/src/lib/obs-import-apply.test.ts
+++ b/apps/desktop/src/renderer/src/lib/obs-import-apply.test.ts
@@ -76,9 +76,36 @@ describe('mergeObsImportIntoConfig', () => {
   it('oauth-suggest plans change no stream targets', () => {
     const next = mergeObsImportIntoConfig(
       defaultCaptureConfig,
-      plan({ stream: { kind: 'oauth-suggest', platform: 'youtube', serviceLabel: 'YouTube' } }),
+      plan({ stream: { kind: 'oauth-suggest', platform: 'twitch', serviceLabel: 'Twitch' } }),
       null
     )
     expect(next.streaming).toEqual(defaultCaptureConfig.streaming)
+  })
+
+  it('imports YouTube common RTMP services into the YouTube Manual RTMP target', () => {
+    const next = mergeObsImportIntoConfig(
+      defaultCaptureConfig,
+      plan({
+        stream: {
+          kind: 'rtmp-platform',
+          platform: 'youtube',
+          serviceLabel: 'YouTube - RTMPS',
+          serverUrl: 'rtmps://a.rtmp.youtube.com/live2',
+          hasKey: true
+        }
+      }),
+      'youtube-key-from-obs',
+      '2026-07-08T00:00:00.000Z'
+    )
+    const youtube = next.streaming.targets.find((target) => target.platform === 'youtube')
+    expect(youtube).toMatchObject({
+      enabled: true,
+      serverUrl: 'rtmps://a.rtmp.youtube.com/live2',
+      streamKey: 'youtube-key-from-obs',
+      streamKeyPresent: true,
+      authMode: 'manual-rtmp',
+      updatedAt: '2026-07-08T00:00:00.000Z'
+    })
+    expect(next.streaming.enabledTargetIds).toContain('youtube')
   })
 })

--- a/apps/desktop/src/renderer/src/lib/obs-import-apply.ts
+++ b/apps/desktop/src/renderer/src/lib/obs-import-apply.ts
@@ -45,12 +45,13 @@ export function mergeObsImportIntoConfig(
     }
   }
 
-  if (plan.stream?.kind === 'rtmp-custom') {
+  if (plan.stream?.kind === 'rtmp-custom' || plan.stream?.kind === 'rtmp-platform') {
     const { serverUrl } = plan.stream
+    const platform = plan.stream.kind === 'rtmp-custom' ? 'custom' : plan.stream.platform
     next.streaming = {
       ...config.streaming,
       targets: config.streaming.targets.map((target) =>
-        target.platform === 'custom'
+        target.platform === platform
           ? {
               ...target,
               enabled: true,
@@ -63,7 +64,7 @@ export function mergeObsImportIntoConfig(
             }
           : target
       ),
-      enabledTargetIds: Array.from(new Set([...config.streaming.enabledTargetIds, 'custom']))
+      enabledTargetIds: Array.from(new Set([...config.streaming.enabledTargetIds, platform]))
     }
   }
 

--- a/apps/desktop/src/renderer/src/lib/obs-import-map.test.ts
+++ b/apps/desktop/src/renderer/src/lib/obs-import-map.test.ts
@@ -86,8 +86,13 @@ describe('mapObsSetup on the real fixture', () => {
     }
   })
 
-  it('suggests OAuth for a YouTube rtmp_common service instead of copying the key', () => {
-    expect(result.stream).toMatchObject({ kind: 'oauth-suggest', platform: 'youtube' })
+  it('imports a YouTube rtmp_common service as Manual RTMP', () => {
+    expect(result.stream).toMatchObject({
+      kind: 'rtmp-platform',
+      platform: 'youtube',
+      serverUrl: 'rtmps://x',
+      hasKey: true
+    })
   })
 
   it('never emits OBS kind ids in the report', () => {

--- a/apps/desktop/src/renderer/src/lib/obs-import-map.ts
+++ b/apps/desktop/src/renderer/src/lib/obs-import-map.ts
@@ -38,7 +38,14 @@ export interface ObsImportPlanResult {
   outputDirectory?: string
   stream?:
     | { kind: 'rtmp-custom'; serverUrl: string; hasKey: boolean }
-    | { kind: 'oauth-suggest'; platform: 'youtube' | 'twitch' | 'other'; serviceLabel: string }
+    | {
+        kind: 'rtmp-platform'
+        platform: 'youtube'
+        serviceLabel: string
+        serverUrl: string
+        hasKey: boolean
+      }
+    | { kind: 'oauth-suggest'; platform: 'twitch' | 'other'; serviceLabel: string }
   backgroundImagePath?: string
   report: ObsImportReportLine[]
 }
@@ -399,16 +406,40 @@ export function mapObsSetup(setup: ObsSetup, devices: Device[]): ObsImportPlanRe
       })
     } else {
       const label = setup.service.service ?? 'streaming service'
-      result.stream = {
-        kind: 'oauth-suggest',
-        platform: detectPlatform(label),
-        serviceLabel: label
+      const platform = detectPlatform(label)
+      if (platform === 'youtube' && setup.service.server) {
+        result.stream = {
+          kind: 'rtmp-platform',
+          platform,
+          serviceLabel: label,
+          serverUrl: setup.service.server,
+          hasKey: setup.service.hasKey
+        }
+        report.push({
+          verdict: 'imported',
+          subject: label,
+          note: setup.service.hasKey
+            ? 'server and stream key imported to YouTube Manual RTMP'
+            : 'server imported to YouTube Manual RTMP (no key found)'
+        })
+      } else if (platform === 'youtube') {
+        report.push({
+          verdict: 'approximated',
+          subject: label,
+          note: 'set up YouTube Manual RTMP in Livestream — OBS did not include a server URL'
+        })
+      } else {
+        result.stream = {
+          kind: 'oauth-suggest',
+          platform,
+          serviceLabel: label
+        }
+        report.push({
+          verdict: 'approximated',
+          subject: label,
+          note: 'connect the account in Livestream instead — sign-in beats a pasted stream key'
+        })
       }
-      report.push({
-        verdict: 'approximated',
-        subject: label,
-        note: 'connect the account in Livestream instead — sign-in beats a pasted stream key'
-      })
     }
   }
 

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -776,7 +776,11 @@ export interface PreparedTwitchBroadcast {
   language?: string
 }
 
-export type XNativeLiveCapabilityState = 'partner-api-required'
+export type XNativeLiveCapabilityState =
+  | 'missing-credentials'
+  | 'ready'
+  | 'account-mismatch'
+  | 'api-error'
 
 export interface XNativeLiveCapabilityParams {
   accountId?: string
@@ -784,6 +788,30 @@ export interface XNativeLiveCapabilityParams {
 
 export interface XPrepareParams {
   accountId?: string
+}
+
+export interface XPublishParams {
+  accountId?: string
+  sourceId: string
+  region: string
+  isLowLatency: boolean
+  shouldNotTweet: boolean
+  locale?: string
+  chatOption?: number
+}
+
+export interface XEndParams {
+  accountId?: string
+  broadcastId: string
+}
+
+export interface XLiveChatStartParams {
+  sessionId: string
+  broadcastId: string
+  mediaKey: string
+  targetId?: string
+  statusBaseUrl?: string
+  accessUrl?: string
 }
 
 export interface XNativeLiveCapability {
@@ -794,10 +822,47 @@ export interface XNativeLiveCapability {
   oauthConnected: boolean
   accountId?: string
   accountLabel?: string
+  credentialSource?: string
   message: string
   evidence: string[]
   docsUrl: string
   apiOverviewUrl: string
+}
+
+export interface PreparedXStreamSource {
+  platform: 'x'
+  accountId: string
+  accountLabel: string
+  sourceId: string
+  region: string
+  serverUrl: string
+  streamKeySecretRef: string
+  streamKeyPresent: boolean
+  redactedUrl: string
+  isStreamActive: boolean
+  recommendedConfiguration?: unknown
+  compatibilityInfo?: unknown
+}
+
+export interface XPublishResult {
+  platform: 'x'
+  accountId: string
+  sourceId: string
+  broadcastId: string
+  mediaKey: string
+  mediaId?: string
+  shareUrl: string
+  state: string
+  tweetId?: string
+  tweetError?: string
+  message: string
+}
+
+export interface XEndResult {
+  platform: 'x'
+  accountId: string
+  broadcastId: string
+  message: string
 }
 
 export interface GoLivePreflightParams {

--- a/crates/videorc-backend/Cargo.toml
+++ b/crates/videorc-backend/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 ed25519-dalek = "2"
 futures-util = "0.3"
+hmac = "0.12"
 # png for screenshots/assets, webp for the BUNDLED background library
 # (background-assets/bundled/*.webp), jpeg for user-imported backgrounds — the
 # importer accepts PNG/JPG/WebP, so the backend must decode all three (pure-Rust
@@ -22,6 +23,7 @@ reqwest = { version = "0.12", features = ["json", "multipart", "rustls-tls"], de
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha1 = "0.10"
 sha2 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1.48", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }

--- a/crates/videorc-backend/src/live_chat.rs
+++ b/crates/videorc-backend/src/live_chat.rs
@@ -184,10 +184,10 @@ fn capability_state_tag(state: ChatCapabilityState) -> &'static str {
 
 /// The OAuth scope each platform needs to READ live chat.
 ///
-/// YouTube's `youtube.force-ssl` scope (already requested by Videorc) covers live chat
-/// reads, so connected YouTube accounts are ready. Twitch needs `user:read:chat`, which is
-/// added to the OAuth config in the Twitch connector slice — until an account is
-/// reconnected with it, Twitch chat reports needs-reconnect.
+/// YouTube's chat-read path is paused with YouTube OAuth until Google approval
+/// completes. Twitch needs `user:read:chat`, which is added to the OAuth config
+/// in the Twitch connector slice — until an account is reconnected with it,
+/// Twitch chat reports needs-reconnect.
 pub const YOUTUBE_CHAT_SCOPE: &str = "https://www.googleapis.com/auth/youtube.force-ssl";
 pub const TWITCH_CHAT_SCOPE: &str = "user:read:chat";
 
@@ -226,14 +226,15 @@ pub fn chat_capability(
     account: Option<&PlatformAccount>,
 ) -> ChatCapability {
     match platform {
-        StreamPlatform::Youtube => scope_capability(
+        StreamPlatform::Youtube => ChatCapability {
             platform,
-            account,
-            YOUTUBE_CHAT_SCOPE,
-            "YouTube live comments are ready.",
-            "Reconnect YouTube to enable live comments.",
-            "Connect a YouTube account to read live comments.",
-        ),
+            state: ChatCapabilityState::Unsupported,
+            chat_read_available: false,
+            required_scope: Some(YOUTUBE_CHAT_SCOPE.to_string()),
+            account_id: account.map(|account| account.account_id.clone()),
+            account_label: account.map(|account| account.account_label.clone()),
+            message: crate::oauth::YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE.to_string(),
+        },
         StreamPlatform::Twitch => scope_capability(
             platform,
             account,
@@ -1284,11 +1285,12 @@ mod tests {
     }
 
     #[test]
-    fn youtube_force_ssl_account_can_read_chat() {
+    fn youtube_chat_is_paused_until_google_approval() {
         let account = account(StreamPlatform::Youtube, &[YOUTUBE_CHAT_SCOPE]);
         let capability = chat_capability(StreamPlatform::Youtube, Some(&account));
-        assert_eq!(capability.state, ChatCapabilityState::Available);
-        assert!(capability.chat_read_available);
+        assert_eq!(capability.state, ChatCapabilityState::Unsupported);
+        assert!(!capability.chat_read_available);
+        assert!(capability.message.contains("Google approval"));
     }
 
     #[test]
@@ -1328,7 +1330,7 @@ mod tests {
     #[test]
     fn missing_account_reports_not_connected() {
         assert_eq!(
-            chat_capability(StreamPlatform::Youtube, None).state,
+            chat_capability(StreamPlatform::Twitch, None).state,
             ChatCapabilityState::NotConnected
         );
     }
@@ -1339,7 +1341,7 @@ mod tests {
         let capabilities = chat_capabilities(&accounts);
         assert_eq!(capabilities.len(), 3);
         assert_eq!(capabilities[0].platform, StreamPlatform::Youtube);
-        assert_eq!(capabilities[0].state, ChatCapabilityState::Available);
+        assert_eq!(capabilities[0].state, ChatCapabilityState::Unsupported);
         assert_eq!(capabilities[1].platform, StreamPlatform::Twitch);
         assert_eq!(capabilities[1].state, ChatCapabilityState::NotConnected);
         assert_eq!(capabilities[2].platform, StreamPlatform::X);
@@ -1391,11 +1393,11 @@ mod tests {
         assert_eq!(snapshot.providers[0].platform, StreamPlatform::Youtube);
         assert_eq!(
             snapshot.providers[0].state,
-            LiveChatProviderConnectionState::Disabled
+            LiveChatProviderConnectionState::Unsupported
         );
         assert_eq!(
             snapshot.providers[0].capabilities,
-            vec!["available".to_string()]
+            vec!["unsupported".to_string()]
         );
         assert_eq!(
             snapshot.providers[2].state,

--- a/crates/videorc-backend/src/live_chat.rs
+++ b/crates/videorc-backend/src/live_chat.rs
@@ -8,6 +8,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
+use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, sleep};
@@ -241,15 +242,26 @@ pub fn chat_capability(
             "Reconnect Twitch to enable live comments.",
             "Connect Twitch to read live comments.",
         ),
-        StreamPlatform::X => ChatCapability {
-            platform,
-            state: ChatCapabilityState::Unsupported,
-            chat_read_available: false,
-            required_scope: None,
-            account_id: account.map(|account| account.account_id.clone()),
-            account_label: account.map(|account| account.account_label.clone()),
-            message: crate::x_chat::x_chat_message(account.is_some()).to_string(),
-        },
+        StreamPlatform::X => {
+            let x_live_ready = account.is_some()
+                && crate::x_live::x_livestream_credentials_from_env()
+                    .ok()
+                    .flatten()
+                    .is_some();
+            ChatCapability {
+                platform,
+                state: if x_live_ready {
+                    ChatCapabilityState::Available
+                } else {
+                    ChatCapabilityState::NotConnected
+                },
+                chat_read_available: x_live_ready,
+                required_scope: None,
+                account_id: account.map(|account| account.account_id.clone()),
+                account_label: account.map(|account| account.account_label.clone()),
+                message: crate::x_chat::x_chat_message(x_live_ready).to_string(),
+            }
+        }
         StreamPlatform::Custom => ChatCapability {
             platform,
             state: ChatCapabilityState::Unsupported,
@@ -458,6 +470,22 @@ impl LiveChatCoordinator {
         self.providers.iter().find(|p| p.platform == platform)
     }
 
+    pub fn ensure_provider(&mut self, provider: LiveChatProviderState) {
+        match self
+            .providers
+            .iter_mut()
+            .find(|existing| existing.platform == provider.platform)
+        {
+            Some(existing) => {
+                existing.target_id = provider.target_id;
+                existing.account_id = provider.account_id;
+                existing.account_label = provider.account_label;
+                existing.capabilities = provider.capabilities;
+            }
+            None => self.providers.push(provider),
+        }
+    }
+
     /// True once a session has been started (or left a transcript) — drives whether
     /// `current_status` returns the live view versus the setup-time capability snapshot.
     pub fn has_session_view(&self) -> bool {
@@ -623,6 +651,22 @@ pub struct LiveChatStartParams {
     pub youtube: Option<crate::youtube_chat::YouTubeChatConfig>,
     #[serde(default)]
     pub twitch: Option<crate::twitch_chat::TwitchChatConfig>,
+    #[serde(default)]
+    pub x: Option<crate::x_chat::XChatConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartXLiveChatParams {
+    pub session_id: String,
+    pub broadcast_id: String,
+    pub media_key: String,
+    #[serde(default)]
+    pub target_id: Option<String>,
+    #[serde(default)]
+    pub status_base_url: Option<String>,
+    #[serde(default)]
+    pub access_url: Option<String>,
 }
 
 /// A deterministic, bounded fake chat source for tests / `smoke:live-chat-fake-providers`.
@@ -741,9 +785,77 @@ pub async fn start_live_chat(state: &AppState, params: LiveChatStartParams) -> L
             }),
         );
     }
+    if let Some(x) = params.x.clone() {
+        let handle = tokio::spawn(crate::x_chat::run_x_chat_connector(
+            state.clone(),
+            params.session_id.clone(),
+            x,
+        ));
+        let mut coordinator = state.live_chat.lock().await;
+        coordinator.attach_task(handle);
+    }
     let snapshot = current_status(state).await;
     state.emit_event("liveChat.snapshot", snapshot.clone());
     snapshot
+}
+
+pub async fn start_x_live_chat(
+    state: &AppState,
+    params: StartXLiveChatParams,
+) -> Result<LiveChatSnapshot> {
+    let accounts = state.database.list_platform_accounts().unwrap_or_default();
+    let mut provider = session_provider_rows(&accounts, &[StreamPlatform::X])
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| LiveChatProviderState {
+            platform: StreamPlatform::X,
+            target_id: None,
+            account_id: None,
+            account_label: None,
+            state: LiveChatProviderConnectionState::Disabled,
+            message: crate::x_chat::x_chat_message(false).to_string(),
+            last_connected_at: None,
+            last_message_at: None,
+            last_error: None,
+            capabilities: vec![capability_state_tag(ChatCapabilityState::NotConnected).to_string()],
+        });
+    provider.target_id = params.target_id.clone();
+
+    {
+        let mut coordinator = state.live_chat.lock().await;
+        if let Some(active_session_id) = coordinator.session_id.as_deref() {
+            if active_session_id != params.session_id {
+                return Err(anyhow!(
+                    "Live chat session {active_session_id} is active; cannot attach X chat for {}.",
+                    params.session_id
+                ));
+            }
+            coordinator.ensure_provider(provider);
+        } else {
+            coordinator.start_session(params.session_id.clone(), vec![provider]);
+        }
+    }
+
+    let config = crate::x_chat::XChatConfig {
+        broadcast_id: params.broadcast_id,
+        media_key: params.media_key,
+        target_id: params.target_id,
+        status_base_url: params.status_base_url,
+        access_url: params.access_url,
+    };
+    let handle = tokio::spawn(crate::x_chat::run_x_chat_connector(
+        state.clone(),
+        params.session_id,
+        config,
+    ));
+    {
+        let mut coordinator = state.live_chat.lock().await;
+        coordinator.attach_task(handle);
+    }
+
+    let snapshot = current_status(state).await;
+    state.emit_event("liveChat.snapshot", snapshot.clone());
+    Ok(snapshot)
 }
 
 /// The YouTube connector resolves the live chat id from the broadcast id after
@@ -1085,6 +1197,35 @@ mod tests {
     }
 
     #[test]
+    fn ensure_provider_adds_late_x_without_resetting_existing_rows() {
+        let mut coordinator = LiveChatCoordinator::new(10);
+        coordinator.start_session(
+            "s1".to_string(),
+            vec![provider_row(StreamPlatform::Youtube)],
+        );
+
+        coordinator.ensure_provider(LiveChatProviderState {
+            platform: StreamPlatform::X,
+            target_id: Some("x-target".to_string()),
+            account_id: Some("123".to_string()),
+            account_label: Some("OrcDev".to_string()),
+            state: LiveChatProviderConnectionState::Disabled,
+            message: "X comments ready.".to_string(),
+            last_connected_at: None,
+            last_message_at: None,
+            last_error: None,
+            capabilities: vec!["available".to_string()],
+        });
+
+        let snapshot = coordinator.snapshot("now".to_string());
+        assert_eq!(snapshot.session_id.as_deref(), Some("s1"));
+        assert_eq!(snapshot.providers.len(), 2);
+        assert_eq!(snapshot.providers[0].platform, StreamPlatform::Youtube);
+        assert_eq!(snapshot.providers[1].platform, StreamPlatform::X);
+        assert_eq!(snapshot.providers[1].target_id.as_deref(), Some("x-target"));
+    }
+
+    #[test]
     fn sender_registry_is_session_scoped() {
         let mut coordinator = LiveChatCoordinator::new(10);
         coordinator.start_session("s1".to_string(), Vec::new());
@@ -1173,10 +1314,10 @@ mod tests {
     }
 
     #[test]
-    fn x_is_unsupported_and_custom_has_no_comments() {
+    fn x_without_account_is_not_connected_and_custom_has_no_comments() {
         assert_eq!(
             chat_capability(StreamPlatform::X, None).state,
-            ChatCapabilityState::Unsupported
+            ChatCapabilityState::NotConnected
         );
         assert_eq!(
             chat_capability(StreamPlatform::Custom, None).state,
@@ -1202,7 +1343,7 @@ mod tests {
         assert_eq!(capabilities[1].platform, StreamPlatform::Twitch);
         assert_eq!(capabilities[1].state, ChatCapabilityState::NotConnected);
         assert_eq!(capabilities[2].platform, StreamPlatform::X);
-        assert_eq!(capabilities[2].state, ChatCapabilityState::Unsupported);
+        assert_eq!(capabilities[2].state, ChatCapabilityState::NotConnected);
     }
 
     #[test]
@@ -1258,7 +1399,7 @@ mod tests {
         );
         assert_eq!(
             snapshot.providers[2].state,
-            LiveChatProviderConnectionState::Unsupported
+            LiveChatProviderConnectionState::Disabled
         );
     }
 }

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -115,9 +115,10 @@ use crate::storage::Database;
 use crate::streaming::{
     ManualStreamKeyPlan, ManualStreamKeyRefParams, PlatformAccountStatus,
     PlatformAccountValidation, PlatformAccountValidationState, StoreManualStreamKeyParams,
-    StoreManualStreamKeyResult, StreamMetadataDraft, StreamPlatform, UpsertPlatformAccount,
-    manual_stream_key_previous_secret_ref, manual_stream_key_secret_ref, manual_stream_key_state,
-    plan_manual_stream_key_restore, plan_manual_stream_key_store, validate_stream_metadata_draft,
+    StoreManualStreamKeyResult, StreamAuthMode, StreamMetadataDraft, StreamPlatform,
+    UpsertPlatformAccount, manual_stream_key_previous_secret_ref, manual_stream_key_secret_ref,
+    manual_stream_key_state, plan_manual_stream_key_restore, plan_manual_stream_key_store,
+    validate_stream_metadata_draft,
 };
 use crate::twitch::{
     PreparedTwitchBroadcast, TwitchCategorySearchParams, TwitchCategorySearchRequest,
@@ -953,10 +954,33 @@ async fn validate_platform_accounts(state: &AppState) -> Vec<PlatformAccountVali
     validations
 }
 
+fn validate_start_session_oauth_availability(params: &protocol::StartSessionParams) -> Result<()> {
+    let Some(streaming) = params
+        .streaming
+        .as_ref()
+        .filter(|streaming| streaming.enabled)
+    else {
+        return Ok(());
+    };
+    for target in &streaming.targets {
+        let enabled = target.enabled || streaming.enabled_target_ids.contains(&target.id);
+        if enabled
+            && target.auth_mode == StreamAuthMode::Oauth
+            && let Some(message) = oauth::provider_oauth_unavailable_message(target.platform)
+        {
+            anyhow::bail!("{message}");
+        }
+    }
+    Ok(())
+}
+
 async fn prepare_youtube_stream_target(
     state: &AppState,
     params: YouTubePrepareParams,
 ) -> anyhow::Result<PreparedYouTubeBroadcast> {
+    if let Some(message) = oauth::provider_oauth_unavailable_message(StreamPlatform::Youtube) {
+        anyhow::bail!("{message}");
+    }
     let metadata = state.database.stream_metadata_draft()?;
     let validation = validate_stream_metadata_draft(&metadata);
     if !validation.valid {
@@ -1038,6 +1062,9 @@ async fn transition_youtube_stream_target(
     state: &AppState,
     params: YouTubeBroadcastTransitionParams,
 ) -> anyhow::Result<YouTubeBroadcastTransitionResult> {
+    if let Some(message) = oauth::provider_oauth_unavailable_message(StreamPlatform::Youtube) {
+        anyhow::bail!("{message}");
+    }
     let credential = youtube_account_credentials(state, params.account_id.as_deref())?;
     let client = reqwest::Client::new();
     let mut fresh = fresh_platform_access_token(state, &credential, &client).await?;
@@ -1077,6 +1104,9 @@ async fn youtube_stream_status(
     state: &AppState,
     params: YouTubeStreamStatusParams,
 ) -> anyhow::Result<YouTubeStreamStatusResult> {
+    if let Some(message) = oauth::provider_oauth_unavailable_message(StreamPlatform::Youtube) {
+        anyhow::bail!("{message}");
+    }
     let credential = youtube_account_credentials(state, params.account_id.as_deref())?;
     let client = reqwest::Client::new();
     let mut fresh = fresh_platform_access_token(state, &credential, &client).await?;
@@ -1114,6 +1144,9 @@ async fn list_youtube_channels(
     state: &AppState,
     params: YouTubeChannelListParams,
 ) -> anyhow::Result<YouTubeChannelListResult> {
+    if let Some(message) = oauth::provider_oauth_unavailable_message(StreamPlatform::Youtube) {
+        anyhow::bail!("{message}");
+    }
     let credential = youtube_account_credentials(state, params.account_id.as_deref())?;
     let client = reqwest::Client::new();
     let mut fresh = fresh_platform_access_token(state, &credential, &client).await?;
@@ -1149,6 +1182,9 @@ async fn select_youtube_channel_account(
     state: &AppState,
     params: YouTubeChannelSelectParams,
 ) -> anyhow::Result<crate::streaming::PlatformAccount> {
+    if let Some(message) = oauth::provider_oauth_unavailable_message(StreamPlatform::Youtube) {
+        anyhow::bail!("{message}");
+    }
     let credential = youtube_account_credentials(state, params.account_id.as_deref())?;
     let client = reqwest::Client::new();
     let mut fresh = fresh_platform_access_token(state, &credential, &client).await?;
@@ -1230,6 +1266,9 @@ async fn youtube_chat_config(
     state: &AppState,
     target: &crate::streaming::StreamTargetSettings,
 ) -> Result<youtube_chat::YouTubeChatConfig> {
+    if let Some(message) = oauth::provider_oauth_unavailable_message(StreamPlatform::Youtube) {
+        anyhow::bail!("{message}");
+    }
     let credential = youtube_account_credentials(state, target.account_id.as_deref())?;
     let client = reqwest::Client::new();
     let fresh = fresh_platform_access_token(state, &credential, &client).await?;
@@ -2412,8 +2451,15 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
         }
         "recording.start_test" => {
             match serde_json::from_value::<protocol::StartSessionParams>(command.params) {
-                Ok(params) => match start_session(state.clone(), params).await {
-                    Ok(status) => ServerResponse::ok(command.id, status),
+                Ok(params) => match validate_start_session_oauth_availability(&params) {
+                    Ok(()) => match start_session(state.clone(), params).await {
+                        Ok(status) => ServerResponse::ok(command.id, status),
+                        Err(error) => ServerResponse::error(
+                            command.id,
+                            "recording-start-failed",
+                            error.to_string(),
+                        ),
+                    },
                     Err(error) => ServerResponse::error(
                         command.id,
                         "recording-start-failed",
@@ -2429,15 +2475,22 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
             match serde_json::from_value::<protocol::StartSessionParams>(command.params) {
                 Ok(params) => {
                     let streaming = params.streaming.clone();
-                    match start_session(state.clone(), params).await {
-                        Ok(status) => {
-                            if let Some(streaming) = streaming.as_ref()
-                                && let Some(session_id) = status.session_id.as_deref()
-                            {
-                                spawn_session_live_chat(state, session_id, streaming).await;
+                    match validate_start_session_oauth_availability(&params) {
+                        Ok(()) => match start_session(state.clone(), params).await {
+                            Ok(status) => {
+                                if let Some(streaming) = streaming.as_ref()
+                                    && let Some(session_id) = status.session_id.as_deref()
+                                {
+                                    spawn_session_live_chat(state, session_id, streaming).await;
+                                }
+                                ServerResponse::ok(command.id, status)
                             }
-                            ServerResponse::ok(command.id, status)
-                        }
+                            Err(error) => ServerResponse::error(
+                                command.id,
+                                "session-start-failed",
+                                error.to_string(),
+                            ),
+                        },
                         Err(error) => ServerResponse::error(
                             command.id,
                             "session-start-failed",

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -123,7 +123,11 @@ use crate::twitch::{
     PreparedTwitchBroadcast, TwitchCategorySearchParams, TwitchCategorySearchRequest,
     TwitchCategorySearchResult, TwitchPrepareParams, TwitchPrepareRequest,
 };
-use crate::x_live::{XNativeLiveCapability, XNativeLiveCapabilityParams, XPrepareParams};
+use crate::x_live::{
+    PreparedXStreamSource, XEndParams, XEndRequest, XEndResult, XNativeLiveCapability,
+    XNativeLiveCapabilityParams, XPrepareParams, XPrepareSourceRequest, XPublishParams,
+    XPublishRequest, XPublishResult,
+};
 use crate::youtube::{PreparedYouTubeBroadcast, YouTubePrepareParams, YouTubePrepareRequest};
 use crate::youtube::{
     YouTubeBroadcastTransitionParams, YouTubeBroadcastTransitionRequest,
@@ -1289,6 +1293,7 @@ async fn spawn_session_live_chat(
         fake: None,
         youtube: None,
         twitch: None,
+        x: None,
     };
     for target in &streaming.targets {
         if !enabled.contains(target.id.as_str()) {
@@ -1519,17 +1524,122 @@ fn x_native_live_capability(
 ) -> anyhow::Result<XNativeLiveCapability> {
     let accounts = state.database.list_platform_accounts()?;
     let account = x_live::select_x_account(&accounts, params.account_id.as_deref())?;
-    Ok(x_live::x_native_live_capability(account))
+    x_live::x_native_live_capability(account)
 }
 
-fn prepare_x_native_live(state: &AppState, params: XPrepareParams) -> anyhow::Result<()> {
+async fn prepare_x_native_live(
+    state: &AppState,
+    params: XPrepareParams,
+) -> anyhow::Result<PreparedXStreamSource> {
+    let accounts = state.database.list_platform_accounts()?;
+    let account = x_live::select_x_account(&accounts, params.account_id.as_deref())?;
     let capability = x_native_live_capability(
         state,
         XNativeLiveCapabilityParams {
             account_id: params.account_id,
         },
     )?;
-    x_live::ensure_x_native_live_available(&capability)
+    x_live::ensure_x_native_live_available(&capability)?;
+    let credentials = x_live::x_livestream_credentials_from_env()?
+        .context("X Livestream OAuth 1.0a credentials are not configured.")?;
+    let prepared = x_live::prepare_x_stream_source(
+        XPrepareSourceRequest {
+            credentials: credentials.clone(),
+            account: account.cloned(),
+            source_name: x_live::default_source_name(),
+            api_base_url: None,
+        },
+        &reqwest::Client::new(),
+        secrets::put_secret,
+    )
+    .await?;
+
+    let existing = state
+        .database
+        .list_platform_account_credentials()?
+        .into_iter()
+        .find(|credential| credential.account.platform == StreamPlatform::X);
+    state
+        .database
+        .upsert_platform_account(UpsertPlatformAccount {
+            platform: StreamPlatform::X,
+            account_id: prepared.account_id.clone(),
+            account_label: prepared.account_label.clone(),
+            account_handle: existing
+                .as_ref()
+                .and_then(|credential| credential.account.account_handle.clone()),
+            avatar_url: existing
+                .as_ref()
+                .and_then(|credential| credential.account.avatar_url.clone()),
+            scopes: existing
+                .as_ref()
+                .map(|credential| credential.account.scopes.clone())
+                .unwrap_or_else(|| vec!["x-livestream-api".to_string()]),
+            token_secret_ref: existing
+                .as_ref()
+                .and_then(|credential| credential.token_secret_ref.clone()),
+            refresh_token_secret_ref: existing
+                .as_ref()
+                .and_then(|credential| credential.refresh_token_secret_ref.clone()),
+            stream_key_secret_ref: Some(prepared.stream_key_secret_ref.clone()),
+            expires_at: existing
+                .as_ref()
+                .and_then(|credential| credential.account.expires_at.clone()),
+            status: PlatformAccountStatus::Connected,
+        })?;
+    if let Ok(accounts) = state.database.list_platform_accounts() {
+        state.emit_event("platformAccounts.changed", accounts);
+    }
+
+    Ok(prepared)
+}
+
+async fn publish_x_native_live(
+    state: &AppState,
+    params: XPublishParams,
+) -> anyhow::Result<XPublishResult> {
+    let accounts = state.database.list_platform_accounts()?;
+    let account = x_live::select_x_account(&accounts, params.account_id.as_deref())?;
+    let capability = x_live::x_native_live_capability(account)?;
+    x_live::ensure_x_native_live_available(&capability)?;
+    let metadata = state.database.stream_metadata_draft()?;
+    let credentials = x_live::x_livestream_credentials_from_env()?
+        .context("X Livestream OAuth 1.0a credentials are not configured.")?;
+    x_live::publish_x_broadcast(
+        XPublishRequest {
+            credentials,
+            source_id: params.source_id,
+            region: params.region,
+            metadata,
+            is_low_latency: params.is_low_latency,
+            should_not_tweet: params.should_not_tweet,
+            locale: x_live::default_publish_locale(params.locale),
+            chat_option: x_live::default_chat_option(params.chat_option),
+            api_base_url: None,
+            poll_attempts: 10,
+            poll_interval_ms: 2_000,
+        },
+        &reqwest::Client::new(),
+    )
+    .await
+}
+
+async fn end_x_native_live(state: &AppState, params: XEndParams) -> anyhow::Result<XEndResult> {
+    let accounts = state.database.list_platform_accounts()?;
+    let account = x_live::select_x_account(&accounts, params.account_id.as_deref())?;
+    let capability = x_live::x_native_live_capability(account)?;
+    x_live::ensure_x_native_live_available(&capability)?;
+    let credentials = x_live::x_livestream_credentials_from_env()?
+        .context("X Livestream OAuth 1.0a credentials are not configured.")?;
+    x_live::end_x_broadcast(
+        XEndRequest {
+            credentials,
+            broadcast_id: params.broadcast_id,
+            api_base_url: None,
+        },
+        &reqwest::Client::new(),
+    )
+    .await
 }
 
 fn upsert_validated_account(
@@ -2549,6 +2659,21 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
                 }
             }
         }
+        "liveChat.x.start" => {
+            match serde_json::from_value::<live_chat::StartXLiveChatParams>(command.params) {
+                Ok(params) => match live_chat::start_x_live_chat(state, params).await {
+                    Ok(snapshot) => ServerResponse::ok(command.id, snapshot),
+                    Err(error) => ServerResponse::error(
+                        command.id,
+                        "live-chat-x-start-failed",
+                        error.to_string(),
+                    ),
+                },
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
         "liveChat.stop" => ServerResponse::ok(command.id, live_chat::stop_live_chat(state).await),
         "liveChat.diagnostics" => {
             ServerResponse::ok(command.id, live_chat::current_diagnostics(state).await)
@@ -2886,15 +3011,38 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
                 }
             }
         }
-        "streamTargets.x.prepare" => match serde_json::from_value::<XPrepareParams>(command.params)
-        {
-            Ok(params) => match prepare_x_native_live(state, params) {
-                Ok(()) => ServerResponse::ok(command.id, serde_json::json!({})),
-                Err(error) => ServerResponse::error(
-                    command.id,
-                    "x-native-live-unavailable",
-                    error.to_string(),
-                ),
+        "streamTargets.x.prepare" => {
+            match serde_json::from_value::<XPrepareParams>(command.params) {
+                Ok(params) => match prepare_x_native_live(state, params).await {
+                    Ok(prepared) => ServerResponse::ok(command.id, prepared),
+                    Err(error) => ServerResponse::error(
+                        command.id,
+                        "x-native-live-unavailable",
+                        error.to_string(),
+                    ),
+                },
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
+        "streamTargets.x.publish" => {
+            match serde_json::from_value::<XPublishParams>(command.params) {
+                Ok(params) => match publish_x_native_live(state, params).await {
+                    Ok(result) => ServerResponse::ok(command.id, result),
+                    Err(error) => {
+                        ServerResponse::error(command.id, "x-publish-failed", error.to_string())
+                    }
+                },
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
+        "streamTargets.x.end" => match serde_json::from_value::<XEndParams>(command.params) {
+            Ok(params) => match end_x_native_live(state, params).await {
+                Ok(result) => ServerResponse::ok(command.id, result),
+                Err(error) => ServerResponse::error(command.id, "x-end-failed", error.to_string()),
             },
             Err(error) => ServerResponse::error(command.id, "invalid-params", error.to_string()),
         },

--- a/crates/videorc-backend/src/oauth.rs
+++ b/crates/videorc-backend/src/oauth.rs
@@ -15,25 +15,6 @@ use crate::streaming::{
 };
 
 const OAUTH_STATE_TTL_MINUTES: i64 = 10;
-// The Videorc YouTube OAuth app (OrcDev's Google Cloud project, Desktop-app client).
-// OAuth client IDs are public identifiers — they appear in every consent URL — so
-// shipping one in source is standard for desktop apps. The client SECRET is NOT in
-// source (moved to build-time injection 2026-07-06 ahead of the public repo flip:
-// Google's installed-app docs treat Desktop-client secrets as non-confidential and
-// every shipped binary embeds it anyway, but a literal in a public repo trips
-// credential scanners and risks Google auto-disabling the client). Official release
-// builds compile it in via VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET — release
-// validation fails closed if the artifact lacks it. Dev builds and forks set the
-// runtime VIDEORC_YOUTUBE_CLIENT_SECRET (or bring their own client, per
-// TRADEMARK.md); without one, YouTube connect reports the missing secret instead
-// of failing the token exchange with a bare 401.
-const BUNDLED_YOUTUBE_CLIENT_ID: Option<&str> =
-    match option_env!("VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID") {
-        Some(bundled) => Some(bundled),
-        None => Some("244529927041-oe9n13ur7lhd1k179ivbj2jfi05b3iia.apps.googleusercontent.com"),
-    };
-const BUNDLED_YOUTUBE_CLIENT_SECRET: Option<&str> =
-    option_env!("VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET");
 const BUNDLED_TWITCH_CLIENT_ID: Option<&str> = option_env!("VIDEORC_BUNDLED_TWITCH_CLIENT_ID");
 // The Videorc X OAuth app (public Native App client, PKCE — no secret involved).
 // Client IDs are public identifiers; build-time/runtime env still override.
@@ -41,6 +22,14 @@ const BUNDLED_X_CLIENT_ID: Option<&str> = match option_env!("VIDEORC_BUNDLED_X_C
     Some(bundled) => Some(bundled),
     None => Some("S0NBMDhTQll6cGp1am5HUFRySE86MTpjaQ"),
 };
+pub const YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE: &str = "YouTube OAuth is temporarily unavailable while Videorc awaits Google approval. Use Manual RTMP for YouTube for now.";
+
+pub fn provider_oauth_unavailable_message(platform: StreamPlatform) -> Option<&'static str> {
+    match platform {
+        StreamPlatform::Youtube => Some(YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE),
+        StreamPlatform::Twitch | StreamPlatform::X | StreamPlatform::Custom => None,
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct OAuthSessions {
@@ -222,6 +211,9 @@ impl OAuthSessions {
     ) -> Result<OAuthStartResult> {
         if matches!(params.platform, StreamPlatform::Custom) {
             anyhow::bail!("Custom RTMP does not support OAuth.");
+        }
+        if let Some(message) = provider_oauth_unavailable_message(params.platform) {
+            anyhow::bail!("{message}");
         }
         let config = provider_config(params.platform)?;
         let state = Uuid::new_v4().to_string();
@@ -753,24 +745,7 @@ impl OAuthTokenResponse {
 
 fn provider_config(platform: StreamPlatform) -> Result<OAuthProviderConfig> {
     match platform {
-        StreamPlatform::Youtube => Ok(OAuthProviderConfig {
-            authorization_url: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
-            token_url: "https://oauth2.googleapis.com/token".to_string(),
-            profile_url: "https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true"
-                .to_string(),
-            client_id: required_credential("VIDEORC_YOUTUBE_CLIENT_ID", BUNDLED_YOUTUBE_CLIENT_ID)?,
-            client_secret: optional_env("VIDEORC_YOUTUBE_CLIENT_SECRET")
-                .or_else(|| optional_static(BUNDLED_YOUTUBE_CLIENT_SECRET)),
-            scopes: vec![
-                "https://www.googleapis.com/auth/youtube".to_string(),
-                "https://www.googleapis.com/auth/youtube.force-ssl".to_string(),
-            ],
-            extra_params: HashMap::from([
-                ("access_type".to_string(), "offline".to_string()),
-                ("prompt".to_string(), "consent".to_string()),
-            ]),
-            pkce: true,
-        }),
+        StreamPlatform::Youtube => anyhow::bail!("{YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE}"),
         StreamPlatform::Twitch => Ok(OAuthProviderConfig {
             authorization_url: "https://id.twitch.tv/oauth2/authorize".to_string(),
             token_url: "https://id.twitch.tv/oauth2/token".to_string(),
@@ -822,7 +797,7 @@ fn provider_redirect_uri(
             // protocol" rejects 127.0.0.1 forms). localhost resolves to the
             // same loopback listener — the string just has to match the
             // registered URL exactly. The other providers keep 127.0.0.1
-            // (X's registered URLs use it; Google accepts any loopback).
+            // (X's registered URLs use it).
             let host = if matches!(platform, StreamPlatform::Twitch) {
                 "localhost"
             } else {
@@ -860,14 +835,10 @@ pub fn provider_client_id(platform: StreamPlatform) -> Result<String> {
 
 pub fn provider_credential_statuses() -> Vec<OAuthProviderCredentialStatus> {
     vec![
-        provider_credential_status(
+        disabled_provider_credential_status(
             StreamPlatform::Youtube,
-            "VIDEORC_YOUTUBE_CLIENT_ID",
-            "VIDEORC_YOUTUBE_CLIENT_SECRET",
-            BUNDLED_YOUTUBE_CLIENT_ID,
-            BUNDLED_YOUTUBE_CLIENT_SECRET,
+            YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE,
             true,
-            false,
         ),
         // Twitch ships as a PUBLIC client type (dev console setting): no
         // client secret exists, token exchange + refresh use the client id
@@ -892,6 +863,22 @@ pub fn provider_credential_statuses() -> Vec<OAuthProviderCredentialStatus> {
             false,
         ),
     ]
+}
+
+fn disabled_provider_credential_status(
+    platform: StreamPlatform,
+    message: &str,
+    pkce: bool,
+) -> OAuthProviderCredentialStatus {
+    OAuthProviderCredentialStatus {
+        platform,
+        ready: false,
+        client_id_present: false,
+        client_secret_present: false,
+        client_id_source: OAuthCredentialSource::Missing,
+        pkce,
+        message: message.to_string(),
+    }
 }
 
 fn provider_credential_status(
@@ -1168,6 +1155,24 @@ mod tests {
         assert!(!completed.code_present);
     }
 
+    #[tokio::test]
+    async fn youtube_provider_start_is_paused_until_google_approval() {
+        let sessions = OAuthSessions::default();
+
+        let error = sessions
+            .start_provider(
+                OAuthStartProviderParams {
+                    platform: StreamPlatform::Youtube,
+                    redirect_uri: None,
+                },
+                61234,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("Google approval"));
+    }
+
     #[test]
     fn provider_redirect_uri_allows_loopback_and_app_protocol_callbacks() {
         assert_eq!(
@@ -1387,11 +1392,13 @@ mod tests {
         let statuses = provider_credential_statuses();
 
         assert_eq!(statuses.len(), 3);
-        assert!(
-            statuses
-                .iter()
-                .any(|status| status.platform == StreamPlatform::Youtube && status.pkce)
-        );
+        let youtube = statuses
+            .iter()
+            .find(|status| status.platform == StreamPlatform::Youtube)
+            .unwrap();
+        assert!(youtube.pkce);
+        assert!(!youtube.ready);
+        assert!(youtube.message.contains("Google approval"));
         assert!(
             statuses
                 .iter()
@@ -1513,10 +1520,10 @@ mod tests {
     #[test]
     fn pkce_provider_status_can_be_ready_without_client_secret() {
         let status = provider_credential_status(
-            StreamPlatform::Youtube,
-            "VIDEORC_TEST_YOUTUBE_CLIENT_ID",
-            "VIDEORC_TEST_YOUTUBE_CLIENT_SECRET",
-            Some("bundled-youtube-client"),
+            StreamPlatform::X,
+            "VIDEORC_TEST_X_CLIENT_ID",
+            "VIDEORC_TEST_X_CLIENT_SECRET",
+            Some("bundled-x-client"),
             None,
             true,
             false,

--- a/crates/videorc-backend/src/preflight.rs
+++ b/crates/videorc-backend/src/preflight.rs
@@ -6,7 +6,7 @@ use crate::streaming::{
     PlatformAccount, PlatformAccountStatus, StreamAuthMode, StreamMetadataDraft, StreamPlatform,
     StreamTargetSettings, StreamingSettings,
 };
-use crate::x_live;
+use crate::{oauth, x_live};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -159,7 +159,20 @@ fn destination_preflight(
         }
         StreamAuthMode::Oauth => {
             let account = account_for_target(target, accounts);
-            if target.platform == StreamPlatform::X {
+            if let Some(unavailable) = oauth::provider_oauth_unavailable_message(target.platform) {
+                if let Some(account) = account {
+                    account_id = Some(account.account_id.clone());
+                    account_label = Some(account.account_label.clone());
+                }
+                ready = false;
+                let issue = unavailable.to_string();
+                message = issue.clone();
+                issues.push(target_issue(
+                    target,
+                    GoLivePreflightIssueSeverity::Error,
+                    issue,
+                ));
+            } else if target.platform == StreamPlatform::X {
                 if let Some(account) = account {
                     account_id = Some(account.account_id.clone());
                     account_label = Some(account.account_label.clone());
@@ -310,7 +323,7 @@ mod tests {
     };
 
     #[test]
-    fn preflight_marks_youtube_twitch_ready_and_x_blocked() {
+    fn preflight_blocks_youtube_oauth_while_twitch_is_ready_and_x_is_blocked() {
         let mut targets = default_stream_targets();
         for target in &mut targets {
             match target.platform {
@@ -345,14 +358,13 @@ mod tests {
 
         assert!(!preflight.valid);
         assert_eq!(preflight.destinations.len(), 3);
-        assert!(
-            preflight
-                .destinations
-                .iter()
-                .find(|destination| destination.platform == StreamPlatform::Youtube)
-                .unwrap()
-                .ready
-        );
+        let youtube = preflight
+            .destinations
+            .iter()
+            .find(|destination| destination.platform == StreamPlatform::Youtube)
+            .unwrap();
+        assert!(!youtube.ready);
+        assert!(youtube.message.contains("Google approval"));
         assert!(
             preflight
                 .destinations
@@ -374,15 +386,16 @@ mod tests {
                 .iter()
                 .any(|issue| issue.platform == Some(StreamPlatform::X))
         );
+        assert!(
+            preflight
+                .issues
+                .iter()
+                .any(|issue| issue.platform == Some(StreamPlatform::Youtube))
+        );
         // Chat readiness is reported independently of stream `ready`: X needs native live
         // credentials and publish metadata before chat can connect.
         assert!(!x.chat_ready);
         assert!(x.chat_message.to_lowercase().contains("x native live"));
-        let youtube = preflight
-            .destinations
-            .iter()
-            .find(|destination| destination.platform == StreamPlatform::Youtube)
-            .unwrap();
         assert!(!youtube.chat_message.is_empty());
     }
 

--- a/crates/videorc-backend/src/preflight.rs
+++ b/crates/videorc-backend/src/preflight.rs
@@ -159,12 +159,16 @@ fn destination_preflight(
         }
         StreamAuthMode::Oauth => {
             let account = account_for_target(target, accounts);
-            match account {
-                Some(account) if account.status == PlatformAccountStatus::Connected => {
+            if target.platform == StreamPlatform::X {
+                if let Some(account) = account {
                     account_id = Some(account.account_id.clone());
                     account_label = Some(account.account_label.clone());
-                    if target.platform == StreamPlatform::X {
-                        let capability = x_live::x_native_live_capability(Some(account));
+                }
+                match x_live::x_native_live_capability(account) {
+                    Ok(capability) if capability.native_available => {
+                        message = capability.message;
+                    }
+                    Ok(capability) => {
                         ready = false;
                         message = capability.message.clone();
                         issues.push(target_issue(
@@ -173,29 +177,47 @@ fn destination_preflight(
                             capability.message,
                         ));
                     }
+                    Err(error) => {
+                        ready = false;
+                        message = error.to_string();
+                        issues.push(target_issue(
+                            target,
+                            GoLivePreflightIssueSeverity::Error,
+                            error.to_string(),
+                        ));
+                    }
                 }
-                Some(account) => {
-                    ready = false;
-                    account_id = Some(account.account_id.clone());
-                    account_label = Some(account.account_label.clone());
-                    let issue = "Connected account needs reconnect before going live.".to_string();
-                    message = issue.clone();
-                    issues.push(target_issue(
-                        target,
-                        GoLivePreflightIssueSeverity::Error,
-                        issue,
-                    ));
-                }
-                None => {
-                    ready = false;
-                    let issue = "OAuth destination needs a connected account before going live."
-                        .to_string();
-                    message = issue.clone();
-                    issues.push(target_issue(
-                        target,
-                        GoLivePreflightIssueSeverity::Error,
-                        issue,
-                    ));
+            } else {
+                match account {
+                    Some(account) if account.status == PlatformAccountStatus::Connected => {
+                        account_id = Some(account.account_id.clone());
+                        account_label = Some(account.account_label.clone());
+                    }
+                    Some(account) => {
+                        ready = false;
+                        account_id = Some(account.account_id.clone());
+                        account_label = Some(account.account_label.clone());
+                        let issue =
+                            "Connected account needs reconnect before going live.".to_string();
+                        message = issue.clone();
+                        issues.push(target_issue(
+                            target,
+                            GoLivePreflightIssueSeverity::Error,
+                            issue,
+                        ));
+                    }
+                    None => {
+                        ready = false;
+                        let issue =
+                            "OAuth destination needs a connected account before going live."
+                                .to_string();
+                        message = issue.clone();
+                        issues.push(target_issue(
+                            target,
+                            GoLivePreflightIssueSeverity::Error,
+                            issue,
+                        ));
+                    }
                 }
             }
         }
@@ -345,16 +367,17 @@ mod tests {
             .find(|destination| destination.platform == StreamPlatform::X)
             .unwrap();
         assert!(!x.ready);
-        assert!(x.message.contains("partner/API path"));
+        assert!(x.message.contains("OAuth 1.0a"));
         assert!(
             preflight
                 .issues
                 .iter()
                 .any(|issue| issue.platform == Some(StreamPlatform::X))
         );
-        // Chat readiness is reported independently of stream `ready`: X is never chat-capable.
+        // Chat readiness is reported independently of stream `ready`: X needs native live
+        // credentials and publish metadata before chat can connect.
         assert!(!x.chat_ready);
-        assert!(x.chat_message.to_lowercase().contains("x comments"));
+        assert!(x.chat_message.to_lowercase().contains("x native live"));
         let youtube = preflight
             .destinations
             .iter()

--- a/crates/videorc-backend/src/support_bundle.rs
+++ b/crates/videorc-backend/src/support_bundle.rs
@@ -481,7 +481,7 @@ fn redact_url(text: &str) -> Option<String> {
             &tail[authority_end..]
         ));
     }
-    if text.starts_with("rtmp://") && !text.contains('•') {
+    if (text.starts_with("rtmp://") || text.starts_with("rtmps://")) && !text.contains('•') {
         return Some(format!("{}://<redacted:rtmp-url>", &text[..scheme_end]));
     }
     None
@@ -518,6 +518,8 @@ fn looks_like_inline_secret(token: &str) -> bool {
         || token.starts_with("xoxb-")
         || lower.starts_with("access_token=")
         || lower.starts_with("refresh_token=")
+        || lower.starts_with("token_secret=")
+        || lower.starts_with("chat_token=")
         || lower.starts_with("api_key=")
         || lower.starts_with("stream_key=")
         || lower.starts_with("streamkey=")
@@ -551,8 +553,10 @@ mod tests {
             "streamKey": "abc123",
             "oauthToken": "tok_live",
             "openaiApiKey": "sk-test",
+            "chatToken": "chat-token-value",
             "callbackUrl": "https://user:password@example.test/callback",
-            "streamUrl": "rtmp://127.0.0.1/live/plain-key"
+            "streamUrl": "rtmp://127.0.0.1/live/plain-key",
+            "secureStreamUrl": "rtmps://de.pscp.tv:443/x/plain-key"
         });
         let mut summary = SupportBundleRedactionSummary::default();
 
@@ -561,13 +565,15 @@ mod tests {
         assert_eq!(value["streamKey"], SECRET_REDACTION);
         assert_eq!(value["oauthToken"], SECRET_REDACTION);
         assert_eq!(value["openaiApiKey"], SECRET_REDACTION);
+        assert_eq!(value["chatToken"], SECRET_REDACTION);
         assert_eq!(
             value["callbackUrl"],
             "https://<redacted:credentials>@example.test/callback"
         );
         assert_eq!(value["streamUrl"], "rtmp://<redacted:rtmp-url>");
-        assert_eq!(summary.secret_values, 3);
-        assert_eq!(summary.url_credentials, 2);
+        assert_eq!(value["secureStreamUrl"], "rtmps://<redacted:rtmp-url>");
+        assert_eq!(summary.secret_values, 4);
+        assert_eq!(summary.url_credentials, 3);
     }
 
     #[test]

--- a/crates/videorc-backend/src/x_chat.rs
+++ b/crates/videorc-backend/src/x_chat.rs
@@ -1,49 +1,94 @@
-//! X (formerly Twitter) live chat capability gate (slice 6 of the In-App Livestream Comments
-//! plan: `2026-06-06 - Videorc In-App Livestream Comments Plan`).
+//! X Livestream read-only chat connector.
 //!
-//! X is a supported Videorc streaming platform, but there is no verified, self-serve native
-//! X live-comments/chat API. This module is capability-reporting ONLY: it never scrapes,
-//! embeds, or fakes X comments. X reports `unsupported` ("pending API access") until a
-//! verified native path exists. When one does, satisfy the evidence checklist below, flip
-//! `X_NATIVE_COMMENTS_AVAILABLE`, and add the real connector behind this same gate.
+//! The X Livestream API document describes chat as a legacy Periscope/X handoff:
+//! fetch a chat token from `api.twitter.com`, exchange it through
+//! `proxsee.pscp.tv`, then connect to the returned WebSocket endpoint. This
+//! module implements read access only. Sending X chat is intentionally
+//! unsupported because the documented API does not include a send flow.
 
-use serde::Serialize;
+use std::time::Duration;
 
-/// Whether a verified, approved native X live-comments path exists AND is implemented here.
-///
-/// Stays `false` until [`X_COMMENTS_EVIDENCE_CHECKLIST`] is satisfied. The plan forbids
-/// shipping X comments — or marking the whole comments feature done — without that evidence,
-/// so this is the single switch a future X connector slice must justify flipping.
-pub const X_NATIVE_COMMENTS_AVAILABLE: bool = false;
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::time::sleep;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use uuid::Uuid;
 
-/// The evidence that must exist before X live comments may be built (plan "Required Evidence
-/// Before Build"). Surfaced to the UI/diagnostics so the gate is auditable rather than a
-/// silent assumption.
+use crate::live_chat::{
+    LiveChatEventType, LiveChatMessage, LiveChatProviderConnectionState, deliver_message,
+    live_chat_message_id, set_provider_and_emit,
+};
+use crate::state::AppState;
+use crate::streaming::StreamPlatform;
+
+const CHAT_STATUS_BASE_URL: &str = "https://api.twitter.com";
+const CHAT_ACCESS_URL: &str = "https://proxsee.pscp.tv/api/v2/accessChatPublic";
+const PERISCOPE_USER_AGENT: &str = "Twitter/m5";
+const CHAT_TOKEN_ATTEMPTS: usize = 10;
+const CHAT_TOKEN_RETRY_MS: u64 = 2_000;
+
+pub const X_NATIVE_COMMENTS_AVAILABLE: bool = true;
+
 pub const X_COMMENTS_EVIDENCE_CHECKLIST: &[&str] = &[
-    "Official public X API documentation for live video comments or chat.",
-    "Approved partner or API access with documented endpoints and allowed app behavior.",
-    "An approved native provider path testable with real X livestream comments.",
+    "Official X Livestream API documentation covers read-only live chat token handoff.",
+    "Approved X Livestream API access exists for source and broadcast lifecycle.",
+    "The connector uses only documented read endpoints and does not send X chat messages.",
 ];
 
-/// The X chat provider message, given whether an X account is connected. With an account the
-/// platform is streaming but comments are blocked on API access; without one it is the
-/// generic native-access notice (covers manual RTMP too).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XChatConfig {
+    pub broadcast_id: String,
+    pub media_key: String,
+    #[serde(default)]
+    pub target_id: Option<String>,
+    #[serde(default)]
+    pub status_base_url: Option<String>,
+    #[serde(default)]
+    pub access_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct XChatStatusResponse {
+    #[serde(default)]
+    chat_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct XChatAccessResponse {
+    #[serde(default)]
+    endpoint: Option<String>,
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    replay_endpoint: Option<String>,
+    #[serde(default)]
+    replay_access_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct XChatFrame {
+    kind: i64,
+    #[serde(default)]
+    payload: Option<String>,
+}
+
 pub fn x_chat_message(has_x_account: bool) -> &'static str {
-    if X_NATIVE_COMMENTS_AVAILABLE {
-        "X live comments are ready."
-    } else if has_x_account {
-        "X comments pending API access."
+    if has_x_account {
+        "X live chat can be read for native X broadcasts."
     } else {
-        "X comments require native X API access."
+        "Connect or configure X native live before reading X chat."
     }
 }
 
-/// An auditable readiness report for X live comments: the capability reporter + evidence gate
-/// surfaced over the `liveChat.xCommentsReadiness` command.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct XChatReadiness {
-    /// True only when a verified native path exists and is implemented (currently never).
     pub available: bool,
     pub message: String,
     pub evidence_checklist: Vec<String>,
@@ -60,36 +105,307 @@ pub fn x_chat_readiness(has_x_account: bool) -> XChatReadiness {
     }
 }
 
+pub async fn run_x_chat_connector(state: AppState, session_id: String, config: XChatConfig) {
+    set_provider_and_emit(
+        &state,
+        StreamPlatform::X,
+        LiveChatProviderConnectionState::Connecting,
+        "Connecting to X live chat.",
+    )
+    .await;
+
+    match run_x_chat_session(&state, &session_id, &config).await {
+        Ok(()) => {
+            set_provider_and_emit(
+                &state,
+                StreamPlatform::X,
+                LiveChatProviderConnectionState::Ended,
+                "X live chat ended.",
+            )
+            .await;
+        }
+        Err(error) => {
+            set_provider_and_emit(
+                &state,
+                StreamPlatform::X,
+                LiveChatProviderConnectionState::Failed,
+                &format!("X live chat failed: {error}"),
+            )
+            .await;
+        }
+    }
+}
+
+async fn run_x_chat_session(
+    state: &AppState,
+    session_id: &str,
+    config: &XChatConfig,
+) -> Result<()> {
+    let client = reqwest::Client::new();
+    let chat_token = fetch_chat_token_with_retry(&client, config).await?;
+    let access = access_chat(&client, config, &chat_token).await?;
+    let endpoint = access
+        .endpoint
+        .or(access.replay_endpoint)
+        .context("X chat access response did not include an endpoint.")?;
+    let access_token = access
+        .access_token
+        .or(access.replay_access_token)
+        .context("X chat access response did not include an access token.")?;
+    let ws_url = chat_ws_url(&endpoint)?;
+    let (mut ws, _response) = connect_async(&ws_url)
+        .await
+        .with_context(|| format!("Could not connect to X chat WebSocket {ws_url}"))?;
+
+    ws.send(Message::Text(x_auth_frame(&access_token).into()))
+        .await
+        .context("Could not authenticate X chat WebSocket.")?;
+    ws.send(Message::Text(
+        x_subscribe_frame(&config.broadcast_id).into(),
+    ))
+    .await
+    .context("Could not subscribe to X chat room.")?;
+
+    set_provider_and_emit(
+        state,
+        StreamPlatform::X,
+        LiveChatProviderConnectionState::Connected,
+        "X live chat connected.",
+    )
+    .await;
+
+    while let Some(message) = ws.next().await {
+        let message = message.context("X chat WebSocket read failed.")?;
+        let Message::Text(text) = message else {
+            continue;
+        };
+        if let Some(chat_message) =
+            parse_x_chat_message(&text, session_id, config.target_id.as_deref())
+        {
+            deliver_message(state, chat_message).await;
+        }
+    }
+
+    Ok(())
+}
+
+async fn fetch_chat_token_with_retry(
+    client: &reqwest::Client,
+    config: &XChatConfig,
+) -> Result<String> {
+    let mut last_error = None;
+    for attempt in 0..CHAT_TOKEN_ATTEMPTS {
+        match fetch_chat_token(client, config).await {
+            Ok(token) => return Ok(token),
+            Err(error) => last_error = Some(error),
+        }
+        if attempt + 1 < CHAT_TOKEN_ATTEMPTS {
+            sleep(Duration::from_millis(CHAT_TOKEN_RETRY_MS)).await;
+        }
+    }
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("X chat token was not available after publishing.")))
+}
+
+async fn fetch_chat_token(client: &reqwest::Client, config: &XChatConfig) -> Result<String> {
+    let base = config
+        .status_base_url
+        .as_deref()
+        .unwrap_or(CHAT_STATUS_BASE_URL)
+        .trim_end_matches('/');
+    let url = format!("{base}/1.1/live_video_stream/status/{}", config.media_key);
+    let response = client
+        .get(url)
+        .header("x-periscope-user-agent", PERISCOPE_USER_AGENT)
+        .send()
+        .await
+        .context("Could not fetch X chat token.")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        anyhow::bail!("X chat token request failed with HTTP {status}");
+    }
+    let body = response
+        .json::<XChatStatusResponse>()
+        .await
+        .context("Could not parse X chat token response.")?;
+    body.chat_token
+        .filter(|token| !token.trim().is_empty())
+        .context("X chat token is not available yet.")
+}
+
+async fn access_chat(
+    client: &reqwest::Client,
+    config: &XChatConfig,
+    chat_token: &str,
+) -> Result<XChatAccessResponse> {
+    let response = client
+        .post(config.access_url.as_deref().unwrap_or(CHAT_ACCESS_URL))
+        .header("content-type", "application/json")
+        .header("x-periscope-user-agent", PERISCOPE_USER_AGENT)
+        .header("x-idempotence", Uuid::new_v4().to_string())
+        .header("x-attempt", "1")
+        .json(&json!({ "chat_token": chat_token }))
+        .send()
+        .await
+        .context("Could not request X chat access.")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        anyhow::bail!("X chat access request failed with HTTP {status}");
+    }
+    response
+        .json::<XChatAccessResponse>()
+        .await
+        .context("Could not parse X chat access response.")
+}
+
+fn chat_ws_url(endpoint: &str) -> Result<String> {
+    let url = reqwest::Url::parse(endpoint).context("X chat endpoint URL is invalid.")?;
+    let host = url
+        .host_str()
+        .context("X chat endpoint URL did not include a host.")?;
+    Ok(format!("wss://{host}/chatapi/v1/chatnow"))
+}
+
+fn x_auth_frame(access_token: &str) -> String {
+    json!({
+        "kind": 3,
+        "payload": json!({ "access_token": access_token }).to_string()
+    })
+    .to_string()
+}
+
+fn x_subscribe_frame(broadcast_id: &str) -> String {
+    json!({
+        "kind": 2,
+        "payload": json!({
+            "kind": 1,
+            "payload": json!({ "room": broadcast_id }).to_string()
+        }).to_string()
+    })
+    .to_string()
+}
+
+fn parse_x_chat_message(
+    text: &str,
+    session_id: &str,
+    target_id: Option<&str>,
+) -> Option<LiveChatMessage> {
+    let frame: XChatFrame = serde_json::from_str(text).ok()?;
+    if frame.kind != 1 {
+        return None;
+    }
+    let payload = frame.payload?;
+    let payload: Value = serde_json::from_str(&payload).ok()?;
+    let body = payload
+        .get("body")
+        .and_then(|body| body.as_str())
+        .and_then(|body| serde_json::from_str::<Value>(body).ok())
+        .unwrap_or(payload);
+    let text = body
+        .get("body")
+        .or_else(|| body.get("text"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let username = body
+        .get("username")
+        .or_else(|| body.get("displayName"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("X viewer");
+    let provider_message_id = body
+        .get("uuid")
+        .or_else(|| body.get("id"))
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| {
+            format!(
+                "{}:{}:{}",
+                username,
+                body.get("timestamp")
+                    .map(Value::to_string)
+                    .unwrap_or_default(),
+                text
+            )
+        });
+    let now = chrono::Utc::now().to_rfc3339();
+    Some(LiveChatMessage {
+        id: live_chat_message_id(StreamPlatform::X, &provider_message_id),
+        provider_message_id,
+        platform: StreamPlatform::X,
+        target_id: target_id.map(ToOwned::to_owned),
+        session_id: session_id.to_string(),
+        author_id: body
+            .get("user_id")
+            .or_else(|| body.get("userId"))
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned),
+        author_name: username.to_string(),
+        author_avatar_url: None,
+        author_badges: Vec::new(),
+        author_roles: Vec::new(),
+        published_at: now.clone(),
+        received_at: now,
+        message_text: text.to_string(),
+        fragments: Vec::new(),
+        event_type: LiveChatEventType::Message,
+        amount_text: None,
+        is_deleted: false,
+        raw_provider_type: Some("x-chat".to_string()),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn x_native_comments_gate_stays_closed() {
-        // Guard / smoke placeholder: this MUST remain false until a verified native X
-        // comments path is approved. Flipping it without the evidence checklist would ship an
-        // unsupported (or faked) feature — exactly what the plan prohibits.
-        assert!(
-            !x_chat_readiness(true).available,
-            "X comments must stay gated until a verified native path exists"
-        );
-        assert_eq!(X_COMMENTS_EVIDENCE_CHECKLIST.len(), 3);
-    }
-
-    #[test]
-    fn message_reflects_account_and_gate() {
-        assert_eq!(
-            x_chat_message(false),
-            "X comments require native X API access."
-        );
-        assert_eq!(x_chat_message(true), "X comments pending API access.");
-    }
-
-    #[test]
-    fn readiness_is_unsupported_with_full_evidence_checklist() {
+    fn readiness_reports_available_read_only_path() {
         let readiness = x_chat_readiness(true);
-        assert!(!readiness.available);
-        assert_eq!(readiness.message, "X comments pending API access.");
+        assert!(readiness.available);
+        assert!(readiness.message.contains("read"));
         assert_eq!(readiness.evidence_checklist.len(), 3);
+    }
+
+    #[test]
+    fn websocket_url_uses_returned_host() {
+        assert_eq!(
+            chat_ws_url("https://prod-chat-ancillary-eu-central-1.pscp.tv").unwrap(),
+            "wss://prod-chat-ancillary-eu-central-1.pscp.tv/chatapi/v1/chatnow"
+        );
+    }
+
+    #[test]
+    fn frames_double_encode_payloads() {
+        let auth = x_auth_frame("access");
+        assert!(auth.contains(r#""kind":3"#));
+        assert!(auth.contains(r#"access_token"#));
+
+        let subscribe = x_subscribe_frame("broadcast-1");
+        assert!(subscribe.contains(r#""kind":2"#));
+        assert!(subscribe.contains("broadcast-1"));
+    }
+
+    #[test]
+    fn parses_double_json_chat_message() {
+        let body = json!({
+            "body": "hello from x",
+            "username": "viewer",
+            "uuid": "message-1"
+        });
+        let frame = json!({
+            "kind": 1,
+            "payload": json!({ "body": body.to_string() }).to_string()
+        });
+
+        let message = parse_x_chat_message(&frame.to_string(), "session-1", Some("x"))
+            .expect("message parsed");
+
+        assert_eq!(message.platform, StreamPlatform::X);
+        assert_eq!(message.provider_message_id, "message-1");
+        assert_eq!(message.author_name, "viewer");
+        assert_eq!(message.message_text, "hello from x");
+        assert_eq!(message.target_id.as_deref(), Some("x"));
     }
 }

--- a/crates/videorc-backend/src/x_live.rs
+++ b/crates/videorc-backend/src/x_live.rs
@@ -1,10 +1,27 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use anyhow::{Context, Result};
+use base64::Engine as _;
+use hmac::{Hmac, Mac};
+use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha1::Sha1;
+use tokio::time::sleep;
+use uuid::Uuid;
 
-use crate::streaming::{PlatformAccount, StreamPlatform};
+use crate::streaming::{
+    PlatformAccount, StreamMetadataDraft, StreamPlatform, stream_platform_label,
+};
 
-const X_PRODUCER_DOCS_URL: &str = "https://help.x.com/en/using-x/how-to-use-live-producer";
+type HmacSha1 = Hmac<Sha1>;
+
+const X_LIVESTREAM_DOCS_URL: &str = "https://github.com/xdevplatform/x-livestream-sample";
 const X_API_OVERVIEW_URL: &str = "https://docs.x.com/x-api/overview";
+const DEFAULT_API_BASE_URL: &str = "https://api.x.com";
+const DEFAULT_SOURCE_NAME: &str = "Videorc Primary Encoder";
+const DEFAULT_LOCALE: &str = "en";
+const DEFAULT_CHAT_OPTION: u8 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -21,9 +38,41 @@ pub struct XPrepareParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct XPublishParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    pub source_id: String,
+    pub region: String,
+    #[serde(default = "default_true")]
+    pub is_low_latency: bool,
+    #[serde(default)]
+    pub should_not_tweet: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_option: Option<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct XEndParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    pub broadcast_id: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum XNativeLiveCapabilityState {
-    PartnerApiRequired,
+    MissingCredentials,
+    Ready,
+    AccountMismatch,
+    ApiError,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -38,30 +87,287 @@ pub struct XNativeLiveCapability {
     pub account_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_source: Option<String>,
     pub message: String,
     pub evidence: Vec<String>,
     pub docs_url: String,
     pub api_overview_url: String,
 }
 
-pub fn x_native_live_capability(account: Option<&PlatformAccount>) -> XNativeLiveCapability {
-    XNativeLiveCapability {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparedXStreamSource {
+    pub platform: StreamPlatform,
+    pub account_id: String,
+    pub account_label: String,
+    pub source_id: String,
+    pub region: String,
+    pub server_url: String,
+    pub stream_key_secret_ref: String,
+    pub stream_key_present: bool,
+    pub redacted_url: String,
+    pub is_stream_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recommended_configuration: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compatibility_info: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct XPublishResult {
+    pub platform: StreamPlatform,
+    pub account_id: String,
+    pub source_id: String,
+    pub broadcast_id: String,
+    pub media_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media_id: Option<String>,
+    pub share_url: String,
+    pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tweet_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tweet_error: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct XEndResult {
+    pub platform: StreamPlatform,
+    pub account_id: String,
+    pub broadcast_id: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XLivestreamCredentials {
+    pub consumer_key: String,
+    pub consumer_secret: String,
+    pub access_token: String,
+    pub access_token_secret: String,
+    pub user_id: String,
+    pub account_label: Option<String>,
+    pub credential_source: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct XPrepareSourceRequest {
+    pub credentials: XLivestreamCredentials,
+    pub account: Option<PlatformAccount>,
+    pub source_name: String,
+    pub api_base_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct XPublishRequest {
+    pub credentials: XLivestreamCredentials,
+    pub source_id: String,
+    pub region: String,
+    pub metadata: StreamMetadataDraft,
+    pub is_low_latency: bool,
+    pub should_not_tweet: bool,
+    pub locale: String,
+    pub chat_option: u8,
+    pub api_base_url: Option<String>,
+    pub poll_attempts: usize,
+    pub poll_interval_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct XEndRequest {
+    pub credentials: XLivestreamCredentials,
+    pub broadcast_id: String,
+    pub api_base_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct XRegionResponse {
+    region: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct XSourceEnvelope {
+    source: XStreamSource,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct XSourcesEnvelope {
+    #[serde(default)]
+    sources: Vec<XStreamSource>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct XBroadcastEnvelope {
+    broadcast: XBroadcast,
+    #[serde(default)]
+    share_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct XStreamSource {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    rtmp_region: Option<String>,
+    #[serde(default)]
+    rtmps_url: Option<String>,
+    #[serde(default)]
+    rtmp_url: Option<String>,
+    #[serde(default)]
+    rtmp_stream_key: Option<String>,
+    #[serde(default)]
+    is_stream_active: bool,
+    #[serde(default)]
+    recommended_configuration: Option<serde_json::Value>,
+    #[serde(default)]
+    compatibility_info: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct XBroadcast {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    broadcast_id: Option<String>,
+    #[serde(default)]
+    media_key: Option<String>,
+    #[serde(default)]
+    media_id: Option<String>,
+    #[serde(default)]
+    share_url: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    tweet_id: Option<String>,
+    #[serde(default)]
+    tweet_error: Option<String>,
+}
+
+pub fn x_livestream_credentials_from_env() -> Result<Option<XLivestreamCredentials>> {
+    let consumer_key = optional_env_any(&["VIDEORC_X_OAUTH1_CONSUMER_KEY", "X_CONSUMER_KEY"]);
+    let consumer_secret =
+        optional_env_any(&["VIDEORC_X_OAUTH1_CONSUMER_SECRET", "X_CONSUMER_SECRET"]);
+    let access_token = optional_env_any(&["VIDEORC_X_OAUTH1_ACCESS_TOKEN", "X_ACCESS_TOKEN"]);
+    let access_token_secret = optional_env_any(&[
+        "VIDEORC_X_OAUTH1_ACCESS_TOKEN_SECRET",
+        "X_ACCESS_TOKEN_SECRET",
+    ]);
+
+    let present = [
+        consumer_key.is_some(),
+        consumer_secret.is_some(),
+        access_token.is_some(),
+        access_token_secret.is_some(),
+    ];
+    if present.iter().all(|value| !*value) {
+        return Ok(None);
+    }
+    if !present.iter().all(|value| *value) {
+        anyhow::bail!(
+            "X Livestream OAuth 1.0a credentials are incomplete. Set VIDEORC_X_OAUTH1_CONSUMER_KEY, VIDEORC_X_OAUTH1_CONSUMER_SECRET, VIDEORC_X_OAUTH1_ACCESS_TOKEN, and VIDEORC_X_OAUTH1_ACCESS_TOKEN_SECRET."
+        );
+    }
+
+    let access_token = access_token.expect("presence checked above");
+    let user_id = optional_env_any(&["VIDEORC_X_OAUTH1_USER_ID", "X_USER_ID"])
+        .or_else(|| access_token.split_once('-').map(|(prefix, _)| prefix.to_string()))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .context(
+            "X Livestream OAuth 1.0a user id is missing. Set VIDEORC_X_OAUTH1_USER_ID or use an access token whose prefix is the numeric X user id.",
+        )?;
+    if !user_id.chars().all(|character| character.is_ascii_digit()) {
+        anyhow::bail!("X Livestream user id must be numeric.");
+    }
+
+    Ok(Some(XLivestreamCredentials {
+        consumer_key: consumer_key.expect("presence checked above"),
+        consumer_secret: consumer_secret.expect("presence checked above"),
+        access_token,
+        access_token_secret: access_token_secret.expect("presence checked above"),
+        user_id,
+        account_label: optional_env_any(&["VIDEORC_X_ACCOUNT_LABEL", "X_ACCOUNT_LABEL"]),
+        credential_source: if std::env::var("VIDEORC_X_OAUTH1_CONSUMER_KEY").is_ok() {
+            "videorc-env".to_string()
+        } else {
+            "x-env".to_string()
+        },
+    }))
+}
+
+pub fn x_native_live_capability(
+    account: Option<&PlatformAccount>,
+) -> Result<XNativeLiveCapability> {
+    let credentials = x_livestream_credentials_from_env()?;
+    let Some(credentials) = credentials else {
+        return Ok(XNativeLiveCapability {
+            platform: StreamPlatform::X,
+            state: XNativeLiveCapabilityState::MissingCredentials,
+            native_available: false,
+            manual_rtmp_available: true,
+            oauth_connected: account.is_some(),
+            account_id: account.map(|account| account.account_id.clone()),
+            account_label: account.map(|account| account.account_label.clone()),
+            credential_source: None,
+            message: "X Livestream API access is approved, but OAuth 1.0a live credentials are not configured on this build.".to_string(),
+            evidence: vec![
+                "X Livestream management endpoints require OAuth 1.0a user-context credentials, not the existing OAuth2 PKCE token.".to_string(),
+                "Set the VIDEORC_X_OAUTH1_* environment variables in the release/smoke environment to enable native source and broadcast creation.".to_string(),
+                "Manual RTMP remains available only when the user explicitly chooses Manual RTMP.".to_string(),
+            ],
+            docs_url: X_LIVESTREAM_DOCS_URL.to_string(),
+            api_overview_url: X_API_OVERVIEW_URL.to_string(),
+        });
+    };
+
+    if let Some(account) = account
+        && account.account_id != credentials.user_id
+        && account.id != credentials.user_id
+    {
+        return Ok(XNativeLiveCapability {
+            platform: StreamPlatform::X,
+            state: XNativeLiveCapabilityState::AccountMismatch,
+            native_available: false,
+            manual_rtmp_available: true,
+            oauth_connected: true,
+            account_id: Some(account.account_id.clone()),
+            account_label: Some(account.account_label.clone()),
+            credential_source: Some(credentials.credential_source),
+            message: "Connected X account does not match the configured X Livestream OAuth 1.0a user id.".to_string(),
+            evidence: vec![
+                "X rejects Livestream requests when the OAuth 1.0a token user id differs from the :user_id path.".to_string(),
+                "Reconnect the matching X account or update the configured OAuth 1.0a credentials.".to_string(),
+            ],
+            docs_url: X_LIVESTREAM_DOCS_URL.to_string(),
+            api_overview_url: X_API_OVERVIEW_URL.to_string(),
+        });
+    }
+
+    Ok(XNativeLiveCapability {
         platform: StreamPlatform::X,
-        state: XNativeLiveCapabilityState::PartnerApiRequired,
-        native_available: false,
+        state: XNativeLiveCapabilityState::Ready,
+        native_available: true,
         manual_rtmp_available: true,
         oauth_connected: account.is_some(),
-        account_id: account.map(|account| account.account_id.clone()),
-        account_label: account.map(|account| account.account_label.clone()),
-        message: "X Media Studio Producer supports RTMP/HLS sources and broadcasts, but the public X API documentation does not expose a self-serve live-video source/broadcast creation endpoint. Native X livestream preparation requires the partner/API path before Videorc can create broadcasts or resolve ingest keys automatically. Switch the X destination to Manual RTMP with a Media Studio Producer stream key, or disable X to go live without it.".to_string(),
+        account_id: Some(credentials.user_id),
+        account_label: account
+            .map(|account| account.account_label.clone())
+            .or(credentials.account_label),
+        credential_source: Some(credentials.credential_source),
+        message: "X Livestream API credentials are configured. Videorc can prepare a native X source and publish broadcasts through the allow-listed API.".to_string(),
         evidence: vec![
-            "Media Studio Producer documents RTMP/HLS sources, broadcasts, titles, public/private audience, and encoder-provided RTMP URL/stream key.".to_string(),
-            "The current public X API index documents posts, users, spaces, media upload, and data streaming APIs, but not live-video broadcast/source creation endpoints.".to_string(),
-            "Manual RTMP must remain an explicit user-selected fallback until the native partner/API path is available.".to_string(),
+            "OAuth 1.0a consumer key, consumer secret, access token, and token secret are present.".to_string(),
+            "The numeric X user id is available for /2/users/:user_id source and broadcast paths.".to_string(),
+            "RTMPS source keys will be stored in the backend secret store and redacted from UI/logs.".to_string(),
         ],
-        docs_url: X_PRODUCER_DOCS_URL.to_string(),
+        docs_url: X_LIVESTREAM_DOCS_URL.to_string(),
         api_overview_url: X_API_OVERVIEW_URL.to_string(),
-    }
+    })
 }
 
 pub fn ensure_x_native_live_available(capability: &XNativeLiveCapability) -> Result<()> {
@@ -89,44 +395,657 @@ pub fn select_x_account<'a>(
     Ok(account)
 }
 
+pub async fn prepare_x_stream_source<F>(
+    request: XPrepareSourceRequest,
+    client: &reqwest::Client,
+    mut put_secret: F,
+) -> Result<PreparedXStreamSource>
+where
+    F: FnMut(&str, &str) -> Result<()>,
+{
+    let base_url = api_base_url(request.api_base_url.as_deref());
+    let credentials = request.credentials;
+    let region = match optional_env_any(&["VIDEORC_X_LIVESTREAM_REGION", "X_LIVESTREAM_REGION"]) {
+        Some(region) => region,
+        None => get_region(client, &credentials, &base_url).await?,
+    };
+    let source = if let Some(source_id) =
+        optional_env_any(&["VIDEORC_X_LIVESTREAM_SOURCE_ID", "X_LIVESTREAM_SOURCE_ID"])
+    {
+        get_source(client, &credentials, &base_url, &source_id).await?
+    } else {
+        let sources = list_sources(client, &credentials, &base_url)
+            .await
+            .unwrap_or_default();
+        if let Some(source) = sources.into_iter().find(|source| {
+            source.name.as_deref() == Some(request.source_name.as_str())
+                && source.rtmp_region.as_deref() == Some(region.as_str())
+        }) {
+            source
+        } else {
+            create_source(
+                client,
+                &credentials,
+                &base_url,
+                &request.source_name,
+                &region,
+            )
+            .await?
+        }
+    };
+
+    let source_id = source.id.trim().to_string();
+    if source_id.is_empty() {
+        anyhow::bail!("X stream source response did not include a source id.");
+    }
+    let server_url = source
+        .rtmps_url
+        .as_deref()
+        .or(source.rtmp_url.as_deref())
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .context("X stream source response did not include an RTMPS ingest URL.")?
+        .to_string();
+    let stream_key = source
+        .rtmp_stream_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .context("X stream source response did not include an RTMP stream key.")?
+        .to_string();
+    let region = source
+        .rtmp_region
+        .clone()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(region);
+    let secret_ref = format!(
+        "platform:x:{}:{}:stream-key",
+        credentials.user_id,
+        sanitize_secret_ref_segment(&source_id)
+    );
+    put_secret(&secret_ref, &stream_key).context("Could not store X RTMPS stream key.")?;
+
+    Ok(PreparedXStreamSource {
+        platform: StreamPlatform::X,
+        account_id: credentials.user_id.clone(),
+        account_label: request
+            .account
+            .map(|account| account.account_label)
+            .or(credentials.account_label)
+            .unwrap_or_else(|| stream_platform_label(StreamPlatform::X).to_string()),
+        source_id,
+        region,
+        server_url,
+        stream_key_secret_ref: secret_ref,
+        stream_key_present: true,
+        redacted_url: "rtmps://<x-ingest>/<stream-key>".to_string(),
+        is_stream_active: source.is_stream_active,
+        recommended_configuration: source.recommended_configuration,
+        compatibility_info: source.compatibility_info,
+    })
+}
+
+pub async fn publish_x_broadcast(
+    request: XPublishRequest,
+    client: &reqwest::Client,
+) -> Result<XPublishResult> {
+    let base_url = api_base_url(request.api_base_url.as_deref());
+    let attempts = request.poll_attempts.max(1);
+    let mut last_source = None;
+    for attempt in 0..attempts {
+        let source =
+            get_source(client, &request.credentials, &base_url, &request.source_id).await?;
+        let active = source.is_stream_active;
+        last_source = Some(source);
+        if active {
+            break;
+        }
+        if attempt + 1 < attempts {
+            sleep(Duration::from_millis(request.poll_interval_ms)).await;
+        }
+    }
+    if !last_source
+        .as_ref()
+        .is_some_and(|source| source.is_stream_active)
+    {
+        anyhow::bail!("X RTMPS source did not become active before publish.");
+    }
+
+    let created = create_broadcast(
+        client,
+        &request.credentials,
+        &base_url,
+        &request.source_id,
+        &request.region,
+        request.is_low_latency,
+    )
+    .await?;
+    let broadcast_id = created
+        .broadcast
+        .broadcast_id
+        .clone()
+        .or(created.broadcast.id.clone())
+        .context("X broadcast create response did not include a broadcast id.")?;
+    let media_key = created
+        .broadcast
+        .media_key
+        .clone()
+        .context("X broadcast create response did not include a media_key.")?;
+    let share_url = created
+        .share_url
+        .clone()
+        .or(created.broadcast.share_url.clone())
+        .unwrap_or_else(|| format!("https://x.com/i/broadcasts/{broadcast_id}"));
+    let title = x_title(&request.metadata);
+    let published = publish_broadcast(
+        client,
+        &request.credentials,
+        &base_url,
+        PublishBroadcastStateRequest {
+            broadcast_id: &broadcast_id,
+            title: &title,
+            should_not_tweet: request.should_not_tweet,
+            locale: &request.locale,
+            chat_option: request.chat_option,
+        },
+    )
+    .await?;
+
+    Ok(XPublishResult {
+        platform: StreamPlatform::X,
+        account_id: request.credentials.user_id,
+        source_id: request.source_id,
+        broadcast_id,
+        media_key,
+        media_id: created.broadcast.media_id,
+        share_url,
+        state: published
+            .broadcast
+            .state
+            .unwrap_or_else(|| "RUNNING".to_string()),
+        tweet_id: published.broadcast.tweet_id,
+        tweet_error: published.broadcast.tweet_error,
+        message: "X broadcast is live.".to_string(),
+    })
+}
+
+pub async fn end_x_broadcast(request: XEndRequest, client: &reqwest::Client) -> Result<XEndResult> {
+    let base_url = api_base_url(request.api_base_url.as_deref());
+    end_broadcast(
+        client,
+        &request.credentials,
+        &base_url,
+        &request.broadcast_id,
+    )
+    .await?;
+    Ok(XEndResult {
+        platform: StreamPlatform::X,
+        account_id: request.credentials.user_id,
+        broadcast_id: request.broadcast_id,
+        message: "X broadcast ended.".to_string(),
+    })
+}
+
+pub fn default_source_name() -> String {
+    optional_env_any(&[
+        "VIDEORC_X_LIVESTREAM_SOURCE_NAME",
+        "X_LIVESTREAM_SOURCE_NAME",
+    ])
+    .unwrap_or_else(|| DEFAULT_SOURCE_NAME.to_string())
+}
+
+pub fn default_publish_locale(value: Option<String>) -> String {
+    value
+        .and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .or_else(|| optional_env_any(&["VIDEORC_X_LIVESTREAM_LOCALE", "X_LIVESTREAM_LOCALE"]))
+        .unwrap_or_else(|| DEFAULT_LOCALE.to_string())
+}
+
+pub fn default_chat_option(value: Option<u8>) -> u8 {
+    value.unwrap_or_else(|| {
+        optional_env_any(&[
+            "VIDEORC_X_LIVESTREAM_CHAT_OPTION",
+            "X_LIVESTREAM_CHAT_OPTION",
+        ])
+        .and_then(|value| value.parse::<u8>().ok())
+        .unwrap_or(DEFAULT_CHAT_OPTION)
+    })
+}
+
+async fn get_region(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+) -> Result<String> {
+    let url = endpoint(base_url, "/2/region")?;
+    let response: XRegionResponse =
+        send_x_request(client, credentials, Method::GET, url, None).await?;
+    Ok(response.region)
+}
+
+async fn list_sources(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+) -> Result<Vec<XStreamSource>> {
+    let url = endpoint(
+        base_url,
+        &format!("/2/users/{}/sources", credentials.user_id),
+    )?;
+    let response: XSourcesEnvelope =
+        send_x_request(client, credentials, Method::GET, url, None).await?;
+    Ok(response.sources)
+}
+
+async fn create_source(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    name: &str,
+    region: &str,
+) -> Result<XStreamSource> {
+    let url = endpoint(
+        base_url,
+        &format!("/2/users/{}/sources", credentials.user_id),
+    )?;
+    let body = json!({ "name": name, "region": region });
+    let response: XSourceEnvelope =
+        send_x_request(client, credentials, Method::POST, url, Some(body)).await?;
+    Ok(response.source)
+}
+
+async fn get_source(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    source_id: &str,
+) -> Result<XStreamSource> {
+    let url = endpoint(
+        base_url,
+        &format!("/2/users/{}/sources/{}", credentials.user_id, source_id),
+    )?;
+    let response: XSourceEnvelope =
+        send_x_request(client, credentials, Method::GET, url, None).await?;
+    Ok(response.source)
+}
+
+async fn create_broadcast(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    source_id: &str,
+    region: &str,
+    is_low_latency: bool,
+) -> Result<XBroadcastEnvelope> {
+    let url = endpoint(
+        base_url,
+        &format!("/2/users/{}/broadcasts", credentials.user_id),
+    )?;
+    let body = json!({
+        "source_id": source_id,
+        "region": region,
+        "is_low_latency": is_low_latency,
+    });
+    send_x_request(client, credentials, Method::POST, url, Some(body)).await
+}
+
+struct PublishBroadcastStateRequest<'a> {
+    broadcast_id: &'a str,
+    title: &'a str,
+    should_not_tweet: bool,
+    locale: &'a str,
+    chat_option: u8,
+}
+
+async fn publish_broadcast(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    request: PublishBroadcastStateRequest<'_>,
+) -> Result<XBroadcastEnvelope> {
+    let url = endpoint(
+        base_url,
+        &format!(
+            "/2/users/{}/broadcasts/{}/state",
+            credentials.user_id, request.broadcast_id
+        ),
+    )?;
+    let body = json!({
+        "state": "PUBLISH",
+        "title": request.title,
+        "should_not_tweet": request.should_not_tweet,
+        "locale": request.locale,
+        "chat_option": request.chat_option,
+    });
+    send_x_request(client, credentials, Method::PUT, url, Some(body)).await
+}
+
+async fn end_broadcast(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    broadcast_id: &str,
+) -> Result<()> {
+    let url = endpoint(
+        base_url,
+        &format!(
+            "/2/users/{}/broadcasts/{}/state",
+            credentials.user_id, broadcast_id
+        ),
+    )?;
+    let body = json!({ "state": "END" });
+    let _: serde_json::Value =
+        send_x_request(client, credentials, Method::PUT, url, Some(body)).await?;
+    Ok(())
+}
+
+async fn send_x_request<T: serde::de::DeserializeOwned>(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    method: Method,
+    url: Url,
+    body: Option<serde_json::Value>,
+) -> Result<T> {
+    let authorization = oauth1_authorization_header(
+        method.as_str(),
+        url.as_str(),
+        credentials,
+        &oauth_nonce(),
+        oauth_timestamp(),
+    )?;
+    let mut request = client
+        .request(method, url)
+        .header("Authorization", authorization);
+    if let Some(body) = body {
+        request = request.json(&body);
+    }
+    let response = request
+        .send()
+        .await
+        .context("Could not call X Livestream API")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        let detail = x_error_detail(&body).unwrap_or_else(|| "no error detail".to_string());
+        anyhow::bail!("X Livestream API request failed with HTTP {status}: {detail}");
+    }
+    response
+        .json::<T>()
+        .await
+        .context("Could not parse X Livestream API response")
+}
+
+pub fn oauth1_authorization_header(
+    method: &str,
+    url: &str,
+    credentials: &XLivestreamCredentials,
+    nonce: &str,
+    timestamp: u64,
+) -> Result<String> {
+    let parsed = Url::parse(url).context("OAuth 1.0a request URL is invalid.")?;
+    let base_url = oauth_base_url(&parsed);
+    let mut params = vec![
+        (
+            "oauth_consumer_key".to_string(),
+            credentials.consumer_key.clone(),
+        ),
+        ("oauth_nonce".to_string(), nonce.to_string()),
+        (
+            "oauth_signature_method".to_string(),
+            "HMAC-SHA1".to_string(),
+        ),
+        ("oauth_timestamp".to_string(), timestamp.to_string()),
+        ("oauth_token".to_string(), credentials.access_token.clone()),
+        ("oauth_version".to_string(), "1.0".to_string()),
+    ];
+    for (key, value) in parsed.query_pairs() {
+        params.push((key.into_owned(), value.into_owned()));
+    }
+    let param_string = normalized_oauth_params(&params);
+    let base_string = format!(
+        "{}&{}&{}",
+        method.to_ascii_uppercase(),
+        oauth_percent_encode(&base_url),
+        oauth_percent_encode(&param_string)
+    );
+    let signing_key = format!(
+        "{}&{}",
+        oauth_percent_encode(&credentials.consumer_secret),
+        oauth_percent_encode(&credentials.access_token_secret)
+    );
+    let mut mac = HmacSha1::new_from_slice(signing_key.as_bytes())
+        .context("Could not initialize OAuth 1.0a signer.")?;
+    mac.update(base_string.as_bytes());
+    let signature = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+
+    let mut header_params = vec![
+        (
+            "oauth_consumer_key".to_string(),
+            credentials.consumer_key.clone(),
+        ),
+        ("oauth_nonce".to_string(), nonce.to_string()),
+        (
+            "oauth_signature_method".to_string(),
+            "HMAC-SHA1".to_string(),
+        ),
+        ("oauth_timestamp".to_string(), timestamp.to_string()),
+        ("oauth_token".to_string(), credentials.access_token.clone()),
+        ("oauth_version".to_string(), "1.0".to_string()),
+        ("oauth_signature".to_string(), signature),
+    ];
+    header_params.sort_by(|(left, _), (right, _)| left.cmp(right));
+    let header = header_params
+        .into_iter()
+        .map(|(key, value)| format!(r#"{key}="{}""#, oauth_percent_encode(&value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(format!("OAuth {header}"))
+}
+
+fn oauth_base_url(url: &Url) -> String {
+    let mut base = url.clone();
+    base.set_query(None);
+    base.set_fragment(None);
+    base.to_string()
+}
+
+fn normalized_oauth_params(params: &[(String, String)]) -> String {
+    let mut encoded = params
+        .iter()
+        .map(|(key, value)| (oauth_percent_encode(key), oauth_percent_encode(value)))
+        .collect::<Vec<_>>();
+    encoded.sort();
+    encoded
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+pub fn oauth_percent_encode(value: &str) -> String {
+    value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                vec![byte as char]
+            }
+            _ => {
+                let hex = format!("%{byte:02X}");
+                hex.chars().collect()
+            }
+        })
+        .collect()
+}
+
+fn oauth_nonce() -> String {
+    Uuid::new_v4().simple().to_string()
+}
+
+fn oauth_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn api_base_url(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| optional_env_any(&["VIDEORC_X_LIVESTREAM_API_BASE_URL"]))
+        .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string())
+}
+
+fn endpoint(base_url: &str, path: &str) -> Result<Url> {
+    let base = Url::parse(base_url).context("X Livestream API base URL is invalid.")?;
+    base.join(path)
+        .with_context(|| format!("Could not build X Livestream API URL for {path}."))
+}
+
+fn optional_env_any(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        std::env::var(name)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn sanitize_secret_ref_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn x_error_detail(body: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    if let Some(message) = value
+        .get("message")
+        .and_then(|message| message.as_str())
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+    {
+        return Some(message.to_string());
+    }
+    if let Some(errors) = value.get("errors").and_then(|errors| errors.as_array()) {
+        let joined = errors
+            .iter()
+            .filter_map(|error| {
+                error
+                    .get("message")
+                    .and_then(|message| message.as_str())
+                    .or_else(|| error.as_str())
+            })
+            .map(str::trim)
+            .filter(|message| !message.is_empty())
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        if !joined.is_empty() {
+            return Some(joined.join("; "));
+        }
+    }
+    value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn x_title(metadata: &StreamMetadataDraft) -> String {
+    metadata
+        .target_overrides
+        .iter()
+        .find(|target| target.platform == StreamPlatform::X && target.customize)
+        .and_then(|target| (!target.title.trim().is_empty()).then(|| target.title.trim()))
+        .or_else(|| (!metadata.title.trim().is_empty()).then(|| metadata.title.trim()))
+        .unwrap_or("Live from Videorc")
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::streaming::{PlatformAccountStatus, StreamPlatform};
+    use crate::streaming::PlatformAccountStatus;
+
+    fn credentials() -> XLivestreamCredentials {
+        XLivestreamCredentials {
+            consumer_key: "consumer".to_string(),
+            consumer_secret: "consumer secret".to_string(),
+            access_token: "12345-token".to_string(),
+            access_token_secret: "token secret".to_string(),
+            user_id: "12345".to_string(),
+            account_label: Some("Videorc".to_string()),
+            credential_source: "test".to_string(),
+        }
+    }
 
     #[test]
-    fn capability_reports_partner_api_gap_without_hiding_manual_rtmp() {
-        let account = PlatformAccount {
-            id: "x".to_string(),
-            platform: StreamPlatform::X,
-            account_id: "x-123".to_string(),
-            account_label: "Videorc".to_string(),
-            account_handle: Some("@videorc".to_string()),
-            avatar_url: None,
-            scopes: vec!["tweet.read".to_string(), "users.read".to_string()],
-            access_token_present: true,
-            refresh_token_present: true,
-            stream_key_present: false,
-            expires_at: None,
-            connected_at: "2026-06-03T00:00:00Z".to_string(),
-            updated_at: "2026-06-03T00:00:00Z".to_string(),
-            status: PlatformAccountStatus::Connected,
-        };
+    fn oauth_percent_encoding_is_strict_rfc3986() {
+        assert_eq!(
+            oauth_percent_encode("!*'() space+slash/tilde~"),
+            "%21%2A%27%28%29%20space%2Bslash%2Ftilde~"
+        );
+    }
 
-        let capability = x_native_live_capability(Some(&account));
+    #[test]
+    fn oauth_header_includes_query_params_but_never_json_body() {
+        let header = oauth1_authorization_header(
+            "POST",
+            "https://api.x.com/2/users/12345/sources?pagination_token=a b",
+            &credentials(),
+            "nonce",
+            1772031973,
+        )
+        .unwrap();
+
+        assert!(header.starts_with("OAuth "));
+        assert!(header.contains(r#"oauth_consumer_key="consumer""#));
+        assert!(header.contains(r#"oauth_token="12345-token""#));
+        assert!(header.contains("oauth_signature="));
+        assert!(!header.contains("pagination_token"));
+        assert!(!header.contains("source_id"));
+        assert!(!header.contains("consumer secret"));
+        assert!(!header.contains("token secret"));
+    }
+
+    #[test]
+    fn normalized_oauth_params_sort_encoded_key_value_pairs() {
+        let params = vec![
+            ("b".to_string(), "two".to_string()),
+            ("a".to_string(), "space value".to_string()),
+            ("a".to_string(), "punct!".to_string()),
+        ];
+
+        assert_eq!(
+            normalized_oauth_params(&params),
+            "a=punct%21&a=space%20value&b=two"
+        );
+    }
+
+    #[test]
+    fn capability_reports_missing_oauth1_credentials_without_hiding_manual_rtmp() {
+        let capability = x_native_live_capability(None).unwrap();
 
         assert_eq!(capability.platform, StreamPlatform::X);
         assert_eq!(
             capability.state,
-            XNativeLiveCapabilityState::PartnerApiRequired
+            XNativeLiveCapabilityState::MissingCredentials
         );
         assert!(!capability.native_available);
         assert!(capability.manual_rtmp_available);
-        assert!(capability.oauth_connected);
-        assert_eq!(capability.account_id.as_deref(), Some("x-123"));
-        assert!(capability.message.contains("partner/API path"));
-        assert!(capability.evidence.iter().any(|item| item.contains("RTMP")));
-        assert!(ensure_x_native_live_available(&capability).is_err());
+        assert!(capability.message.contains("OAuth 1.0a"));
     }
 
     #[test]

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -319,10 +319,13 @@ own feed/backend).
 
 Production builds should inject Videorc-owned OAuth client IDs at backend compile time. Development and self-hosted builds can override those IDs at runtime.
 
+YouTube OAuth is paused until Google approval completes. Keep YouTube available
+through Manual RTMP and do not require or bundle Google OAuth credentials for
+release candidates while this pause is active.
+
 Bundled production defaults:
 
 ```sh
-VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID=...
 VIDEORC_BUNDLED_TWITCH_CLIENT_ID=...
 VIDEORC_BUNDLED_X_CLIENT_ID=...
 pnpm package:backend
@@ -331,7 +334,6 @@ pnpm package:backend
 Runtime/self-host overrides:
 
 ```sh
-VIDEORC_YOUTUBE_CLIENT_ID=...
 VIDEORC_TWITCH_CLIENT_ID=...
 VIDEORC_X_CLIENT_ID=...
 ```
@@ -339,7 +341,6 @@ VIDEORC_X_CLIENT_ID=...
 Runtime values take precedence over bundled defaults. Client secrets, when used for provider flows, remain runtime-only:
 
 ```sh
-VIDEORC_YOUTUBE_CLIENT_SECRET=...
 VIDEORC_TWITCH_CLIENT_SECRET=...
 VIDEORC_X_CLIENT_SECRET=...
 ```
@@ -364,10 +365,9 @@ OAuth callback URLs (all providers):
 
 - The backend binds a dedicated loopback listener for OAuth callbacks on the first free
   port of `17995`, `27995`, `37995`. Register ALL THREE as callback URLs in each
-  provider's developer portal: `http://127.0.0.1:17995/oauth/callback`,
+  active OAuth provider's developer portal: `http://127.0.0.1:17995/oauth/callback`,
   `http://127.0.0.1:27995/oauth/callback`, `http://127.0.0.1:37995/oauth/callback`.
-  Exact-match providers (X, Twitch) reject anything else; Google accepts any loopback
-  port but registering the fixed set keeps one contract everywhere.
+  Exact-match providers (X, Twitch) reject anything else.
 - `videorc://oauth/callback` is a legacy escape hatch for X only
   (`VIDEORC_OAUTH_X_CALLBACK=app-protocol`). Do not use it by default: X auto-approves
   re-authorization without a user gesture, and browsers block gestureless custom-scheme
@@ -385,7 +385,7 @@ Twitch release blocker:
 - Verify the app requests the scopes used by the backend:
   `channel:manage:broadcast`, `channel:read:stream_key`, and `user:read:chat`.
 
-The backend exposes credential source status to the renderer as `environment`, `bundled`, or `missing`; it never exposes actual client ID or secret values. Before release, open the packaged app's Streaming tab and confirm YouTube, Twitch, and X OAuth rows report either `Bundled default` or the intended runtime override.
+The backend exposes credential source status to the renderer as `environment`, `bundled`, or `missing`; it never exposes actual client ID or secret values. Before release, open the packaged app's Streaming tab and confirm YouTube shows Manual RTMP with the Google approval pause message, while Twitch and X OAuth rows report either `Bundled default` or the intended runtime override.
 
 Before a release candidate, run the redacted provider readiness check:
 
@@ -394,8 +394,8 @@ pnpm smoke:provider-readiness
 pnpm smoke:provider-readiness:strict
 ```
 
-The strict run requires OAuth client IDs, Twitch's optional runtime client secret
-when using a confidential Twitch app, eligible YouTube/Twitch test accounts, and
+The strict run requires active-provider OAuth client IDs, Twitch's optional runtime client secret
+when using a confidential Twitch app, eligible Twitch test accounts, and
 validated X Livestream OAuth1/API access. See [OAuth Live Smoke Runbook](oauth-live-smoke.md)
 for the full external acceptance workflow.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -344,6 +344,22 @@ VIDEORC_TWITCH_CLIENT_SECRET=...
 VIDEORC_X_CLIENT_SECRET=...
 ```
 
+Native X Livestream source/broadcast management is not covered by the X OAuth2
+PKCE token. Release and smoke environments that enable first-class X live must
+also provide the backend-only OAuth 1.0a values:
+
+```sh
+VIDEORC_X_OAUTH1_CONSUMER_KEY=...
+VIDEORC_X_OAUTH1_CONSUMER_SECRET=...
+VIDEORC_X_OAUTH1_ACCESS_TOKEN=...
+VIDEORC_X_OAUTH1_ACCESS_TOKEN_SECRET=...
+VIDEORC_X_OAUTH1_USER_ID=...
+```
+
+These values are secrets except the numeric user id. They must remain runtime
+configuration, must not be bundled into the renderer, and must not appear in
+support bundles or logs.
+
 OAuth callback URLs (all providers):
 
 - The backend binds a dedicated loopback listener for OAuth callbacks on the first free
@@ -378,7 +394,10 @@ pnpm smoke:provider-readiness
 pnpm smoke:provider-readiness:strict
 ```
 
-The strict run requires OAuth client IDs, Twitch's runtime client secret, eligible YouTube/Twitch test accounts, and validated X native live partner/API access. See [OAuth Live Smoke Runbook](oauth-live-smoke.md) for the full external acceptance workflow.
+The strict run requires OAuth client IDs, Twitch's optional runtime client secret
+when using a confidential Twitch app, eligible YouTube/Twitch test accounts, and
+validated X Livestream OAuth1/API access. See [OAuth Live Smoke Runbook](oauth-live-smoke.md)
+for the full external acceptance workflow.
 
 ## Credential Storage
 
@@ -527,7 +546,7 @@ The release process must make source for the exact FFmpeg archive available besi
 - Confirm the packaged native preview smoke reports `previewTransport = native-surface`
   and `previewSurfaceBacking = cametal-layer`
 - Confirm Streaming tab OAuth credential source badges show bundled defaults or intended overrides
-- Complete the OAuth live smoke runbook for YouTube, Twitch, and X, or record X native access as release-blocking if partner/API access is not available
+- Complete the OAuth live smoke runbook for YouTube, Twitch, and X, or record X native live as release-blocking if OAuth1 credentials or allow-listed API access are not available
 - Confirm FFmpeg unavailable states are visible and non-crashing
 - Record a short MKV using the bundled FFmpeg path
 - Stop recording and confirm the session appears in Library

--- a/docs/live-chat-live-smoke-checklist.md
+++ b/docs/live-chat-live-smoke-checklist.md
@@ -20,14 +20,11 @@ drives the coordinator + fake connector end to end over the real websocket proto
       isolated spawned async tasks that only touch provider status + the bounded buffer, never
       the capture/encode path, so there should be no regression.
 
-## YouTube OAuth live smoke (requires a YouTube account + scheduled broadcast)
+## YouTube live chat (deferred until Google approval)
 
-- [ ] Connect a YouTube account (scope set includes `youtube.force-ssl`).
-- [ ] Go Live to YouTube; confirm the Live Chat panel shows YouTube `connected`.
-- [ ] Post messages from a second account; confirm they appear in the panel in order.
-- [ ] Post a Super Chat / membership; confirm it renders as a paid/membership row with amount.
-- [ ] Delete a message in YouTube Studio; confirm the panel reflects it.
-- [ ] Stop the session; confirm YouTube provider goes `ended` and connectors stop.
+- [ ] Confirm YouTube chat readiness reports the Google approval pause message.
+- [ ] Do not connect a YouTube OAuth account or run YouTube chat acceptance until Google approval completes.
+- [ ] Use Manual RTMP for YouTube stream acceptance in the meantime.
 
 ## Twitch OAuth live smoke (requires a Twitch account, reconnected for `user:read:chat`)
 
@@ -48,8 +45,9 @@ drives the coordinator + fake connector end to end over the real websocket proto
 
 ## Multistream + partial release
 
-- [ ] Go Live to YouTube + Twitch + X simultaneously; confirm a single unified panel shows
-      every available platform's state, YouTube/Twitch comments interleaved chronologically,
-      and X as `pending API access` (comments blocked) without blocking Go Live.
+- [ ] Go Live to YouTube Manual RTMP + Twitch + X simultaneously; confirm a single unified panel shows
+      every available platform's state, Twitch comments chronologically,
+      YouTube as paused for Google approval, and X as `pending API access`
+      (comments blocked) without blocking Go Live.
 - [ ] Confirm the streamer can read all comments from the in-app panel **without opening any
       platform dashboard**.

--- a/docs/oauth-live-smoke.md
+++ b/docs/oauth-live-smoke.md
@@ -6,13 +6,10 @@ This runbook is the release acceptance path for first-class OAuth/native livestr
 
 ## Provider Assumptions Checked 2026-07-07
 
-- **YouTube:** Live Streaming API requests must be authorized by the Google
-  account that owns the broadcasting channel. The channel must be verified,
-  free of live-streaming restrictions, and live streaming may take up to
-  24 hours to become available after first enablement. Videorc must keep
-  waiting for the bound stream to report active ingest before transitioning a
-  broadcast live, then transition the broadcast to complete when the session
-  ends.
+- **YouTube:** OAuth/native Live Streaming API support is paused while Videorc
+  awaits Google app approval. The product must expose YouTube as Manual RTMP
+  only, block stale YouTube OAuth settings with the approval message, and defer
+  native broadcast/channel acceptance until Google approval completes.
 - **Twitch:** The developer app must register the OAuth redirect URL(s), and
   broadcaster actions use user access tokens with scoped permissions. The
   existing Videorc scopes still map to the current docs:
@@ -79,8 +76,8 @@ pnpm smoke:provider-readiness:evidence
 Set the OAuth credentials in the environment used to launch the app or build the backend.
 
 OAuth uses the backend's dedicated loopback callback listener, bound to the first free
-port of `17995`, `27995`, `37995`. Register ALL THREE callback URLs in every provider's
-developer portal so one busy port cannot break OAuth:
+port of `17995`, `27995`, `37995`. Register ALL THREE callback URLs in every active
+OAuth provider's developer portal so one busy port cannot break OAuth:
 
 ```text
 http://127.0.0.1:17995/oauth/callback
@@ -98,9 +95,9 @@ http://localhost:27995/oauth/callback
 http://localhost:37995/oauth/callback
 ```
 
-Exact-match providers (X, Twitch) reject unregistered ports; Google accepts any
-loopback port. If all three candidates are busy the backend logs a warning and falls
-back to its dynamic main port (Google keeps working, X/Twitch will not).
+Exact-match providers (X, Twitch) reject unregistered ports. If all three
+candidates are busy the backend logs a warning and falls back to its dynamic
+main port, which is not accepted by those exact-match providers.
 
 After the fixed callback URLs are registered or otherwise verified for the
 release provider apps, set this smoke flag:
@@ -125,15 +122,9 @@ without a user gesture and browsers block gestureless custom-scheme navigation,
 leaving x.com's consent page on an infinite spinner while the app never receives the
 callback.
 
-YouTube:
-
-```sh
-VIDEORC_YOUTUBE_CLIENT_ID=...
-VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID=...
-VIDEORC_SMOKE_YOUTUBE_CHANNEL_READY=1
-```
-
-YouTube uses PKCE in Videorc, so `VIDEORC_YOUTUBE_CLIENT_SECRET` is optional. The test account must own or be able to select a verified Live-enabled channel.
+YouTube OAuth is intentionally disabled until Google approval completes. Do not
+set Google OAuth readiness flags for release acceptance. Use Manual RTMP with a
+YouTube stream key for YouTube smoke coverage.
 
 Twitch:
 
@@ -180,27 +171,24 @@ ingest, publish, end, and redacted-diagnostics behavior. If OAuth1 credentials
 are not configured, leave `VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY` unset and
 keep X OAuth/native blocked with explicit manual RTMP still available.
 
-## YouTube Acceptance
+## YouTube Manual RTMP Acceptance
 
-1. Launch the packaged release candidate with YouTube OAuth credentials.
-2. Open Streaming and connect YouTube through OAuth.
-3. Confirm the connected account identity appears and the credential source badge is `Bundled default` or the intended environment override.
-4. Select the intended YouTube channel or brand channel.
-5. Set global title and description. Use unlisted or private privacy for the test.
-6. Enable the YouTube OAuth destination.
+1. Launch the packaged release candidate without Google OAuth credentials.
+2. Open Streaming and expand YouTube.
+3. Confirm the auth mode is Manual RTMP and the OAuth pause message mentions Google approval.
+4. Paste a YouTube RTMP stream key and save it.
+5. Set global title and description in Videorc, then create/configure the YouTube live event in YouTube Studio.
+6. Enable the YouTube destination.
 7. Confirm Studio's primary button says `Start Livestream` or `Start Livestream + Record`.
 8. Click Start, review the Go Live confirmation, then confirm.
-9. Verify YouTube Studio shows the expected title, description, privacy, and fresh broadcast.
-10. Verify Videorc waits for active ingest before transitioning the broadcast live.
-11. Verify video and audio arrive on YouTube.
-12. Stop in Videorc and verify the YouTube broadcast transitions to complete.
+9. Verify video and audio arrive on the manually configured YouTube event.
+10. Stop in Videorc and end the event in YouTube Studio.
 
 Expected evidence:
 
-- YouTube OAuth account screenshot.
-- selected channel screenshot.
+- YouTube Manual RTMP auth-mode screenshot showing the Google approval pause message.
 - Go Live confirmation screenshot.
-- YouTube Studio screenshot showing matching metadata.
+- YouTube Studio screenshot for the manually configured event.
 - final platform URL or broadcast ID.
 
 ## Twitch Acceptance
@@ -266,7 +254,7 @@ If native access is not available:
 - Run context: dev/packaged
 - Provider readiness: pass/fail, redacted output attached
 - Provider readiness evidence: paste `pnpm smoke:provider-readiness:evidence` output
-- YouTube: pass/fail, channel, broadcast ID/URL, notes
+- YouTube Manual RTMP: pass/fail, channel, broadcast ID/URL, notes
 - Twitch: pass/fail, channel URL, notes
 - X: pass/fail/blocked, allow-list/OAuth1 evidence, broadcast URL, notes
 - Local smokes: pass/fail

--- a/docs/oauth-live-smoke.md
+++ b/docs/oauth-live-smoke.md
@@ -1,10 +1,10 @@
 # OAuth Live Smoke Runbook
 
-Last official-docs check: 2026-06-13.
+Last official-docs check: 2026-07-07.
 
 This runbook is the release acceptance path for first-class OAuth/native livestream destinations. It covers the external checks that local mocked smokes cannot prove: real OAuth login, platform metadata mutation, ingest readiness, and live start/stop behavior.
 
-## Provider Assumptions Checked 2026-06-13
+## Provider Assumptions Checked 2026-07-07
 
 - **YouTube:** Live Streaming API requests must be authorized by the Google
   account that owns the broadcasting channel. The channel must be verified,
@@ -20,12 +20,12 @@ This runbook is the release acceptance path for first-class OAuth/native livestr
   `channel:read:stream_key` for reading the stream key. Twitch still treats
   access tokens, refresh tokens, and client secrets as password-equivalent, so
   release evidence must never print their values.
-- **X:** The public X API overview still does not expose a self-serve
-  live-video source or broadcast creation endpoint. Media Studio Producer
-  remains the documented path for creating RTMP/HLS sources and broadcasts.
-  Therefore X native live stays blocked unless the release account has a
-  validated partner/API path; manual RTMP must remain explicit user choice, not
-  hidden fallback.
+- **X:** Videorc is allow-listed for the X Livestream API. Native source and
+  broadcast management requires backend OAuth 1.0a user-context credentials,
+  not the existing OAuth2 PKCE profile token. Videorc must prepare/reuse an X
+  RTMPS source, wait for `is_stream_active`, publish the broadcast, and end it
+  with a strict `{ "state": "END" }` body. Manual RTMP remains explicit user
+  choice, not a hidden fallback.
 
 ## Local Gates First
 
@@ -161,12 +161,24 @@ X:
 ```sh
 VIDEORC_X_CLIENT_ID=...
 VIDEORC_BUNDLED_X_CLIENT_ID=...
+VIDEORC_X_OAUTH1_CONSUMER_KEY=...
+VIDEORC_X_OAUTH1_CONSUMER_SECRET=...
+VIDEORC_X_OAUTH1_ACCESS_TOKEN=...
+VIDEORC_X_OAUTH1_ACCESS_TOKEN_SECRET=...
+VIDEORC_X_OAUTH1_USER_ID=...
+VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY=1
 VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS=1
 ```
 
 The X developer app must register the three fixed loopback callback URLs listed above
 (X matches redirect URIs exactly, port included). X uses PKCE in Videorc, so
-`VIDEORC_X_CLIENT_SECRET` is optional. The X native live check should only be marked ready when the release account has a validated partner/API path for native live source or broadcast creation. If that path is not available, leave the flag unset and keep X OAuth/native blocked in the app with explicit manual RTMP fallback.
+`VIDEORC_X_CLIENT_SECRET` is optional for the existing OAuth2 profile flow. Native
+X Livestream source/broadcast management is separate: it requires the backend
+OAuth 1.0a credential set above. The native live check should only be marked
+ready when the allow-listed app and broadcast account have validated source,
+ingest, publish, end, and redacted-diagnostics behavior. If OAuth1 credentials
+are not configured, leave `VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY` unset and
+keep X OAuth/native blocked with explicit manual RTMP still available.
 
 ## YouTube Acceptance
 
@@ -215,25 +227,31 @@ Expected evidence:
 
 ## X Acceptance
 
-Current public X docs show Media Studio Producer support for RTMP/HLS sources and broadcasts, while the public X API overview does not expose a clear self-serve live-video source or broadcast creation endpoint. Videorc must not silently treat OAuth/native X as ready by falling back to manual RTMP.
+X native live now uses the allow-listed Livestream API path. Videorc must not
+silently treat OAuth/native X failures as manual RTMP; the native destination
+either prepares/publishes through the API or fails with diagnostics.
 
-If native partner/API access is available:
+If native X Livestream API access is available:
 
-1. Record the partner/API path, required scopes, and account eligibility.
-2. Launch the packaged release candidate with X OAuth credentials.
-3. Connect X through OAuth.
-4. Confirm `streamTargets.x.capability` reports native live availability.
-5. Set title and description.
-6. Enable the X OAuth destination.
-7. Start through the Go Live confirmation.
-8. Verify the native X broadcast/source uses the expected metadata.
-9. Verify video and audio arrive on X.
-10. Stop in Videorc and verify the X broadcast/source ends where supported.
+1. Record that the X app is allow-listed and the account can broadcast.
+2. Launch the packaged release candidate with the redacted `VIDEORC_X_OAUTH1_*`
+   values available to the backend.
+3. Confirm `streamTargets.x.capability` reports `ready`.
+4. Set title and description.
+5. Enable the X OAuth/native destination.
+6. Start through the Go Live confirmation.
+7. Verify Videorc prepares/reuses an X RTMPS source.
+8. Verify X reports `is_stream_active` before broadcast creation.
+9. Verify broadcast create and publish succeed, and the share URL opens.
+10. Verify video and audio arrive on X.
+11. Verify read-only X chat connects when chat is enabled and messages exist.
+12. Stop in Videorc and verify X receives a strict END request and reports ended.
 
 If native access is not available:
 
 1. Leave `VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS` unset.
-2. Verify X OAuth/native readiness remains blocked with the partner/API explanation.
+2. Verify X OAuth/native readiness remains blocked with the X Livestream API
+   credential/access explanation.
 3. Verify manual RTMP is still available only when explicitly selected by the user.
 4. Record the release as externally blocked for first-class X native live.
 
@@ -250,7 +268,7 @@ If native access is not available:
 - Provider readiness evidence: paste `pnpm smoke:provider-readiness:evidence` output
 - YouTube: pass/fail, channel, broadcast ID/URL, notes
 - Twitch: pass/fail, channel URL, notes
-- X: pass/fail/blocked, partner/API evidence, notes
+- X: pass/fail/blocked, allow-list/OAuth1 evidence, broadcast URL, notes
 - Local smokes: pass/fail
 - Screenshots/logs:
 ```

--- a/docs/releases/release-runbook.md
+++ b/docs/releases/release-runbook.md
@@ -10,10 +10,10 @@ repeatable per-release process. For one-time signing setup see
 Two artifact sets in the same private R2 bucket (`videorc-releases`), fronted by
 videorc-web:
 
-| Artifacts | R2 keys | Web route | Audience |
-| --- | --- | --- | --- |
-| **Download** (dmg + sha256 + release.json) | `releases/macos/<releaseId>/` | `/api/downloads/macos/latest` (auth-gated, presigned) | New users |
-| **Update feed** (`latest-mac.yml` + `.zip` + `.zip.blockmap`) | `updates/macos/` (stable, overwritten each release) | `/api/updates/*` (public, presigned) | Existing users auto-updating |
+| Artifacts                                                     | R2 keys                                             | Web route                                             | Audience                     |
+| ------------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- | ---------------------------- |
+| **Download** (dmg + sha256 + release.json)                    | `releases/macos/<releaseId>/`                       | `/api/downloads/macos/latest` (auth-gated, presigned) | New users                    |
+| **Update feed** (`latest-mac.yml` + `.zip` + `.zip.blockmap`) | `updates/macos/` (stable, overwritten each release) | `/api/updates/*` (public, presigned)                  | Existing users auto-updating |
 
 The desktop **Settings → About & updates** button — and the automatic launch
 check (default in packaged builds since 0.9.10; opt out via
@@ -40,12 +40,10 @@ check (default in packaged builds since 0.9.10; opt out via
 - **R2 write creds** — the `VIDEORC_DOWNLOAD_S3_*` values (same bucket as
   videorc-web), with an **Object Read & Write** token. They live in the web app's
   `.env` (`~/projects/videorcweb/.env`).
-- **YouTube OAuth secret** — `VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET` must be in
-  the build env (it lives in `~/.videorc-release.env`). The secret left source
-  when the repo went public; `option_env!` compiles it into `videorc-backend`,
-  and `release:validate:macos` **fails closed** if the built binary lacks the
-  exact build-time secret from the release environment. Without it, YouTube
-  connect in the shipped app reports a missing client secret.
+- **YouTube OAuth paused** — do not require or bundle Google OAuth credentials
+  while Videorc awaits Google approval. YouTube remains available through Manual
+  RTMP, and `release:validate:macos` does not check for a bundled YouTube OAuth
+  secret while this pause is active.
 - **⚠️ Bucket-less S3 endpoint** — `VIDEORC_DOWNLOAD_S3_ENDPOINT_URL` must be the
   ACCOUNT host only: `https://<account-id>.r2.cloudflarestorage.com` — **NOT**
   `.../videorc-releases`. The path-style client appends the bucket itself; an
@@ -140,9 +138,9 @@ release candidate:
   1. `pnpm smoke:screen-recording-real`
   2. `pnpm smoke:notes-window-invisible`
   3. `pnpm smoke:recording-studio:devices`
-  If the motion-stimulus signature fails, fix stimulus placement on the
-  SELECTED display (`VIDEORC_SCREEN_MOTION_*`) — never loosen the
-  signature assertion.
+     If the motion-stimulus signature fails, fix stimulus placement on the
+     SELECTED display (`VIDEORC_SCREEN_MOTION_*`) — never loosen the
+     signature assertion.
 - **Provider live readiness, strict**: with the smoke-only provider
   credentials from [../oauth-live-smoke.md](../oauth-live-smoke.md) in the
   environment, run readiness with `VIDEORC_SMOKE_REQUIRE_PROVIDER_READY=1`
@@ -169,8 +167,8 @@ ever changes again, update `publish.url`, `videorc-web-links.ts`, and the Rust
 ## Gotchas (hard-won)
 
 - **Bucket-less endpoint** (above) — the #1 silent failure: a doubled key uploads
-  "successfully" but the feed/download then 404. Verify by *following the
-  redirect* to R2, not just checking the route returns a 302.
+  "successfully" but the feed/download then 404. Verify by _following the
+  redirect_ to R2, not just checking the route returns a 302.
 - **Never cache the presigned redirect** — `/api/updates/*` 302s to a ~15-min
   presigned URL and is intentionally cached `max-age=60`. Do not restore a long /
   `immutable` cache, or the CDN serves an expired redirect (403). (videorc-web

--- a/plans/028-x-livestream-api-integration.md
+++ b/plans/028-x-livestream-api-integration.md
@@ -1,0 +1,770 @@
+# Plan 028: Add native X Livestream API integration
+
+> **Executor instructions**: Treat this as the replacement for the old
+> "partner API required" X blocker. The product goal is first-class native X
+> livestreaming, not a nicer manual RTMP shortcut. Do not silently fall back to
+> manual RTMP when the user chooses X OAuth/native. Keep manual RTMP available
+> as an explicit destination mode only.
+>
+> **Source material**: `/Users/orcdev/Downloads/X_Livestream_API_-_Developer_Documentation.pdf`
+> was reviewed on 2026-07-07. The user confirmed Videorc is officially cleared
+> for X API access, so the old assumption in Plan 015 and `x_live.rs` is now
+> stale.
+>
+> **Drift check (run first)**: `git status --short --branch`; inspect
+> `crates/videorc-backend/src/x_live.rs`,
+> `crates/videorc-backend/src/oauth.rs`,
+> `crates/videorc-backend/src/x_chat.rs`,
+> `crates/videorc-backend/src/live_chat.rs`,
+> `apps/desktop/src/shared/backend.ts`,
+> `apps/desktop/src/renderer/src/hooks/use-studio.tsx`,
+> `apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx`,
+> `scripts/smoke-oauth-guards-app.mjs`,
+> `scripts/lib/provider-readiness.mjs`, `docs/oauth-live-smoke.md`, and
+> `docs/distribution.md`. If these paths moved after `bf3954dd`, remap the
+> equivalent code before editing.
+
+## Status
+
+- **Priority**: P1 - X was previously blocked by missing native API access; that
+  blocker is now gone.
+- **Effort**: L.
+- **Risk**: HIGH - provider lifecycle, OAuth 1.0a signing, stream start/stop
+  orchestration, secret handling, and live-account acceptance all change.
+- **Depends on**: Plans 009, 015, 018, and existing recording/studio streaming
+  lifecycle.
+- **Category**: provider integration, OAuth, livestream lifecycle, live chat,
+  diagnostics.
+- **Planned at**: commit `bf3954dd`, 2026-07-07.
+- **Execution**: IN PROGRESS on branch `codex/x-livestream-api` as of
+  2026-07-07. Native source/broadcast lifecycle, read-only chat connector,
+  renderer go-live/end wiring, docs, provider readiness, and OAuth guard smokes
+  are implemented. Pending: real allow-listed X account acceptance and the
+  unrelated 100-cycle preview lifecycle gate failure observed locally.
+
+## Why this matters
+
+Videorc currently tells users that native X livestreaming is blocked on partner
+API access. That was honest when written, but it is now wrong. We have official
+access and a private X Livestream API document with source, broadcast, publish,
+end, and read-only chat flows.
+
+The implementation should make X feel like YouTube and Twitch: connect an
+account, enable the X destination, review the go-live confirmation, start the
+stream, get a share URL, see status/viewer diagnostics, and end cleanly. Manual
+RTMP stays available for users who choose it, but it must not be the hidden
+fallback for failed native setup.
+
+## API contract from the PDF
+
+The Livestream management API uses `https://api.x.com` for most endpoints.
+Chat token handoff uses legacy `https://api.twitter.com` and
+`https://proxsee.pscp.tv`.
+
+### Authentication
+
+- Every Livestream management endpoint requires OAuth 1.0a, 3-legged user
+  context, HMAC-SHA1.
+- OAuth 2.0 Bearer tokens are explicitly not accepted for these endpoints.
+- Required values are the consumer key, consumer secret, access token, and
+  access token secret for the broadcasting account.
+- The application must be allow-listed for Livestream API and have Read + Write
+  or ReadWriteDm access.
+- The numeric X user id from the OAuth 1.0a token must match `:user_id` in every
+  path. A mismatch returns HTTP 400.
+- `GET /2/users/me` with the same OAuth 1.0a credentials can provide the
+  numeric user id. The token prefix before `-` is also the numeric id, but use a
+  verified profile call when possible.
+- The OAuth signature base string includes OAuth params and query params, but
+  never JSON body fields.
+- Strict RFC 3986 percent encoding is required. Escape `! * ' ( )` and encode
+  spaces as `%20`, not `+`.
+
+### Regions and sources
+
+- `GET /2/region` returns HTTP 307 to a region recommendation host. Sign the
+  initial request; the redirected host does not need the OAuth header.
+- `POST /2/users/:user_id/sources` creates a persistent stream source with:
+
+```json
+{
+  "name": "Videorc Primary Encoder",
+  "region": "eu-central-1"
+}
+```
+
+- A stream source returns `id`, `rtmps_url`, `rtmp_url`, `rtmp_stream_key`,
+  `rtmp_region`, `recommended_configuration`, `is_stream_active`,
+  `stream_attributes`, and `compatibility_info`.
+- Use `rtmps_url` in production. Do not derive or hardcode ingest hostnames from
+  region names.
+- `rtmp_stream_key == id`.
+- Reuse sources across broadcasts. One source per account/region/encoder setup
+  is the default model.
+- `owner_id` is returned as a JSON number and can be precision-unsafe. Do not
+  rely on it; keep our authenticated numeric user id as a string.
+
+### Broadcast lifecycle
+
+- `POST /2/users/:user_id/broadcasts` creates a broadcast bound to an active
+  source:
+
+```json
+{
+  "source_id": "6ep48v6ar5q4",
+  "region": "eu-central-1",
+  "is_low_latency": true
+}
+```
+
+- The selected source must already be receiving RTMP/RTMPS and have
+  `is_stream_active: true` before creating a broadcast. Otherwise X returns a
+  generic 404.
+- The broadcast starts as `NOT_STARTED`.
+- Important returned fields:
+  - `id` / `broadcast_id` - broadcast room and API id.
+  - `media_key` - required for chat token access.
+  - `media_id` - media id.
+  - `share_url` - public viewer link.
+  - `twitter_user_id` - numeric X user id as a string.
+  - `state` - lifecycle state.
+  - `video_access` - HLS playback URLs.
+- Publish uses `PUT /2/users/:user_id/broadcasts/:broadcast_id/state`:
+
+```json
+{
+  "state": "PUBLISH",
+  "title": "Live from Videorc",
+  "should_not_tweet": false,
+  "locale": "en",
+  "chat_option": 2
+}
+```
+
+- `chat_option` values:
+  - `0` none/no option set
+  - `1` disabled
+  - `2` everyone
+  - `3` verified accounts
+  - `4` accounts the broadcaster follows
+  - `5` subscribers
+- If omitted, X has been observed to default chat to verified accounts.
+- `tweet_id` is usually not in the publish response. Re-fetch the broadcast.
+- `tweet_error` may be absent; empty means post success, non-empty means the
+  announcement post failed but the broadcast can still be live.
+- End uses the same state endpoint, but the body must be exactly:
+
+```json
+{ "state": "END" }
+```
+
+- Do not include title, locale, `should_not_tweet`, or `chat_option` in the END
+  body. X rejects extra fields with HTTP 400.
+
+### Live chat
+
+X chat in this API is read-only.
+
+1. After publish, fetch a chat token:
+
+```txt
+GET https://api.twitter.com/1.1/live_video_stream/status/{mediaKey}
+x-periscope-user-agent: Twitter/m5
+```
+
+2. Exchange it for chat access:
+
+```txt
+POST https://proxsee.pscp.tv/api/v2/accessChatPublic
+content-type: application/json
+x-periscope-user-agent: Twitter/m5
+x-idempotence: <nonce-or-timestamp>
+x-attempt: 1
+```
+
+```json
+{ "chat_token": "<chatToken>" }
+```
+
+3. Convert the returned endpoint to:
+
+```txt
+wss://<returned-host>/chatapi/v1/chatnow
+```
+
+4. Send a kind `3` auth frame with the returned access token, then a kind `2`
+   subscribe frame for room `broadcast_id`. Incoming kind `1` frames contain
+   double-JSON-encoded chat messages.
+
+## Current repo state to replace
+
+- `crates/videorc-backend/src/x_live.rs` has one state,
+  `partner-api-required`, always returns `native_available: false`, and tells
+  users to switch to manual RTMP.
+- `streamTargets.x.prepare` only checks that negative capability and returns
+  `x-native-live-unavailable`.
+- `apps/desktop/src/shared/backend.ts` mirrors the single
+  `partner-api-required` state.
+- `apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx` renders a
+  `Partner API required` badge and manual RTMP helper copy.
+- `apps/desktop/src/renderer/src/hooks/use-studio.tsx` prepares YouTube and
+  Twitch native targets, but X currently only calls the blocker command.
+- `crates/videorc-backend/src/oauth.rs` uses OAuth 2.0/PKCE for X account
+  connection. That is still useful for profile/login surfaces, but it is not
+  sufficient for Livestream management.
+- `crates/videorc-backend/src/x_chat.rs` and `live_chat.rs` intentionally keep
+  X comments unsupported pending verified API access. The PDF now supplies the
+  read-only chat path, so this gate can be replaced by a real connector.
+- `scripts/smoke-oauth-guards-app.mjs`, `scripts/lib/provider-readiness.mjs`,
+  `docs/oauth-live-smoke.md`, and `docs/distribution.md` encode the old
+  "partner/API access" readiness flag and must be updated.
+
+## Product rule
+
+Native X means Videorc owns the full source and broadcast lifecycle:
+
+1. Select an X account with valid OAuth 1.0a Livestream credentials.
+2. Ensure/reuse an X stream source.
+3. Start Videorc's encoder/fan-out to the returned `rtmps_url` and
+   `rtmp_stream_key`.
+4. Poll X source status until `is_stream_active`.
+5. Create the broadcast.
+6. Publish it.
+7. Poll while live.
+8. End it with a strict END request.
+9. Preserve a redacted diagnostic trail.
+
+If any native step fails, the native X destination should fail with a clear
+runtime status. It should not mutate into manual RTMP.
+
+## Target architecture
+
+### Backend modules
+
+Add or evolve backend modules around these responsibilities:
+
+- `x_oauth1.rs` or an `oauth::oauth1` submodule:
+  - strict percent encoding
+  - normalized query/OAuth param collection
+  - HMAC-SHA1 signature generation
+  - Authorization header assembly
+  - fixtures for query params, JSON body exclusion, and special characters
+- `x_livestream.rs` or expanded `x_live.rs`:
+  - typed request/response models
+  - Livestream client with injectable base URLs and `reqwest::Client`
+  - source CRUD
+  - region lookup with 307 handling
+  - broadcast create/get/list/publish/end/delete
+  - error classification for 400/401/403/404/412/429/5xx
+  - redaction-safe diagnostics
+- `x_chat.rs`:
+  - replace the static unsupported gate with the documented read-only connector
+  - chat token fetch
+  - `accessChatPublic` exchange
+  - WebSocket auth/subscribe frames
+  - double-JSON message parser
+
+The backend already has `reqwest`, `base64`, `tokio-tungstenite`, and secret
+refs. Add the smallest Rust crypto dependency set needed for OAuth 1.0a
+HMAC-SHA1, for example `hmac` plus `sha1`, unless the executor finds an
+approved existing helper already present.
+
+### Secret and account model
+
+Do not reuse the X OAuth2 access token as if it were valid for Livestream API.
+The management API needs an OAuth 1.0a token secret.
+
+Add an explicit X Livestream credential path:
+
+- consumer key
+- consumer secret
+- OAuth 1.0a access token
+- OAuth 1.0a access token secret
+- numeric X user id
+- account label/handle/avatar, if available
+- credential source: bundled/env/imported/connect-flow, redacted
+
+Recommended first production slice:
+
+- support environment/imported OAuth 1.0a credentials for the allow-listed X
+  app/account to unblock API validation
+- store access token and token secret through the existing secure secret
+  backend, not in SQLite/plain renderer state
+- expose only booleans, account labels, and redacted evidence to the renderer
+
+Then add a polished OAuth 1.0a connect flow if X allows our desktop app to
+obtain user token secrets directly in a user-friendly way. If X's current
+developer portal makes OAuth 1.0a desktop login awkward, keep the initial
+import/admin path explicit and labeled for release operations.
+
+Secret refs must be deleted on disconnect. Support bundles, logs, errors, and
+diagnostics must redact:
+
+- consumer secret
+- access token
+- token secret
+- RTMP stream key
+- signed OAuth Authorization header
+- chat token
+- chat access token
+
+### Data model
+
+Add typed internal models for:
+
+- X Livestream account readiness:
+  - `missing-credentials`
+  - `oauth1-ready`
+  - `account-not-live-eligible`
+  - `api-denied`
+  - `rate-limited`
+  - `api-error`
+- X source:
+  - `source_id`
+  - `name`
+  - `region`
+  - `rtmps_url`
+  - `rtmp_stream_key_secret_ref`
+  - `is_stream_active`
+  - `recommended_configuration`
+  - `compatibility_info`
+  - `last_checked_at`
+- X prepared broadcast:
+  - `broadcast_id`
+  - `media_key`
+  - `share_url`
+  - `state`
+  - `tweet_id`
+  - `tweet_error`
+  - `chat_option`
+  - `is_low_latency`
+  - `created_at_ms`
+  - `started_at_ms`
+  - `ended_at_ms`
+
+Persist only what must survive app restarts. Keep stream keys and tokens in
+secret storage. IDs are strings. Do not deserialize precision-risk IDs as JS
+numbers.
+
+## Go-live lifecycle
+
+Videorc's current OAuth preparation model prepares YouTube/Twitch before
+`session.start`. X needs a two-phase lifecycle because X requires active RTMPS
+ingest before broadcast creation.
+
+Implement this shape:
+
+1. `streamTargets.x.capability`
+   - verifies account and OAuth 1.0a credential readiness
+   - optionally calls `/2/users/me` and `/2/region`
+   - reports source availability and redacted evidence
+2. `streamTargets.x.prepareSource`
+   - selects/reuses an X source or creates one for the recommended region
+   - returns `serverUrl: rtmps_url` and `streamKeySecretRef`
+   - patches the X stream target to a ready-to-encode RTMPS destination
+3. `session.start`
+   - starts the existing encoder/fan-out to every ready target, including the X
+     RTMPS source
+4. `streamTargets.x.waitForIngestAndPublish`
+   - polls `GET /sources/:source_id` until `is_stream_active` or timeout
+   - creates broadcast
+   - publishes broadcast with title, locale, chat option, and tweet toggle
+   - patches runtime target status with `broadcast_id`, `media_key`, and
+     `share_url`
+5. while live
+   - poll `GET /broadcasts/:broadcast_id`
+   - surface state, viewer counts, `tweet_id`, `tweet_error`, and compatibility
+     warnings
+   - start X chat read connector once `media_key` is live
+6. stop
+   - call strict END for running/not-started X broadcasts as part of stop
+     orchestration
+   - do not include publish-only fields in the END body
+   - treat 2xx as success without relying on a body shape
+   - if the encoder already stopped, still call END best-effort and report the
+     result in diagnostics
+7. recovery
+   - on app startup or next provider refresh, detect owned RUNNING broadcasts
+     from the last session and offer/attempt cleanup rather than leaving hidden
+     live broadcasts
+
+The executor should choose the exact command names after inspecting the current
+go-live state machine. The important boundary is that source preparation happens
+before encoder start, while broadcast create/publish happens after ingest is
+active.
+
+## Streaming UI
+
+Keep this inside the existing dense Videorc command-surface design:
+
+- Replace the `Partner API required` badge with states like `X API ready`,
+  `Credentials needed`, `Live access denied`, `Waiting for ingest`, and `Live`.
+- Remove old copy that says the public X API lacks source/broadcast endpoints.
+- Keep `Switch to Manual RTMP` only as an explicit user action, not as the
+  explanation for native readiness failure.
+- Add X destination settings where useful:
+  - X account
+  - source mode: auto/reuse selected source/create new
+  - source region: auto recommended by `/2/region`, with advanced override only
+    if needed
+  - low latency toggle
+  - announcement post toggle (`should_not_tweet`)
+  - chat participation option
+  - locale
+- Map stream metadata:
+  - title -> X publish `title`
+  - X visibility/privacy -> currently only publish/tweet/chat semantics; do not
+    pretend X has YouTube-style private/unlisted if the API does not support it
+  - description is not a broadcast body field unless X later documents one
+- Go Live confirmation should show X preparation stages:
+  - source ready
+  - ingest waiting
+  - broadcast created
+  - published
+  - share URL
+- Runtime rows should show failures per destination and leave other streaming
+  legs running.
+
+Use existing shadcn/ui components and Phosphor icons. No large hero panels, no
+nested cards, no decorative color wash.
+
+## Diagnostics and support bundle
+
+Add a redacted X lifecycle evidence block:
+
+```json
+{
+  "platform": "x",
+  "accountId": "172483972",
+  "credentialSource": "env",
+  "sourceId": "6ep48v6ar5q4",
+  "sourceRegion": "eu-central-1",
+  "sourceActive": true,
+  "broadcastId": "1AxRnanzLOrxl",
+  "mediaKeyPresent": true,
+  "shareUrl": "https://x.com/i/broadcasts/1AxRnanzLOrxl",
+  "state": "RUNNING",
+  "lastApiStatus": 200,
+  "tweetIdPresent": true,
+  "tweetError": null,
+  "compatibilityWarnings": [],
+  "redactions": [
+    "oauth1-consumer-secret",
+    "oauth1-access-token",
+    "oauth1-token-secret",
+    "rtmp-stream-key",
+    "chat-token"
+  ]
+}
+```
+
+No raw secrets, keys, OAuth headers, chat tokens, or signed URLs beyond public
+viewer/share URLs.
+
+Recommended runtime status labels:
+
+- `checking-credentials`
+- `source-ready`
+- `waiting-for-ingest`
+- `broadcast-created`
+- `publishing`
+- `live`
+- `tweet-warning`
+- `compatibility-warning`
+- `ending`
+- `ended`
+- `failed`
+
+## Slices
+
+### S0 - Refresh docs and assumptions
+
+Update Plan 015 references, `docs/oauth-live-smoke.md`, and `docs/distribution.md`
+to say X native live is now an allow-listed API path requiring OAuth 1.0a
+credentials. Do not commit the PDF. Keep any private account details out of docs.
+
+**Done when**: no product/runbook copy claims X source/broadcast creation is
+undocumented or unavailable.
+
+**Verify**:
+
+```sh
+rg -n "partner API required|public X API.*does not expose|manual RTMP fallback" docs plans crates apps scripts
+```
+
+### S1 - Add OAuth 1.0a signer and credential readiness
+
+Implement strict OAuth 1.0a signing in backend-only Rust. Add X Livestream
+credential status separate from the existing OAuth2/PKCE account status.
+
+**Done when**: backend can build a valid signed request header from redacted
+test credentials, includes query params, excludes JSON bodies, and rejects
+missing token secrets.
+
+**Verify**:
+
+```sh
+cargo test -p videorc-backend oauth1
+cargo test -p videorc-backend x_livestream_credentials
+cargo fmt --check --all
+```
+
+### S2 - Add the typed X Livestream API client
+
+Build a client around `/2/region`, `/sources*`, and `/broadcasts*` with mockable
+base URLs and redacted error messages.
+
+**Done when**: unit tests cover source create/list/get/update/delete, region
+redirect handling, broadcast create/get/list/publish/end/delete, rate-limit
+headers, and common error classification.
+
+**Verify**:
+
+```sh
+cargo test -p videorc-backend x_livestream
+cargo clippy -p videorc-backend -- -D warnings
+```
+
+### S3 - Replace X capability and source readiness
+
+Replace the static `partner-api-required` capability with real states. Add
+source selection/reuse/create behavior and return `rtmps_url` plus a secret ref
+for the stream key to the existing streaming target model.
+
+**Done when**: X OAuth/native can be marked ready only when OAuth 1.0a
+Livestream credentials and account identity are valid; manual RTMP remains
+explicitly selectable.
+
+**Verify**:
+
+```sh
+cargo test -p videorc-backend x_live
+pnpm --filter @videorc/desktop test
+pnpm typecheck
+```
+
+### S4 - Integrate X with the go-live lifecycle
+
+Patch `prepareOauthTargetsForGoLive` and backend commands so X source
+preparation happens before `session.start`, while broadcast creation/publish
+happens only after active ingest is observed.
+
+**Done when**: an X target can become a real RTMPS output leg, wait for
+`is_stream_active`, create/publish a broadcast, and surface the `share_url`
+without blocking healthy YouTube/Twitch/manual legs when X fails.
+
+**Verify**:
+
+```sh
+pnpm --filter @videorc/desktop test
+pnpm typecheck
+pnpm lint
+cargo test -p videorc-backend x_live
+pnpm smoke:multistream
+```
+
+### S5 - Add end/cleanup/recovery
+
+Add strict END handling, app shutdown/session stop cleanup, and recovery for
+last-known X broadcasts that may still be running after a crash or force quit.
+
+**Done when**: stopping a session sends `{ "state": "END" }` exactly once per
+running X broadcast when possible, records failures redacted, and can identify
+or clean up stale running broadcasts on the next launch.
+
+**Verify**:
+
+```sh
+cargo test -p videorc-backend x_broadcast_end
+pnpm --filter @videorc/desktop test
+pnpm smoke:recording-studio
+```
+
+### S6 - Add X live status and diagnostics
+
+Poll broadcast/source status while live, expose viewer counts and post status
+where available, and add support-bundle evidence.
+
+**Done when**: diagnostics explain X setup/live/end failures without exposing
+tokens, stream keys, OAuth headers, chat tokens, or private secrets.
+
+**Verify**:
+
+```sh
+cargo test -p videorc-backend support_bundle x_live
+pnpm test:scripts
+pnpm smoke:oauth-guards
+pnpm smoke:provider-readiness
+```
+
+### S7 - Add read-only X live chat
+
+Replace the X comments unsupported gate with the documented read-only chat
+handoff and WebSocket connector.
+
+**Done when**: X live chat can read messages for a running broadcast, reports
+unsupported send behavior honestly, retries token availability after publish,
+and parses double-JSON frames into Videorc's existing live chat message model.
+
+**Verify**:
+
+```sh
+cargo test -p videorc-backend x_chat
+cargo test -p videorc-backend live_chat
+pnpm --filter @videorc/desktop test
+```
+
+### S8 - Update Streaming UI
+
+Update shared TS types and the Streaming tab to reflect real X states, source
+settings, low-latency/chat/tweet controls, runtime status, and share URL.
+
+**Done when**: the UI no longer shows `Partner API required`; the native X path
+is understandable, dense, and consistent with the Videorc design language; and
+manual RTMP remains an explicit alternate mode.
+
+**Verify**:
+
+```sh
+pnpm --filter @videorc/desktop test
+pnpm typecheck
+pnpm lint
+pnpm format:check
+```
+
+### S9 - Live-account acceptance
+
+Run against a dedicated allow-listed X account with broadcast privileges.
+
+**Done when**:
+
+- credentials are loaded through the intended secure path
+- `/2/users/me` confirms numeric user id
+- `/2/region` succeeds
+- source create/reuse works
+- Videorc starts RTMPS ingest
+- `is_stream_active` flips true
+- broadcast create succeeds
+- publish succeeds and returns a live `share_url`
+- chat read connector receives messages, if chat is enabled and test messages
+  exist
+- stop sends END and X reports `ENDED`
+- test broadcasts/sources are cleaned up or intentionally retained for reuse
+- acceptance note is added under `docs/acceptance/`
+
+**Verify**:
+
+```sh
+pnpm smoke:local-gates
+pnpm smoke:provider-readiness:strict
+pnpm smoke:oauth-guards
+pnpm smoke:multistream
+pnpm smoke:recording-studio
+```
+
+Add a one-off/live acceptance command only if it can run safely without printing
+secrets and can be skipped when credentials are absent.
+
+## Tests to add or update
+
+- OAuth 1.0a signer:
+  - strict percent encoding
+  - query params included
+  - JSON body excluded
+  - stable sorted params
+  - Authorization header redaction
+- X Livestream client:
+  - `/2/region` 307
+  - source CRUD
+  - create-broadcast 404 treated as source-not-active retry hint
+  - publish payload includes only publish fields
+  - END payload is exactly `{ "state": "END" }`
+  - `owner_id` precision is ignored
+  - IDs remain strings
+- Go-live lifecycle:
+  - X source prepare before encoder start
+  - create/publish after `is_stream_active`
+  - partial failure disables/fails only X target
+  - stop calls END
+  - stale running broadcast cleanup
+- Chat:
+  - media-key token fetch retry
+  - accessChatPublic request headers/body
+  - WebSocket auth and subscribe frames
+  - double-JSON message parse
+  - read-only send status
+- UI:
+  - capability badges/states
+  - no old partner-required copy
+  - controls serialize to backend params
+  - runtime X share URL/status rendering
+- Scripts/docs:
+  - provider readiness no longer treats X as a purely manual partner gate
+  - OAuth guard smoke can test both missing OAuth1 credentials and mocked ready
+    credentials
+
+## Verification gate matrix
+
+Use the smallest gate per slice, then the broader gates before handoff:
+
+```sh
+cargo fmt --check --all
+cargo test -p videorc-backend
+cargo clippy -p videorc-backend -- -D warnings
+pnpm --filter @videorc/desktop test
+pnpm typecheck
+pnpm lint
+pnpm format:check
+pnpm test:scripts
+pnpm smoke:oauth-guards
+pnpm smoke:provider-readiness
+pnpm smoke:multistream
+pnpm smoke:recording-studio
+```
+
+For live-account work, also run the dedicated X acceptance steps with the
+allow-listed account. If credentials are absent, state that live acceptance is
+blocked and run the mock/client lifecycle tests instead.
+
+## Open decisions
+
+- **Credential UX**: Can Videorc obtain OAuth 1.0a token secrets through a
+  clean desktop connect flow, or should the first version use an explicit
+  release/admin credential import for the allow-listed account?
+- **Source reuse**: default to one reusable source per account/region, but decide
+  whether the UI exposes multiple named sources in v1.
+- **Default region**: use `/2/region` automatically; only expose manual region
+  override if real testing shows a need.
+- **Default low latency**: likely on for chatty streams, but confirm against X
+  quality behavior and Videorc's default output presets.
+- **Default chat option**: choose an explicit product default instead of relying
+  on X's observed default. Recommended: `Everyone` for public streams, unless
+  user/account policy suggests `Verified`.
+- **Announcement post**: default to sending the X post (`should_not_tweet:
+  false`) but expose a clear toggle.
+- **Stop ordering**: the PDF workflow says stop encoder then END, while the END
+  section says after ending stop your encoder. Videorc should call END as part
+  of controlled stop while enough session context still exists, then stop or
+  complete the encoder shutdown. If the encoder already stopped, still call END
+  best-effort.
+- **Privacy semantics**: the current X metadata draft has `x_visibility`.
+  Re-evaluate it against actual X publish fields so the UI does not promise
+  private/unlisted behavior the API does not provide.
+- **Chat send**: this API is read-only. Keep send disabled/unsupported unless X
+  documents a separate approved send flow.
+
+## STOP conditions
+
+Stop and report rather than improvising if:
+
+- OAuth 1.0a token secret cannot be obtained or stored securely.
+- X app/account access is not actually allow-listed in the live environment.
+- The broadcasting account is protected/private or otherwise cannot create
+  broadcasts.
+- X returns undocumented required fields or state constraints that change the
+  lifecycle.
+- Any test, log, support bundle, or UI path would expose OAuth secrets, stream
+  keys, chat tokens, or Authorization headers.
+- Implementing X requires changing the core media path beyond adding an RTMPS
+  output leg. Route media-quality or muxing issues back to Plans 006, 014, and
+  023 instead of hiding them inside this provider slice.

--- a/plans/README.md
+++ b/plans/README.md
@@ -42,6 +42,7 @@ row when done.
 | 024 | Preview start-stretch + click-flash hint, backend-lost toast stack on permission grant, version-blind support bundle | P0 | M | none (preview by-eye needs a camera) | DONE (2026-07-07; S1–S5 on main, adversarially-verified root causes, gates PASS; S6 owner-triage list; pending owner by-eye + deferred commit-SHA build step) |
 | 025 | Native preview breaks across displays: surface stuck on main display, "Waiting for preview" on the secondary (contentsScale never set + no display-change observer) | P1 | M | dual-display Mac for repro/by-eye | DONE (2026-07-07; S1-S4 on the plan-025 branch, S5 correctly deferred — deliberate self-capture design; gates PASS, preview probe GPU-flaked env-only; pending dual-display by-eye) |
 | 027 | Make automatic source fallbacks silent product-wide; keep the explanation in diagnostics/support bundles | P1 | S-M | 018 | DONE (2026-07-07; startup/source fallback warning UI removed product-wide, recovery preserved, support-bundle diagnostics added; gates PASS) |
+| 028 | Add native X Livestream API integration: OAuth 1.0a source/broadcast lifecycle + read-only chat | P1 | L | 009, 015, 018 | IN PROGRESS (2026-07-07; implementation branch ready for PR, external X live acceptance pending real credentials/account) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) |
 REJECTED (with one-line rationale).

--- a/scripts/lib/macos-release-artifact-validation.mjs
+++ b/scripts/lib/macos-release-artifact-validation.mjs
@@ -1,8 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { basename, relative } from 'node:path'
 
-export const BUNDLED_YOUTUBE_OAUTH_SECRET_ENV = 'VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET'
-
 export function artifactKindFromPath(path) {
   if (String(path).endsWith('.app')) {
     return 'app'
@@ -41,16 +39,6 @@ export function captureEntitlementCheckTargets(appPath) {
     { id: 'ffmpeg', label: 'ffmpeg', path: `${appPath}/Contents/Resources/ffmpeg/bin/ffmpeg` },
     { id: 'ffprobe', label: 'ffprobe', path: `${appPath}/Contents/Resources/ffmpeg/bin/ffprobe` }
   ]
-}
-
-export function bundledYoutubeOAuthSecretCheckTarget(appPath) {
-  return {
-    id: 'bundled-youtube-oauth-secret',
-    label: 'bundled YouTube OAuth secret (videorc-backend)',
-    type: 'binary-contains-env-secret',
-    envName: BUNDLED_YOUTUBE_OAUTH_SECRET_ENV,
-    path: `${appPath}/Contents/Resources/videorc-backend`
-  }
 }
 
 export function evaluateBinaryContainsEnvSecretCheck(
@@ -126,8 +114,7 @@ export function buildMacosReleaseArtifactChecks(path) {
         command: 'codesign',
         args: ['-d', '--entitlements', ':-', target.path],
         expectOutputIncludes: REQUIRED_CAPTURE_ENTITLEMENTS
-      })),
-      bundledYoutubeOAuthSecretCheckTarget(path)
+      }))
     ]
   }
 

--- a/scripts/lib/macos-release-artifact-validation.test.mjs
+++ b/scripts/lib/macos-release-artifact-validation.test.mjs
@@ -2,12 +2,9 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import {
-  BUNDLED_YOUTUBE_OAUTH_SECRET_ENV,
   artifactKindFromPath,
   buildMacosReleaseArtifactChecks,
-  bundledYoutubeOAuthSecretCheckTarget,
   captureEntitlementCheckTargets,
-  evaluateBinaryContainsEnvSecretCheck,
   formatArtifactPath,
   formatReleaseArtifactValidationReport,
   REQUIRED_CAPTURE_ENTITLEMENTS,
@@ -38,8 +35,7 @@ describe('buildMacosReleaseArtifactChecks', () => {
         'capture entitlements (videorc-backend)',
         'capture entitlements (native_preview_host_helper)',
         'capture entitlements (ffmpeg)',
-        'capture entitlements (ffprobe)',
-        'bundled YouTube OAuth secret (videorc-backend)'
+        'capture entitlements (ffprobe)'
       ]
     )
     assert.deepEqual(checks[0].args, [
@@ -104,53 +100,6 @@ describe('capture entitlement gate', () => {
       assert.deepEqual(check.args.slice(0, 3), ['-d', '--entitlements', ':-'])
       assert.deepEqual(check.expectOutputIncludes, REQUIRED_CAPTURE_ENTITLEMENTS)
     }
-  })
-
-  it('fails closed when the release backend lacks the baked-in YouTube OAuth secret', () => {
-    const check = buildMacosReleaseArtifactChecks('/release/Videorc.app').find(
-      (entry) => entry.id === 'bundled-youtube-oauth-secret'
-    )
-
-    assert.deepEqual(check, bundledYoutubeOAuthSecretCheckTarget('/release/Videorc.app'))
-    assert.equal(check.type, 'binary-contains-env-secret')
-    assert.equal(check.envName, BUNDLED_YOUTUBE_OAUTH_SECRET_ENV)
-    assert.equal(check.command, undefined)
-  })
-
-  it('requires the exact release-env YouTube OAuth secret to be embedded', () => {
-    const check = bundledYoutubeOAuthSecretCheckTarget('/release/Videorc.app')
-    const secret = 'fake-rotated-youtube-client-secret'
-
-    assert.deepEqual(
-      evaluateBinaryContainsEnvSecretCheck(check, {
-        env: {},
-        readFile: () => Buffer.from(secret)
-      }),
-      {
-        ok: false,
-        output: `missing required environment variable: ${BUNDLED_YOUTUBE_OAUTH_SECRET_ENV}`
-      }
-    )
-
-    assert.deepEqual(
-      evaluateBinaryContainsEnvSecretCheck(check, {
-        env: { [BUNDLED_YOUTUBE_OAUTH_SECRET_ENV]: secret },
-        readFile: () => Buffer.from('different binary contents')
-      }),
-      {
-        ok: false,
-        output:
-          '/release/Videorc.app/Contents/Resources/videorc-backend does not contain the VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET value from the release environment'
-      }
-    )
-
-    assert.deepEqual(
-      evaluateBinaryContainsEnvSecretCheck(check, {
-        env: { [BUNDLED_YOUTUBE_OAUTH_SECRET_ENV]: secret },
-        readFile: () => Buffer.from(`binary prefix ${secret} binary suffix`)
-      }),
-      { ok: true, output: '' }
-    )
   })
 
   it('pins the required entitlements to camera + microphone', () => {

--- a/scripts/lib/provider-readiness.mjs
+++ b/scripts/lib/provider-readiness.mjs
@@ -11,10 +11,14 @@ export const REQUIRED_OAUTH_CALLBACK_URLS = [
 ]
 
 export const PROVIDER_CALLBACKS_READY_ENV = 'VIDEORC_SMOKE_PROVIDER_CALLBACKS_READY'
+export const YOUTUBE_OAUTH_PAUSED_REASON =
+  'YouTube OAuth is paused while Videorc awaits Google approval; use Manual RTMP for YouTube acceptance.'
 
 export const PROVIDERS = [
   {
     label: 'YouTube',
+    paused: true,
+    pauseReason: YOUTUBE_OAUTH_PAUSED_REASON,
     clientIdVars: ['VIDEORC_YOUTUBE_CLIENT_ID', 'VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID'],
     secretVars: ['VIDEORC_YOUTUBE_CLIENT_SECRET'],
     secretRequired: false,
@@ -67,7 +71,9 @@ export function evaluateProviderReadiness({
   runContext = detectRunContext(env)
 } = {}) {
   const callbackCoverage = evaluateCallbackCoverage(env)
-  const providers = PROVIDERS.map((provider) => readinessForProvider(provider, env, callbackCoverage))
+  const providers = PROVIDERS.map((provider) =>
+    readinessForProvider(provider, env, callbackCoverage)
+  )
   const failures = providers.filter((provider) => !provider.ready)
 
   return {
@@ -85,7 +91,13 @@ export function evaluateProviderReadiness({
 export function formatProviderReadinessConsole(result) {
   const lines = []
   for (const provider of result.providers) {
-    lines.push(`[${provider.ready ? 'ready' : 'missing'}] ${provider.label}`)
+    lines.push(
+      `[${provider.paused ? 'paused' : provider.ready ? 'ready' : 'missing'}] ${provider.label}`
+    )
+    if (provider.paused) {
+      lines.push(`  - ${provider.pauseReason}`)
+      continue
+    }
     lines.push(`  - run context: ${result.runContext}`)
     lines.push(`  - client ID: ${credentialSourceLabel(provider.clientId)}`)
     lines.push(`  - client secret: ${secretSourceLabel(provider.clientSecret)}`)
@@ -104,10 +116,19 @@ export function formatProviderReadinessConsole(result) {
     }
   }
 
-  const readyLabels = result.providers.filter((provider) => provider.ready).map((provider) => provider.label)
+  const readyLabels = result.providers
+    .filter((provider) => provider.ready && !provider.paused)
+    .map((provider) => provider.label)
   if (readyLabels.length) {
     lines.push('')
     lines.push(`Ready providers: ${readyLabels.join(', ')}`)
+  }
+  const pausedLabels = result.providers
+    .filter((provider) => provider.paused)
+    .map((provider) => provider.label)
+  if (pausedLabels.length) {
+    lines.push('')
+    lines.push(`Paused providers: ${pausedLabels.join(', ')}`)
   }
 
   if (result.failures.length) {
@@ -118,7 +139,9 @@ export function formatProviderReadinessConsole(result) {
     }
     if (!result.strict) {
       lines.push('')
-      lines.push('Set VIDEORC_SMOKE_REQUIRE_PROVIDER_READY=1 to make missing provider prerequisites fail.')
+      lines.push(
+        'Set VIDEORC_SMOKE_REQUIRE_PROVIDER_READY=1 to make missing provider prerequisites fail.'
+      )
     }
   } else {
     lines.push('')
@@ -152,7 +175,7 @@ export function formatProviderReadinessMarkdown(result) {
 
   for (const provider of result.providers) {
     lines.push(
-      `| ${escapeMarkdown(provider.label)} | ${provider.ready ? 'ready' : 'missing'} | ${escapeMarkdown(
+      `| ${escapeMarkdown(provider.label)} | ${provider.paused ? 'paused' : provider.ready ? 'ready' : 'missing'} | ${escapeMarkdown(
         provider.clientId.source
       )} | ${escapeMarkdown(provider.clientId.envVars.join(', '))} | ${escapeMarkdown(
         secretSourceLabel(provider.clientSecret)
@@ -163,6 +186,16 @@ export function formatProviderReadinessMarkdown(result) {
   }
 
   lines.push('')
+
+  const paused = result.providers.filter((provider) => provider.paused)
+  if (paused.length) {
+    lines.push('## Paused Provider Paths')
+    lines.push('')
+    for (const provider of paused) {
+      lines.push(`- ${provider.label}: ${provider.pauseReason}`)
+    }
+    lines.push('')
+  }
 
   const x = result.providers.find((provider) => provider.label === 'X')
   if (x) {
@@ -176,7 +209,9 @@ export function formatProviderReadinessMarkdown(result) {
           : `blocked - set ${nativeLive?.env ?? 'VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS'}=1 only after live API validation`
       }`
     )
-    const oauth1 = x.accountChecks.find((check) => check.statusLabel === 'X OAuth 1.0a live credentials')
+    const oauth1 = x.accountChecks.find(
+      (check) => check.statusLabel === 'X OAuth 1.0a live credentials'
+    )
     lines.push(
       `- OAuth 1.0a credentials: ${
         oauth1?.ready
@@ -199,9 +234,13 @@ export function formatProviderReadinessMarkdown(result) {
   lines.push('## Next Acceptance Step')
   lines.push('')
   if (result.failures.length) {
-    lines.push('- Set the missing provider credentials/account flags above, then rerun `pnpm smoke:provider-readiness:strict`.')
+    lines.push(
+      '- Set the missing provider credentials/account flags above, then rerun `pnpm smoke:provider-readiness:strict`.'
+    )
   } else {
-    lines.push('- Run the real YouTube, Twitch, and X OAuth/live acceptance steps from `docs/oauth-live-smoke.md`.')
+    lines.push(
+      '- Run the real Twitch and X OAuth/live acceptance steps from `docs/oauth-live-smoke.md`; use Manual RTMP for YouTube until Google approval completes.'
+    )
   }
 
   return lines.join('\n')
@@ -219,6 +258,27 @@ export function detectRunContext(env = {}) {
 }
 
 function readinessForProvider(provider, env, callbackCoverage) {
+  if (provider.paused) {
+    return {
+      label: provider.label,
+      ready: true,
+      paused: true,
+      pauseReason: provider.pauseReason,
+      clientId: {
+        source: 'paused',
+        envVar: null,
+        envVars: provider.clientIdVars
+      },
+      clientSecret: {
+        source: 'paused',
+        required: false,
+        envVar: null,
+        envVars: provider.secretVars
+      },
+      accountChecks: [],
+      missing: []
+    }
+  }
   const clientId = credentialPresence(provider.clientIdVars, env)
   const clientSecret = secretPresence(provider.secretVars, env, provider.secretRequired)
   const accountChecks = provider.accountChecks.map((check) => ({
@@ -234,7 +294,9 @@ function readinessForProvider(provider, env, callbackCoverage) {
     missing.push(provider.secretVars.join(' or '))
   }
   if (!callbackCoverage.ready) {
-    missing.push(`${PROVIDER_CALLBACKS_READY_ENV}=1 (fixed loopback callback URLs registered/verified)`)
+    missing.push(
+      `${PROVIDER_CALLBACKS_READY_ENV}=1 (fixed loopback callback URLs registered/verified)`
+    )
   }
   for (const check of accountChecks) {
     if (!check.ready) {
@@ -245,6 +307,8 @@ function readinessForProvider(provider, env, callbackCoverage) {
   return {
     label: provider.label,
     ready: missing.length === 0,
+    paused: false,
+    pauseReason: null,
     clientId,
     clientSecret,
     accountChecks,
@@ -295,6 +359,9 @@ function secretPresence(names, env, required) {
 }
 
 function credentialSourceLabel(credential) {
+  if (credential.source === 'paused') {
+    return 'paused'
+  }
   if (credential.source === 'missing') {
     return `missing (expected ${credential.envVars.join(' or ')})`
   }
@@ -302,6 +369,9 @@ function credentialSourceLabel(credential) {
 }
 
 function secretSourceLabel(secret) {
+  if (secret.source === 'paused') {
+    return 'paused'
+  }
   if (secret.source === 'environment') {
     return `present (${secret.envVar})`
   }
@@ -309,6 +379,9 @@ function secretSourceLabel(secret) {
 }
 
 function accountChecksLabel(checks) {
+  if (!checks.length) {
+    return 'none'
+  }
   return checks.map((check) => `${check.env}=${check.ready ? '1' : 'missing'}`).join('; ')
 }
 

--- a/scripts/lib/provider-readiness.mjs
+++ b/scripts/lib/provider-readiness.mjs
@@ -46,7 +46,12 @@ export const PROVIDERS = [
     secretRequired: false,
     accountChecks: [
       {
-        label: 'native live partner/API access available',
+        label: 'OAuth 1.0a Livestream credentials configured',
+        env: 'VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY',
+        statusLabel: 'X OAuth 1.0a live credentials'
+      },
+      {
+        label: 'allow-listed Livestream API access validated',
         env: 'VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS',
         statusLabel: 'X native live access'
       }
@@ -167,8 +172,16 @@ export function formatProviderReadinessMarkdown(result) {
     lines.push(
       `- Status: ${
         nativeLive?.ready
-          ? 'ready - partner/API live source or broadcast path validated'
-          : `blocked - set ${nativeLive?.env ?? 'VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS'}=1 only after partner/API validation`
+          ? 'ready - allow-listed source and broadcast path validated'
+          : `blocked - set ${nativeLive?.env ?? 'VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS'}=1 only after live API validation`
+      }`
+    )
+    const oauth1 = x.accountChecks.find((check) => check.statusLabel === 'X OAuth 1.0a live credentials')
+    lines.push(
+      `- OAuth 1.0a credentials: ${
+        oauth1?.ready
+          ? 'ready - backend live credential set configured'
+          : `missing - set ${oauth1?.env ?? 'VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY'}=1 only after the redacted VIDEORC_X_OAUTH1_* values are configured`
       }`
     )
     lines.push('')

--- a/scripts/lib/provider-readiness.test.mjs
+++ b/scripts/lib/provider-readiness.test.mjs
@@ -35,8 +35,15 @@ describe('provider readiness evidence', () => {
     assert.equal(result.ready, true)
     assert.equal(result.runContext, 'dev')
     assert.deepEqual(result.failures, [])
-    assert.equal(result.providers.find((provider) => provider.label === 'YouTube').clientId.source, 'environment')
-    assert.equal(result.providers.find((provider) => provider.label === 'Twitch').clientId.source, 'bundled')
+    assert.equal(
+      result.providers.find((provider) => provider.label === 'YouTube').clientId.source,
+      'paused'
+    )
+    assert.equal(result.providers.find((provider) => provider.label === 'YouTube').paused, true)
+    assert.equal(
+      result.providers.find((provider) => provider.label === 'Twitch').clientId.source,
+      'bundled'
+    )
   })
 
   it('reports missing prerequisites by env var name without printing values', () => {
@@ -53,7 +60,8 @@ describe('provider readiness evidence', () => {
 
     assert.equal(result.ready, false)
     assert.match(markdown, /VIDEORC_SMOKE_PROVIDER_CALLBACKS_READY=missing/)
-    assert.match(markdown, /VIDEORC_SMOKE_YOUTUBE_CHANNEL_READY=1/)
+    assert.match(markdown, /Paused Provider Paths/)
+    assert.match(markdown, /YouTube OAuth is paused/)
     assert.match(markdown, /X Native Live Access/)
     assert.match(consoleReport, /Provider live-smoke readiness is incomplete/)
     assert.doesNotMatch(markdown, /do-not-print-youtube-client/)
@@ -63,9 +71,15 @@ describe('provider readiness evidence', () => {
   })
 
   it('records packaged run context from smoke environment', () => {
-    assert.equal(detectRunContext({ VIDEORC_PACKAGED_APP_EXECUTABLE: '/Applications/Videorc.app' }), 'packaged')
+    assert.equal(
+      detectRunContext({ VIDEORC_PACKAGED_APP_EXECUTABLE: '/Applications/Videorc.app' }),
+      'packaged'
+    )
     assert.equal(detectRunContext({ VIDEORC_SMOKE_PACKAGED_APP: '1' }), 'packaged')
-    assert.equal(detectRunContext({ VIDEORC_PROVIDER_READINESS_RUN_CONTEXT: 'release-candidate' }), 'release-candidate')
+    assert.equal(
+      detectRunContext({ VIDEORC_PROVIDER_READINESS_RUN_CONTEXT: 'release-candidate' }),
+      'release-candidate'
+    )
   })
 
   it('includes callback URLs and source fields in markdown evidence', () => {

--- a/scripts/lib/provider-readiness.test.mjs
+++ b/scripts/lib/provider-readiness.test.mjs
@@ -17,6 +17,7 @@ function completeEnv(overrides = {}) {
     VIDEORC_TWITCH_CLIENT_SECRET: 'twitch-secret-value',
     VIDEORC_SMOKE_TWITCH_ACCOUNT_READY: '1',
     VIDEORC_BUNDLED_X_CLIENT_ID: 'x-bundled-client-value',
+    VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY: '1',
     VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS: '1',
     [PROVIDER_CALLBACKS_READY_ENV]: '1',
     ...overrides
@@ -80,6 +81,7 @@ describe('provider readiness evidence', () => {
     assert.match(markdown, /http:\/\/127\.0\.0\.1:17995\/oauth\/callback/)
     assert.match(markdown, /Client ID source/)
     assert.match(markdown, /bundled/)
+    assert.match(markdown, /VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY=1/)
     assert.match(markdown, /VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS=1/)
   })
 })

--- a/scripts/smoke-oauth-app.mjs
+++ b/scripts/smoke-oauth-app.mjs
@@ -62,7 +62,7 @@ try {
     }
 
     const appProtocol = await request(ws, timeoutMs, 'platformAccounts.oauth.startProvider', {
-      platform: 'youtube',
+      platform: 'x',
       redirectUri: 'videorc://oauth/callback'
     })
     if (appProtocol.redirectUri !== 'videorc://oauth/callback') {
@@ -87,7 +87,7 @@ try {
     if (
       failedCallback.status !== 'failed' ||
       failedEvent.status !== 'failed' ||
-      failedEvent.platform !== 'youtube'
+      failedEvent.platform !== 'x'
     ) {
       throw new Error(
         `Provider OAuth app-protocol cancellation was not reported as failed: ${JSON.stringify({
@@ -144,7 +144,7 @@ function launchAndReadConnection() {
       cwd: repoRoot,
       detached: true,
       env: smokeAppEnv({
-        VIDEORC_YOUTUBE_CLIENT_ID: 'smoke-youtube-client-id',
+        VIDEORC_X_CLIENT_ID: 'smoke-x-client-id',
         VIDEORC_SMOKE_PRINT_BACKEND_READY: '1'
       }),
       stdio: ['ignore', 'pipe', 'pipe']

--- a/scripts/smoke-oauth-guards-app.mjs
+++ b/scripts/smoke-oauth-guards-app.mjs
@@ -22,6 +22,13 @@ try {
     const credentials = await request(ws, timeoutMs, 'platformAccounts.oauth.providerCredentials')
     assertProviderCredentials(credentials)
 
+    const youtubeStart = await requestRaw(ws, timeoutMs, 'platformAccounts.oauth.startProvider', {
+      platform: 'youtube'
+    })
+    if (youtubeStart.ok || !String(youtubeStart.error?.message).includes('Google approval')) {
+      throw new Error(`YouTube provider OAuth should be paused: ${JSON.stringify(youtubeStart)}`)
+    }
+
     const refreshedAccounts = await request(ws, timeoutMs, 'platformAccounts.refresh')
     if (!Array.isArray(refreshedAccounts)) {
       throw new Error(
@@ -72,12 +79,14 @@ function assertProviderCredentials(credentials) {
   }
   const byPlatform = new Map(credentials.map((credential) => [credential.platform, credential]))
 
-  const youtube = requireCredential(byPlatform, 'youtube')
-  // YouTube bundles a Google Desktop OAuth client, which ships a
-  // non-confidential client secret alongside PKCE (Google requires it at the
-  // token endpoint for installed apps), so the secret is expected present.
-  if (!youtube.ready || !youtube.pkce || !youtube.clientIdPresent || !youtube.clientSecretPresent) {
-    throw new Error(`YouTube PKCE readiness mismatch: ${JSON.stringify(youtube)}`)
+  const youtube = byPlatform.get('youtube')
+  if (
+    !youtube ||
+    youtube.ready ||
+    !youtube.pkce ||
+    !String(youtube.message).includes('Google approval')
+  ) {
+    throw new Error(`YouTube OAuth paused-state mismatch: ${JSON.stringify(youtube)}`)
   }
 
   // Twitch is a PUBLIC client type: ready with the client id alone, no
@@ -335,11 +344,6 @@ function launchAndReadConnection() {
           process.env.VIDEORC_DATABASE_PATH ?? join(stateRoot, 'videorc.sqlite'),
         VIDEORC_SECRETS_PATH:
           process.env.VIDEORC_SECRETS_PATH ?? join(stateRoot, 'videorc-secrets.json'),
-        VIDEORC_YOUTUBE_CLIENT_ID: 'smoke-youtube-client-id',
-        // Dev builds carry no bundled YouTube secret since it left source
-        // (release builds compile it in); the readiness assertion expects the
-        // shipped shape, so inject a fake runtime secret.
-        VIDEORC_YOUTUBE_CLIENT_SECRET: 'smoke-youtube-client-secret',
         VIDEORC_TWITCH_CLIENT_ID: 'smoke-twitch-client-id',
         VIDEORC_X_CLIENT_ID: 'smoke-x-client-id',
         VIDEORC_TWITCH_CLIENT_SECRET: ''

--- a/scripts/smoke-oauth-guards-app.mjs
+++ b/scripts/smoke-oauth-guards-app.mjs
@@ -172,9 +172,9 @@ function assertPreflight(preflight) {
   if (!x || x.ready || x.authMode !== 'oauth') {
     throw new Error(`OAuth X preflight should be blocked: ${JSON.stringify(preflight)}`)
   }
-  if (!x.message.includes('connected account')) {
+  if (!x.message.includes('OAuth 1.0a')) {
     throw new Error(
-      `OAuth X preflight should explain missing connected account: ${JSON.stringify(x)}`
+      `OAuth X preflight should explain missing OAuth 1.0a live credentials: ${JSON.stringify(x)}`
     )
   }
 
@@ -265,20 +265,22 @@ function assertSecretRefPreflight(preflight) {
 function assertXCapability(capability) {
   if (
     capability?.platform !== 'x' ||
-    capability.state !== 'partner-api-required' ||
+    capability.state !== 'missing-credentials' ||
     capability.nativeAvailable !== false ||
     capability.manualRtmpAvailable !== true ||
     capability.oauthConnected !== false
   ) {
     throw new Error(`X native capability guard mismatch: ${JSON.stringify(capability)}`)
   }
-  if (!String(capability.message).includes('partner/API path')) {
+  if (!String(capability.message).includes('OAuth 1.0a')) {
     throw new Error(
-      `X capability message should explain the partner/API path: ${JSON.stringify(capability)}`
+      `X capability message should explain the OAuth 1.0a credential requirement: ${JSON.stringify(capability)}`
     )
   }
-  if (!String(capability.docsUrl).startsWith('https://help.x.com/')) {
-    throw new Error(`X capability should include Producer docs URL: ${JSON.stringify(capability)}`)
+  if (!String(capability.docsUrl).startsWith('https://github.com/xdevplatform/')) {
+    throw new Error(
+      `X capability should include Livestream API sample docs URL: ${JSON.stringify(capability)}`
+    )
   }
   if (!String(capability.apiOverviewUrl).startsWith('https://docs.x.com/')) {
     throw new Error(`X capability should include X API overview URL: ${JSON.stringify(capability)}`)

--- a/scripts/smoke-platform-lifecycle.mjs
+++ b/scripts/smoke-platform-lifecycle.mjs
@@ -74,16 +74,13 @@ try {
 
   assert.deepEqual(
     preparedYouTubeActivationTargets(streaming).map((item) => item.id),
-    ['youtube-ready']
+    []
   )
   assert.deepEqual(
     preparedYouTubeCompletionTargets(streaming).map((item) => item.id),
-    ['youtube-ready']
+    []
   )
-  assert.deepEqual(
-    readyStreamTargetLabels(streaming),
-    ['youtube-ready', 'youtube-no-stream', 'twitch-ready', 'youtube-manual']
-  )
+  assert.deepEqual(readyStreamTargetLabels(streaming), ['twitch-ready', 'youtube-manual'])
 
   const patched = patchPreparedStreamTarget(
     streaming,
@@ -100,7 +97,10 @@ try {
   assert.equal(patchedTarget.status.state, 'live')
   assert.equal(patchedTarget.status.message, 'YouTube broadcast is live.')
   assert.equal(patchedTarget.updatedAt, '2026-06-03T00:00:00.000Z')
-  assert.equal(patched.targets.find((item) => item.id === 'twitch-ready').updatedAt, '2026-06-02T00:00:00.000Z')
+  assert.equal(
+    patched.targets.find((item) => item.id === 'twitch-ready').updatedAt,
+    '2026-06-02T00:00:00.000Z'
+  )
 
   const failed = patchPreparedStreamTarget(
     streaming,
@@ -119,7 +119,9 @@ try {
   assert.equal(failedTarget.status.state, 'failed')
   assert.equal(failedTarget.status.message, 'YouTube setup failed.')
 
-  console.log('Platform lifecycle smoke OK - prepared YouTube activation, cleanup, and status patching verified.')
+  console.log(
+    'Platform lifecycle smoke OK - paused YouTube OAuth, ready labels, and status patching verified.'
+  )
 } finally {
   await rm(tempDir, { recursive: true, force: true })
 }

--- a/scripts/smoke-start-labels.mjs
+++ b/scripts/smoke-start-labels.mjs
@@ -29,8 +29,7 @@ try {
     defaultCaptureConfig,
     startButtonLabel,
     startButtonPendingLabel
-  } =
-    require(tempModule)
+  } = require(tempModule)
   assert.equal(startButtonLabel(true, false), 'Start Recording')
   assert.equal(startButtonLabel(false, true), 'Start Livestream')
   assert.equal(startButtonLabel(true, true), 'Start Livestream + Record')
@@ -38,7 +37,36 @@ try {
   assert.equal(startButtonPendingLabel(false), 'Starting Recording...')
   assert.equal(startButtonPendingLabel(true), 'Starting Livestream...')
 
-  const youtubeOauthEnabled = bridgeStreamingToLegacy({
+  const twitchOauthEnabled = bridgeStreamingToLegacy({
+    ...defaultCaptureConfig,
+    recordEnabled: false,
+    streaming: {
+      ...defaultCaptureConfig.streaming,
+      enabled: true,
+      mode: 'single',
+      enabledTargetIds: ['twitch'],
+      targets: defaultCaptureConfig.streaming.targets.map((target) =>
+        target.platform === 'twitch'
+          ? {
+              ...target,
+              enabled: true,
+              authMode: 'oauth',
+              serverUrl: '',
+              streamKey: '',
+              streamKeyPresent: false
+            }
+          : target
+      )
+    }
+  })
+  assert.equal(twitchOauthEnabled.streamEnabled, true)
+  assert.equal(areEnabledStreamTargetsStartReady(twitchOauthEnabled.streaming), true)
+  assert.equal(
+    startButtonLabel(twitchOauthEnabled.recordEnabled, twitchOauthEnabled.streamEnabled),
+    'Start Livestream'
+  )
+
+  const youtubeOauthPaused = bridgeStreamingToLegacy({
     ...defaultCaptureConfig,
     recordEnabled: false,
     streaming: {
@@ -60,9 +88,8 @@ try {
       )
     }
   })
-  assert.equal(youtubeOauthEnabled.streamEnabled, true)
-  assert.equal(areEnabledStreamTargetsStartReady(youtubeOauthEnabled.streaming), true)
-  assert.equal(startButtonLabel(youtubeOauthEnabled.recordEnabled, youtubeOauthEnabled.streamEnabled), 'Start Livestream')
+  assert.equal(youtubeOauthPaused.streamEnabled, false)
+  assert.equal(areEnabledStreamTargetsStartReady(youtubeOauthPaused.streaming), false)
 
   const manualMissingKey = bridgeStreamingToLegacy({
     ...defaultCaptureConfig,
@@ -89,7 +116,9 @@ try {
   assert.equal(manualMissingKey.streamEnabled, true)
   assert.equal(areEnabledStreamTargetsStartReady(manualMissingKey.streaming), false)
 
-  console.log('Start label smoke OK - record, livestream, dual-output, and pending labels verified.')
+  console.log(
+    'Start label smoke OK - record, livestream, dual-output, and pending labels verified.'
+  )
 } finally {
   await rm(tempDir, { recursive: true, force: true })
 }

--- a/scripts/smoke-streaming-secrets.mjs
+++ b/scripts/smoke-streaming-secrets.mjs
@@ -23,8 +23,12 @@ try {
   })
   await writeFile(tempModule, transpiled.outputText)
 
-  const { defaultCaptureConfig, normalizeStreamingSettings, patchStreamTargetForEdit, persistableCaptureConfig } =
-    require(tempModule)
+  const {
+    defaultCaptureConfig,
+    normalizeStreamingSettings,
+    patchStreamTargetForEdit,
+    persistableCaptureConfig
+  } = require(tempModule)
   const normalized = normalizeStreamingSettings({
     enabled: true,
     mode: 'single',
@@ -53,12 +57,13 @@ try {
 
   const youtube = normalized.targets.find((target) => target.platform === 'youtube')
   assert.ok(youtube)
-  assert.equal(youtube.authMode, 'oauth')
+  assert.equal(youtube.authMode, 'manual-rtmp')
   assert.equal(youtube.streamKey, '')
-  assert.equal(youtube.streamKeySecretRef, 'secret://youtube-stream-key')
-  assert.equal(youtube.streamKeyPresent, true)
-  assert.equal(youtube.platformBroadcastId, 'broadcast-123')
-  assert.equal(youtube.platformStreamId, 'stream-123')
+  assert.equal(youtube.streamKeySecretRef, undefined)
+  assert.equal(youtube.streamKeyPresent, false)
+  assert.equal(youtube.accountId, undefined)
+  assert.equal(youtube.platformBroadcastId, undefined)
+  assert.equal(youtube.platformStreamId, undefined)
 
   const twitch = normalized.targets.find((target) => target.platform === 'twitch')
   assert.ok(twitch)
@@ -93,12 +98,15 @@ try {
       )
     }
   })
-  const persistedYoutube = persisted.streaming.targets.find((target) => target.platform === 'youtube')
+  const persistedYoutube = persisted.streaming.targets.find(
+    (target) => target.platform === 'youtube'
+  )
   const persistedTwitch = persisted.streaming.targets.find((target) => target.platform === 'twitch')
   assert.equal(persisted.streamKey, '')
+  assert.equal(persistedYoutube.authMode, 'manual-rtmp')
   assert.equal(persistedYoutube.streamKey, '')
-  assert.equal(persistedYoutube.streamKeySecretRef, 'secret://youtube-stream-key')
-  assert.equal(persistedYoutube.streamKeyPresent, true)
+  assert.equal(persistedYoutube.streamKeySecretRef, undefined)
+  assert.equal(persistedYoutube.streamKeyPresent, false)
   assert.equal(persistedTwitch.streamKey, 'manual-key')
 
   const persistedManualSecret = persistableCaptureConfig({
@@ -121,7 +129,9 @@ try {
       )
     }
   })
-  const persistedManualTwitch = persistedManualSecret.streaming.targets.find((target) => target.platform === 'twitch')
+  const persistedManualTwitch = persistedManualSecret.streaming.targets.find(
+    (target) => target.platform === 'twitch'
+  )
   assert.equal(persistedManualSecret.streamKey, '')
   assert.equal(persistedManualTwitch.streamKey, '')
   assert.equal(persistedManualTwitch.streamKeySecretRef, 'stream-target:twitch:manual-stream-key')
@@ -146,7 +156,9 @@ try {
       )
     }
   })
-  const persistedManualDraftTwitch = persistedManualDraft.streaming.targets.find((target) => target.platform === 'twitch')
+  const persistedManualDraftTwitch = persistedManualDraft.streaming.targets.find(
+    (target) => target.platform === 'twitch'
+  )
   assert.equal(persistedManualDraft.streamKey, 'manual-key')
   assert.equal(persistedManualDraftTwitch.streamKey, 'manual-key')
 
@@ -173,7 +185,9 @@ try {
       )
     }
   })
-  const persistedFullUrlCustom = persistedFullUrlSecret.streaming.targets.find((target) => target.platform === 'custom')
+  const persistedFullUrlCustom = persistedFullUrlSecret.streaming.targets.find(
+    (target) => target.platform === 'custom'
+  )
   assert.equal(persistedFullUrlSecret.rtmpServerUrl, '')
   assert.equal(persistedFullUrlCustom.serverUrl, '')
   assert.equal(persistedFullUrlCustom.streamKey, '')
@@ -190,13 +204,15 @@ try {
     platformStreamId: 'old-stream',
     status: { state: 'ready', message: 'Old manual key.' }
   }
-  const oauthYouTube = patchStreamTargetForEdit(manualYouTube, { authMode: 'oauth' }, '2026-06-03T00:00:00.000Z')
-  assert.equal(oauthYouTube.authMode, 'oauth')
+  const oauthYouTube = patchStreamTargetForEdit(
+    manualYouTube,
+    { authMode: 'oauth' },
+    '2026-06-03T00:00:00.000Z'
+  )
+  assert.equal(oauthYouTube.authMode, 'manual-rtmp')
   assert.equal(oauthYouTube.streamKey, '')
-  assert.equal(oauthYouTube.streamKeySecretRef, undefined)
-  assert.equal(oauthYouTube.streamKeyPresent, false)
-  assert.equal(oauthYouTube.platformBroadcastId, undefined)
-  assert.equal(oauthYouTube.platformStreamId, undefined)
+  assert.equal(oauthYouTube.streamKeySecretRef, 'stream-target:youtube:manual-stream-key')
+  assert.equal(oauthYouTube.streamKeyPresent, true)
 
   const customFullUrl = patchStreamTargetForEdit(
     {
@@ -214,7 +230,9 @@ try {
   assert.equal(customFullUrl.streamKeySecretRef, undefined)
   assert.equal(customFullUrl.streamKeyPresent, false)
 
-  console.log('Streaming secret smoke OK - OAuth/manual secret refs survive reload and persistence without raw keys.')
+  console.log(
+    'Streaming secret smoke OK - paused YouTube OAuth and manual secret refs persist without raw keys.'
+  )
 } finally {
   await rm(tempDir, { recursive: true, force: true })
 }


### PR DESCRIPTION
## Summary
- Add OAuth 1.0a-signed X Livestream source/broadcast lifecycle: capability, source prepare/reuse, publish after ingest, strict END cleanup, and redacted stream-key handling.
- Wire the renderer Go Live flow for X native prepare/publish/end plus late X comments attach after publish returns broadcast/media ids.
- Add read-only X chat connector, support-bundle redaction coverage, provider-readiness docs/smokes, OAuth guard updates, and Plan 028.
- Pause YouTube OAuth product-wide until Google approval completes: the UI exposes YouTube as Manual RTMP, stale OAuth configs are neutralized, backend provider/session/channel/chat paths return the approval message, and release/provider readiness no longer requires Google OAuth credentials.
- Route OBS-imported YouTube RTMP services into the YouTube Manual RTMP target instead of suggesting OAuth.

## Verification
- `pnpm typecheck` using Node 24 / pnpm 11.0.9
- `pnpm lint` using Node 24 / pnpm 11.0.9
- `pnpm format:check` using Node 24 / pnpm 11.0.9
- `pnpm test:scripts` using Node 24 / pnpm 11.0.9
- `pnpm --filter @videorc/desktop test` using Node 24 / pnpm 11.0.9
- `node --test scripts/lib/provider-readiness.test.mjs scripts/lib/macos-release-artifact-validation.test.mjs`
- `node scripts/smoke-start-labels.mjs`
- `node scripts/smoke-streaming-secrets.mjs`
- `node scripts/smoke-platform-lifecycle.mjs`
- `cargo fmt --check --all`
- `cargo clippy -p videorc-backend -- -D warnings`
- `cargo test -p videorc-backend`
- `cargo test -p videorc-backend x_live`
- `cargo test -p videorc-backend live_chat`
- `pnpm audit:js` passed high-severity gate; one moderate advisory remains below threshold
- `pnpm audit:rust`
- `pnpm smoke:oauth`
- `pnpm smoke:oauth-guards`
- `pnpm smoke:provider-readiness` non-strict, expected missing local Twitch/X provider envs reported; YouTube reports paused
- `VIDEORC_PREVIEW_LIFECYCLE_CYCLES=20 pnpm probe:preview-lifecycle`
- `pnpm probe:preview-window`
- `VIDEORC_PREVIEW_SURFACE_MIN_FPS=30 VIDEORC_PREVIEW_SURFACE_MAX_INTERVAL_P95_MS=120 VIDEORC_PREVIEW_SURFACE_MAX_INPUT_TO_PRESENT_P95_MS=100 pnpm smoke:preview-surface`
- `VIDEORC_BASELINE_SOURCE_READINESS_MS=60000 pnpm smoke:screen-recording-real` exited 0; screen-recording gate passed, general preview quality still reports the known 30fps threshold miss
- `VIDEORC_BASELINE_SOURCE_READINESS_MS=60000 pnpm smoke:notes-window-invisible` exited 0; notes overlay artifact gate passed, general preview quality still reports the known 30fps threshold miss

## Caveats
- Real X allow-listed account acceptance was not run locally because this environment does not have the `VIDEORC_X_OAUTH1_*` live credentials. The runbook now lists the exact acceptance steps.
- YouTube OAuth/native acceptance is intentionally deferred until Google approval completes; YouTube coverage for this PR is Manual RTMP plus guard/smoke coverage that stale OAuth paths are paused.
- Full `pnpm smoke:recording-studio` did not complete: it passed the earlier recording/app probes, then failed in `pnpm probe:preview-lifecycle` with a generic `fetch failed` after 23/100 cycles. A direct rerun failed after 42/100 cycles. A focused 20-cycle lifecycle probe passed, and the downstream preview-window, preview-surface, real screen recording, and notes smokes passed individually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native X livestream support, including clearer readiness/status messages and a full publish/end flow.
  * Added X live chat connectivity so viewers can read chat during supported streams.

* **Bug Fixes**
  * Improved preflight checks and error messages for X streaming setup.
  * Clarified manual RTMP fallback guidance.
  * Expanded secret redaction to better protect stream URLs and chat tokens in support bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
