### PR TITLE
Release 0.9.20-beta.1: native X live (official X partnership)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.20-beta.1.md
+++ b/changelog/0.9.20-beta.1.md
@@ -1,0 +1,32 @@
+---
+version: 0.9.20-beta.1
+date: 2026-07-08
+channel: beta
+title: Go live on X natively — official X partnership
+summary: Videorc is an official X Livestream API partner — connect your X account, authorize once in the browser, and go live on X directly from Videorc, no stream keys needed.
+highlights:
+  - Go live on X natively through our official X partnership — no manual stream keys or RTMP setup.
+  - One-time "Authorize X Live" button in the Streaming tab approves Videorc on x.com and you're ready to broadcast.
+  - Your X broadcast is created, published, and ended by Videorc, with the share link ready to post.
+  - Manual RTMP stays available as an explicit choice for any destination.
+---
+
+## Go live on X natively — official X partnership
+
+Videorc is now an official X Livestream API partner. That means you can
+broadcast to X directly from Videorc: pick X as a destination, and Videorc
+creates the stream source, publishes the broadcast, and ends it for you. No
+copying stream keys, no RTMP settings, and your broadcast's share link is ready
+to post the moment you're live.
+
+## Authorize once, stream whenever
+
+Enabling it takes one click. In the Streaming tab, connect your X account and
+press **Authorize X Live** — your browser opens x.com, you approve Videorc, and
+the app is ready to broadcast on your behalf. The authorization is stored
+securely on your Mac and stays valid until you disconnect the account.
+
+## Manual RTMP is still there
+
+Prefer to run your own ingest? Manual RTMP remains available as an explicit
+mode for X and every other destination — nothing changes unless you choose it.


### PR DESCRIPTION
Version bump to 0.9.20 + changelog entry for the X Livestream official-partnership release (feature landed in #15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)