### PR TITLE
Docs: record 0.9.20 release

### DIFF
--- a/docs/releases/0.9.20.md
+++ b/docs/releases/0.9.20.md
@@ -1,0 +1,60 @@
+# Videorc 0.9.20 Beta 1
+
+Videorc 0.9.20 ships native X livestreaming for every user through the
+official X Livestream API partnership: connect X, authorize once in the
+browser, go live — no stream keys.
+
+## Scope
+
+- **Native X Livestream integration** (`x_live.rs`, plan 028, PR #15) —
+  OAuth 1.0a source/broadcast lifecycle against the allow-listed Livestream
+  API: prepare/reuse RTMPS source, wait for `is_stream_active`, publish, end;
+  read-only live chat connector.
+- **Per-user X live authorization** (`x_oauth1.rs`, plan 029, PR #15) —
+  in-app 3-legged OAuth 1.0a ("Authorize X Live" in the Streaming tab). The
+  app-level consumer pair is baked at build time
+  (`VIDEORC_BUNDLED_X_OAUTH1_CONSUMER_KEY/_SECRET`); each user's access token
+  is minted in the browser flow and stored in the local secret store. Env
+  token vars remain a smoke/self-host override. Disconnecting X deletes the
+  stored token.
+- **OAuth callback parsing fix** (`main.rs`) — `OAuthCallbackQuery` no longer
+  camelCases provider wire names; `oauth_token`/`oauth_verifier` (and OAuth2
+  `error_description`) parse correctly. Regression test added.
+- **Release gate** (`macos-release-artifact-validation.mjs`) — artifact
+  validation fails closed unless the release backend binary embeds both exact
+  bundled X consumer values.
+
+## Release status
+
+- [x] Feature PR merged through the protected `main` rule:
+      https://github.com/TheOrcDev/videorc/pull/15
+- [x] Release prep PR merged: https://github.com/TheOrcDev/videorc/pull/16
+- [x] Signed + notarized build (releaseId `0.9.20-beta.1`); artifact
+      validation PASS incl. the bundled X consumer gate.
+- [x] Uploaded to R2, all objects verified by `pnpm release:upload:macos`.
+- [x] Feed verified: `www.videorc.com/api/updates/latest-mac.yml` serves
+      `version: 0.9.20` (followed the redirect to R2).
+- [x] Public changelog API verified latest entry is `0.9.20-beta.1`
+      ("Go live on X natively — official X partnership").
+- [x] Discord announced (`pnpm release:notify:discord`).
+
+## Verification
+
+- `pnpm changelog:check` — PASS (21 entries, latest `0.9.20-beta.1`).
+- `cargo fmt --check --all`, `cargo clippy -p videorc-backend -- -D warnings`,
+  `cargo test -p videorc-backend` — PASS (824 tests incl. 3-legged flow
+  stub-server tests and the callback-parsing regression test).
+- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — PASS.
+- `pnpm --filter @videorc/desktop test` — PASS (59 files / 486 tests).
+- `pnpm test:scripts` — PASS (355 tests incl. the new release-gate tests).
+- `pnpm smoke:oauth` + `pnpm smoke:oauth-guards` — PASS against the real app.
+- End-to-end 3-legged OAuth 1.0a flow exercised against a stub X server
+  (start → callback → token stored → capability ready).
+- Owner verified Authorize X Live end-to-end against real X on a dev build
+  (badge flips to "X API ready").
+
+## Pending owner acceptance
+
+- [ ] Packaged-build fresh-profile by-eye: install 0.9.20, connect X,
+      Authorize X Live, go live natively, end broadcast.
+- [ ] Real X broadcast A/V by-eye on the published stream.


### PR DESCRIPTION
Internal release record for 0.9.20-beta.1 (native X live via the official X partnership): scope, gates, upload/feed verification, pending owner acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)