### PR TITLE
X native live: playback verification, source health, lifecycle logs (plan 030)

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -145,6 +145,7 @@ import type {
   XEndResult,
   XLiveAuthorizationStart,
   XLiveChatStartParams,
+  XPlaybackEvent,
   XPublishResult,
   YouTubeBroadcastTransitionResult,
   YouTubeChannel,
@@ -1329,6 +1330,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const automaticSourceFallbacks = useRef<AutomaticSourceFallbackEvent[]>([])
   const toastedFailedTargets = useRef<Set<string>>(new Set())
   const platformLifecycleRun = useRef(0)
+  // One-shot playback toasts per broadcast+status (probe events may repeat).
+  const xPlaybackToastsRef = useRef(new Set<string>())
   const [previewRefreshNonce, setPreviewRefreshNonce] = useState(0)
   const nativePreviewSurfaceEnabled = Boolean(runtimeInfo?.nativePreviewSurfaceProofEnabled)
 
@@ -2581,6 +2584,63 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           toast.error('OAuth callback failed.', {
             description: result.message ?? result.status ?? 'Connection could not be completed.'
           })
+        }
+      }),
+      nextClient.on('streamTargets.x.playback', (payload) => {
+        const event = payload as XPlaybackEvent
+        // One toast per broadcast+status; the probe may re-emit while polling.
+        const toastKey = `${event.broadcastId}:${event.status}`
+        const alreadyToasted = xPlaybackToastsRef.current.has(toastKey)
+        xPlaybackToastsRef.current.add(toastKey)
+        const patch =
+          event.status === 'verified'
+            ? {
+                state: 'live' as const,
+                message: `Viewers can watch your X broadcast: ${event.shareUrl}`,
+                redactedUrl: event.shareUrl
+              }
+            : event.status === 'pending'
+              ? {
+                  state: 'warning' as const,
+                  message:
+                    'X is still provisioning playback — viewers may see a loading spinner. Keep streaming; this can take a few minutes.',
+                  redactedUrl: event.shareUrl
+                }
+              : {
+                  state: 'warning' as const,
+                  message:
+                    'X never produced playback for this broadcast — viewers saw a loading spinner. Your local recording is unaffected.',
+                  redactedUrl: event.shareUrl
+                }
+        setCaptureConfig((current) => {
+          const target = current.streaming.targets.find(
+            (candidate) =>
+              candidate.platform === 'x' && candidate.enabled && candidate.authMode === 'oauth'
+          )
+          if (!target) {
+            return current
+          }
+          return bridgeStreamingToLegacy({
+            ...current,
+            streaming: patchPreparedStreamTarget(current.streaming, target.id, { status: patch })
+          })
+        })
+        if (!alreadyToasted) {
+          if (event.status === 'verified') {
+            toast.success('Viewers can watch your X broadcast.', {
+              description: event.shareUrl
+            })
+          } else if (event.status === 'pending') {
+            toast.warning('X is still provisioning playback.', {
+              description:
+                'Viewers may see a loading spinner for a few minutes. Keep streaming — Videorc keeps checking.'
+            })
+          } else {
+            toast.error('X never produced playback for this broadcast.', {
+              description:
+                'Viewers saw a loading spinner. Your local recording is unaffected; the next Go Live uses a replacement source if this repeats.'
+            })
+          }
         }
       }),
       nextClient.on('ai.artifacts.changed', () => {
@@ -4863,7 +4923,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             isLowLatency: true,
             shouldNotTweet: false,
             locale: 'en',
-            chatOption: 2
+            chatOption: 2,
+            sessionId
           })
 
           if (platformLifecycleRun.current !== runId) {

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -806,11 +806,14 @@ export interface XPublishParams {
   shouldNotTweet: boolean
   locale?: string
   chatOption?: number
+  /** Active capture session — X lifecycle events land in its session log. */
+  sessionId?: string
 }
 
 export interface XEndParams {
   accountId?: string
   broadcastId: string
+  sessionId?: string
 }
 
 export interface XLiveChatStartParams {
@@ -850,6 +853,9 @@ export interface PreparedXStreamSource {
   isStreamActive: boolean
   recommendedConfiguration?: unknown
   compatibilityInfo?: unknown
+  /** How prepare picked the source (env-override | reused-name-match | adopted-measured | created). */
+  selection: string
+  deletedRetiredSourceIds: string[]
 }
 
 export interface XPublishResult {
@@ -863,7 +869,20 @@ export interface XPublishResult {
   state: string
   tweetId?: string
   tweetError?: string
+  hlsUrl?: string
+  playableBeforePublish?: boolean
+  prePublishWaitMs?: number
+  compatibilityInfo?: unknown
   message: string
+}
+
+/** `streamTargets.x.playback` event — the post-publish watchability probe. */
+export interface XPlaybackEvent {
+  sessionId?: string | null
+  broadcastId: string
+  shareUrl: string
+  status: 'verified' | 'pending' | 'unavailable'
+  msAfterPublish?: number
 }
 
 export interface XEndResult {

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -1708,17 +1708,44 @@ async fn prepare_x_native_live(
     x_live::ensure_x_native_live_available(&capability)?;
     let credentials = x_live::x_livestream_credentials()?
         .context("X Livestream OAuth 1.0a credentials are not available. Run Authorize X Live from the Streaming tab.")?;
-    let prepared = x_live::prepare_x_stream_source(
+    let prepared = match x_live::prepare_x_stream_source(
         XPrepareSourceRequest {
             credentials: credentials.clone(),
             account: account.cloned(),
             source_name: x_live::default_source_name(),
             api_base_url: None,
+            retired_source_ids: retired_x_source_ids(state),
         },
         &reqwest::Client::new(),
         secrets::put_secret,
     )
-    .await?;
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            state.emit_log("error", format!("X source prepare failed: {error}"));
+            return Err(error);
+        }
+    };
+    // Prepare runs before the capture session exists — the global log is the
+    // durable record (the ring no longer floods with FFmpeg progress spam).
+    state.emit_log(
+        "info",
+        format!(
+            "X source prepared: {} ({:?}, region {}){}",
+            prepared.source_id,
+            prepared.selection,
+            prepared.region,
+            if prepared.deleted_retired_source_ids.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "; deleted retired source(s) {}",
+                    prepared.deleted_retired_source_ids.join(", ")
+                )
+            }
+        ),
+    );
 
     let existing = state
         .database
@@ -1764,6 +1791,7 @@ async fn publish_x_native_live(
     state: &AppState,
     params: XPublishParams,
 ) -> anyhow::Result<XPublishResult> {
+    let session_id = params.session_id.clone();
     let accounts = state.database.list_platform_accounts()?;
     let account = x_live::select_x_account(&accounts, params.account_id.as_deref())?;
     let capability = x_live::x_native_live_capability(account)?;
@@ -1771,7 +1799,8 @@ async fn publish_x_native_live(
     let metadata = state.database.stream_metadata_draft()?;
     let credentials = x_live::x_livestream_credentials()?
         .context("X Livestream OAuth 1.0a credentials are not available. Run Authorize X Live from the Streaming tab.")?;
-    x_live::publish_x_broadcast(
+    let source_id = params.source_id.clone();
+    let result = x_live::publish_x_broadcast(
         XPublishRequest {
             credentials,
             source_id: params.source_id,
@@ -1784,20 +1813,85 @@ async fn publish_x_native_live(
             api_base_url: None,
             poll_attempts: 10,
             poll_interval_ms: 2_000,
+            // Bounded pre-publish playback gate: up to 45s for X to bring up
+            // the transcode BEFORE the announcement post goes out.
+            pre_publish_probe_attempts: 9,
+            pre_publish_probe_interval_ms: 5_000,
         },
         &reqwest::Client::new(),
     )
-    .await
+    .await;
+
+    match &result {
+        Ok(published) => {
+            log_x_lifecycle(
+                state,
+                session_id.as_deref(),
+                protocol::HealthLevel::Info,
+                "x-broadcast-published",
+                &format!(
+                    "X broadcast {} is live: {}{}{}",
+                    published.broadcast_id,
+                    published.share_url,
+                    match published.playable_before_publish {
+                        Some(true) => " (playback verified before the announcement post)",
+                        Some(false) =>
+                            " (playback was NOT ready before the announcement post; watching)",
+                        None => "",
+                    },
+                    published
+                        .tweet_error
+                        .as_deref()
+                        .map(|error| format!("; announcement post failed: {error}"))
+                        .unwrap_or_default()
+                ),
+            );
+            if let Some(compatibility) = published
+                .compatibility_info
+                .as_ref()
+                .filter(|info| x_compatibility_notable(info))
+            {
+                log_x_lifecycle(
+                    state,
+                    session_id.as_deref(),
+                    protocol::HealthLevel::Warn,
+                    "x-source-compatibility",
+                    &format!("X ingest compatibility report: {compatibility}"),
+                );
+            }
+            spawn_x_playback_watch(
+                state.clone(),
+                session_id.clone(),
+                source_id,
+                published.broadcast_id.clone(),
+                published.share_url.clone(),
+                published.hls_url.clone(),
+                published.playable_before_publish,
+            );
+        }
+        Err(error) => {
+            log_x_lifecycle(
+                state,
+                session_id.as_deref(),
+                protocol::HealthLevel::Error,
+                "x-publish-failed",
+                &format!("X broadcast publish failed: {error}"),
+            );
+        }
+    }
+
+    result
 }
 
 async fn end_x_native_live(state: &AppState, params: XEndParams) -> anyhow::Result<XEndResult> {
+    let session_id = params.session_id.clone();
     let accounts = state.database.list_platform_accounts()?;
     let account = x_live::select_x_account(&accounts, params.account_id.as_deref())?;
     let capability = x_live::x_native_live_capability(account)?;
     x_live::ensure_x_native_live_available(&capability)?;
     let credentials = x_live::x_livestream_credentials()?
         .context("X Livestream OAuth 1.0a credentials are not available. Run Authorize X Live from the Streaming tab.")?;
-    x_live::end_x_broadcast(
+    let result = x_live::end_x_broadcast(
         XEndRequest {
             credentials,
             broadcast_id: params.broadcast_id,
@@ -1805,7 +1899,229 @@ async fn end_x_native_live(state: &AppState, params: XEndParams) -> anyhow::Resu
         },
         &reqwest::Client::new(),
     )
-    .await
+    .await;
+    match &result {
+        Ok(ended) => log_x_lifecycle(
+            state,
+            session_id.as_deref(),
+            protocol::HealthLevel::Info,
+            "x-broadcast-ended",
+            &format!("X broadcast {} ended.", ended.broadcast_id),
+        ),
+        Err(error) => log_x_lifecycle(
+            state,
+            session_id.as_deref(),
+            protocol::HealthLevel::Error,
+            "x-end-failed",
+            &format!("X broadcast end failed: {error}"),
+        ),
+    }
+    result
+}
+
+/// X lifecycle evidence: session log when a session exists, global log
+/// otherwise — either way it reaches the support bundle.
+fn log_x_lifecycle(
+    state: &AppState,
+    session_id: Option<&str>,
+    level: protocol::HealthLevel,
+    code: &str,
+    message: &str,
+) {
+    let log_level = match level {
+        protocol::HealthLevel::Error => "error",
+        protocol::HealthLevel::Warn => "warn",
+        protocol::HealthLevel::Info => "info",
+    };
+    match session_id {
+        Some(session_id) => {
+            if recording::emit_health_event(state, Some(session_id), level, code, message).is_err()
+            {
+                state.emit_log(log_level, message);
+            }
+        }
+        None => state.emit_log(log_level, message),
+    }
+}
+
+fn x_compatibility_notable(info: &serde_json::Value) -> bool {
+    ["errors", "warnings"].iter().any(|key| {
+        info.get(key)
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|entries| !entries.is_empty())
+    })
+}
+
+fn retired_x_source_ids(state: &AppState) -> Vec<String> {
+    x_source_health_map(state)
+        .into_iter()
+        .filter(|(_, health)| health.retired)
+        .map(|(source_id, _)| source_id)
+        .collect()
+}
+
+fn x_source_health_map(
+    state: &AppState,
+) -> std::collections::HashMap<String, x_live::XSourceHealth> {
+    state
+        .database
+        .load_setting(x_live::X_SOURCE_HEALTH_SETTING)
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+}
+
+fn record_x_playback_outcome(state: &AppState, source_id: &str, verified: bool) {
+    let mut map = x_source_health_map(state);
+    let health = map.remove(source_id).unwrap_or_default();
+    let updated =
+        x_live::apply_x_playback_outcome(health, verified, &chrono::Utc::now().to_rfc3339());
+    let retired = updated.retired;
+    map.insert(source_id.to_string(), updated);
+    if let Err(error) = state
+        .database
+        .save_setting(x_live::X_SOURCE_HEALTH_SETTING, &map)
+    {
+        state.emit_log(
+            "warn",
+            format!("Could not persist X source health for {source_id}: {error}"),
+        );
+    }
+    if retired && !verified {
+        state.emit_log(
+            "warn",
+            format!(
+                "X source {source_id} retired after {} consecutive sessions without playback; the next Go Live will replace it.",
+                x_live::X_SOURCE_RETIRE_FAILURES
+            ),
+        );
+    }
+}
+
+const X_PLAYBACK_WATCH_INTERVAL_MS: u64 = 5_000;
+const X_PLAYBACK_WATCH_MAX_ATTEMPTS: u32 = 60; // ~5 minutes
+const X_PLAYBACK_PENDING_WARN_AFTER_MS: u128 = 90_000;
+
+/// Post-publish playback watch: keeps probing the broadcast's HLS playlist
+/// so the broadcaster learns within seconds whether viewers can actually
+/// watch — the 2026-07-08 incident streamed 108s to a spinner in silence.
+#[allow(clippy::too_many_arguments)]
+fn spawn_x_playback_watch(
+    state: AppState,
+    session_id: Option<String>,
+    source_id: String,
+    broadcast_id: String,
+    share_url: String,
+    hls_url: Option<String>,
+    playable_before_publish: Option<bool>,
+) {
+    let Some(hls_url) = hls_url else {
+        log_x_lifecycle(
+            &state,
+            session_id.as_deref(),
+            protocol::HealthLevel::Warn,
+            "x-playback-unknown",
+            "X did not return a playback URL for this broadcast; watchability cannot be verified.",
+        );
+        return;
+    };
+
+    tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        let published_at = std::time::Instant::now();
+        let emit_status = |status: &str, ms_after_publish: Option<u64>| {
+            state.emit_event(
+                "streamTargets.x.playback",
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "broadcastId": broadcast_id,
+                    "shareUrl": share_url,
+                    "status": status,
+                    "msAfterPublish": ms_after_publish,
+                }),
+            );
+        };
+
+        if playable_before_publish == Some(true) {
+            log_x_lifecycle(
+                &state,
+                session_id.as_deref(),
+                protocol::HealthLevel::Info,
+                "x-playback-verified",
+                &format!(
+                    "Viewers can watch your X broadcast (verified before publish): {share_url}"
+                ),
+            );
+            emit_status("verified", Some(0));
+            record_x_playback_outcome(&state, &source_id, true);
+            return;
+        }
+
+        let mut warned_pending = false;
+        for _ in 0..X_PLAYBACK_WATCH_MAX_ATTEMPTS {
+            if x_live::x_playlist_playable(&client, &hls_url)
+                .await
+                .unwrap_or(false)
+            {
+                let elapsed = published_at.elapsed().as_millis() as u64;
+                log_x_lifecycle(
+                    &state,
+                    session_id.as_deref(),
+                    protocol::HealthLevel::Info,
+                    "x-playback-verified",
+                    &format!(
+                        "Viewers can watch your X broadcast ({}s after publish): {share_url}",
+                        elapsed / 1_000
+                    ),
+                );
+                emit_status("verified", Some(elapsed));
+                record_x_playback_outcome(&state, &source_id, true);
+                return;
+            }
+            if !warned_pending
+                && published_at.elapsed().as_millis() >= X_PLAYBACK_PENDING_WARN_AFTER_MS
+            {
+                warned_pending = true;
+                log_x_lifecycle(
+                    &state,
+                    session_id.as_deref(),
+                    protocol::HealthLevel::Warn,
+                    "x-playback-pending",
+                    "X is still provisioning playback — viewers may see a loading spinner. Keep streaming; this can take a few minutes.",
+                );
+                emit_status("pending", Some(published_at.elapsed().as_millis() as u64));
+            }
+            // Stop probing once this session is no longer the active one.
+            if let Some(session_id) = session_id.as_deref() {
+                let active = state
+                    .recording
+                    .lock()
+                    .await
+                    .as_ref()
+                    .map(|active| active.session_id.clone());
+                if active.as_deref() != Some(session_id) {
+                    return;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(
+                X_PLAYBACK_WATCH_INTERVAL_MS,
+            ))
+            .await;
+        }
+
+        log_x_lifecycle(
+            &state,
+            session_id.as_deref(),
+            protocol::HealthLevel::Error,
+            "x-playback-unavailable",
+            "X never produced playback for this broadcast — viewers saw a loading spinner. Your local recording is unaffected.",
+        );
+        emit_status(
+            "unavailable",
+            Some(published_at.elapsed().as_millis() as u64),
+        );
+        record_x_playback_outcome(&state, &source_id, false);
+    });
 }
 
 fn upsert_validated_account(

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -1088,7 +1088,14 @@ pub async fn start_session(
                     continue;
                 }
 
-                log_state.emit_log("warn", trimmed);
+                // Progress/stat spam must not reach the bounded log ring —
+                // it evicted every useful entry within ~60s during the
+                // 2026-07-08 X incident. Stats still feed stream health.
+                if is_ffmpeg_progress_noise(trimmed) {
+                    tracing::debug!("{trimmed}");
+                } else {
+                    log_state.emit_log("warn", trimmed);
+                }
                 if let Some(stream_health) = parse_ffmpeg_stream_health(&log_session_id, trimmed) {
                     let scene_revision = current_compositor_scene_revision(&log_state).await;
                     let diagnostic_stats = {
@@ -7098,6 +7105,35 @@ fn emit_session_log(
     Ok(())
 }
 
+/// FFmpeg `-progress`/stats output: either the combined `frame= ... speed=`
+/// status line or a single `key=value` counter. These arrive multiple times
+/// per second and must stay out of the bounded log ring buffer.
+pub(crate) fn is_ffmpeg_progress_noise(line: &str) -> bool {
+    const PROGRESS_KEYS: [&str; 12] = [
+        "frame",
+        "fps",
+        "bitrate",
+        "total_size",
+        "out_time_us",
+        "out_time_ms",
+        "out_time",
+        "dup_frames",
+        "drop_frames",
+        "speed",
+        "progress",
+        "elapsed",
+    ];
+    let line = line.trim();
+    if line.starts_with("frame=") && line.contains("speed=") {
+        return true;
+    }
+    let Some((key, _)) = line.split_once('=') else {
+        return false;
+    };
+    let key = key.trim();
+    PROGRESS_KEYS.contains(&key) || key.starts_with("stream_") && key.ends_with("_q")
+}
+
 fn looks_like_ffmpeg_health_event(line: &str) -> bool {
     let normalized = line.to_lowercase();
     normalized.contains("dropped")
@@ -7163,6 +7199,41 @@ mod tests {
         StreamTargetState, default_stream_targets,
     };
     use tokio::sync::broadcast;
+
+    // Plan 030 S1: progress spam flooded the 200-entry log ring during the
+    // 2026-07-08 X incident, evicting every useful entry in ~60s. The filter
+    // must catch both the combined status line and per-key counters while
+    // letting real FFmpeg errors through.
+    #[test]
+    fn ffmpeg_progress_noise_filter_catches_stats_but_not_errors() {
+        assert!(is_ffmpeg_progress_noise(
+            "frame= 2224 fps= 29 q=-1.0 q=-1.0 size=   73984KiB time=00:01:16.00 bitrate=7974.7kbits/s speed=0.998x elapsed=0:01:16.12    frame=2224"
+        ));
+        for line in [
+            "fps=29.21",
+            "stream_0_0_q=-1.0",
+            "stream_1_0_q=-1.0",
+            "bitrate=7974.7kbits/s",
+            "total_size=75759616",
+            "out_time_us=76000011",
+            "out_time=00:01:16.000011",
+            "dup_frames=0",
+            "drop_frames=0",
+            "speed=0.998x",
+            "progress=continue",
+        ] {
+            assert!(is_ffmpeg_progress_noise(line), "should filter: {line}");
+        }
+        for line in [
+            "FFmpeg did not stop promptly after stdin quit command; sending SIGTERM.",
+            "[rtmp @ 0x7f8] Connection refused",
+            "Error writing trailer: Broken pipe",
+            "Conversion failed!",
+            "x=1", // unknown key=value stays visible
+        ] {
+            assert!(!is_ffmpeg_progress_noise(line), "should keep: {line}");
+        }
+    }
 
     // Plan 021 F3 (external tester: "gave it mic permissions but it's not
     // recording audio"): the silent-mic verdict must catch BOTH failure shapes —

--- a/crates/videorc-backend/src/storage.rs
+++ b/crates/videorc-backend/src/storage.rs
@@ -615,6 +615,20 @@ impl Database {
         Ok(SessionStorageTotals { count, total_bytes })
     }
 
+    pub fn load_setting<T: serde::de::DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {
+        let conn = self.lock()?;
+        let value_json: Option<String> = conn
+            .query_row(
+                "SELECT value_json FROM app_settings WHERE key = ?1",
+                params![key],
+                |row| row.get(0),
+            )
+            .optional()?;
+        value_json
+            .map(|value_json| serde_json::from_str(&value_json).map_err(Into::into))
+            .transpose()
+    }
+
     pub fn save_setting<T: serde::Serialize>(&self, key: &str, value: &T) -> Result<()> {
         let conn = self.lock()?;
         conn.execute(

--- a/crates/videorc-backend/src/x_live.rs
+++ b/crates/videorc-backend/src/x_live.rs
@@ -73,6 +73,9 @@ pub struct XPublishParams {
     pub locale: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_option: Option<u8>,
+    /// Active capture session — X lifecycle events land in its session log.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -81,6 +84,8 @@ pub struct XEndParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account_id: Option<String>,
     pub broadcast_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -138,6 +143,10 @@ pub struct PreparedXStreamSource {
     pub recommended_configuration: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compatibility_info: Option<serde_json::Value>,
+    pub selection: XSourceSelection,
+    /// Retired sources deleted during this prepare (best-effort cleanup).
+    #[serde(default)]
+    pub deleted_retired_source_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -156,6 +165,14 @@ pub struct XPublishResult {
     pub tweet_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tweet_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hls_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub playable_before_publish: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pre_publish_wait_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compatibility_info: Option<serde_json::Value>,
     pub message: String,
 }
 
@@ -185,6 +202,19 @@ pub struct XPrepareSourceRequest {
     pub account: Option<PlatformAccount>,
     pub source_name: String,
     pub api_base_url: Option<String>,
+    /// Sources retired by the playback health model — never selected, and
+    /// deleted best-effort when idle.
+    pub retired_source_ids: Vec<String>,
+}
+
+/// How prepare arrived at the source it returns (session-log evidence).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum XSourceSelection {
+    EnvOverride,
+    ReusedNameMatch,
+    AdoptedMeasured,
+    Created,
 }
 
 #[derive(Debug, Clone)]
@@ -200,6 +230,13 @@ pub struct XPublishRequest {
     pub api_base_url: Option<String>,
     pub poll_attempts: usize,
     pub poll_interval_ms: u64,
+    // Pre-publish playback gate: after CREATE, wait for the HLS playlist to
+    // carry real segments before the PUBLISH that posts the announcement —
+    // so the tweet points at working video whenever X provisions in time.
+    // 0 attempts disables the gate. Publish proceeds either way (X may only
+    // provision on publish; never deadlock on the gate).
+    pub pre_publish_probe_attempts: usize,
+    pub pre_publish_probe_interval_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -231,6 +268,28 @@ struct XBroadcastEnvelope {
     broadcast: XBroadcast,
     #[serde(default)]
     share_url: Option<String>,
+    // Playback URLs exist from CREATE (before publish) — the watchability
+    // probe uses them to verify X is actually transcoding.
+    #[serde(default)]
+    video_access: Option<XVideoAccess>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct XVideoAccess {
+    #[serde(default)]
+    hls_url: Option<String>,
+    #[serde(default)]
+    https_hls_url: Option<String>,
+}
+
+impl XVideoAccess {
+    fn best_hls_url(&self) -> Option<String> {
+        self.https_hls_url
+            .clone()
+            .or_else(|| self.hls_url.clone())
+            .map(|url| url.trim().to_string())
+            .filter(|url| !url.is_empty())
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -252,6 +311,56 @@ struct XStreamSource {
     recommended_configuration: Option<serde_json::Value>,
     #[serde(default)]
     compatibility_info: Option<serde_json::Value>,
+    // X's measurement of the LAST stream this source received; present only
+    // once it has ever streamed. Nonzero video_bitrate = proven-real source.
+    #[serde(default)]
+    stream_attributes: Option<serde_json::Value>,
+}
+
+impl XStreamSource {
+    fn has_measured_stream(&self) -> bool {
+        self.stream_attributes
+            .as_ref()
+            .and_then(|attributes| attributes.get("video_bitrate"))
+            .and_then(serde_json::Value::as_f64)
+            .is_some_and(|bitrate| bitrate > 0.0)
+    }
+}
+
+/// Persisted per-source playback record (app_settings key `xSourceHealth`,
+/// a `{source_id: XSourceHealth}` map). Retirement is conservative — the
+/// 2026-07-08 incident proved a source can transcode one hour and not the
+/// next, so one bad probe only counts, it does not retire.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct XSourceHealth {
+    #[serde(default)]
+    pub last_verified_at: Option<String>,
+    #[serde(default)]
+    pub consecutive_failures: u32,
+    #[serde(default)]
+    pub retired: bool,
+}
+
+pub const X_SOURCE_HEALTH_SETTING: &str = "xSourceHealth";
+pub const X_SOURCE_RETIRE_FAILURES: u32 = 2;
+
+pub fn apply_x_playback_outcome(
+    mut health: XSourceHealth,
+    verified: bool,
+    now_rfc3339: &str,
+) -> XSourceHealth {
+    if verified {
+        health.last_verified_at = Some(now_rfc3339.to_string());
+        health.consecutive_failures = 0;
+        health.retired = false;
+    } else {
+        health.consecutive_failures = health.consecutive_failures.saturating_add(1);
+        if health.consecutive_failures >= X_SOURCE_RETIRE_FAILURES {
+            health.retired = true;
+        }
+    }
+    health
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -545,28 +654,67 @@ where
         Some(region) => region,
         None => get_region(client, &credentials, &base_url).await?,
     };
-    let source = if let Some(source_id) =
+    let mut deleted_retired_source_ids = Vec::new();
+    let (source, selection) = if let Some(source_id) =
         optional_env_any(&["VIDEORC_X_LIVESTREAM_SOURCE_ID", "X_LIVESTREAM_SOURCE_ID"])
     {
-        get_source(client, &credentials, &base_url, &source_id).await?
+        (
+            get_source(client, &credentials, &base_url, &source_id).await?,
+            XSourceSelection::EnvOverride,
+        )
     } else {
         let sources = list_sources(client, &credentials, &base_url)
             .await
             .unwrap_or_default();
-        if let Some(source) = sources.into_iter().find(|source| {
-            source.name.as_deref() == Some(request.source_name.as_str())
-                && source.rtmp_region.as_deref() == Some(region.as_str())
-        }) {
-            source
-        } else {
-            create_source(
-                client,
-                &credentials,
-                &base_url,
-                &request.source_name,
-                &region,
-            )
-            .await?
+        let retired = |source: &XStreamSource| {
+            request
+                .retired_source_ids
+                .iter()
+                .any(|retired_id| retired_id == &source.id)
+        };
+        // Best-effort cleanup: retired sources are dead weight against the
+        // per-user source quota. Never delete one that is actively receiving.
+        for source in sources.iter().filter(|s| retired(s) && !s.is_stream_active) {
+            if delete_source(client, &credentials, &base_url, &source.id)
+                .await
+                .is_ok()
+            {
+                deleted_retired_source_ids.push(source.id.clone());
+            }
+        }
+        let selected = sources
+            .iter()
+            .find(|source| {
+                !retired(source)
+                    && source.name.as_deref() == Some(request.source_name.as_str())
+                    && source.rtmp_region.as_deref() == Some(region.as_str())
+            })
+            .map(|source| (source.clone(), XSourceSelection::ReusedNameMatch))
+            .or_else(|| {
+                // Adopt any proven source in the region (e.g. one created in
+                // X Media Studio) before minting a fresh unproven one.
+                sources
+                    .iter()
+                    .find(|source| {
+                        !retired(source)
+                            && source.rtmp_region.as_deref() == Some(region.as_str())
+                            && source.has_measured_stream()
+                    })
+                    .map(|source| (source.clone(), XSourceSelection::AdoptedMeasured))
+            });
+        match selected {
+            Some(selected) => selected,
+            None => (
+                create_source(
+                    client,
+                    &credentials,
+                    &base_url,
+                    &request.source_name,
+                    &region,
+                )
+                .await?,
+                XSourceSelection::Created,
+            ),
         }
     };
 
@@ -618,6 +766,8 @@ where
         is_stream_active: source.is_stream_active,
         recommended_configuration: source.recommended_configuration,
         compatibility_info: source.compatibility_info,
+        selection,
+        deleted_retired_source_ids,
     })
 }
 
@@ -646,6 +796,9 @@ pub async fn publish_x_broadcast(
     {
         anyhow::bail!("X RTMPS source did not become active before publish.");
     }
+    let compatibility_info = last_source
+        .as_ref()
+        .and_then(|source| source.compatibility_info.clone());
 
     let created = create_broadcast(
         client,
@@ -672,6 +825,33 @@ pub async fn publish_x_broadcast(
         .clone()
         .or(created.broadcast.share_url.clone())
         .unwrap_or_else(|| format!("https://x.com/i/broadcasts/{broadcast_id}"));
+    let hls_url = created
+        .video_access
+        .as_ref()
+        .and_then(XVideoAccess::best_hls_url);
+
+    // Pre-publish playback gate: give X a bounded window to bring up the
+    // transcode BEFORE the announcement post goes out. Never fails publish.
+    let mut playable_before_publish = None;
+    let mut pre_publish_wait_ms = None;
+    if let Some(hls_url) = hls_url.as_deref()
+        && request.pre_publish_probe_attempts > 0
+    {
+        let started = std::time::Instant::now();
+        let mut playable = false;
+        for attempt in 0..request.pre_publish_probe_attempts {
+            if x_playlist_playable(client, hls_url).await.unwrap_or(false) {
+                playable = true;
+                break;
+            }
+            if attempt + 1 < request.pre_publish_probe_attempts {
+                sleep(Duration::from_millis(request.pre_publish_probe_interval_ms)).await;
+            }
+        }
+        playable_before_publish = Some(playable);
+        pre_publish_wait_ms = Some(started.elapsed().as_millis() as u64);
+    }
+
     let title = x_title(&request.metadata);
     let published = publish_broadcast(
         client,
@@ -701,8 +881,86 @@ pub async fn publish_x_broadcast(
             .unwrap_or_else(|| "RUNNING".to_string()),
         tweet_id: published.broadcast.tweet_id,
         tweet_error: published.broadcast.tweet_error,
+        hls_url,
+        playable_before_publish,
+        pre_publish_wait_ms,
+        compatibility_info,
         message: "X broadcast is live.".to_string(),
     })
+}
+
+/// One playback probe: does the HLS playlist behind `url` currently carry
+/// real media segments? Text-only fetches — never downloads video. A master
+/// playlist is followed one level to its first variant. `Ok(false)` covers
+/// every not-ready shape (HTTP errors, empty playlists) so callers can poll.
+pub async fn x_playlist_playable(client: &reqwest::Client, url: &str) -> Result<bool> {
+    let body = match fetch_playlist_text(client, url).await? {
+        Some(body) => body,
+        None => return Ok(false),
+    };
+    match playlist_verdict(&body) {
+        PlaylistVerdict::Playable => Ok(true),
+        PlaylistVerdict::NotReady => Ok(false),
+        PlaylistVerdict::Variant(variant) => {
+            let variant_url = resolve_playlist_url(url, &variant)?;
+            let Some(body) = fetch_playlist_text(client, &variant_url).await? else {
+                return Ok(false);
+            };
+            Ok(matches!(playlist_verdict(&body), PlaylistVerdict::Playable))
+        }
+    }
+}
+
+async fn fetch_playlist_text(client: &reqwest::Client, url: &str) -> Result<Option<String>> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .context("Could not reach the X playback playlist.")?;
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    Ok(Some(response.text().await.unwrap_or_default()))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PlaylistVerdict {
+    Playable,
+    /// Master playlist: the first variant URI to follow.
+    Variant(String),
+    NotReady,
+}
+
+fn playlist_verdict(body: &str) -> PlaylistVerdict {
+    let mut variant = None;
+    let mut saw_stream_inf = false;
+    for line in body.lines() {
+        let line = line.trim();
+        if line.starts_with("#EXTINF") {
+            return PlaylistVerdict::Playable;
+        }
+        if saw_stream_inf && !line.is_empty() && !line.starts_with('#') && variant.is_none() {
+            variant = Some(line.to_string());
+        }
+        if line.starts_with("#EXT-X-STREAM-INF") {
+            saw_stream_inf = true;
+        }
+    }
+    match variant {
+        Some(variant) => PlaylistVerdict::Variant(variant),
+        None => PlaylistVerdict::NotReady,
+    }
+}
+
+fn resolve_playlist_url(playlist_url: &str, reference: &str) -> Result<String> {
+    if reference.starts_with("http://") || reference.starts_with("https://") {
+        return Ok(reference.to_string());
+    }
+    let base = Url::parse(playlist_url).context("X playback playlist URL is invalid.")?;
+    Ok(base
+        .join(reference)
+        .context("Could not resolve the X playback variant URL.")?
+        .to_string())
 }
 
 pub async fn end_x_broadcast(request: XEndRequest, client: &reqwest::Client) -> Result<XEndResult> {
@@ -791,6 +1049,21 @@ async fn create_source(
     let response: XSourceEnvelope =
         send_x_request(client, credentials, Method::POST, url, Some(body)).await?;
     Ok(response.source)
+}
+
+async fn delete_source(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    source_id: &str,
+) -> Result<()> {
+    let url = endpoint(
+        base_url,
+        &format!("/2/users/{}/sources/{}", credentials.user_id, source_id),
+    )?;
+    let _: serde_json::Value =
+        send_x_request(client, credentials, Method::DELETE, url, None).await?;
+    Ok(())
 }
 
 async fn get_source(
@@ -1302,6 +1575,135 @@ mod tests {
         .unwrap();
 
         assert_eq!(direct, general);
+    }
+
+    #[test]
+    fn playlist_verdict_detects_segments_variants_and_not_ready() {
+        assert_eq!(
+            playlist_verdict("#EXTM3U\n#EXT-X-TARGETDURATION:2\n#EXTINF:2.0,\nseg0.ts\n"),
+            PlaylistVerdict::Playable
+        );
+        assert_eq!(
+            playlist_verdict(
+                "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=800000\nvariant/playlist.m3u8\n"
+            ),
+            PlaylistVerdict::Variant("variant/playlist.m3u8".to_string())
+        );
+        assert_eq!(
+            playlist_verdict("#EXTM3U\n#EXT-X-TARGETDURATION:2\n"),
+            PlaylistVerdict::NotReady
+        );
+        assert_eq!(playlist_verdict(""), PlaylistVerdict::NotReady);
+    }
+
+    #[test]
+    fn playlist_variant_urls_resolve_relative_and_absolute() {
+        assert_eq!(
+            resolve_playlist_url(
+                "https://video.pscp.tv/x/master.m3u8?type=live",
+                "variant/playlist.m3u8"
+            )
+            .unwrap(),
+            "https://video.pscp.tv/x/variant/playlist.m3u8"
+        );
+        assert_eq!(
+            resolve_playlist_url(
+                "https://video.pscp.tv/x/master.m3u8",
+                "https://other.pscp.tv/v.m3u8"
+            )
+            .unwrap(),
+            "https://other.pscp.tv/v.m3u8"
+        );
+    }
+
+    #[tokio::test]
+    async fn playlist_probe_follows_master_to_variant() {
+        use axum::Router;
+        use axum::routing::get;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new()
+                    .route(
+                        "/master.m3u8",
+                        get(|| async {
+                            "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=800000\nmedia.m3u8\n"
+                        }),
+                    )
+                    .route(
+                        "/media.m3u8",
+                        get(|| async { "#EXTM3U\n#EXTINF:2.0,\nseg0.ts\n" }),
+                    )
+                    .route("/empty.m3u8", get(|| async { "#EXTM3U\n" })),
+            )
+            .await
+            .unwrap();
+        });
+        let client = reqwest::Client::new();
+        assert!(
+            x_playlist_playable(&client, &format!("http://{address}/master.m3u8"))
+                .await
+                .unwrap()
+        );
+        assert!(
+            !x_playlist_playable(&client, &format!("http://{address}/empty.m3u8"))
+                .await
+                .unwrap()
+        );
+        assert!(
+            !x_playlist_playable(&client, &format!("http://{address}/missing.m3u8"))
+                .await
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn playback_outcomes_retire_only_after_consecutive_failures() {
+        let health = XSourceHealth::default();
+        let after_one = apply_x_playback_outcome(health, false, "2026-07-08T12:00:00Z");
+        assert_eq!(after_one.consecutive_failures, 1);
+        assert!(!after_one.retired);
+
+        let after_two = apply_x_playback_outcome(after_one.clone(), false, "2026-07-08T13:00:00Z");
+        assert_eq!(after_two.consecutive_failures, 2);
+        assert!(after_two.retired);
+
+        // A verified playback fully rehabilitates the source.
+        let recovered = apply_x_playback_outcome(after_two, true, "2026-07-08T14:00:00Z");
+        assert_eq!(recovered.consecutive_failures, 0);
+        assert!(!recovered.retired);
+        assert_eq!(
+            recovered.last_verified_at.as_deref(),
+            Some("2026-07-08T14:00:00Z")
+        );
+
+        // One failure after a success does NOT retire (the 2026-07-08
+        // incident source worked at 7 min and failed at 2 min same day).
+        let one_bad = apply_x_playback_outcome(recovered, false, "2026-07-08T15:00:00Z");
+        assert!(!one_bad.retired);
+    }
+
+    #[test]
+    fn measured_stream_requires_nonzero_video_bitrate() {
+        let mut source = XStreamSource {
+            id: "s1".to_string(),
+            name: None,
+            rtmp_region: None,
+            rtmps_url: None,
+            rtmp_url: None,
+            rtmp_stream_key: None,
+            is_stream_active: false,
+            recommended_configuration: None,
+            compatibility_info: None,
+            stream_attributes: None,
+        };
+        assert!(!source.has_measured_stream());
+        source.stream_attributes = Some(serde_json::json!({ "video_bitrate": 0.0 }));
+        assert!(!source.has_measured_stream());
+        source.stream_attributes = Some(serde_json::json!({ "video_bitrate": 5980074.0 }));
+        assert!(source.has_measured_stream());
     }
 
     #[test]


### PR DESCRIPTION
Implements plan 030 S1–S4 (see plans/030-x-native-playback-verification.md for the incident evidence).

## What
- **Pre-publish playback gate + post-publish watch**: Videorc now probes the broadcast's HLS playlist. The announce post waits up to 45s for real playback; after publish the watcher reports **verified** (with time-to-playable), **pending** (90s warning), or **unavailable** (error) — in the session log, support bundle, and UI.
- **X lifecycle in session logs**: prepared/published/ended/failed events; FFmpeg progress spam demoted out of the log ring (it evicted everything useful in ~60s during the incident).
- **Source health**: per-source playback outcomes persisted; 2-strike retirement (one strike must not retire — the incident source worked and failed the same day); selection ladder adopts measured healthy sources before creating fresh ones; retired sources deleted when idle.
- **Renderer**: playback status drives the X target row + one-shot toasts.

## Verification
cargo fmt/clippy/test (830), typecheck/lint/format, desktop tests (486), test:scripts (355), smoke:oauth-guards, smoke:platform-lifecycle, smoke:streaming-secrets. Live acceptance = plan 030 S5 (long session, second account watching) on 0.9.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger X live streaming status updates, including post-publish playback checks and clearer readiness feedback.
  * Improved source handling with automatic cleanup of retired sources and more detailed publish status information.

* **Bug Fixes**
  * Reduced noisy recording logs by filtering out FFmpeg progress output.
  * Improved error handling and toast notifications so users see more accurate publish/playback results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->