### PR TITLE
Release 0.9.21-beta.1: X playback verification

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.21-beta.1.md
+++ b/changelog/0.9.21-beta.1.md
@@ -1,0 +1,36 @@
+---
+version: 0.9.21-beta.1
+date: 2026-07-08
+channel: beta
+title: X broadcasts now verify that viewers can watch
+summary: Going live on X now confirms your broadcast is actually watchable — Videorc checks playback the way a viewer's player does and warns you immediately if X is still getting your stream ready.
+highlights:
+  - Videorc verifies your X broadcast plays for viewers, not just that video is flowing to X.
+  - The announcement post now waits briefly for playback to be ready, so it links to working video.
+  - If X is still preparing playback, you get a clear heads-up while you stream instead of silence.
+  - Your broadcast link is shown right on the X destination while you are live.
+---
+
+## X broadcasts now verify that viewers can watch
+
+Pushing video to X and viewers being able to watch are two different things —
+and until now Videorc only knew about the first one. Starting with this
+release, Videorc checks your X broadcast's playback the same way a viewer's
+player does. When it is confirmed watchable you'll see it in the app, along
+with your broadcast link ready to share.
+
+## Clear warnings instead of silence
+
+If X is still getting playback ready, Videorc tells you right away — viewers
+may see a loading spinner for a few minutes while X finishes preparing, and
+the app keeps checking until it clears. If playback never becomes available,
+Videorc says so plainly, and your local recording is never affected. Videorc
+also remembers which of your X ingest setups have worked before and quietly
+replaces ones that repeatedly fail.
+
+## Better answers when something goes wrong
+
+Every step of an X broadcast — setup, going live, the announcement post,
+playback checks, ending — is now recorded with your session, so support
+diagnostics can explain exactly what happened during a stream instead of
+guessing.


### PR DESCRIPTION
Version bump + changelog for the plan-030 playback-verification release (feature landed in #19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new beta release entry for the desktop app version update.

* **Bug Fixes**
  * Improved X broadcast reliability by checking whether playback is actually available to viewers.
  * Added clearer warnings when playback is still preparing, instead of failing silently.
  * If playback never becomes available, the app now reports this clearly without affecting local recording.
  * More detailed broadcast session logging is now included to help diagnose issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->