### PR TITLE
Release 0.9.22-beta.1: X source hygiene

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.22-beta.1.md
+++ b/changelog/0.9.22-beta.1.md
@@ -1,0 +1,35 @@
+---
+version: 0.9.22-beta.1
+date: 2026-07-08
+channel: beta
+title: X broadcasts start clean every time
+summary: Every X broadcast now gets a fresh ingest setup and a clean, properly ordered shutdown — fixing streams that looked live but never became watchable after an earlier session.
+highlights:
+  - Each X session now broadcasts on a fresh ingest setup — the condition that reliably plays for viewers right away.
+  - Stopping a stream now ends the X broadcast first, then shuts down the encoder, matching how X expects broadcasts to close.
+  - Stream shutdown is gentler, giving the connection to X time to close cleanly instead of being cut off.
+  - Old ingest setups are tidied up automatically, so nothing accumulates on your X account.
+---
+
+## X broadcasts start clean every time
+
+We traced the "stream looks live but viewers only see a spinner" problem to
+reusing X ingest setups after a previous session. The first broadcast on a
+fresh setup always played instantly; reusing it after a shutdown did not.
+Videorc now creates a fresh ingest setup for every X session, so each
+broadcast starts in the state that reliably works — and old setups are
+cleaned up automatically so your X account stays tidy.
+
+## Shutdown in the right order
+
+X expects a broadcast to be ended first, then the encoder to stop. Videorc
+used to do it the other way around, and the abrupt cut-off could leave the
+ingest in a bad state for the next session. Stopping a stream now ends the
+X broadcast while the feed is still up, then winds the encoder down with
+enough time to close the connection to X cleanly.
+
+## Verified, not assumed
+
+Together with the playback verification from 0.9.21, Videorc now confirms
+within seconds that viewers can actually watch — and with this release,
+every session starts from the clean state that makes that check pass.


### PR DESCRIPTION
Version bump + changelog for plan 031 (fresh X source per session, END-before-stop, graceful teardown; feature landed in #22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)