### PR TITLE
Docs: record 0.9.22 release

### DIFF
--- a/docs/releases/0.9.22.md
+++ b/docs/releases/0.9.22.md
@@ -1,0 +1,47 @@
+# Videorc 0.9.22 Beta 1
+
+Videorc 0.9.22 ships plan 031: fresh X source per session, END-before-stop
+teardown ordering, and graceful RTMP shutdown — the our-side fix for the
+recurring "live but viewers see a spinner" incident.
+
+## Scope
+
+- **Fresh source per session** (`x_live.rs`, plan 031 S2) — prepare creates
+  a new source every session (the only condition that ever produced
+  instantly-watchable playback); name-match reuse only when create fails;
+  idle Videorc-named leftovers + retired sources deleted best-effort
+  (quota-flat, never active/foreign sources).
+- **END before encoder stop** (`use-studio.tsx`, S1) — X's documented order
+  ("After ending, stop your encoder"); stopSession ENDs live X broadcasts
+  (bounded 4 s/target, timeout falls to the post-stop retry pass) before
+  `session.stop`; `x.end` carries the sessionId.
+- **Graceful RTMP teardown** (`recording.rs`, S3) — stream-leg sessions get
+  quit 8 s → SIGTERM 5 s (was 3 s/3 s → SIGKILL every session); finalize
+  timeout 12 s → 20 s. Success criterion: no "sending SIGKILL" lines in
+  record+stream session logs.
+
+## Release status
+
+- [x] Plan/impl PR https://github.com/TheOrcDev/videorc/pull/22, release
+      prep PR https://github.com/TheOrcDev/videorc/pull/23 — merged via
+      protected `main`.
+- [x] Signed + notarized build (releaseId `0.9.22-beta.1`); artifact
+      validation PASS incl. the bundled X consumer gate.
+- [x] Uploaded to R2, all objects verified.
+- [x] Feed verified: `www.videorc.com/api/updates/latest-mac.yml` serves
+      `version: 0.9.22`; changelog latest entry `0.9.22-beta.1`.
+- [x] Discord announced.
+
+## Verification
+
+- `cargo fmt/clippy/test` — PASS (830 tests; new source-cleanup rules).
+- `pnpm typecheck/lint/format:check` — PASS; desktop tests 486; scripts 355.
+- `pnpm smoke:oauth-guards`, `pnpm smoke:platform-lifecycle` — PASS.
+
+## Pending owner acceptance (plan 031)
+
+- [ ] TWO consecutive short (~2 min) real X sessions on 0.9.22. Each must
+      log `x-source-prepared … (Created)` with a NEW source id and
+      `x-playback-verified` within seconds; stop must show no
+      SIGTERM/SIGKILL escalation. If a fresh source still never verifies,
+      escalate to the X partner manager with the plans 030+031 evidence.


### PR DESCRIPTION
Internal release record for 0.9.22-beta.1 (X source hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)