### PR TITLE
Livestream metadata reaches every platform truthfully (Plan 032)

### DIFF
--- a/apps/desktop/src/renderer/src/components/go-live-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/go-live-dialog.tsx
@@ -126,8 +126,9 @@ export function GoLiveConfirmationDialog({
               </Select>
               <FieldDescription>
                 {draft?.defaultPrivacy === 'public'
-                  ? 'YouTube will be discoverable from the channel while live.'
-                  : 'YouTube will not be discoverable from the channel while live.'}
+                  ? 'YouTube will be discoverable from the channel while live. '
+                  : 'YouTube will not be discoverable from the channel while live. '}
+                Twitch and X broadcasts are always public.
               </FieldDescription>
             </Field>
 

--- a/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
@@ -1446,6 +1446,10 @@ function MetadataEditor({
                 <SelectItem value="public">Public</SelectItem>
               </SelectContent>
             </Select>
+            <FieldDescription>
+              Applies to YouTube. Twitch channels are always public; X broadcasts are always public
+              — use its Announce toggle below to control the announcement post.
+            </FieldDescription>
           </Field>
 
           <div className="flex flex-col gap-4">
@@ -1562,16 +1566,25 @@ function MetadataOverride({
         <FieldLabel htmlFor={`${override.platform}-metadata-description`}>Description</FieldLabel>
         <Textarea
           className="min-h-20 resize-y"
-          disabled={fieldsDisabled || twitch}
+          disabled={fieldsDisabled || twitch || x}
           id={`${override.platform}-metadata-description`}
           placeholder={
-            twitch ? 'Not supported by Twitch' : draft.description || 'Inherits global description'
+            twitch
+              ? 'Not supported by Twitch'
+              : x
+                ? 'Not supported by X'
+                : draft.description || 'Inherits global description'
           }
-          value={twitch ? '' : override.description}
+          value={twitch || x ? '' : override.description}
           onChange={(event) => onPatch({ description: event.target.value })}
         />
         {twitch ? (
           <FieldDescription>Twitch supports title, category, and language.</FieldDescription>
+        ) : null}
+        {x ? (
+          <FieldDescription>
+            X broadcasts carry a title only; it doubles as the announcement post text.
+          </FieldDescription>
         ) : null}
       </Field>
 
@@ -1679,23 +1692,20 @@ function MetadataOverride({
       ) : null}
 
       {x ? (
-        <Field>
-          <FieldLabel>Visibility</FieldLabel>
-          <Select
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-col">
+            <span className="text-sm font-medium">Announce on X timeline</span>
+            <span className="text-xs text-muted-foreground">
+              X broadcasts are always public. Off skips the announcement post.
+            </span>
+          </div>
+          <Switch
+            aria-label="Announce on X timeline"
+            checked={override.xAnnounce ?? true}
             disabled={fieldsDisabled}
-            value={override.xVisibility ?? 'public'}
-            onValueChange={(value) => onPatch({ xVisibility: value as StreamPrivacy })}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="public">Public</SelectItem>
-              <SelectItem value="unlisted">Unlisted</SelectItem>
-              <SelectItem value="private">Private</SelectItem>
-            </SelectContent>
-          </Select>
-        </Field>
+            onCheckedChange={(xAnnounce) => onPatch({ xAnnounce })}
+          />
+        </div>
       ) : null}
     </div>
   )

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -111,6 +111,7 @@ import type {
   PlatformAccountValidation,
   PreparedXStreamSource,
   PreparedTwitchBroadcast,
+  TwitchAppliedMetadata,
   PreparedYouTubeBroadcast,
   OAuthCompleteParams,
   OAuthStartResult,
@@ -4916,14 +4917,13 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             })
           )
 
+          // Metadata (title, announce-on-timeline) is derived backend-side
+          // from the stream metadata draft — never hardcoded here.
           const result = await client.request<XPublishResult>('streamTargets.x.publish', {
             accountId: target.accountId,
             sourceId,
             region,
             isLowLatency: true,
-            shouldNotTweet: false,
-            locale: 'en',
-            chatOption: 2,
             sessionId
           })
 
@@ -5359,6 +5359,45 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       }
     }
 
+    // Manual-RTMP Twitch targets: the transport is a user-provided stream
+    // key, but Helix channel updates work regardless of ingest path — push
+    // title/category/language through the connected account. Best-effort:
+    // a metadata failure must not block going live over the key.
+    const twitchAccount = platformAccounts.find((item) => item.platform === 'twitch')
+    for (const target of captureConfig.streaming.targets.filter(
+      (target) => target.enabled && target.authMode !== 'oauth' && target.platform === 'twitch'
+    )) {
+      if (!twitchAccount) {
+        nextStreaming = patchPreparedStreamTarget(nextStreaming, target.id, {
+          status: {
+            state: 'ready',
+            message: 'Streaming over stream key. Connect Twitch to push title and category.'
+          }
+        })
+        continue
+      }
+      try {
+        const applied = await client.request<TwitchAppliedMetadata>(
+          'streamTargets.twitch.applyMetadata',
+          { accountId: twitchAccount.accountId }
+        )
+        nextStreaming = patchPreparedStreamTarget(nextStreaming, target.id, {
+          status: {
+            state: 'ready',
+            message: `Twitch channel metadata updated ("${applied.title}").`
+          }
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        nextStreaming = patchPreparedStreamTarget(nextStreaming, target.id, {
+          status: {
+            state: 'ready',
+            message: `Streaming over stream key; channel metadata update failed: ${message}`
+          }
+        })
+      }
+    }
+
     setCaptureConfig((current) => bridgeStreamingToLegacy({ ...current, streaming: nextStreaming }))
     await refreshPlatformAccountsForClient(client)
     return {
@@ -5366,7 +5405,13 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       failures,
       readyLabels: readyStreamTargetLabels(nextStreaming)
     }
-  }, [captureConfig.streaming, captureConfig.video, client, refreshPlatformAccountsForClient])
+  }, [
+    captureConfig.streaming,
+    captureConfig.video,
+    client,
+    platformAccounts,
+    refreshPlatformAccountsForClient
+  ])
 
   const openGoLiveConfirmation = useCallback(async () => {
     if (!client || startBlockedReason) {

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -638,7 +638,11 @@ export interface StreamTargetMetadataDraft {
   twitchCategoryId?: string
   twitchCategoryName?: string
   twitchLanguage?: string
-  xVisibility?: StreamPrivacy
+  /**
+   * X has no unlisted/private concept — the only reach lever is suppressing
+   * the announcement post. Undefined means announce (the platform default).
+   */
+  xAnnounce?: boolean
   updatedAt: string
 }
 
@@ -762,6 +766,17 @@ export interface TwitchCategory {
   boxArtUrl?: string
 }
 
+/** Result of `streamTargets.twitch.applyMetadata` — channel metadata pushed without touching the stream key. */
+export interface TwitchAppliedMetadata {
+  platform: 'twitch'
+  accountId: string
+  accountLabel: string
+  title: string
+  categoryId?: string
+  categoryName?: string
+  language?: string
+}
+
 export interface PreparedTwitchBroadcast {
   platform: 'twitch'
   accountId: string
@@ -803,9 +818,6 @@ export interface XPublishParams {
   sourceId: string
   region: string
   isLowLatency: boolean
-  shouldNotTweet: boolean
-  locale?: string
-  chatOption?: number
   /** Active capture session — X lifecycle events land in its session log. */
   sessionId?: string
 }

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -1589,6 +1589,46 @@ async fn search_twitch_categories(
     .await
 }
 
+/// Push channel title/category/language for a manual-RTMP Twitch target.
+/// Helix channel updates work regardless of ingest path, so a stream-key
+/// session with a connected account still gets its metadata applied.
+async fn apply_twitch_stream_target_metadata(
+    state: &AppState,
+    params: TwitchPrepareParams,
+) -> anyhow::Result<twitch::TwitchAppliedMetadata> {
+    let metadata = state.database.stream_metadata_draft()?;
+    let validation = validate_stream_metadata_draft(&metadata);
+    if !validation.valid {
+        let message = validation
+            .issues
+            .first()
+            .map(|issue| issue.message.as_str())
+            .unwrap_or("Stream metadata is invalid.");
+        anyhow::bail!("{message}");
+    }
+
+    let credential = twitch_account_credentials(state, params.account_id.as_deref())?;
+    let access_ref = credential
+        .token_secret_ref
+        .as_deref()
+        .context("No Twitch access token is stored.")?;
+    let access_token = secrets::get_secret(access_ref)?;
+    let client_id = oauth::provider_client_id(StreamPlatform::Twitch)?;
+
+    twitch::apply_twitch_channel_metadata(
+        &TwitchPrepareRequest {
+            access_token,
+            client_id,
+            account_id: credential.account.account_id.clone(),
+            account_label: credential.account.account_label.clone(),
+            metadata,
+            api_base_url: None,
+        },
+        &reqwest::Client::new(),
+    )
+    .await
+}
+
 async fn prepare_twitch_stream_target(
     state: &AppState,
     params: TwitchPrepareParams,
@@ -1807,9 +1847,8 @@ async fn publish_x_native_live(
             region: params.region,
             metadata,
             is_low_latency: params.is_low_latency,
-            should_not_tweet: params.should_not_tweet,
-            locale: x_live::default_publish_locale(params.locale),
-            chat_option: x_live::default_chat_option(params.chat_option),
+            locale: x_live::default_publish_locale(),
+            chat_option: x_live::default_chat_option(),
             api_base_url: None,
             poll_attempts: 10,
             poll_interval_ms: 2_000,
@@ -3505,6 +3544,21 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
                     Err(error) => ServerResponse::error(
                         command.id,
                         "twitch-prepare-failed",
+                        error.to_string(),
+                    ),
+                },
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
+        "streamTargets.twitch.applyMetadata" => {
+            match serde_json::from_value::<TwitchPrepareParams>(command.params) {
+                Ok(params) => match apply_twitch_stream_target_metadata(state, params).await {
+                    Ok(applied) => ServerResponse::ok(command.id, applied),
+                    Err(error) => ServerResponse::error(
+                        command.id,
+                        "twitch-apply-metadata-failed",
                         error.to_string(),
                     ),
                 },

--- a/crates/videorc-backend/src/streaming.rs
+++ b/crates/videorc-backend/src/streaming.rs
@@ -288,8 +288,11 @@ pub struct StreamTargetMetadataDraft {
     pub twitch_category_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub twitch_language: Option<String>,
+    /// X has no unlisted/private concept — the only reach lever the
+    /// Livestream API exposes is suppressing the announcement post
+    /// (`should_not_tweet`). None means announce (the platform default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub x_visibility: Option<StreamPrivacy>,
+    pub x_announce: Option<bool>,
     pub updated_at: String,
 }
 
@@ -453,7 +456,7 @@ pub fn default_stream_metadata_draft(updated_at: String) -> StreamMetadataDraft 
             twitch_category_id: None,
             twitch_category_name: None,
             twitch_language: (platform == StreamPlatform::Twitch).then(|| "en".to_string()),
-            x_visibility: (platform == StreamPlatform::X).then_some(StreamPrivacy::Public),
+            x_announce: (platform == StreamPlatform::X).then_some(true),
             updated_at: updated_at.clone(),
         })
         .collect(),
@@ -782,8 +785,8 @@ mod tests {
                 .iter()
                 .find(|target| target.platform == StreamPlatform::X)
                 .unwrap()
-                .x_visibility,
-            Some(StreamPrivacy::Public)
+                .x_announce,
+            Some(true)
         );
     }
 

--- a/crates/videorc-backend/src/twitch.rs
+++ b/crates/videorc-backend/src/twitch.rs
@@ -63,6 +63,24 @@ pub struct PreparedTwitchBroadcast {
     pub language: Option<String>,
 }
 
+/// Result of pushing channel metadata without touching the stream key —
+/// used for manual-RTMP Twitch targets, where the stream transport is a
+/// user-provided key but the channel page can still be updated via Helix.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TwitchAppliedMetadata {
+    pub platform: StreamPlatform,
+    pub account_id: String,
+    pub account_label: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TwitchCategorySearchResult {
@@ -102,14 +120,17 @@ struct TwitchCategorySearchResponse {
     data: Vec<TwitchCategory>,
 }
 
-pub async fn prepare_twitch_broadcast(
-    request: TwitchPrepareRequest,
+/// Push effective title/category/language to the channel via Helix
+/// `PATCH /helix/channels`. Works regardless of how the stream is ingested
+/// (OAuth-prepared or manual stream key).
+pub async fn apply_twitch_channel_metadata(
+    request: &TwitchPrepareRequest,
     client: &reqwest::Client,
-    put_secret: impl FnOnce(&str, &str) -> Result<()>,
-) -> Result<PreparedTwitchBroadcast> {
+) -> Result<TwitchAppliedMetadata> {
     let metadata = effective_twitch_metadata(&request.metadata)?;
     let base_url = request
         .api_base_url
+        .clone()
         .unwrap_or_else(|| TWITCH_API_BASE_URL.to_string());
 
     let mut channel_body = Map::new();
@@ -141,6 +162,28 @@ pub async fn prepare_twitch_broadcast(
         .context("Could not update Twitch channel metadata.")?
         .error_for_status()
         .context("Twitch channel metadata update failed.")?;
+
+    Ok(TwitchAppliedMetadata {
+        platform: StreamPlatform::Twitch,
+        account_id: request.account_id.clone(),
+        account_label: request.account_label.clone(),
+        title: metadata.title,
+        category_id: metadata.category_id,
+        category_name: metadata.category_name,
+        language: metadata.language,
+    })
+}
+
+pub async fn prepare_twitch_broadcast(
+    request: TwitchPrepareRequest,
+    client: &reqwest::Client,
+    put_secret: impl FnOnce(&str, &str) -> Result<()>,
+) -> Result<PreparedTwitchBroadcast> {
+    let base_url = request
+        .api_base_url
+        .clone()
+        .unwrap_or_else(|| TWITCH_API_BASE_URL.to_string());
+    let applied = apply_twitch_channel_metadata(&request, client).await?;
 
     let key_response: TwitchStreamKeyResponse = client
         .get(twitch_api_url(
@@ -176,10 +219,10 @@ pub async fn prepare_twitch_broadcast(
         stream_key_secret_ref,
         stream_key_present: true,
         redacted_url: "rtmp://live.twitch.tv/app/<stream-key>".to_string(),
-        title: metadata.title,
-        category_id: metadata.category_id,
-        category_name: metadata.category_name,
-        language: metadata.language,
+        title: applied.title,
+        category_id: applied.category_id,
+        category_name: applied.category_name,
+        language: applied.language,
     })
 }
 

--- a/crates/videorc-backend/src/x_live.rs
+++ b/crates/videorc-backend/src/x_live.rs
@@ -67,12 +67,6 @@ pub struct XPublishParams {
     pub region: String,
     #[serde(default = "default_true")]
     pub is_low_latency: bool,
-    #[serde(default)]
-    pub should_not_tweet: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub locale: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub chat_option: Option<u8>,
     /// Active capture session — X lifecycle events land in its session log.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
@@ -226,7 +220,6 @@ pub struct XPublishRequest {
     pub region: String,
     pub metadata: StreamMetadataDraft,
     pub is_low_latency: bool,
-    pub should_not_tweet: bool,
     pub locale: String,
     pub chat_option: u8,
     pub api_base_url: Option<String>,
@@ -858,7 +851,7 @@ pub async fn publish_x_broadcast(
         PublishBroadcastStateRequest {
             broadcast_id: &broadcast_id,
             title: &title,
-            should_not_tweet: request.should_not_tweet,
+            should_not_tweet: x_should_not_tweet(&request.metadata),
             locale: &request.locale,
             chat_option: request.chat_option,
         },
@@ -986,25 +979,21 @@ pub fn default_source_name() -> String {
     .unwrap_or_else(|| DEFAULT_SOURCE_NAME.to_string())
 }
 
-pub fn default_publish_locale(value: Option<String>) -> String {
-    value
-        .and_then(|value| {
-            let trimmed = value.trim();
-            (!trimmed.is_empty()).then(|| trimmed.to_string())
-        })
-        .or_else(|| optional_env_any(&["VIDEORC_X_LIVESTREAM_LOCALE", "X_LIVESTREAM_LOCALE"]))
+pub fn default_publish_locale() -> String {
+    optional_env_any(&["VIDEORC_X_LIVESTREAM_LOCALE", "X_LIVESTREAM_LOCALE"])
         .unwrap_or_else(|| DEFAULT_LOCALE.to_string())
 }
 
-pub fn default_chat_option(value: Option<u8>) -> u8 {
-    value.unwrap_or_else(|| {
-        optional_env_any(&[
-            "VIDEORC_X_LIVESTREAM_CHAT_OPTION",
-            "X_LIVESTREAM_CHAT_OPTION",
-        ])
-        .and_then(|value| value.parse::<u8>().ok())
-        .unwrap_or(DEFAULT_CHAT_OPTION)
-    })
+/// PUBLISH `chat_option` enum (X Livestream API doc): 0 none, 1 disabled,
+/// 2 everyone, 3 verified accounts (platform default), 4 follows,
+/// 5 subscribers.
+pub fn default_chat_option() -> u8 {
+    optional_env_any(&[
+        "VIDEORC_X_LIVESTREAM_CHAT_OPTION",
+        "X_LIVESTREAM_CHAT_OPTION",
+    ])
+    .and_then(|value| value.parse::<u8>().ok())
+    .unwrap_or(DEFAULT_CHAT_OPTION)
 }
 
 async fn get_region(
@@ -1424,6 +1413,20 @@ fn x_title(metadata: &StreamMetadataDraft) -> String {
         .to_string()
 }
 
+/// X has no visibility control; the only reach lever the Livestream API
+/// exposes is `should_not_tweet` on PUBLISH (suppresses the announcement
+/// post). The draft stores it as `x_announce` (None/true = announce, the
+/// platform default).
+fn x_should_not_tweet(metadata: &StreamMetadataDraft) -> bool {
+    metadata
+        .target_overrides
+        .iter()
+        .find(|target| target.platform == StreamPlatform::X)
+        .and_then(|target| target.x_announce)
+        .map(|announce| !announce)
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1439,6 +1442,47 @@ mod tests {
             account_label: Some("Videorc".to_string()),
             credential_source: "test".to_string(),
         }
+    }
+
+    #[test]
+    fn x_publish_metadata_derives_from_the_draft() {
+        let mut draft =
+            crate::streaming::default_stream_metadata_draft("2026-07-08T00:00:00Z".to_string());
+
+        // Global title, no override customization: announce by default.
+        draft.title = "Global title".to_string();
+        assert_eq!(x_title(&draft), "Global title");
+        assert!(!x_should_not_tweet(&draft));
+
+        // Customized X override wins the title; announce off maps to
+        // should_not_tweet.
+        let x_override = draft
+            .target_overrides
+            .iter_mut()
+            .find(|target| target.platform == StreamPlatform::X)
+            .unwrap();
+        x_override.customize = true;
+        x_override.title = "X title".to_string();
+        x_override.x_announce = Some(false);
+        assert_eq!(x_title(&draft), "X title");
+        assert!(x_should_not_tweet(&draft));
+
+        // Missing x_announce (pre-migration drafts) means announce.
+        let x_override = draft
+            .target_overrides
+            .iter_mut()
+            .find(|target| target.platform == StreamPlatform::X)
+            .unwrap();
+        x_override.x_announce = None;
+        assert!(!x_should_not_tweet(&draft));
+
+        // Empty titles everywhere fall back to the fixed default.
+        draft.title = String::new();
+        draft
+            .target_overrides
+            .iter_mut()
+            .for_each(|target| target.title = String::new());
+        assert_eq!(x_title(&draft), "Live from Videorc");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Title, description, and privacy set in the Livestream tab were only fully honored by YouTube:

- The X "Visibility" select (`xVisibility`) was a **dead field** — collected and persisted, never read by the publish path.
- X publish metadata (`shouldNotTweet: false, locale: 'en', chatOption: 2`) was **hardcoded in the renderer** (`use-studio.tsx`), not derived from the draft.
- The X description textarea was editable but **silently dropped** (the X Livestream API has no description field at all).
- **Manual-RTMP targets got zero metadata** — the go-live prep loop skipped every non-OAuth target, even Twitch where Helix channel updates work regardless of ingest path.
- Privacy copy implied a platform-wide control; only YouTube consumes it.

## Fix

Verified against the X Livestream API developer documentation: PUBLISH accepts only `state/title/should_not_tweet/locale/chat_option` — no visibility, no description; broadcasts are always public.

- **Backend owns X publish metadata**: `xAnnounce` (new draft field, replaces `xVisibility`) maps to `should_not_tweet`; title/announce derive from the effective draft in `publish_x_native_live`. `locale`/`chat_option` are env-overridable backend defaults with the enum documented.
- **UI honesty**: X gets an "Announce on X timeline" toggle (its real capability) and a disabled description with explanatory copy; the global Default privacy and Go Live dialog state per-platform effect ("Twitch and X broadcasts are always public").
- **Manual-RTMP Twitch**: new `streamTargets.twitch.applyMetadata` command pushes title/category/language via Helix through the connected account, best-effort at go-live (a metadata failure never blocks streaming over the key). Factored out of `prepare_twitch_broadcast`, which now reuses it.
- **Regression coverage**: Rust test pins `x_title`/`x_should_not_tweet` draft derivation (override wins, pre-migration drafts default to announce, fixed fallback title); removing the metadata params from `XPublishParams` makes renderer-side literals a type error.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` ✅
- `pnpm --filter @videorc/desktop test` — 486 passed ✅
- `pnpm build` ✅
- `cargo fmt`, `cargo test -p videorc-backend` — 789 passed ✅, `cargo clippy -D warnings` ✅
- Owner by-eye pending: go live to YouTube+Twitch+X with distinct title/description/Unlisted; verify each dashboard + the X announce toggle behavior; manual-key Twitch session updates channel title/category.

Plan: `2026-07-08 - Videorc Livestream Metadata Per-Platform Fix Plan` (Obsidian).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer go-live settings for platform-specific streaming behavior, including an **Announce on X timeline** toggle.
  * Twitch manual-RTMP streams can now apply channel metadata without blocking the go-live flow.

* **Bug Fixes**
  * Improved platform guidance and messaging for YouTube, Twitch, and X settings.
  * X publishing now uses the stream draft to determine announcement behavior more consistently.
  * Twitch and X description fields now behave more predictably based on the selected platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->