### PR TITLE
Release 0.9.23-beta.1: bundled ffmpeg RTMPS TLS fix

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.23-beta.1.md
+++ b/changelog/0.9.23-beta.1.md
@@ -1,0 +1,35 @@
+---
+version: 0.9.23-beta.1
+date: 2026-07-08
+channel: beta
+title: Secure streaming connections fixed — X broadcasts play for viewers
+summary: A flaw in the bundled video engine silently starved secure (RTMPS) stream connections, so X broadcasts looked live but never played for viewers — fixed, with your full stream now reliably reaching the platform.
+highlights:
+  - X broadcasts now actually play for viewers — the bundled video engine could silently starve secure stream connections down to a trickle.
+  - The fix applies to every secure (RTMPS) destination, not just X.
+  - The bundled video engine no longer depends on developer tools being installed on your Mac.
+  - Combined with the recent playback checks, Videorc now confirms within seconds that your broadcast is watchable.
+---
+
+## Secure streaming connections fixed
+
+We found the root cause of X broadcasts that looked live but only showed
+viewers a loading spinner: the video engine bundled with Videorc had a flaw
+in how it handled secure (RTMPS) streaming connections. Writes to the
+platform could stall for long stretches, and the stream silently degraded to
+a tiny fraction of its real bitrate — enough for X to consider you "live",
+far too little to actually play. This release ships a rebuilt engine with a
+proper secure-connection stack, verified end to end against X's own ingest:
+your full stream now arrives at full quality.
+
+## More reliable on every Mac
+
+The same rebuild fixes a second hidden issue: the bundled engine could
+depend on developer libraries that most Macs don't have. It is now fully
+self-contained, so recording and streaming behave the same on every machine.
+
+## You'll know it works
+
+Together with the playback verification added in 0.9.21, Videorc now
+confirms within seconds of going live that viewers can watch — and with this
+fix, that check should come back green.


### PR DESCRIPTION
Version bump + changelog for plan 032 (static-OpenSSL bundled ffmpeg; feature landed in #26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)