### PR TITLE
Docs: record 0.9.23 release

### DIFF
--- a/docs/releases/0.9.23.md
+++ b/docs/releases/0.9.23.md
@@ -1,0 +1,61 @@
+# Videorc 0.9.23 Beta 1
+
+Videorc 0.9.23 ships plan 032: the bundled FFmpeg is rebuilt with static
+OpenSSL TLS — the proven root cause of the X "live but viewers see a
+spinner" saga — and no longer links Homebrew dylibs.
+
+## Scope
+
+- **RTMPS TLS fix** (`scripts/build-ffmpeg-macos.sh`, plan 032) — the
+  bundled ffmpeg had no TLS library; rtmps:// rode Apple SecureTransport,
+  whose writes stall on video payloads (A/B on X's own ingest measurement:
+  0.0 fps received via the old bundle, 29.998 fps via OpenSSL builds). The
+  fifo stream leg dropped the overflow silently, starving X to ~2% of the
+  stream. Dev builds always worked (PATH/Homebrew ffmpeg) — the hidden
+  variable behind the earlier source/duration/teardown theories.
+- **Homebrew dylib leak fixed** — shipped bundles hard-linked
+  /opt/homebrew libX11/libxcb (configure auto-detect); the bundled ffmpeg
+  could not launch on Macs without Homebrew. Pinned off
+  (`--disable-xlib --disable-libxcb --disable-sdl2`).
+- **Fail-closed build gates** — staging refuses unless: configuration has
+  `--enable-openssl`, the `tls` protocol exists, and `otool -L` shows no
+  /opt/homebrew or /usr/local references. Licensing: LGPLv3
+  (`--enable-version3`) + Apache-2.0 OpenSSL; still no GPL/nonfree.
+- **Maintained repro** — `pnpm probe:split-flv` captures the split-profile
+  FLV leg against a local RTMP listener and ffprobes what platforms
+  receive.
+
+## Release status
+
+- [x] Fix PR https://github.com/TheOrcDev/videorc/pull/26, release prep PR
+      https://github.com/TheOrcDev/videorc/pull/27 — merged via protected
+      `main`.
+- [x] Built from a CLEAN worktree at `origin/main` (concurrent in-flight
+      metadata work in the primary worktree excluded by construction).
+- [x] Bundled ffmpeg rebuilt from source in that worktree; all three new
+      gates PASS.
+- [x] Signed + notarized; artifact validation PASS incl. bundled X
+      consumer gate.
+- [x] Uploaded to R2, all objects verified; feed serves `version: 0.9.23`;
+      changelog latest entry `0.9.23-beta.1`; updater zip HTTP 206.
+- [x] Discord announced (note: a duplicate 0.9.22 announcement was posted
+      first by mistake — script run from a stale worktree — followed by the
+      correct 0.9.23 post).
+
+## Verification
+
+- A/B pushes to the X test source (`5nww…`), same file/network:
+  old bundle → X measured video 0.0 fps (writer stalled 47.8s);
+  Homebrew OpenSSL → 29.998 fps; NEW bundle → 29.998 fps.
+- Local FLV captures of tee and split fanout legs: valid H.264 High +
+  avcC extradata, AAC-LC + ASC (encoding was never the issue).
+- `pnpm changelog:check` PASS (24 entries).
+
+## Pending owner acceptance
+
+- [ ] Update to 0.9.23, run one short (~2 min) real X session:
+      expect `x-playback-verified` within seconds (0.9.21 probe),
+      a NEW source id (0.9.22 hygiene), clean stop without SIGKILL,
+      and actual video on a second account.
+- [ ] If green: close plans 030/031/032 acceptance in one shot and close
+      plan 026's real-stream A/V by-eye on the same session.


### PR DESCRIPTION
Internal release record for 0.9.23-beta.1 (bundled ffmpeg RTMPS TLS fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)