### PR TITLE
Notes cursor leak, D shortcut in Settings, live Library row

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1218,7 +1218,11 @@ function notesWindowHtml(document: NotesDocument): string {
     textarea { flex: 1; resize: none; border: 0; outline: none; padding: 20px 22px;
       box-sizing: border-box; background: ${DARK_WINDOW_PALETTE.base}; color: ${DARK_WINDOW_PALETTE.textPrimary}; caret-color: ${DARK_WINDOW_PALETTE.textPrimary};
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      line-height: 1.45; -webkit-app-region: no-drag; }
+      line-height: 1.45; -webkit-app-region: no-drag;
+      /* Keep the arrow cursor: the window is capture-protected but the OS
+         composites the pointer separately, so an I-beam over "empty" space
+         would betray the hidden notes to viewers. */
+      cursor: default; }
     body[data-font-scale="sm"] textarea { font-size: 18px; }
     body[data-font-scale="md"] textarea { font-size: 24px; }
     body[data-font-scale="lg"] textarea { font-size: 32px; }

--- a/apps/desktop/src/renderer/src/components/tabs/library-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/library-tab.tsx
@@ -21,6 +21,7 @@ import { useEffect, useMemo, useState, type ReactElement } from 'react'
 import { toast } from 'sonner'
 
 import { PageHeader } from '@/components/page'
+import { StatusDot } from '@/components/status-dot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -55,7 +56,9 @@ import { dayLabel, durationMsLabel, formatBytes, isActiveRecordingState } from '
 import {
   LIBRARY_FILTERS,
   filterLibrarySessions,
+  isLiveSession,
   libraryStorageLabel,
+  liveSessionLabel,
   sessionFormatLabel,
   sessionPosterUrl,
   sortLibrarySessions,
@@ -395,8 +398,13 @@ function LibraryRow({
   onRename: () => void
   onDelete: () => void
 }): ReactElement {
+  const { recording } = useStudio()
   const filePath = session.mp4Path ?? session.outputPath ?? null
   const format = sessionFormatLabel(session)
+  // A live row shows the capture's ticking elapsed time; the session row only
+  // gets duration_ms at finalize.
+  const live = isLiveSession(session, recording)
+  const durationMs = live ? recording.durationMs : session.durationMs
   return (
     <div
       className={cn(
@@ -416,7 +424,7 @@ function LibraryRow({
           <p className="truncate text-sm font-medium">{session.title || 'Untitled session'}</p>
           <p className="truncate text-xs text-muted-foreground">
             {dayLabel(session.startedAt)}
-            {!filePath ? ' · no local file' : ''}
+            {!filePath && !live ? ' · no local file' : ''}
           </p>
         </div>
       </div>
@@ -428,13 +436,17 @@ function LibraryRow({
         ) : null}
       </div>
       <span className="text-xs text-muted-foreground tabular-nums">
-        {typeof session.durationMs === 'number' ? durationMsLabel(session.durationMs) : '—'}
+        {typeof durationMs === 'number' ? durationMsLabel(durationMs) : '—'}
       </span>
       <span className="text-xs text-muted-foreground tabular-nums">
         {formatBytes(session.fileSizeBytes)}
       </span>
       <div>
-        {format ? <Badge variant={session.mp4Path ? 'success' : 'outline'}>{format}</Badge> : null}
+        {live ? (
+          <StatusDot pulse label={liveSessionLabel(recording.state)} tone="error" />
+        ) : format ? (
+          <Badge variant={session.mp4Path ? 'success' : 'outline'}>{format}</Badge>
+        ) : null}
       </div>
       <RowActions
         filePath={filePath}
@@ -448,20 +460,25 @@ function LibraryRow({
 }
 
 /** Poster with one lazy backfill attempt: older sessions have no poster yet;
- * a 404 triggers a single sessions.poster round-trip (idle-aware backend). */
+ * a 404 triggers a single sessions.poster round-trip (idle-aware backend).
+ * Running sessions never request the poster — extraction waits for capture
+ * idle, so the request is guaranteed to 404. */
 export function SessionPoster({
   session
 }: {
-  session: Pick<SessionSummary, 'id' | 'durationMs'>
+  session: Pick<SessionSummary, 'id' | 'durationMs' | 'status'>
 }): ReactElement {
-  const { connection, ensureSessionPoster } = useStudio()
+  const { connection, ensureSessionPoster, recording } = useStudio()
   const [attempt, setAttempt] = useState(0)
   const [failed, setFailed] = useState(false)
-  const url = sessionPosterUrl(connection, session)
+  const running = session.status === 'running'
+  const url = running ? null : sessionPosterUrl(connection, session)
   const source = url && attempt > 0 ? `${url}&attempt=${attempt}` : url
   return (
     <span className="grid h-10 w-[4.5rem] shrink-0 place-items-center overflow-hidden rounded-row border bg-muted/30">
-      {source && !failed ? (
+      {isLiveSession(session, recording) ? (
+        <StatusDot pulse tone="error" />
+      ) : source && !failed ? (
         <img
           alt=""
           className="size-full object-cover"
@@ -535,6 +552,9 @@ function RowActions({
   const busy = phase === 'checking' || phase === 'repairing'
   const disconnected = wsStatus !== 'connected'
   const captureProtected = isActiveRecordingState(recording.state)
+  // The live row's file is still being written: playing or duplicating a
+  // partial container yields garbage, so those wait for finalize.
+  const live = isLiveSession(session, recording)
   const canRepair = assessment?.repairable ?? false
   const persistedRepaired = session.qualityStatus?.status === 'repaired'
   const canExportMp4 = Boolean(
@@ -627,9 +647,9 @@ function RowActions({
       <Button
         aria-label="Play recording"
         className="size-8"
-        disabled={!filePath}
+        disabled={!filePath || live}
         size="icon"
-        title="Play in the default player"
+        title={live ? 'Available when the session ends' : 'Play in the default player'}
         variant="ghost"
         onClick={() => void playFile()}
       >
@@ -662,7 +682,7 @@ function RowActions({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem disabled={!filePath} onClick={() => void playFile()}>
+          <DropdownMenuItem disabled={!filePath || live} onClick={() => void playFile()}>
             <Play />
             Play
           </DropdownMenuItem>
@@ -697,7 +717,7 @@ function RowActions({
             Rename
           </DropdownMenuItem>
           <DropdownMenuItem
-            disabled={!filePath || busy || duplicating}
+            disabled={!filePath || busy || duplicating || live}
             onClick={() => void runDuplicate()}
           >
             <Copy />

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -2372,6 +2372,15 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           // Session over: the viewer chip must clear, not freeze (rider V2).
           void window.videorc?.pushViewerSample?.(null)
         }
+        // Capture started: pull the fresh 'running' row so the Library shows
+        // the live session immediately (status ticks repeat the state, so
+        // only refresh on the transition).
+        if (
+          ['recording', 'streaming'].includes(status.state) &&
+          !['recording', 'streaming'].includes(previousState ?? '')
+        ) {
+          void refreshSessions(nextClient)
+        }
         // D6: the moment a recording lands is the moment to publish it.
         if (
           status.state === 'idle' &&

--- a/apps/desktop/src/renderer/src/lib/library-view.test.ts
+++ b/apps/desktop/src/renderer/src/lib/library-view.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest'
 import type { SessionSummary } from '@/lib/backend'
 import {
   filterLibrarySessions,
+  isLiveSession,
   libraryStorageLabel,
+  liveSessionLabel,
   sessionFormatLabel,
   sessionPosterUrl,
   sortLibrarySessions,
@@ -83,6 +85,37 @@ describe('selection', () => {
     expect(toggleAllLibrarySelection(['a', 'b'], ['a', 'b'])).toEqual([])
     expect(toggleAllLibrarySelection(['a'], ['a', 'b'])).toEqual(['a', 'b'])
     expect(toggleAllLibrarySelection(['a'], [])).toEqual([])
+  })
+})
+
+describe('isLiveSession', () => {
+  it('is live only for the running row that matches the active capture', () => {
+    const row = { id: 'live-1', status: 'running' }
+    expect(isLiveSession(row, { state: 'recording', sessionId: 'live-1' })).toBe(true)
+    expect(isLiveSession(row, { state: 'streaming', sessionId: 'live-1' })).toBe(true)
+    expect(isLiveSession(row, { state: 'stopping', sessionId: 'live-1' })).toBe(true)
+    // Stale 'running' row from a dead backend: no matching active capture.
+    expect(isLiveSession(row, { state: 'recording', sessionId: 'other' })).toBe(false)
+    expect(isLiveSession(row, { state: 'idle', sessionId: 'live-1' })).toBe(false)
+    expect(isLiveSession(row, { state: 'idle', sessionId: undefined })).toBe(false)
+    expect(
+      isLiveSession(
+        { id: 'live-1', status: 'completed' },
+        { state: 'recording', sessionId: 'live-1' }
+      )
+    ).toBe(false)
+    expect(
+      isLiveSession({ id: 'live-1', status: 'failed' }, { state: 'recording', sessionId: 'live-1' })
+    ).toBe(false)
+  })
+})
+
+describe('liveSessionLabel', () => {
+  it('labels the capture state for the live row', () => {
+    expect(liveSessionLabel('recording')).toBe('Recording')
+    expect(liveSessionLabel('starting')).toBe('Recording')
+    expect(liveSessionLabel('streaming')).toBe('Streaming')
+    expect(liveSessionLabel('stopping')).toBe('Finishing')
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/library-view.ts
+++ b/apps/desktop/src/renderer/src/lib/library-view.ts
@@ -1,5 +1,5 @@
-import type { BackendConnection, SessionSummary } from '@/lib/backend'
-import { formatBytes } from '@/lib/format'
+import type { BackendConnection, RecordingStatus, SessionSummary } from '@/lib/backend'
+import { formatBytes, isActiveRecordingState } from '@/lib/format'
 
 // Library table view logic (Library rewrite L4): filtering, sorting, search,
 // selection, poster URLs, and the storage footer — all pure and unit-tested;
@@ -58,6 +58,31 @@ export function sessionFormatLabel(session: SessionSummary): string | null {
   return session.container.toLowerCase() === 'tee'
     ? 'MKV + stream'
     : session.container.toUpperCase()
+}
+
+/** The session being captured RIGHT NOW. A 'running' row that does not match
+ * the active recording is stale (backend died mid-session; it gets reconciled
+ * to 'failed' only on the next backend start) and must not claim to be live. */
+export function isLiveSession(
+  session: Pick<SessionSummary, 'id' | 'status'>,
+  recording: Pick<RecordingStatus, 'state' | 'sessionId'>
+): boolean {
+  return (
+    session.status === 'running' &&
+    recording.sessionId === session.id &&
+    isActiveRecordingState(recording.state)
+  )
+}
+
+/** Row status label while a session is live. */
+export function liveSessionLabel(state: RecordingStatus['state']): string {
+  if (state === 'streaming') {
+    return 'Streaming'
+  }
+  if (state === 'stopping') {
+    return 'Finishing'
+  }
+  return 'Recording'
 }
 
 /** Poster over the backend's token-authenticated HTTP server; null while the

--- a/apps/desktop/src/renderer/src/lib/shortcuts.test.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcuts.test.ts
@@ -29,7 +29,12 @@ describe('SHORTCUTS registry', () => {
     }
   })
 
-  it('groups cover Navigation, Session, and Windows', () => {
-    expect([...shortcutsByGroup().keys()]).toEqual(['Navigation', 'Session', 'Windows'])
+  it('groups cover Navigation, Session, Windows, and Appearance', () => {
+    expect([...shortcutsByGroup().keys()]).toEqual([
+      'Navigation',
+      'Session',
+      'Windows',
+      'Appearance'
+    ])
   })
 })

--- a/apps/desktop/src/renderer/src/lib/shortcuts.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcuts.ts
@@ -8,7 +8,7 @@ export interface ShortcutEntry {
   /** Keys as displayed, in press order (⌘ modifiers split out for Kbd chips). */
   keys: string[]
   label: string
-  group: 'Navigation' | 'Session' | 'Windows'
+  group: 'Navigation' | 'Session' | 'Windows' | 'Appearance'
 }
 
 export const SHORTCUTS: readonly ShortcutEntry[] = [
@@ -28,7 +28,9 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 
   { id: 'preview-window', keys: ['⌘', 'P'], label: 'Open preview window', group: 'Windows' },
   { id: 'notes-window', keys: ['⌘', '⇧', 'N'], label: 'Open notes window', group: 'Windows' },
-  { id: 'comments-window', keys: ['⌘', '⇧', 'J'], label: 'Open comments window', group: 'Windows' }
+  { id: 'comments-window', keys: ['⌘', '⇧', 'J'], label: 'Open comments window', group: 'Windows' },
+
+  { id: 'theme-toggle', keys: ['D'], label: 'Toggle light / dark theme', group: 'Appearance' }
 ] as const
 
 export function shortcutsByGroup(): Map<ShortcutEntry['group'], ShortcutEntry[]> {


### PR DESCRIPTION
## What changed

Three product-quality fixes:

**1. Invisible notes no longer leak via the cursor** — `apps/desktop/src/main/index.ts`
The Notes window is capture-protected, but macOS composites the mouse pointer into the recording independently of window pixels, so hovering the notes `<textarea>` showed an I-beam floating over "empty" space to viewers. The textarea now keeps the arrow cursor (`cursor: default`); editing and the text caret are unaffected.

**2. "D" light/dark shortcut listed in Settings** — `lib/shortcuts.ts`
The toggle already worked (`use-theme-toggle.ts`), but the Settings > Shortcuts table renders from the `SHORTCUTS` registry and had no entry for it. Added a `theme-toggle` entry under a new **Appearance** group; the table picks it up automatically.

**3. In-progress recordings render as a live row instead of a broken one** — `lib/library-view.ts`, `library-tab.tsx`, `use-studio.tsx`
A session row is inserted at capture start with `status='running'`, no duration, and no poster (extraction deliberately waits for capture idle), so the Library showed a 404-backed placeholder and a dash duration. Now:
- New `isLiveSession(session, recording)` predicate: live = `running` row + matching `recording.sessionId` + active capture state. Stale `running` rows (backend died mid-session; reconciled only on next backend start) keep the icon fallback instead of claiming to be live.
- `SessionPoster` never requests a poster for running rows (the request is guaranteed to 404); the live row shows a pulsing red `StatusDot`.
- The badge cell shows a pulsing Recording / Streaming / Finishing label; the duration cell ticks with live elapsed time from `recording.durationMs`.
- Play and Duplicate are disabled on the live row (file still being written); Delete/repair were already capture-gated.
- Sessions refresh on the transition **into** recording/streaming (previously only on idle/failed), so the live row appears the moment capture starts and flips to a normal row with poster at finalize (existing lazy backfill covers the extraction window).

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- `pnpm --filter @videorc/desktop test` — 488/488 pass, including new `isLiveSession`/`liveSessionLabel` truth-table tests and the updated shortcuts-registry group test
- Renderer/notes-chrome only — no recording pipeline or native preview changes, so no smoke needed

## Reviewer notes

- By-eye still worth doing: hover Notes text during a capture (arrow in the recording), Settings > Shortcuts shows the Appearance group, and a short recording shows the live Library row then flips to a normal one.
- `main/index.ts` contains a NUL byte (embedded asset) — use `grep -a` if searching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new shortcut for toggling between light and dark themes.
  * Improved the Library to better show active live sessions with clearer status labels and live duration updates.

* **Bug Fixes**
  * Prevented play, duplicate, and poster-loading actions from appearing or running incorrectly for sessions that are still live.
  * The Library now refreshes sooner when a capture starts, so live sessions appear immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->