### PR TITLE
Stable first paint: no more layout churn on launch

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -734,6 +734,10 @@ function createWindow(): void {
     minWidth: 960,
     minHeight: 660,
     title: 'Videorc',
+    // Hold the (transparent) window until the renderer has painted its first
+    // frame — showing it at create time put an empty pane on screen that then
+    // visibly filled in piece by piece.
+    show: false,
     ...platformWindowChromeOptions(),
     ...appWindowIconOptions(),
     webPreferences: {
@@ -744,6 +748,19 @@ function createWindow(): void {
       backgroundThrottling: false
     }
   })
+
+  let mainWindowShown = false
+  const showMainWindow = (): void => {
+    if (mainWindowShown || !mainWindow || mainWindow.isDestroyed()) {
+      return
+    }
+    mainWindowShown = true
+    mainWindow.show()
+  }
+  mainWindow.once('ready-to-show', showMainWindow)
+  // ready-to-show is not fully reliable on transparent windows: never strand
+  // the user with an invisible app.
+  setTimeout(showMainWindow, 3000)
 
   const rendererUrl = process.env.ELECTRON_RENDERER_URL
   if (rendererUrl) {
@@ -7406,6 +7423,12 @@ app.whenReady().then(async () => {
     app.quit()
     return
   }
+
+  // Warm the glass-wallpaper cache while Electron/renderer boot: the underlay
+  // then finds it on first mount instead of swapping the whole background in
+  // a beat after the window shows. Fire-and-forget — osascript can stall on
+  // an Automation prompt and must never delay the window.
+  void refreshGlassWallpaper()
 
   registerOAuthCallbackProtocol()
   registerManagedAssetProtocol()

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -8,6 +8,26 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Theme pre-hydration: next-themes applies the `.dark` class only after
+      // React mounts, but :root CSS defaults to the LIGHT palette — without
+      // this the first frame can flash light before recoloring. Resolve the
+      // stored theme (same key/default as the ThemeProvider in App.tsx)
+      // before the bundle loads so frame one is already the right theme.
+      ;(() => {
+        try {
+          const stored = window.localStorage.getItem('videorc.theme')
+          const dark =
+            stored === 'system'
+              ? window.matchMedia('(prefers-color-scheme: dark)').matches
+              : stored !== 'light'
+          document.documentElement.classList.add(dark ? 'dark' : 'light')
+          document.documentElement.style.colorScheme = dark ? 'dark' : 'light'
+        } catch {
+          document.documentElement.classList.add('dark')
+        }
+      })()
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/desktop/src/renderer/src/components/app-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/app-shell.tsx
@@ -290,7 +290,10 @@ export function AppShell(): ReactElement {
                 <Kbd>P</Kbd>
               </KbdGroup>
             </Button>
-            {runtimeInfo?.notesWindowEnabled ? (
+            {/* Flags default ON and runtimeInfo lands async — treating null
+                as enabled keeps the footer at its final width from the first
+                paint instead of growing when the fetch resolves. */}
+            {runtimeInfo?.notesWindowEnabled !== false ? (
               <>
                 <FooterActionDivider />
                 <Button
@@ -309,7 +312,7 @@ export function AppShell(): ReactElement {
                 </Button>
               </>
             ) : null}
-            {runtimeInfo?.commentsWindowEnabled ? (
+            {runtimeInfo?.commentsWindowEnabled !== false ? (
               <>
                 <FooterActionDivider />
                 <Button

--- a/apps/desktop/src/renderer/src/components/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar.tsx
@@ -1,5 +1,5 @@
 import { ArrowsClockwise, MagnifyingGlass, type Icon } from '@phosphor-icons/react'
-import type { ReactElement } from 'react'
+import { useEffect, useState, type ReactElement } from 'react'
 
 import logoUrl from '@/assets/videorc-logo.png'
 import { AccountMenu } from '@/components/account-menu'
@@ -80,22 +80,38 @@ function SidebarUpdateChip({
 }): ReactElement | null {
   const { status, install } = useUpdater()
   const chip = updateChip(status, captureActive)
+  const hasChip = Boolean(chip)
+  // The chip appears mid-session (updater status lands after launch); sliding
+  // it open keeps the account row from teleporting down when it mounts.
+  const [expanded, setExpanded] = useState(false)
+  useEffect(() => {
+    setExpanded(hasChip)
+  }, [hasChip])
   if (!chip) {
     return null
   }
   return (
-    <div className="border-t px-3 py-2">
-      <button
-        className="flex w-full items-center gap-2 rounded-row px-2.5 py-2 text-left text-xs font-medium text-foreground transition-colors hover:bg-accent"
-        type="button"
-        onClick={() => (chip.action === 'install' ? install() : onOpenSettings())}
-      >
-        <span className="relative flex size-4 shrink-0 items-center justify-center">
-          <ArrowsClockwise className="size-4 text-muted-foreground" />
-          <span className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-[oklch(0.72_0.19_150)]" />
-        </span>
-        <span className="min-w-0 flex-1 truncate">{chip.label}</span>
-      </button>
+    <div
+      className={cn(
+        'grid transition-[grid-template-rows] duration-150 ease-out',
+        expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+      )}
+    >
+      <div className="overflow-hidden">
+        <div className="border-t px-3 py-2">
+          <button
+            className="flex w-full items-center gap-2 rounded-row px-2.5 py-2 text-left text-xs font-medium text-foreground transition-colors hover:bg-accent"
+            type="button"
+            onClick={() => (chip.action === 'install' ? install() : onOpenSettings())}
+          >
+            <span className="relative flex size-4 shrink-0 items-center justify-center">
+              <ArrowsClockwise className="size-4 text-muted-foreground" />
+              <span className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-[oklch(0.72_0.19_150)]" />
+            </span>
+            <span className="min-w-0 flex-1 truncate">{chip.label}</span>
+          </button>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Problem

On first open the window appears and "everything moves" for about a second. Audit traced it to a compound cause: the transparent main window is shown **before the renderer paints anything**, and then several async payloads each mutate the already-visible shell.

## What changed

**1. Window held until first paint** — `main/index.ts createWindow()`
`show: false` + `once('ready-to-show', show)`, with a 3s `setTimeout` show fallback so an unreliable ready-to-show on transparent windows can never strand the user with an invisible app. The Notes/Comments/Captions child windows already used this pattern. Verified nothing assumes early visibility: docked preview re-parents off the main window's show/move events, and probes/smokes wait on stdout markers, not window visibility.

**2. Wallpaper prefetch** — `main/index.ts app.whenReady()`
`refreshGlassWallpaper()` (osascript + image work, hundreds of ms) was only kicked on `did-finish-load`, so the whole background swapped from the solid fallback to the blurred wallpaper a beat after open. It's now also kicked at `whenReady`, before the window exists — verified re-entrant (path+cache early return; pre-window call fills the cache, renderer pulls it on mount). Fire-and-forget: never blocks show (osascript can stall on an Automation prompt).

**3. Stable footer** — `app-shell.tsx`
"Open Notes"/"Open Comments" were gated on `runtimeInfo?.flag` with `runtimeInfo` starting null, so the footer grew when the fetch landed. The flags are env checks defaulting to true (`runtime-info.ts`), so `!== false` renders them from the first paint; the rare `VIDEORC_NOTES_WINDOW=0` case still hides them once runtimeInfo lands.

**4. Theme pre-hydration** — `renderer/index.html`
`:root` CSS is the light palette and next-themes applies `.dark` only after React mounts — first frame could flash light. A plain inline script resolves `localStorage['videorc.theme']` (null → dark, matching `defaultTheme="dark"`; `system` → matchMedia) and sets the class + `colorScheme` before the bundle loads. No CSP exists to block it (verified).

**5. Update chip slides instead of jumping** — `sidebar.tsx`
The chip mounts mid-session when updater status lands and used to teleport the account row down; it now expands with a 150ms `grid-rows-[0fr→1fr]` transition (design-skill motion rule).

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- `pnpm --filter @videorc/desktop test` — 488/488
- `pnpm probe:preview-lifecycle` — fails identically on clean main in this environment (`fetch failed`, pre-existing local issue), i.e. baseline-equal; the probe failure is not introduced by this change.
- By-eye (recommended before release): relaunch a few times — window should appear once, fully formed: dark from frame one, wallpaper glass already in place, footer at final width, no shifting. `VIDEORC_NOTES_WINDOW=0` still hides the Notes button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)