### PR TITLE
Release 0.9.24-beta.1: stable launch, private glass, live Library row

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.24-beta.1.md
+++ b/changelog/0.9.24-beta.1.md
@@ -1,0 +1,53 @@
+---
+version: 0.9.24-beta.1
+date: 2026-07-08
+channel: beta
+title: Steadier launch, more private glass, and stream details that reach every platform
+summary: The app now opens fully formed instead of shifting into place, the glass background and hidden notes no longer leak what they shouldn't, in-progress recordings look right in the Library, and your stream title and category now reach every platform.
+highlights:
+  - The app opens fully formed — no more flashing and shifting while everything loads in the first second.
+  - The glass background no longer lets text from windows behind Videorc show through.
+  - A recording in progress now appears in the Library as a live entry with a pulsing indicator and running time, instead of a broken row.
+  - Your stream title, category, and description now reach every connected platform — including Twitch over a manual stream key.
+  - Hovering hidden notes during a capture no longer changes the cursor and gives them away.
+---
+
+## The app opens fully formed
+
+Launching Videorc used to show an empty window that filled in piece by piece —
+the background popped in, buttons appeared, and the theme could flash for a
+frame. The window now stays hidden until the first real frame is ready, the
+glass backdrop is prepared before the window exists, and the theme is resolved
+before anything is drawn. What you see first is what you get.
+
+## More private glass
+
+The glass look kept a hint of transparency to whatever sat behind the app —
+enough that sharp text behind Videorc could faintly be read through it, which
+is not what you want on a screen share. The frost is now nearly opaque: same
+glass depth, nothing legible bleeding through.
+
+The same idea applies to hidden notes: the notes window is invisible to your
+recording, but hovering it changed the mouse cursor to a text cursor — and the
+cursor IS captured. It now stays a normal arrow, so your notes stay your
+secret.
+
+## The Library tells the truth while you record
+
+Starting a recording or stream used to drop a broken-looking row into the
+Library — missing thumbnail, blank duration. That entry is now a proper live
+row: a pulsing indicator, a Recording or Streaming label, and the elapsed time
+ticking up. When you stop, it becomes a normal recording with its thumbnail.
+
+## Stream details reach every platform
+
+Your stream title, category, and description are now delivered to each
+connected platform when you go live — including Twitch when you stream with a
+manual stream key. For X, Videorc is now honest about what X supports: a
+single switch controls whether going live posts an announcement to your
+timeline.
+
+## Small things
+
+- The light/dark theme shortcut (D) is now listed with every other shortcut in
+  Settings.


### PR DESCRIPTION
Version bump 0.9.23 → 0.9.24 and the changelog entry for 0.9.24-beta.1.

Covers everything merged since 0.9.23: livestream metadata delivery (#25), notes-cursor leak + D shortcut + live Library row (#29), glass privacy (#30), stable first paint (#31).

`pnpm changelog:check` passes (25 entries valid, latest 0.9.24-beta.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)