### PR TITLE
Docs: record 0.9.24 release

### DIFF
--- a/docs/releases/0.9.24.md
+++ b/docs/releases/0.9.24.md
@@ -1,0 +1,74 @@
+# Videorc 0.9.24 Beta 1
+
+Videorc 0.9.24 is a polish + privacy batch: stable first paint on launch,
+the glass frost privacy fix, the live Library row, the notes-cursor leak
+fix, the D-shortcut registry gap, and the livestream metadata delivery
+work (plan 032, X/Twitch metadata).
+
+## Scope
+
+- **Stable first paint** (PR #31) — main window now `show: false` +
+  `ready-to-show` (3s show failsafe for transparent-window flakiness);
+  glass wallpaper cache warmed at `app.whenReady()` before the window
+  exists; footer Notes/Comments buttons treat `runtimeInfo === null` as
+  enabled (env flags default true); theme pre-hydration script in
+  `renderer/index.html` (`:root` CSS is the light palette — first frame
+  could flash); sidebar update chip slides open instead of shoving the
+  account row.
+- **Glass privacy** (PR #30) — `--glass-underlay-opacity` 0.86/0.82 →
+  0.94/0.92. Bleed-through of windows behind the app is UNBLURRED
+  (backdrop blur cannot see behind an Electron window; probe-bisected),
+  so text behind the app was faintly readable. Comments in styles.css +
+  GlassWallpaperUnderlay mark the token as a privacy dial.
+- **Notes cursor leak + D shortcut + live Library row** (PR #29) —
+  notes textarea keeps the arrow cursor (the OS composites the pointer
+  outside content protection, so the I-beam betrayed hidden notes on
+  stream); `theme-toggle` entry added to the SHORTCUTS registry
+  (Appearance group); Library shows a live row for the active session
+  (`isLiveSession`: running + matching `recording.sessionId` + active
+  state) — pulsing StatusDot, ticking elapsed, no doomed poster request
+  (posters only extract at capture-idle → guaranteed 404 while
+  recording), Play/Duplicate gated until finalize, sessions refresh on
+  the transition into recording/streaming.
+- **Livestream metadata** (PR #25, plan 032) — stream title/category/
+  description delivered per platform at go-live, incl. Twitch
+  `applyMetadata` for manual-RTMP; X reduced to the honest single lever
+  (announce on timeline — X API has no description/visibility).
+
+## Release status
+
+- [x] Feature PRs #25, #29, #30, #31 merged via protected `main`;
+      release prep PR https://github.com/TheOrcDev/videorc/pull/32.
+- [x] Built from a tree identical to `origin/main` post-merge
+      (verified `git diff origin/main` empty before building).
+- [x] Signed + notarized; `release:validate:macos` PASS (codesign,
+      Gatekeeper, stapler, bundled-secret gates).
+- [x] Uploaded to R2, all 8 objects verified; feed serves
+      `version: 0.9.24` through the www redirect; changelog latest
+      entry `0.9.24-beta.1` (25 entries valid).
+- [x] Discord announced (dry-run previewed first, single post).
+
+## Verification
+
+- Local gates green on every feature PR (typecheck, lint, format,
+  488 desktop vitest).
+- `pnpm probe:preview-lifecycle` fails on CLEAN main in the build
+  environment ("fetch failed") — pre-existing, baseline-equal for the
+  window-show change in #31; a diagnose task was spawned for it.
+
+## Pending owner acceptance
+
+- [ ] Update to 0.9.24; relaunch a few times: window appears once,
+      fully formed (dark from frame one, wallpaper glass in place,
+      footer at final width, no shifting).
+- [ ] With a page of dense text behind the app (both themes): nothing
+      legible through the glass.
+- [ ] Start a short recording: Library shows the live row (pulsing
+      indicator, ticking time, no 404 poster), flips to a normal row
+      with thumbnail on stop.
+- [ ] Hover the Notes window text during a capture: cursor stays the
+      arrow in the recording.
+- [ ] Settings → Shortcuts shows "Toggle light / dark theme — D" under
+      Appearance.
+- [ ] One go-live with metadata: Twitch (manual RTMP) title/category
+      applied; X announce switch honored.


### PR DESCRIPTION
Internal release record for 0.9.24-beta.1: scope (#25/#29/#30/#31), build/upload/verify/announce all checked, owner acceptance checklist pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)