### PR TITLE
Fix Windows backend isolation test paths

### DIFF
--- a/apps/desktop/src/main/backend-isolation.test.ts
+++ b/apps/desktop/src/main/backend-isolation.test.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { backendIsolationEnv } from './backend-isolation'
@@ -9,30 +11,33 @@ describe('backendIsolationEnv', () => {
   })
 
   it('pins backend sqlite + secrets + recordings inside the isolated app-data dir', () => {
+    const appDataDir = '/tmp/smoke/app-data'
     expect(backendIsolationEnv({ VIDEORC_APP_DATA_DIR: '/tmp/smoke/app-data' })).toEqual({
-      VIDEORC_DATABASE_PATH: '/tmp/smoke/app-data/videorc.sqlite3',
-      VIDEORC_SECRETS_PATH: '/tmp/smoke/app-data/videorc-secrets.json',
-      VIDEORC_RECORDINGS_DIR: '/tmp/smoke/app-data/recordings'
+      VIDEORC_DATABASE_PATH: join(appDataDir, 'videorc.sqlite3'),
+      VIDEORC_SECRETS_PATH: join(appDataDir, 'videorc-secrets.json'),
+      VIDEORC_RECORDINGS_DIR: join(appDataDir, 'recordings')
     })
   })
 
   it('falls back to the isolated user-data dir when only that is set', () => {
-    expect(backendIsolationEnv({ VIDEORC_USER_DATA_DIR: '/tmp/probe/user-data' })).toEqual({
-      VIDEORC_DATABASE_PATH: '/tmp/probe/user-data/videorc.sqlite3',
-      VIDEORC_SECRETS_PATH: '/tmp/probe/user-data/videorc-secrets.json',
-      VIDEORC_RECORDINGS_DIR: '/tmp/probe/user-data/recordings'
+    const userDataDir = '/tmp/probe/user-data'
+    expect(backendIsolationEnv({ VIDEORC_USER_DATA_DIR: userDataDir })).toEqual({
+      VIDEORC_DATABASE_PATH: join(userDataDir, 'videorc.sqlite3'),
+      VIDEORC_SECRETS_PATH: join(userDataDir, 'videorc-secrets.json'),
+      VIDEORC_RECORDINGS_DIR: join(userDataDir, 'recordings')
     })
   })
 
   it('respects explicit backend path overrides', () => {
+    const appDataDir = '/tmp/smoke/app-data'
     expect(
       backendIsolationEnv({
-        VIDEORC_APP_DATA_DIR: '/tmp/smoke/app-data',
+        VIDEORC_APP_DATA_DIR: appDataDir,
         VIDEORC_DATABASE_PATH: '/tmp/custom/db.sqlite'
       })
     ).toEqual({
-      VIDEORC_SECRETS_PATH: '/tmp/smoke/app-data/videorc-secrets.json',
-      VIDEORC_RECORDINGS_DIR: '/tmp/smoke/app-data/recordings'
+      VIDEORC_SECRETS_PATH: join(appDataDir, 'videorc-secrets.json'),
+      VIDEORC_RECORDINGS_DIR: join(appDataDir, 'recordings')
     })
     expect(
       backendIsolationEnv({


### PR DESCRIPTION
## Summary
- fixes the Windows smoke gate blocker from the tester log
- makes backend isolation test expectations use platform-aware path joining
- keeps the isolation contract unchanged: sqlite, secrets, and recordings stay under the isolated app data root

## Tester failure
Windows failed in the first smoke gate: `pnpm --filter @videorc/desktop test`.
`backend-isolation.test.ts` expected POSIX `/tmp/...` strings, while Windows correctly returned `\tmp\...` paths from Node's `path.join`.

## Verification
- `pnpm --filter @videorc/desktop exec vitest run src/main/backend-isolation.test.ts`
- `pnpm --filter @videorc/desktop test`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated backend isolation test coverage to use path-safe directory construction for expected app data and user data locations.
  * Verified the existing launch and override behaviors still produce the same results across isolated and non-isolated scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->