### PR TITLE
Fix Windows FIFO stale pipe recreate

### DIFF
--- a/crates/videorc-backend/src/fifo.rs
+++ b/crates/videorc-backend/src/fifo.rs
@@ -141,6 +141,17 @@ pub fn create(path: &Path) -> io::Result<()> {
         ));
     }
 
+    {
+        let mut registry = pipe_registry()
+            .lock()
+            .map_err(|_| io::Error::other("named-pipe registry lock poisoned"))?;
+        // The stale server handle must be closed before CreateNamedPipeW runs:
+        // FILE_FLAG_FIRST_PIPE_INSTANCE checks existing OS pipe instances, so
+        // replacing the map entry after creation still leaves the old handle
+        // busy long enough for Windows to reject the replacement.
+        drop(registry.remove(path));
+    }
+
     // PIPE_NOWAIT so `open_writer` can poll ConnectNamedPipe against the
     // stop flag; it flips the handle back to blocking once a reader attaches.
     let handle = unsafe {
@@ -163,8 +174,6 @@ pub fn create(path: &Path) -> io::Result<()> {
     let mut registry = pipe_registry()
         .lock()
         .map_err(|_| io::Error::other("named-pipe registry lock poisoned"))?;
-    // Replacing an entry drops (closes) any stale server instance for the
-    // same path — the named-pipe twin of removing a stale filesystem FIFO.
     registry.insert(path.to_path_buf(), owned);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- fixes the Windows FIFO seam failure where re-creating a named pipe at the same path returns ERROR_PIPE_BUSY / code 231
- closes any registry-owned stale server handle before calling CreateNamedPipeW with FILE_FLAG_FIRST_PIPE_INSTANCE
- keeps the existing Windows regression test as the proof seam: create_replaces_a_stale_pipe_for_the_same_path

## Tester failure
`fifo::windows_tests::create_replaces_a_stale_pipe_for_the_same_path` failed with:
`Os { code: 231, message: "All pipe instances are busy." }`

## Verification
- `cargo fmt --check --all`
- `cargo test -p videorc-backend fifo`
- `pnpm check:windows`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of named-pipe connections on Windows by clearing out stale server handles before creating a new pipe.
  * Reduced the chance of handle conflicts or delayed cleanup during pipe creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->