### PR TITLE
Fix Windows dev app launcher pnpm spawn

### DIFF
--- a/scripts/lib/app-launcher.mjs
+++ b/scripts/lib/app-launcher.mjs
@@ -87,12 +87,7 @@ export function launchDevApp({
     let stopping = false
     const childEnv = smokeAppEnv(env)
 
-    const child = spawn('pnpm', ['dev'], {
-      cwd: repoRoot,
-      detached: true,
-      env: childEnv,
-      stdio: ['ignore', 'pipe', 'pipe']
-    })
+    const child = spawn('pnpm', ['dev'], devAppSpawnOptions({ env: childEnv }))
 
     const stop = () => stopProcess(child, () => (stopping = true))
 
@@ -153,6 +148,16 @@ export function launchDevApp({
       )
     })
   })
+}
+
+export function devAppSpawnOptions({ env, platform = process.platform } = {}) {
+  return {
+    cwd: repoRoot,
+    detached: true,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: platform === 'win32'
+  }
 }
 
 /** SIGTERM the process tree, escalating to SIGKILL after bounded grace periods. */

--- a/scripts/lib/app-launcher.test.mjs
+++ b/scripts/lib/app-launcher.test.mjs
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { resolve } from 'node:path'
 
-import { resolveSmokeAppDirs, smokeAppEnv, stopProcess } from './app-launcher.mjs'
+import {
+  devAppSpawnOptions,
+  resolveSmokeAppDirs,
+  smokeAppEnv,
+  stopProcess
+} from './app-launcher.mjs'
 
 const SMOKE_ENV_KEYS = [
   'VIDEORC_APP_DATA_DIR',
@@ -58,6 +63,12 @@ test('smokeAppEnv preserves explicit app dirs and reaper policy', () => {
     assert.equal(env.VIDEORC_DISABLE_BACKEND_REAP, '0')
     assert.equal(env.VIDEORC_SMOKE_PRINT_BACKEND_READY, '0')
   })
+})
+
+test('dev app launch uses a shell on Windows so Corepack pnpm shims resolve', () => {
+  assert.equal(devAppSpawnOptions({ platform: 'win32' }).shell, true)
+  assert.equal(devAppSpawnOptions({ platform: 'darwin' }).shell, false)
+  assert.equal(devAppSpawnOptions({ platform: 'linux' }).shell, false)
 })
 
 test('stopProcess reports a graceful process-group stop', async () => {


### PR DESCRIPTION
## Summary
- fixes the Windows owned-process lifecycle smoke failing with `spawn pnpm ENOENT`
- makes the shared dev-app launcher use `shell: true` on Windows so Corepack's `pnpm.cmd` shim resolves
- adds a regression test for the launcher spawn options

## Tester failure
`pnpm smoke:local-gates:windows` failed in `owned process lifecycle cleanup smoke`:
`Error: spawn pnpm ENOENT` from `scripts/smoke-process-lifecycle.mjs` via `launchDevApp()`.

## Verification
- `node --test scripts/lib/app-launcher.test.mjs`
- `pnpm test:scripts`
- `pnpm format:check`