### PR TITLE
Harden Windows dev app launcher failures

### DIFF
--- a/scripts/lib/app-launcher.mjs
+++ b/scripts/lib/app-launcher.mjs
@@ -1,9 +1,10 @@
 // Shared dev-app launcher for harnesses that need a real backend connection.
 //
-// Spawns `pnpm dev`, parses the `[smoke] <marker> {json}` handshake lines the main
-// process prints, and resolves once every required marker has been seen. Factored out
-// of the per-smoke launch boilerplate so the real-source baseline harness (and future
-// honest-gate harnesses) reuse one battle-tested launch/teardown path.
+// Spawns `pnpm --filter @videorc/desktop dev`, parses the `[smoke] <marker> {json}`
+// handshake lines the main process prints, and resolves once every required marker has
+// been seen. Factored out of the per-smoke launch boilerplate so the real-source
+// baseline harness (and future honest-gate harnesses) reuse one battle-tested
+// launch/teardown path.
 //
 // Harnesses default to isolated app/user data and ledger reaping. Product launches
 // still use the normal app data path unless a smoke explicitly opts into this helper.
@@ -85,18 +86,21 @@ export function launchDevApp({
     const connections = {}
     let settled = false
     let stopping = false
+    const recentOutput = []
     const childEnv = smokeAppEnv(env)
+    const spawnSpec = devAppSpawnSpec({ env: childEnv })
 
-    const child = spawn('pnpm', ['dev'], devAppSpawnOptions({ env: childEnv }))
+    const child = spawn(spawnSpec.command, spawnSpec.args, spawnSpec.options)
 
     const stop = () => stopProcess(child, () => (stopping = true))
+    const launchError = (message) => new Error(devAppFailureMessage(message, recentOutput))
 
     const timer = setTimeout(() => {
       if (settled) return
       settled = true
       void stop()
       rejectLaunch(
-        new Error(`Timed out waiting for [${requiredMarkers.join(', ')}] after ${timeoutMs}ms.`)
+        launchError(`Timed out waiting for [${requiredMarkers.join(', ')}] after ${timeoutMs}ms.`)
       )
     }, timeoutMs)
 
@@ -112,6 +116,7 @@ export function launchDevApp({
     const handle = (text) => {
       for (const line of text.split(/\r?\n/)) {
         if (!line.trim()) continue
+        rememberRecentOutput(recentOutput, line)
         if (onLine && !stopping) onLine(line)
         const idx = line.indexOf(MARKER_PREFIX)
         if (idx === -1) continue
@@ -137,17 +142,25 @@ export function launchDevApp({
       if (settled) return
       settled = true
       clearTimeout(timer)
-      rejectLaunch(error)
+      rejectLaunch(launchError(error.message))
     })
     child.on('exit', (code, signal) => {
       if (settled) return
       settled = true
       clearTimeout(timer)
       rejectLaunch(
-        new Error(`Dev app exited before handshake completed: code=${code} signal=${signal}`)
+        launchError(`Dev app exited before handshake completed: code=${code} signal=${signal}`)
       )
     })
   })
+}
+
+export function devAppSpawnSpec({ env, platform = process.platform } = {}) {
+  return {
+    command: 'pnpm',
+    args: ['--filter', '@videorc/desktop', 'dev'],
+    options: devAppSpawnOptions({ env, platform })
+  }
 }
 
 export function devAppSpawnOptions({ env, platform = process.platform } = {}) {
@@ -157,6 +170,21 @@ export function devAppSpawnOptions({ env, platform = process.platform } = {}) {
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: platform === 'win32'
+  }
+}
+
+export function devAppFailureMessage(message, recentOutput = []) {
+  const output = recentOutput.filter((line) => line.trim())
+  if (output.length === 0) {
+    return message
+  }
+  return `${message}\n\nLast dev app output:\n${output.join('\n')}`
+}
+
+function rememberRecentOutput(output, line, limit = 40) {
+  output.push(line)
+  if (output.length > limit) {
+    output.splice(0, output.length - limit)
   }
 }
 

--- a/scripts/lib/app-launcher.test.mjs
+++ b/scripts/lib/app-launcher.test.mjs
@@ -3,7 +3,9 @@ import test from 'node:test'
 import { resolve } from 'node:path'
 
 import {
+  devAppFailureMessage,
   devAppSpawnOptions,
+  devAppSpawnSpec,
   resolveSmokeAppDirs,
   smokeAppEnv,
   stopProcess
@@ -65,10 +67,28 @@ test('smokeAppEnv preserves explicit app dirs and reaper policy', () => {
   })
 })
 
-test('dev app launch uses a shell on Windows so Corepack pnpm shims resolve', () => {
-  assert.equal(devAppSpawnOptions({ platform: 'win32' }).shell, true)
+test('dev app launch targets the desktop package and uses a shell on Windows', () => {
+  const windowsSpec = devAppSpawnSpec({ platform: 'win32' })
+
+  assert.equal(windowsSpec.command, 'pnpm')
+  assert.deepEqual(windowsSpec.args, ['--filter', '@videorc/desktop', 'dev'])
+  assert.equal(windowsSpec.options.shell, true)
   assert.equal(devAppSpawnOptions({ platform: 'darwin' }).shell, false)
   assert.equal(devAppSpawnOptions({ platform: 'linux' }).shell, false)
+})
+
+test('dev app launch failures include the latest child output', () => {
+  const message = devAppFailureMessage('Dev app exited before handshake completed', [
+    '',
+    'vite failed to bind port 5173',
+    'electron-vite exited with code 1'
+  ])
+
+  assert.match(message, /Dev app exited before handshake completed/)
+  assert.match(message, /Last dev app output:/)
+  assert.match(message, /vite failed to bind port 5173/)
+  assert.match(message, /electron-vite exited with code 1/)
+  assert.equal(devAppFailureMessage('plain failure', []), 'plain failure')
 })
 
 test('stopProcess reports a graceful process-group stop', async () => {


### PR DESCRIPTION
## Summary
- launch the desktop dev app directly from the shared smoke launcher instead of going through the root `pnpm dev` script
- keep the Windows Corepack shell behavior from PR #36
- include the latest child stdout/stderr lines when the dev app exits before the `backend-ready` handshake, so Windows tester logs show the actual Electron/Vite/backend startup failure instead of only `code=1`

## Windows failure addressed
```
Error: Dev app exited before handshake completed: code=1 signal=null
Error: owned process lifecycle cleanup smoke failed: pnpm smoke:process-lifecycle exited with code=1 signal=null
```

## Verification
- `node --test scripts/lib/app-launcher.test.mjs`
- `pnpm test:scripts`
- `pnpm format:check`

Merging immediately per owner request; not waiting for CI green lights.