### PR TITLE
Windows CI: run the gates and build an installer artifact on every PR

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,115 @@
+name: Windows
+
+# Windows counterparts of the fast CI gates plus a downloadable installer.
+# The repo is public, so windows-latest minutes are free. Every failure the
+# first external Windows tester hit (path separators in desktop tests, the
+# stale named-pipe recreate, pnpm spawn semantics, dev-app startup) lived in
+# code that had only ever *compiled* for Windows (pnpm check:windows) and
+# never executed there — these jobs close that gap before a human pulls.
+# Real capture/encode/preview quality still needs the physical Windows box.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gates:
+    name: Windows gates (Rust + JS tests)
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.0.9
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.6.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Clippy
+        # cfg(windows) code is invisible to the macOS clippy job; this is the
+        # only lint pass that sees the named-pipe/Job-Object/dshow arms.
+        run: cargo clippy -p videorc-backend -- -D warnings
+
+      - name: Test
+        # Executes the Windows-only unit tests (named pipes, process Job
+        # Objects, dshow input builders) that `pnpm check:windows` can only
+        # compile. ffmpeg-spawning tests are #[ignore]d, same as macOS CI.
+        run: cargo test -p videorc-backend
+
+      - name: Desktop tests
+        run: pnpm --filter @videorc/desktop test
+
+      - name: Node logic tests
+        run: pnpm test:scripts
+
+  installer:
+    name: Windows installer artifact
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.0.9
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.6.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Windows installer
+        # Backend release build + pinned LGPL ffmpeg fetch + fail-closed
+        # preflight (runs the ffmpeg rtmps/tls/h264_mf capability probe on a
+        # real Windows host) + electron-builder dir/nsis targets. Unsigned:
+        # testers will see a SmartScreen warning until signing lands.
+        run: pnpm dist:desktop:windows
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: videorc-windows-installer
+          path: |
+            apps/desktop/release/*.exe
+            apps/desktop/release/*.blockmap
+            apps/desktop/release/latest.yml
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/windows.yml` with two `windows-latest` jobs (free on a public repo — the CI-budget constraint in the docs predates the open-source flip):
  - **gates** — `cargo clippy` + `cargo test -p videorc-backend` on MSVC, desktop vitest, and `pnpm test:scripts`, all on a real Windows host. This is the first place the Windows-only unit tests (named pipes, Job Objects, dshow input builders) actually *execute*; `pnpm check:windows` only compiles them. Every failure the external tester hit so far (#34–#37) would have been caught here.
  - **installer** — `pnpm dist:desktop:windows` (backend release build → pinned LGPL ffmpeg fetch → fail-closed preflight, including the rtmps/tls/h264_mf ffmpeg capability probe running on Windows for the first time → NSIS), uploaded as the `videorc-windows-installer` artifact (30-day retention). Testers download a build from the latest run instead of cloning the repo and fighting the toolchain. Unsigned for now — SmartScreen warning expected until signing lands.
- `workflow_dispatch` included so an installer can be built on demand from any branch.

## Validation
- `prettier --check .github/workflows/windows.yml` passes (the repo's format gate covers workflow files).
- Workflow-only change; no product code touched. The jobs themselves are the validation — first run happens on this PR.

## Limits
CI cannot judge real capture/encode/preview quality (virtual/no GPU); the physical Windows box remains the bar for recording acceptance per docs/windows-port-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Windows CI coverage for pushes, pull requests, and manual runs.
  * CI now cancels older in-progress runs on the same branch to save time.

* **Tests**
  * Expanded automated checks to include Rust linting, backend unit tests, desktop tests, and Node script tests on Windows.

* **Build & Release**
  * Added a Windows installer build step and uploads the generated installer artifacts for download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->