### PR TITLE
Get Videorc running on Windows: dev boot, FFmpeg, and verify-loop fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# LF everywhere: prettier enforces LF, and macOS/Linux boxes commit LF.
+# Without this, Windows checkouts with core.autocrlf=true materialize CRLF
+# and every format:check fails repo-wide. Git still auto-detects binaries.
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The app launches the Rust backend automatically. Recordings default to
 `~/Movies/Videorc/Recordings`; session metadata lives in
 `~/Library/Application Support/Videorc/videorc.sqlite3`.
 
+Developing on Windows? See [docs/windows-dev-loop.md](docs/windows-dev-loop.md)
+for setup, the version-floor escape hatch, and the fast verify loop.
+
 To produce a local unsigned macOS app bundle:
 
 ```sh

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4799,6 +4799,14 @@ function enforceWindowsVersionFloor(): boolean {
   if (!isWindows) {
     return false
   }
+  // Dev/lab escape hatch: Windows 10 boxes stay useful for development even
+  // though Windows 11 is the supported floor. Anything Windows-11-specific
+  // (Mica/acrylic, Windows.Graphics.Capture maturity) is unverified below
+  // build 22000 — expect degraded chrome, not a supported configuration.
+  if (process.env.VIDEORC_ALLOW_UNSUPPORTED_WINDOWS === '1') {
+    logBackend('warn', `Windows version floor bypassed (build ${release()}); unsupported setup.`)
+    return false
+  }
   const build = Number.parseInt(release().split('.')[2] ?? '', 10)
   if (Number.isFinite(build) && build >= 22000) {
     return false
@@ -5027,11 +5035,17 @@ function resolveBackendPermissionTargetPath(): string {
 }
 
 function resolvePackagedFfmpegBinDir(): string | null {
-  if (!app.isPackaged) {
+  // Dev mode on Windows: use the pinned vendor FFmpeg from
+  // `pnpm ffmpeg:fetch:windows` when present, so development does not depend
+  // on a system-wide ffmpeg install. macOS dev keeps resolving via PATH.
+  const binDir = app.isPackaged
+    ? join(process.resourcesPath, 'ffmpeg', 'bin')
+    : process.platform === 'win32'
+      ? join(workspaceRoot(), 'vendor', 'ffmpeg', 'windows-x64', 'bin')
+      : null
+  if (!binDir) {
     return null
   }
-
-  const binDir = join(process.resourcesPath, 'ffmpeg', 'bin')
   const binary = join(binDir, process.platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg')
   return existsSync(binary) ? binDir : null
 }
@@ -5156,7 +5170,9 @@ function startBackendWithRegistryLock(): void {
       // silently using the real ~/Library/Application Support/Videorc profile.
       ...backendIsolationEnv(process.env),
       PATH: pathEntries.join(delimiter),
-      VIDEORC_BUNDLED_FFMPEG_PATH: ffmpegBinDir ? join(ffmpegBinDir, 'ffmpeg') : '',
+      VIDEORC_BUNDLED_FFMPEG_PATH: ffmpegBinDir
+        ? join(ffmpegBinDir, process.platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg')
+        : '',
       // The backend's watchdog also exits when THIS process dies — the ppid
       // check alone misses the dev chain (electron -> cargo -> backend), where
       // killing Electron leaves cargo alive as the backend's parent.

--- a/docs/windows-dev-loop.md
+++ b/docs/windows-dev-loop.md
@@ -1,0 +1,114 @@
+# Windows dev loop
+
+How to develop and verify Videorc on a Windows box. First proven on-box
+2026-07-08 (Windows 10 x64, unsupported configuration — see the floor note).
+
+## One-time setup
+
+Prerequisites: Node 22+, pnpm 11 (`packageManager` pin), Rust stable with the
+MSVC toolchain (Visual Studio Build Tools), git.
+
+```powershell
+pnpm install
+pnpm ffmpeg:fetch:windows   # pinned LGPL FFmpeg -> vendor/ffmpeg/windows-x64
+```
+
+Dev mode wires the vendored `ffmpeg.exe`/`ffprobe.exe` in automatically
+(`resolvePackagedFfmpegBinDir` in `apps/desktop/src/main/index.ts` and
+`scripts/smoke-dev-app.mjs` both prefer it) — no PATH edits needed.
+
+## The Windows version floor
+
+Videorc supports Windows 11 (build 22000+) only. On older builds the app quits
+at startup with a dialog. For development on a Windows 10 box, set:
+
+```powershell
+$env:VIDEORC_ALLOW_UNSUPPORTED_WINDOWS = '1'
+```
+
+This bypasses the startup floor (`enforceWindowsVersionFloor`) and the
+`smoke:local-gates:windows` host check. It is a dev/lab escape hatch, not a
+supported configuration: Mica/acrylic and Windows.Graphics.Capture behavior
+below build 22000 is unverified.
+
+## Run the app
+
+```powershell
+pnpm dev   # electron-vite + cargo run of the backend (first run compiles Rust)
+```
+
+## Fast change -> is-it-fixed loop
+
+Keep the app running with the smoke command server, then drive it without
+relaunching anything:
+
+```powershell
+# terminal 1 — stays up; prints "UI driver ready" when the command server is live
+$env:VIDEORC_ALLOW_UNSUPPORTED_WINDOWS = '1'
+pnpm ui:driver
+```
+
+```powershell
+# terminal 2 — one command per check, results in ~1s
+node scripts/ui-cmd.mjs eval-js '{"code":"return document.title"}'
+node scripts/ui-cmd.mjs capture-page '{"name":"my-check"}'   # PNG into docs/acceptance/sweeps/.staging
+node scripts/ui-cmd.mjs open-tab '{"tab":"settings"}'
+```
+
+Call `node scripts/ui-cmd.mjs` directly rather than `pnpm ui:cmd` on Windows —
+the pnpm/cmd shim layer mangles quoted JSON arguments.
+
+Renderer changes hot-reload via electron-vite, so the loop for UI work is:
+edit -> save -> `capture-page`/`eval-js` -> look. Backend (Rust) changes need a
+driver restart (`cargo run` recompiles incrementally).
+
+## Verify gates that work on Windows
+
+Cheap, no Electron (run these first):
+
+```powershell
+pnpm typecheck
+pnpm test:scripts
+pnpm --filter @videorc/desktop test
+cargo test -p videorc-backend
+cargo clippy -p videorc-backend -- -D warnings
+```
+
+Real-app gate (boots the dev app, records a test pattern, gates on quality):
+
+```powershell
+$env:VIDEORC_ALLOW_UNSUPPORTED_WINDOWS = '1'
+pnpm smoke:dev
+```
+
+Full Windows merge gate (release build + package + packaged smoke; slow):
+
+```powershell
+$env:VIDEORC_ALLOW_UNSUPPORTED_WINDOWS = '1'   # only needed below Windows 11
+pnpm smoke:local-gates:windows
+```
+
+## Windows-specific launcher rules (for smoke/script authors)
+
+Learned on-box 2026-07-08; encoded in `scripts/lib/app-launcher.mjs`:
+
+- Spawn `pnpm` with `shell: true` on win32 (the pnpm shim is a `.cmd`; Node
+  also blocks direct `.cmd` spawns without a shell — CVE-2024-27980).
+- Never combine `detached: true` with `shell: true` on win32: the child runs
+  but its piped stdout/stderr silently never arrive, so marker handshakes
+  (`[smoke] backend-ready …`) time out with zero output. `detached` is
+  POSIX-only in `devAppSpawnOptions`.
+- There are no POSIX process groups: `stopProcess` tree-kills via
+  `taskkill /PID <pid> /T` (`/F` on escalation). Killing only the direct child
+  leaks the pnpm -> electron -> cargo -> backend chain.
+- Derive `ffprobe` from a configured ffmpeg path with `.exe` awareness
+  (`resolveSiblingFfprobe` in `scripts/smoke-recording-session.mjs`), and use
+  `basename()` instead of `split('/')` for path math (`recording-analyzer.mjs`).
+
+## FFmpeg pin rot
+
+`vendor/ffmpeg/windows-pin.json` pins a BtbN autobuild URL + sha256. BtbN
+deletes old autobuild releases, so the pin 404s over time. Re-pin by picking a
+current `ffmpeg-n8.x-*-win64-lgpl-8.x.zip` from
+https://github.com/BtbN/FFmpeg-Builds/releases, downloading it, and recording
+its sha256 in the pin (LGPL-only assets — repo policy).

--- a/docs/windows-port-plan.md
+++ b/docs/windows-port-plan.md
@@ -9,6 +9,16 @@ Dark-glass UI carries over; macOS-only niceties degrade gracefully.
 This plan is still a follow-through track, not a claim that Windows is ready.
 The completed work is packaging and platform-seam preparation:
 
+- **First on-box run happened (2026-07-08, Windows 10 x64 dev box).** `pnpm dev`
+  boots, the backend compiles and runs, DXGI display + MediaFoundation
+  camera/mic rows appear in the UI, `pnpm ui:driver`/`ui:cmd` drive the app, and
+  `pnpm smoke:dev` passes end to end (all five layout presets record MP4s that
+  clear the quality gates; A/V skew 4–16ms). Dev-loop setup and the
+  Windows-specific launcher rules learned from that run live in
+  `docs/windows-dev-loop.md`. Known on-box issues: the permissions onboarding
+  dialog shows macOS copy ("capture your Mac", ⌘ shortcuts) on Windows, and the
+  main-process first-frame healer logs macOS-specific "Metal IOSurface" retries.
+
 - **Parent track exists.** The Obsidian parent plan is
   `2026-07-07 - Videorc Complete Windows App Plan`; this repo file remains the
   engineering detail for Windows capture/package execution. W0 evidence now

--- a/scripts/lib/app-launcher.mjs
+++ b/scripts/lib/app-launcher.mjs
@@ -9,7 +9,7 @@
 // Harnesses default to isolated app/user data and ledger reaping. Product launches
 // still use the normal app data path unless a smoke explicitly opts into this helper.
 
-import { spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -166,7 +166,12 @@ export function devAppSpawnSpec({ env, platform = process.platform } = {}) {
 export function devAppSpawnOptions({ env, platform = process.platform } = {}) {
   return {
     cwd: repoRoot,
-    detached: true,
+    // POSIX only: detached puts the app in its own process group so stopProcess
+    // can signal the whole tree. On Windows, detached + shell silently routes
+    // the child's stdout/stderr away from our pipes (observed 2026-07-08: zero
+    // captured output, handshake markers never seen), and group signalling
+    // doesn't exist anyway — stopProcess uses taskkill /T there instead.
+    detached: platform !== 'win32',
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: platform === 'win32'
@@ -312,6 +317,23 @@ function isChildExited(child) {
 }
 
 function signalProcessGroup(pid, child, sig) {
+  if (process.platform === 'win32') {
+    // No POSIX process groups on Windows: taskkill /T walks the child tree
+    // (shell -> pnpm -> electron -> cargo -> backend). Always force with /F —
+    // without it taskkill only posts WM_CLOSE, which console processes ignore;
+    // the shell root then exits on its own and a later forced pass has no tree
+    // left to walk, orphaning electron/cargo/backend (observed 2026-07-08).
+    try {
+      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' })
+    } catch {
+      try {
+        child?.kill(sig)
+      } catch {
+        // Nothing left to signal.
+      }
+    }
+    return
+  }
   try {
     process.kill(-pid, sig)
   } catch {
@@ -349,8 +371,11 @@ function waitForProcessGroupExit(pid, timeoutMs, processGroupExistsFn = processG
 }
 
 function processGroupExists(pid) {
+  // Windows has no process groups; the spawned shell pid stands in for the
+  // tree (taskkill /T above removes it together with its descendants).
+  const target = process.platform === 'win32' ? pid : -pid
   try {
-    process.kill(-pid, 0)
+    process.kill(target, 0)
     return true
   } catch (error) {
     return error?.code === 'EPERM'

--- a/scripts/lib/app-launcher.test.mjs
+++ b/scripts/lib/app-launcher.test.mjs
@@ -32,21 +32,23 @@ test('resolveSmokeAppDirs derives isolated dirs from an explicit smoke state dir
 
 test('smokeAppEnv enables ledger reaping by default for isolated smoke launches', () => {
   withCleanSmokeEnv(() => {
-    const env = smokeAppEnv({ VIDEORC_SMOKE_STATE_DIR: '/tmp/videorc-smoke-state' })
+    const stateDir = '/tmp/videorc-smoke-state'
+    const env = smokeAppEnv({ VIDEORC_SMOKE_STATE_DIR: stateDir })
 
     assert.equal(env.VIDEORC_DISABLE_BACKEND_REAP, '0')
     assert.equal(env.VIDEORC_SMOKE_PRINT_BACKEND_READY, '1')
-    assert.equal(env.VIDEORC_APP_DATA_DIR, '/tmp/videorc-smoke-state/app-data')
-    assert.equal(env.VIDEORC_USER_DATA_DIR, '/tmp/videorc-smoke-state/user-data')
+    assert.equal(env.VIDEORC_APP_DATA_DIR, resolve(stateDir, 'app-data'))
+    assert.equal(env.VIDEORC_USER_DATA_DIR, resolve(stateDir, 'user-data'))
   })
 })
 
 test('smokeAppEnv reuses the smoke output dir as the default isolated state dir', () => {
   withCleanSmokeEnv(() => {
-    const env = smokeAppEnv({ VIDEORC_SMOKE_OUTPUT_DIR: '/tmp/videorc-smoke-output' })
+    const outputDir = '/tmp/videorc-smoke-output'
+    const env = smokeAppEnv({ VIDEORC_SMOKE_OUTPUT_DIR: outputDir })
 
-    assert.equal(env.VIDEORC_APP_DATA_DIR, '/tmp/videorc-smoke-output/app-data')
-    assert.equal(env.VIDEORC_USER_DATA_DIR, '/tmp/videorc-smoke-output/user-data')
+    assert.equal(env.VIDEORC_APP_DATA_DIR, resolve(outputDir, 'app-data'))
+    assert.equal(env.VIDEORC_USER_DATA_DIR, resolve(outputDir, 'user-data'))
   })
 })
 
@@ -75,6 +77,11 @@ test('dev app launch targets the desktop package and uses a shell on Windows', (
   assert.equal(windowsSpec.options.shell, true)
   assert.equal(devAppSpawnOptions({ platform: 'darwin' }).shell, false)
   assert.equal(devAppSpawnOptions({ platform: 'linux' }).shell, false)
+  // detached is POSIX-only: on Windows it silently drops the piped output the
+  // marker handshake depends on, and there is no process group to signal.
+  assert.equal(windowsSpec.options.detached, false)
+  assert.equal(devAppSpawnOptions({ platform: 'darwin' }).detached, true)
+  assert.equal(devAppSpawnOptions({ platform: 'linux' }).detached, true)
 })
 
 test('dev app launch failures include the latest child output', () => {

--- a/scripts/lib/macos-release-artifact-validation.test.mjs
+++ b/scripts/lib/macos-release-artifact-validation.test.mjs
@@ -15,6 +15,12 @@ import {
   selectLatestReleaseArtifacts
 } from './macos-release-artifact-validation.mjs'
 
+// relative() emits platform separators, so repo-relative path assertions must
+// not hardcode '/' — these tests run on both macOS and Windows boxes.
+function posixPath(value) {
+  return value.replaceAll('\\', '/')
+}
+
 describe('artifactKindFromPath', () => {
   it('recognizes app bundles and DMGs only', () => {
     assert.equal(artifactKindFromPath('/tmp/Videorc.app'), 'app')
@@ -195,10 +201,12 @@ describe('selectLatestReleaseArtifacts', () => {
 describe('release artifact report redaction', () => {
   it('formats repo-relative artifact paths', () => {
     assert.equal(
-      formatArtifactPath('/repo/apps/desktop/release/mac-arm64/Videorc.app', {
-        repoRoot: '/repo',
-        homeDir: '/Users/orcdev'
-      }),
+      posixPath(
+        formatArtifactPath('/repo/apps/desktop/release/mac-arm64/Videorc.app', {
+          repoRoot: '/repo',
+          homeDir: '/Users/orcdev'
+        })
+      ),
       'apps/desktop/release/mac-arm64/Videorc.app'
     )
   })

--- a/scripts/lib/packaged-smoke-paths.test.mjs
+++ b/scripts/lib/packaged-smoke-paths.test.mjs
@@ -7,23 +7,33 @@ import {
   defaultPackagedAppExecutable
 } from './packaged-smoke-paths.mjs'
 
+// resolve() emits platform separators (and resolves POSIX-style roots against
+// the current drive on Windows), so path assertions must not hardcode '/' —
+// these tests run on both macOS and Windows boxes.
+function posixPath(value) {
+  return value.replaceAll('\\', '/')
+}
+
 describe('packaged smoke paths', () => {
   it('resolves the default macOS packaged executable and bundled FFmpeg', () => {
     const executable = defaultPackagedAppExecutable({ repoRoot: '/repo', platform: 'darwin' })
 
-    assert.equal(executable, '/repo/apps/desktop/release/mac-arm64/Videorc.app/Contents/MacOS/Videorc')
-    assert.equal(
-      bundledFfmpegPathForPackagedApp({ appExecutable: executable, platform: 'darwin' }),
-      '/repo/apps/desktop/release/mac-arm64/Videorc.app/Contents/Resources/ffmpeg/bin/ffmpeg'
+    assert.match(
+      posixPath(executable),
+      /\/repo\/apps\/desktop\/release\/mac-arm64\/Videorc\.app\/Contents\/MacOS\/Videorc$/
+    )
+    assert.match(
+      posixPath(bundledFfmpegPathForPackagedApp({ appExecutable: executable, platform: 'darwin' })),
+      /\/repo\/apps\/desktop\/release\/mac-arm64\/Videorc\.app\/Contents\/Resources\/ffmpeg\/bin\/ffmpeg$/
     )
   })
 
   it('resolves the default Windows packaged executable and bundled FFmpeg', () => {
     const executable = defaultPackagedAppExecutable({ repoRoot: 'C:/repo', platform: 'win32' })
 
-    assert.match(executable, /C:\/repo\/apps\/desktop\/release\/win-unpacked\/Videorc\.exe$/)
+    assert.match(posixPath(executable), /C:\/repo\/apps\/desktop\/release\/win-unpacked\/Videorc\.exe$/)
     assert.match(
-      bundledFfmpegPathForPackagedApp({ appExecutable: executable, platform: 'win32' }),
+      posixPath(bundledFfmpegPathForPackagedApp({ appExecutable: executable, platform: 'win32' })),
       /C:\/repo\/apps\/desktop\/release\/win-unpacked\/resources\/ffmpeg\/bin\/ffmpeg\.exe$/
     )
   })

--- a/scripts/lib/recording-analyzer.mjs
+++ b/scripts/lib/recording-analyzer.mjs
@@ -20,7 +20,7 @@
 
 import { spawn } from 'node:child_process'
 import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 /**
  * Strict OBS-quality gates. All thresholds come from the root-fix plan's
@@ -906,10 +906,7 @@ export function renderMarkdownReport(report) {
 export function writeReports(report, { outDir } = {}) {
   const dir = outDir ?? dirname(report.file)
   mkdirSync(dir, { recursive: true })
-  const base = report.file
-    .split('/')
-    .pop()
-    .replace(/\.[^.]+$/, '')
+  const base = basename(report.file).replace(/\.[^.]+$/, '')
   const jsonPath = join(dir, `${base}.quality.json`)
   const mdPath = join(dir, `${base}.quality.md`)
   writeFileSync(jsonPath, JSON.stringify(report, null, 2))

--- a/scripts/lib/windows-local-gates.mjs
+++ b/scripts/lib/windows-local-gates.mjs
@@ -5,7 +5,8 @@ export const WINDOWS_LOCAL_GATE_MANIFEST_NAME = 'windows-local-gates.manifest.js
 export function evaluateWindowsLocalGateHost({
   platform = process.platform,
   arch = process.arch,
-  release = ''
+  release = '',
+  allowUnsupportedBuild = false
 } = {}) {
   const failures = []
   if (platform !== 'win32') {
@@ -16,7 +17,7 @@ export function evaluateWindowsLocalGateHost({
   }
 
   const build = windowsBuildNumber(release)
-  if (platform === 'win32' && build !== null && build < 22000) {
+  if (platform === 'win32' && build !== null && build < 22000 && !allowUnsupportedBuild) {
     failures.push(`requires Windows 11 build 22000 or newer; current build is ${build}`)
   }
 

--- a/scripts/lib/windows-local-gates.test.mjs
+++ b/scripts/lib/windows-local-gates.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { join } from 'node:path'
 import { describe, it } from 'node:test'
 
 import {
@@ -10,6 +11,12 @@ import {
   windowsLocalGateManifestPath,
   windowsLocalGateOutputDir
 } from './windows-local-gates.mjs'
+
+// resolve() emits platform separators, so path assertions must not hardcode
+// '/' — these tests run on both macOS and Windows boxes.
+function posixPath(value) {
+  return value.replaceAll('\\', '/')
+}
 
 describe('evaluateWindowsLocalGateHost', () => {
   it('accepts Windows 11 x64 hosts', () => {
@@ -57,15 +64,15 @@ describe('buildWindowsLocalGateSteps', () => {
     ])
     assert.deepEqual(steps.at(-1).args, ['smoke:packaged:bundled'])
     assert.match(
-      steps.at(-1).env.VIDEORC_PACKAGED_APP_EXECUTABLE,
+      posixPath(steps.at(-1).env.VIDEORC_PACKAGED_APP_EXECUTABLE),
       /C:\/repo\/apps\/desktop\/release\/win-unpacked\/Videorc\.exe$/
     )
     assert.match(
-      steps.at(-1).env.VIDEORC_SMOKE_OUTPUT_DIR,
+      posixPath(steps.at(-1).env.VIDEORC_SMOKE_OUTPUT_DIR),
       /C:\/repo\/docs\/acceptance\/artifacts\/windows\/\d{4}-\d{2}-\d{2}$/
     )
     assert.match(
-      windowsLocalGateOutputDir(steps),
+      posixPath(windowsLocalGateOutputDir(steps)),
       /C:\/repo\/docs\/acceptance\/artifacts\/windows\/\d{4}-\d{2}-\d{2}$/
     )
   })
@@ -77,7 +84,7 @@ describe('buildWindowsLocalGateSteps', () => {
     })
 
     assert.match(
-      steps.at(-1).env.VIDEORC_SMOKE_OUTPUT_DIR,
+      posixPath(steps.at(-1).env.VIDEORC_SMOKE_OUTPUT_DIR),
       /C:\/repo\/docs\/acceptance\/artifacts\/windows\/2026-07-08-lab-1$/
     )
   })
@@ -130,7 +137,7 @@ describe('buildWindowsLocalGateSteps', () => {
       'pnpm',
       'support-bundle:verify',
       '--',
-      `${outputDir}/support-bundle.json`,
+      join(outputDir, 'support-bundle.json'),
       '--windows-acceptance'
     ])
     assert.match(manifest.evidence.acceptanceTemplate, /windows-app-acceptance-template\.md$/)
@@ -139,7 +146,7 @@ describe('buildWindowsLocalGateSteps', () => {
       (step) => step.label === 'owned process lifecycle cleanup smoke'
     )
     assert.deepEqual(processSmoke.env, {
-      VIDEORC_SMOKE_OUTPUT_DIR: `${outputDir}/process-lifecycle`
+      VIDEORC_SMOKE_OUTPUT_DIR: join(outputDir, 'process-lifecycle')
     })
 
     const packagedSmoke = manifest.steps.at(-1)
@@ -168,7 +175,7 @@ describe('buildWindowsLocalGateSteps', () => {
       }
     )
     assert.match(
-      packagedSmoke.env.VIDEORC_PACKAGED_APP_EXECUTABLE,
+      posixPath(packagedSmoke.env.VIDEORC_PACKAGED_APP_EXECUTABLE),
       /C:\/repo\/apps\/desktop\/release\/win-unpacked\/Videorc\.exe$/
     )
     assert.equal(packagedSmoke.env.VIDEORC_SMOKE_OUTPUT_DIR, outputDir)

--- a/scripts/smoke-dev-app.mjs
+++ b/scripts/smoke-dev-app.mjs
@@ -1,18 +1,32 @@
-import { mkdtempSync } from 'node:fs'
+import { existsSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { spawn } from 'node:child_process'
 
-import { smokeAppEnv, stopProcess } from './lib/app-launcher.mjs'
+import { devAppSpawnSpec, smokeAppEnv, stopProcess } from './lib/app-launcher.mjs'
 import { runBackendRecordingSmoke } from './smoke-recording-session.mjs'
 
-const repoRoot = resolve(import.meta.dirname, '..')
 const outputDirectory = resolve(
   process.env.VIDEORC_SMOKE_OUTPUT_DIR ?? join(tmpdir(), `videorc-dev-smoke-${Date.now()}`)
 )
 const userDataDir =
   process.env.VIDEORC_USER_DATA_DIR ?? mkdtempSync(join(tmpdir(), 'videorc-dev-smoke-user-data-'))
-const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+const vendorWindowsFfmpeg = resolve(
+  import.meta.dirname,
+  '..',
+  'vendor',
+  'ffmpeg',
+  'windows-x64',
+  'bin',
+  'ffmpeg.exe'
+)
+const ffmpegPath =
+  process.env.VIDEORC_SMOKE_FFMPEG_PATH ??
+  // Windows dev boxes rarely have ffmpeg on PATH; prefer the pinned vendor
+  // build from `pnpm ffmpeg:fetch:windows` (same one dev mode wires in).
+  (process.platform === 'win32' && existsSync(vendorWindowsFfmpeg)
+    ? vendorWindowsFfmpeg
+    : 'ffmpeg')
 const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 90000)
 
 let appProcess
@@ -37,15 +51,15 @@ function launchAndReadConnection() {
       rejectConnection(new Error(`Timed out waiting for dev backend READY after ${timeoutMs}ms.`))
     }, timeoutMs)
 
-    appProcess = spawn('pnpm', ['dev'], {
-      cwd: repoRoot,
-      detached: true,
+    // devAppSpawnSpec handles the Windows pnpm shim (shell: true) — a bare
+    // spawn('pnpm', …) fails with ENOENT on win32.
+    const spec = devAppSpawnSpec({
       env: smokeAppEnv({
         VIDEORC_USER_DATA_DIR: userDataDir,
         VIDEORC_SMOKE_PRINT_BACKEND_READY: '1'
-      }),
-      stdio: ['ignore', 'pipe', 'pipe']
+      })
     })
+    appProcess = spawn(spec.command, spec.args, spec.options)
 
     appProcess.stdout.setEncoding('utf8')
     appProcess.stderr.setEncoding('utf8')

--- a/scripts/smoke-local-gates-windows.mjs
+++ b/scripts/smoke-local-gates-windows.mjs
@@ -14,7 +14,12 @@ import {
 const repoRoot = resolve(import.meta.dirname, '..')
 const dryRun = process.argv.includes('--dry-run') || process.argv.includes('--print-only')
 const startedAt = new Date()
-const host = evaluateWindowsLocalGateHost({ release: release() })
+const host = evaluateWindowsLocalGateHost({
+  release: release(),
+  // Same dev/lab escape hatch as the app's startup floor: lets Windows 10
+  // boxes run the gates as an unsupported configuration.
+  allowUnsupportedBuild: process.env.VIDEORC_ALLOW_UNSUPPORTED_WINDOWS === '1'
+})
 const steps = buildWindowsLocalGateSteps({
   repoRoot,
   acceptanceDir: process.env.VIDEORC_WINDOWS_ACCEPTANCE_DIR

--- a/scripts/smoke-recording-session.mjs
+++ b/scripts/smoke-recording-session.mjs
@@ -492,10 +492,16 @@ function sleep(ms) {
 }
 
 function resolveSiblingFfprobe(ffmpegPath) {
-  if (typeof ffmpegPath !== 'string' || !ffmpegPath.endsWith('ffmpeg')) {
+  if (typeof ffmpegPath !== 'string') {
     return null
   }
-  return `${ffmpegPath.slice(0, -'ffmpeg'.length)}ffprobe`
+  if (ffmpegPath.endsWith('ffmpeg')) {
+    return `${ffmpegPath.slice(0, -'ffmpeg'.length)}ffprobe`
+  }
+  if (ffmpegPath.endsWith('ffmpeg.exe')) {
+    return `${ffmpegPath.slice(0, -'ffmpeg.exe'.length)}ffprobe.exe`
+  }
+  return null
 }
 
 function formatMetricMs(value) {

--- a/vendor/ffmpeg/windows-pin.json
+++ b/vendor/ffmpeg/windows-pin.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-12-14-04/ffmpeg-n8.1.1-12-ge0e38acd2f-win64-lgpl-8.1.zip",
-  "sha256": "2ed0e01ec57cc6cb16554b8878e1b7ceac1a26368517cbb076650b925d372a6c"
+  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-08-13-30/ffmpeg-n8.1.2-22-g94138f6973-win64-lgpl-8.1.zip",
+  "sha256": "771f0145c860e31a2bf607045af950450d8b820f6fa1ce1fec9bd1144e21dcf4"
 }


### PR DESCRIPTION
## Summary

First verified on-box Windows run of Videorc (Windows 10 x64, 2026-07-08). `pnpm dev` boots, the Rust backend compiles and runs, DXGI display + MediaFoundation camera/mic rows appear in the UI, `pnpm ui:driver`/`ui:cmd` drive the app, and **`pnpm smoke:dev` passes end to end** — all five layout presets record MP4s that clear the recording quality gates (A/V skew 4–16ms), with zero leaked processes after teardown.

This PR fixes everything that stood between a fresh Windows checkout and a working change→verify loop. Per `docs/windows-port-plan.md`, all of the Windows seams had been compile-checked but never run on real hardware; this is that on-box shakeout.

## What was broken → fixed

- **Windows 11 startup floor blocked dev boxes.** `enforceWindowsVersionFloor` quits the app below build 22000 with no override. Added a `VIDEORC_ALLOW_UNSUPPORTED_WINDOWS=1` dev/lab escape hatch (app startup + `smoke:local-gates:windows` host check). Explicitly logged/documented as an unsupported configuration; default behavior unchanged.
- **The FFmpeg pin 404s.** BtbN deletes old autobuild releases, so `pnpm ffmpeg:fetch:windows` failed for everyone. Re-pinned to a current n8.1.2 win64 LGPL build (sha256 verified). Also wired the vendored ffmpeg into dev mode and `smoke:dev` (previously dev only used PATH ffmpeg, so the fetched vendor build was never used), and fixed `VIDEORC_BUNDLED_FFMPEG_PATH` to point at `ffmpeg.exe` on win32.
- **The app launcher silently lost all output on Windows.** `devAppSpawnOptions` combined `detached: true` with `shell: true`; on win32 the child runs but piped stdout/stderr never arrive, so every `[smoke] backend-ready` handshake timed out with zero captured output. `detached` is POSIX-only now (it only exists for process-group signalling, which Windows doesn't have).
- **Teardown leaked whole process trees.** `process.kill(-pid)` has no Windows equivalent and the fallback killed only the outer shell, orphaning pnpm → electron → cargo → backend (observed 27 leaked processes across a few runs). `stopProcess` now tree-kills via `taskkill /PID <pid> /T /F` — forced, because graceful `taskkill` only posts WM_CLOSE, which console processes ignore, and once the shell root exits there is no tree left to walk.
- **`smoke:dev` bypassed the shared launcher.** A bare `spawn('pnpm', ...)` fails with ENOENT on win32 (and Node blocks direct `.cmd` spawns — CVE-2024-27980). Routed through `devAppSpawnSpec`.
- **`.exe`/path-separator bugs in the verify tooling.** `resolveSiblingFfprobe` only matched paths ending in `ffmpeg`, so the analyzer fell back to a bare `ffprobe` PATH lookup and crashed; the report writer computed basenames with `split('/')`, producing a doubled absolute path on Windows. Both fixed with `.exe`-aware/`basename()` logic.
- **8 script tests only ever passed on macOS** (hardcoded POSIX separators in path assertions across `app-launcher`, `windows-local-gates`, `macos-release-artifact-validation`, `packaged-smoke-paths` tests). Made separator-agnostic; `pnpm test:scripts` is now 360/360 on Windows and unchanged on macOS.
- **CRLF poisoning.** With `core.autocrlf=true` (the Git-for-Windows default-ish setup), the entire checkout materializes CRLF and `pnpm format:check` fails on 232 files. Added `.gitattributes` with `* text=auto eol=lf`.

## Docs

- New `docs/windows-dev-loop.md`: setup, the floor escape hatch, the fast `ui:driver`/`ui:cmd` loop, which gates run on Windows, the launcher rules above, and how to re-pin FFmpeg when it rots.
- `docs/windows-port-plan.md`: status note recording the first on-box run and the two known on-box issues left open (permissions onboarding dialog shows macOS copy/⌘ shortcuts on Windows; main-process first-frame healer logs macOS "Metal IOSurface" retries on Windows).

## Verification (on Windows 10 x64)

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — pass
- `pnpm test:scripts` — 360/360
- `cargo build -p videorc-backend` — clean (warnings only, unused mac-only symbols under `cfg(windows)`)
- `pnpm smoke:dev` — PASS twice consecutively, `LEFTOVER=0` app processes after exit
- Manual: `pnpm ui:driver` reaches `backend-ready` + `preview-motion-ready` with real (non-synthetic) preview motion; `capture-page`/`eval-js` verified against the live app

macOS behavior is intended to be unchanged (all platform branches are win32-gated; test fixes only normalize separators) — but this branch was authored on Windows, so a macOS gate run before merge would be a sensible check.

Draft because: authored/verified on a Windows 10 box (below the supported floor), and the maintainers may want to weigh in on the `VIDEORC_ALLOW_UNSUPPORTED_WINDOWS` escape hatch and the repo-wide `.gitattributes` before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows development support with a faster edit-and-verify loop and an option to continue on older supported builds when explicitly allowed.
  * Improved app startup on Windows to use the correct bundled media tools automatically.

* **Bug Fixes**
  * Fixed cross-platform path handling and process cleanup issues in dev and smoke workflows.
  * Standardized line endings to reduce formatting check failures on Windows.

* **Documentation**
  * Added detailed Windows setup, development, and verification guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->