### PR TITLE
Release 0.9.25-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.25-beta.1.md
+++ b/changelog/0.9.25-beta.1.md
@@ -1,0 +1,37 @@
+---
+version: 0.9.25-beta.1
+date: 2026-07-09
+channel: beta
+title: The scary post-recording warning is gone — and repairs actually work now
+summary: The "Recording quality check failed" error that could pop up after a perfectly good recording is gone, automatic recording repairs now actually work in the shipped app, and quality warnings only appear when something is truly wrong with your file.
+highlights:
+  - The red "Recording quality check failed" error after ordinary recordings is gone — your file was always fine; the check itself was failing.
+  - Automatic recording repairs (fixing choppy or uneven playback) now actually work in the installed app instead of silently failing.
+  - Quality warnings now only appear when your recording is genuinely damaged — like missing audio — instead of for technicalities you'd never notice.
+  - At most one quality notice per recording, so finishing a session no longer stacks up toasts.
+---
+
+## No more false alarms after recording
+
+Some of you saw a red "Recording quality check failed … Unrecognized option
+'crf'" error after finishing a normal recording. The recording was never the
+problem — the automatic check-and-repair step behind the scenes was broken in
+the shipped app, and its internal error was being shown to you as if your file
+was damaged. That error is gone. If the automatic check ever can't run, it now
+notes it quietly in the session's history and leaves your recording untouched.
+
+## Repairs that actually repair
+
+When a recording comes out with uneven pacing or dropped frames, Videorc can
+re-process it into a smooth copy — and it only ever swaps in the repaired
+version after verifying it's genuinely better, keeping a backup of the
+original. That repair step now works properly in the installed app on every
+machine, using the Mac's built-in hardware encoder.
+
+## Warnings you can trust
+
+Quality notices now follow a simple rule: if you'd notice the problem watching
+the file — like a recording with no sound — Videorc tells you. If it's an
+internal technicality you'd never see, it stays in the Library and Diagnostics
+where you can look it up, not in your face. And you'll get at most one quality
+notice per recording.


### PR DESCRIPTION
Bumps the desktop app to 0.9.25 and adds the user-facing changelog entry for the recording quality toast-noise fix batch (#43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)