### PR TITLE
Sign the Windows installer with Azure Trusted Signing

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -102,9 +102,45 @@ jobs:
       - name: Build Windows installer
         # Backend release build + pinned LGPL ffmpeg fetch + fail-closed
         # preflight (runs the ffmpeg rtmps/tls/h264_mf capability probe on a
-        # real Windows host) + electron-builder dir/nsis targets. Unsigned:
-        # testers will see a SmartScreen warning until signing lands.
-        run: pnpm dist:desktop:windows
+        # real Windows host) + electron-builder dir/nsis targets.
+        #
+        # Authenticode: signed via Azure Trusted Signing when the AZURE_*
+        # secrets are available (same-repo PRs, pushes, dispatch). Fork PRs
+        # get no secrets and fall back to the unsigned build instead of
+        # failing — electron-builder hard-errors if azureSignOptions is
+        # configured without credentials, hence the branch here and the
+        # separate overlay config. Setup: docs/windows-signing.md.
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: |
+          if ($env:AZURE_CLIENT_ID) {
+            Write-Host "Azure signing secrets present - building SIGNED installer"
+            pnpm dist:desktop:windows:signed
+          } else {
+            Write-Host "No Azure signing secrets (fork PR?) - building UNSIGNED installer"
+            pnpm dist:desktop:windows
+          }
+
+      - name: Verify Authenticode signature
+        # Fail closed: if we intended to sign (secrets present), an unsigned
+        # or broken-signature exe must fail the job, not ship as an artifact.
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        run: |
+          $exe = Get-ChildItem apps/desktop/release/*.exe | Select-Object -First 1
+          if (-not $exe) { throw "no installer exe found in apps/desktop/release" }
+          $sig = Get-AuthenticodeSignature $exe.FullName
+          Write-Host "signature status for $($exe.Name): $($sig.Status)"
+          if ($env:AZURE_CLIENT_ID) {
+            if ($sig.Status -ne 'Valid') {
+              throw "signing was requested but $($exe.Name) has signature status '$($sig.Status)'"
+            }
+            Write-Host "signer: $($sig.SignerCertificate.Subject)"
+          } else {
+            Write-Host "unsigned build (no signing secrets) - skipping verification"
+          }
 
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4

--- a/apps/desktop/electron-builder.windows-signed.yml
+++ b/apps/desktop/electron-builder.windows-signed.yml
@@ -1,0 +1,28 @@
+# Azure Trusted Signing overlay for Windows release builds.
+#
+# This is a SEPARATE config on purpose: when `win.azureSignOptions` is present,
+# electron-builder 26 hard-fails the build unless the Entra ID credentials
+# (AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET) are in the
+# environment. Keeping it out of the base electron-builder.yml keeps unsigned
+# builds (fork PRs, local dev boxes without Azure access) working.
+#
+# Used by `pnpm dist:windows:signed` (see the windows.yml installer job, which
+# picks this path only when the Azure secrets are available). Setup runbook:
+# docs/windows-signing.md.
+#
+# electron-builder installs the TrustedSigning PowerShell module itself and
+# defaults the timestamp server to http://timestamp.acs.microsoft.com — no
+# extra CI steps needed.
+extends: ./electron-builder.yml
+
+win:
+  azureSignOptions:
+    # Region endpoint of the Trusted Signing account (weu = West Europe).
+    # Must match the region chosen when creating the account in the Azure
+    # portal — see docs/windows-signing.md.
+    endpoint: https://weu.codesigning.azure.net
+    codeSigningAccountName: videorc-signing
+    certificateProfileName: videorc-public-trust
+    # TODO(windows-auto-update): once the Trusted Signing cert is issued, set
+    # `publisherName` to its exact subject CN. electron-updater uses it to
+    # verify downloaded update signatures when the Windows update feed ships.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -84,9 +84,13 @@ mac:
     - dmg
     - zip
 
-# Windows 11 x64. Unsigned for now (internal testing); Authenticode signing is
-# Phase 5. The .exe backend and the windows-x64 ffmpeg dir override the
-# top-level (macOS) extraResources paths. See docs/windows-port-plan.md.
+# Windows 11 x64. This base config builds UNSIGNED (fork PRs, boxes without
+# Azure credentials). Authenticode signing lives in the
+# electron-builder.windows-signed.yml overlay (Azure Trusted Signing; see
+# docs/windows-signing.md) because electron-builder fails the build when
+# azureSignOptions is present without AZURE_* env credentials. The .exe
+# backend and the windows-x64 ffmpeg dir override the top-level (macOS)
+# extraResources paths. See docs/windows-port-plan.md.
 win:
   icon: build-resources/icon.ico
   extraResources:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,6 +11,7 @@
     "build": "electron-vite build",
     "package": "pnpm build && electron-builder --dir --config.mac.identity=null --config.mac.notarize=false",
     "dist": "pnpm build && electron-builder --config.mac.identity=null --config.mac.notarize=false --config.dmg.sign=false",
+    "dist:windows:signed": "pnpm build && electron-builder --win --config electron-builder.windows-signed.yml",
     "dist:signed": "pnpm build && electron-builder --mac dmg",
     "dist:release": "pnpm build && APPLE_TEAM_ID=C2PA37RB58 electron-builder --publish never && node scripts/staple-dmg.mjs",
     "release:upload": "node scripts/release-upload.mjs",

--- a/docs/windows-signing.md
+++ b/docs/windows-signing.md
@@ -1,0 +1,63 @@
+# Windows Code Signing (Azure Trusted Signing)
+
+The Windows installer is signed with Azure Trusted Signing so testers stop
+seeing the SmartScreen "Unknown publisher" warning. Signing happens in the
+`windows.yml` installer job whenever the `AZURE_*` repo secrets are available;
+fork PRs (no secrets) build unsigned instead of failing. The signing config is
+the `apps/desktop/electron-builder.windows-signed.yml` overlay — deliberately
+separate from the base config, because electron-builder hard-fails any build
+that has `win.azureSignOptions` without Azure credentials in the environment.
+
+## One-time Azure setup (owner, in the Azure portal)
+
+1. **Create the Trusted Signing account.** Azure portal → "Trusted Signing
+   Accounts" → Create. Pick a region (the overlay assumes **West Europe**,
+   endpoint `https://weu.codesigning.azure.net` — if you pick another region,
+   update `endpoint` in the overlay). SKU: Basic (~$9.99/month). Suggested
+   name: `videorc-signing` (the overlay assumes this).
+2. **Identity validation.** In the account: Identity validations → New →
+   **Individual** (or Organization if/when Videorc is a registered business).
+   This is the slow step — government ID verification, typically hours to a
+   few days. The certificate CN will be your validated legal name.
+3. **Certificate profile.** In the account: Certificate profiles → Create →
+   type **Public Trust**, linked to the finished identity validation.
+   Suggested name: `videorc-public-trust` (the overlay assumes this).
+4. **CI service principal.** Microsoft Entra ID → App registrations → New
+   (e.g. `videorc-ci-signing`) → create a **client secret** (note the expiry;
+   it must be rotated). Then back on the Trusted Signing account: Access
+   control (IAM) → add role assignment **Trusted Signing Certificate Profile
+   Signer** → to that app registration.
+5. **GitHub secrets** (repo `TheOrcDev/videorc`):
+
+   ```sh
+   gh secret set AZURE_TENANT_ID     # Entra ID → tenant (directory) ID
+   gh secret set AZURE_CLIENT_ID     # app registration → application (client) ID
+   gh secret set AZURE_CLIENT_SECRET # the client secret VALUE (not its ID)
+   ```
+
+6. **Confirm the overlay values.** `endpoint`, `codeSigningAccountName`, and
+   `certificateProfileName` in `apps/desktop/electron-builder.windows-signed.yml`
+   must match what you created in steps 1 and 3.
+
+## How it runs
+
+- `pnpm dist:desktop:windows:signed` — the signed variant of the Windows dist
+  pipeline (Windows host only; needs the three `AZURE_*` env vars).
+- The `windows.yml` installer job picks signed vs unsigned by whether
+  `AZURE_CLIENT_ID` is present, then a fail-closed step asserts
+  `Get-AuthenticodeSignature` returns `Valid` on the built exe whenever
+  signing was requested.
+- electron-builder installs the `TrustedSigning` PowerShell module itself and
+  timestamps against `http://timestamp.acs.microsoft.com` by default.
+
+## Expectations and follow-ups
+
+- Trusted Signing certs are short-lived and rotated by the service; the
+  timestamp countersignature keeps installers valid after rotation.
+- SmartScreen reputation with Trusted Signing is effectively immediate, but a
+  first-ever download of a brand-new binary can still occasionally prompt.
+- TODO once the cert is issued: set `win.azureSignOptions.publisherName` in
+  the overlay to the cert's exact subject CN, so electron-updater can verify
+  update signatures when the Windows auto-update feed ships.
+- TODO: client secrets expire — set a calendar reminder for the expiry chosen
+  in step 4 and rotate `AZURE_CLIENT_SECRET`.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dist:desktop:signed-local": "pnpm package:desktop:signed-local && cd apps/desktop && pnpm exec electron-builder --mac dmg --prepackaged release/mac-arm64 --config.mac.identity=null --config.mac.notarize=false --config.dmg.sign=false && cd ../.. && pnpm release:manifest:macos",
     "package:desktop:windows": "pnpm package:backend && pnpm ffmpeg:fetch:windows && pnpm package:preflight:windows && pnpm --filter @videorc/desktop package",
     "dist:desktop:windows": "pnpm package:backend && pnpm ffmpeg:fetch:windows && pnpm package:preflight:windows && pnpm --filter @videorc/desktop dist",
+    "dist:desktop:windows:signed": "pnpm package:backend && pnpm ffmpeg:fetch:windows && pnpm package:preflight:windows && pnpm --filter @videorc/desktop dist:windows:signed",
     "dist:desktop": "pnpm package:backend:macos && pnpm ffmpeg:build:macos && pnpm package:preflight:macos && pnpm --filter @videorc/desktop dist",
     "dist:desktop:signed": "pnpm release:preflight:macos && pnpm package:backend:macos && pnpm ffmpeg:build:macos && pnpm package:preflight:macos && pnpm --filter @videorc/desktop dist:signed && pnpm release:manifest:macos",
     "dist:desktop:release": "pnpm release:preflight:macos && pnpm package:backend:macos && pnpm ffmpeg:build:macos && pnpm package:preflight:macos && pnpm --filter @videorc/desktop dist:release && pnpm release:manifest:macos",


### PR DESCRIPTION
## What

The `windows.yml` installer job now signs the Windows installer with Azure Trusted Signing whenever the `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` repo secrets are present, so testers stop hitting the SmartScreen "Unknown publisher" warning. Fork PRs (no secrets) keep building unsigned instead of failing.

## How

- **`apps/desktop/electron-builder.windows-signed.yml`** — new overlay (`extends` the base config) holding `win.azureSignOptions`. It's a separate file on purpose: electron-builder 26 hard-fails any build that has `azureSignOptions` configured without Azure credentials in the environment, so the base config must stay credential-free for fork PRs and local boxes. Config resolution verified locally via app-builder-lib: the base `win` block (icon, dir/nsis targets, backend + ffmpeg extraResources) survives the merge.
- **`windows.yml`** — the installer job branches on `AZURE_CLIENT_ID` presence (signed vs unsigned script), then a fail-closed step asserts `Get-AuthenticodeSignature` returns `Valid` whenever signing was requested — a broken signature fails the job rather than shipping as an artifact.
- **`pnpm dist:desktop:windows:signed`** — signed variant of the Windows dist pipeline (same backend/ffmpeg/preflight steps, signed electron-builder config).
- **`docs/windows-signing.md`** — owner runbook for the Azure side: Trusted Signing account (West Europe / Basic), individual identity validation, Public Trust cert profile, CI service principal with the Certificate Profile Signer role, and the three `gh secret set` commands.

## Not in this PR (blocked on the Azure account existing)

- The overlay's `codeSigningAccountName` / `certificateProfileName` / `endpoint` assume the names suggested in the runbook — adjust if the created resources differ.
- `publisherName` for electron-updater signature verification — set once the cert is issued (TODO in the overlay), matters when the Windows auto-update feed ships.

## Verification

- `pnpm format:check` green.
- Overlay config resolution checked with app-builder-lib's own `getConfig` (merge preserves the base `win` block).
- This PR's own Windows CI run exercises the **unsigned fallback path** end to end (no secrets configured yet). The signed path gets proven by the first run after the secrets land — the new verify step makes that run fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)