### PR TITLE
Record the 0.9.25-beta.1 release

### DIFF
--- a/docs/releases/0.9.25.md
+++ b/docs/releases/0.9.25.md
@@ -1,0 +1,67 @@
+# Videorc 0.9.25 Beta 1
+
+Videorc 0.9.25 is the recording quality toast-noise batch: the shipped-build
+"Unrecognized option 'crf'" repair failure is fixed at the root, internal
+quality-check failures no longer surface as user-facing error toasts, and the
+quality toast family is right-sized to user-noticeable damage only.
+
+## Scope
+
+- **Capability-truthful repair encoder** (PR #43) — the post-recording
+  repair hardcoded GPL `libx264 -crf 18`, but the bundled FFmpeg is
+  LGPL-only on both platforms (macOS `--disable-gpl`,
+  Windows BtbN lgpl pin), so every transcode-style repair in every
+  shipped build failed with "Unrecognized option 'crf'" (dev hid it via
+  Homebrew GPL ffmpeg — the 0.9.23 rtmps confound class). Repair plans
+  now carry a probed `RepairVideoEncoder` (`ffmpeg -encoders`, cached
+  per binary): libx264 → `h264_videotoolbox -q:v 65 -allow_sw 1` →
+  `h264_mf -rate_control quality -quality 90`. No usable encoder →
+  transcode repairs skipped honestly (audio-only repairs still run),
+  reasons say why.
+- **Toast policy** (PR #43) — `GateStatus::Failed` (tooling failure,
+  file untouched) is info-level with plain copy; raw ffmpeg stderr goes
+  truncated to the app log for support bundles; renderer no longer maps
+  it to `toast.error`. `NotHundredPercent` carries `needs_attention`
+  (missing video/audio) — only that warns and toasts; pacing/skew
+  residuals stay info-level records. One quality toast per session.
+- **Fail-closed gates** (PR #43) — `preflight-macos-package` now runs
+  the bundled ffmpeg and requires `rtmp/rtmps/tls`,
+  `h264_videotoolbox`, `aac` (mirrors the Windows gate's `h264_mf`).
+  New `smoke:repair-encoder` (in `smoke:local-gates`) runs the exact
+  CFR-transcode repair command shape against the BUNDLED binary on a
+  generated fixture.
+
+## Release status
+
+- [x] Feature PR #43 merged via protected `main`; release prep PR
+      https://github.com/TheOrcDev/videorc/pull/44.
+- [x] Built from a tree identical to `origin/main` post-merge
+      (branch `release/0.9.25-build` reset to `origin/main`).
+- [x] Signed + notarized; `release:validate:macos` PASS (codesign,
+      Gatekeeper, stapler, bundled-secret gates); the new ffmpeg
+      capability probe passed in `package:preflight:macos`.
+- [x] Uploaded to R2, all objects verified; feed serves
+      `version: 0.9.25` through the www redirect; changelog latest
+      entry `0.9.25-beta.1` (26 entries valid, /api/changelog serves it).
+- [x] Discord announced (dry-run previewed first, single post).
+
+## Verification
+
+- All gates green on PR #43 (828 backend tests, 490 desktop vitest,
+  376 script tests, clippy/fmt/lint/typecheck, Windows CI gates).
+- `pnpm smoke:repair-encoder` PASS against the real bundled ffmpeg via
+  `h264_videotoolbox` — the exact command shape that used to die.
+- `pnpm smoke:recording-studio`: every recording step green (all-layout
+  recording artifact smoke with ffprobe analysis, imported-screen,
+  live layout-switch recording); stopped at the pre-existing
+  `probe:preview-lifecycle` failure that also fails on clean main
+  (documented 2026-07-08; diagnose task already spawned).
+
+## Pending owner acceptance
+
+- [ ] Update to 0.9.25 and record a normal screen session: the only
+      toast at stop is "Recording saved" — no red quality-check error.
+- [ ] Library row shows the recording's quality state; Diagnostics
+      still records the gate verdict.
+- [ ] Optional: force a VFR-heavy capture (busy 4K screen) and confirm
+      the repair completes (repaired badge, file plays smoothly).


### PR DESCRIPTION
Internal release record for 0.9.25-beta.1: scope (PR #43), build/upload/feed/announce checklist (all done), and the owner acceptance list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)