### PR TITLE
Fix Windows tester feedback: permissions, camera, mic, health copy, Ctrl glyphs

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6980,7 +6980,13 @@ async function requestMediaAccessNative(pane: 'camera' | 'microphone'): Promise<
   return requestMediaAccessWithRestart(
     {
       getStatus: (target) => systemPreferences.getMediaAccessStatus(target),
-      askForAccess: (target) => systemPreferences.askForMediaAccess(target),
+      // askForMediaAccess is a macOS-only API. Windows grants live in the
+      // per-device privacy toggles (ms-settings), so the "prompt" degrades to
+      // a status re-read there.
+      askForAccess:
+        process.platform === 'darwin'
+          ? (target) => systemPreferences.askForMediaAccess(target)
+          : async (target) => systemPreferences.getMediaAccessStatus(target) === 'granted',
       restartBackend,
       stopGrantWatcher: () => mediaPermissionGrantWatcher.stop(),
       log: (level, message) => logBackend(level, message)
@@ -7000,6 +7006,11 @@ async function requestMediaAccessIfNeeded(pane: SystemPermissionPane): Promise<b
       return true
     }
     if (status !== 'not-determined') {
+      return false
+    }
+    if (process.platform !== 'darwin') {
+      // askForMediaAccess is macOS-only; the Windows settings page we are
+      // about to open IS the grant flow.
       return false
     }
     return systemPreferences.askForMediaAccess(pane)

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4027,7 +4027,11 @@ async function presentNativePreviewSurfaceCompositor(
       nativePreviewSurfaceFramePollingSuppressed || effectiveStatus.suppressFramePolling === true,
     sourcePixelsPresent: liveLayerCount > 0,
     updatedAt: new Date().toISOString(),
-    message: proofSurfaceCompositorMessage(effectiveStatus, realSurfaceAttempt.reason)
+    message: proofSurfaceCompositorMessage(
+      effectiveStatus,
+      realSurfaceAttempt.reason,
+      process.platform
+    )
   }
   previewSupervisor.surfaceFallback(
     previewWindowSurfaceGeneration(),
@@ -4119,6 +4123,14 @@ async function tryPresentNativePreviewRealSurfaceCompositor(
   status: PreviewSurfaceCompositorUpdateParams,
   mainTiming: { queueWaitMs?: number } = {}
 ): Promise<NativePreviewRealSurfacePresentAttempt> {
+  // The Metal IOSurface handoff only exists on macOS. Off macOS, image
+  // polling is the intended preview transport, not a fallback — so skip the
+  // native attempt quietly instead of emitting an alarming "no Metal
+  // IOSurface target / falling back" reason on every frame (a Windows
+  // tester-reported false alarm).
+  if (process.platform !== 'darwin') {
+    return { kind: 'skipped', logKey: 'no-handoff:not-macos' }
+  }
   const handoff = compositorStatusMetalTargetHandoff(status, {
     maxAgeMs: DEFAULT_NATIVE_PREVIEW_MAX_HANDOFF_AGE_MS
   })

--- a/apps/desktop/src/main/runtime-info.test.ts
+++ b/apps/desktop/src/main/runtime-info.test.ts
@@ -191,14 +191,26 @@ describe('runtime info helpers', () => {
     ])
   })
 
-  it('rejects permission shortcuts outside macOS', () => {
+  it('supports permission shortcuts on macOS and Windows, rejects the rest', () => {
+    expect(() => assertPermissionShortcutSupported('darwin')).not.toThrow()
+    expect(() => assertPermissionShortcutSupported('win32')).not.toThrow()
     expect(() => assertPermissionShortcutSupported('linux')).toThrow(
-      'Permission shortcut is only available on macOS.'
+      'Permission shortcuts are only available on macOS and Windows.'
     )
   })
 
   it('falls back to the privacy pane for unknown permission panes', () => {
-    expect(permissionUrlForPane('camera')).toContain('Privacy_Camera')
-    expect(permissionUrlForPane('unknown' as never)).toBe(permissionUrlForPane('privacy'))
+    expect(permissionUrlForPane('camera', 'darwin')).toContain('Privacy_Camera')
+    expect(permissionUrlForPane('unknown' as never, 'darwin')).toBe(
+      permissionUrlForPane('privacy', 'darwin')
+    )
+  })
+
+  it('maps panes to ms-settings URIs on Windows', () => {
+    expect(permissionUrlForPane('camera', 'win32')).toBe('ms-settings:privacy-webcam')
+    expect(permissionUrlForPane('microphone', 'win32')).toBe('ms-settings:privacy-microphone')
+    // Windows has no per-app screen permission — screen-recording falls back
+    // to the privacy hub rather than a dedicated pane.
+    expect(permissionUrlForPane('screen-recording', 'win32')).toBe('ms-settings:privacy')
   })
 })

--- a/apps/desktop/src/main/runtime-info.ts
+++ b/apps/desktop/src/main/runtime-info.ts
@@ -10,6 +10,14 @@ export const MACOS_PERMISSION_URLS: Record<SystemPermissionPane, string> = {
   microphone: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone'
 }
 
+// Windows has no per-app screen-capture permission, so 'screen-recording' has
+// no dedicated pane and falls back to the Privacy hub like 'privacy'.
+export const WINDOWS_PERMISSION_URLS: Partial<Record<SystemPermissionPane, string>> = {
+  privacy: 'ms-settings:privacy',
+  camera: 'ms-settings:privacy-webcam',
+  microphone: 'ms-settings:privacy-microphone'
+}
+
 export interface RuntimeInfoInput {
   /** `app.getVersion()` — the running app version. */
   appVersion: string
@@ -52,13 +60,19 @@ function permissionTargetName(path: string, fallback: string): string {
   return name.endsWith('.app') ? name.slice(0, -'.app'.length) : name
 }
 
-export function permissionUrlForPane(pane: SystemPermissionPane = 'privacy'): string {
+export function permissionUrlForPane(
+  pane: SystemPermissionPane = 'privacy',
+  platform: NodeJS.Platform = process.platform
+): string {
+  if (platform === 'win32') {
+    return WINDOWS_PERMISSION_URLS[pane] ?? WINDOWS_PERMISSION_URLS.privacy ?? 'ms-settings:privacy'
+  }
   return MACOS_PERMISSION_URLS[pane] ?? MACOS_PERMISSION_URLS.privacy
 }
 
 export function assertPermissionShortcutSupported(platform: NodeJS.Platform): void {
-  if (platform !== 'darwin') {
-    throw new Error('Permission shortcut is only available on macOS.')
+  if (platform !== 'darwin' && platform !== 'win32') {
+    throw new Error('Permission shortcuts are only available on macOS and Windows.')
   }
 }
 

--- a/apps/desktop/src/renderer/src/components/app-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/app-shell.tsx
@@ -73,11 +73,11 @@ export function AppShell(): ReactElement {
     }
     onboardingEvaluatedRef.current = true
     const dismissed = localStorage.getItem(STORAGE_KEYS.onboarding) !== null
-    const rows = systemAccessRows({ deviceList, audioMeter })
+    const rows = systemAccessRows({ deviceList, audioMeter, platform: runtimeInfo?.platform })
     if (shouldShowPermissionsOnboarding({ rows, dismissed, backendReady })) {
       setOnboardingOpen(true)
     }
-  }, [audioMeter, backendReady, deviceList])
+  }, [audioMeter, backendReady, deviceList, runtimeInfo?.platform])
 
   // Studio control pages are ordinary tabs grouped under "Studio" in the sidebar.
   const openStudioPanel = useCallback((panel: StudioPanel) => {

--- a/apps/desktop/src/renderer/src/components/app-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/app-shell.tsx
@@ -7,6 +7,7 @@ import { PermissionsOnboardingDialog } from '@/components/permissions-onboarding
 import { Sidebar } from '@/components/sidebar'
 import { Button } from '@/components/ui/button'
 import { Kbd, KbdGroup } from '@/components/ui/kbd'
+
 import type { StatusDotTone } from '@/components/status-dot'
 import { AiTab } from '@/components/tabs/ai-tab'
 import { AssetsTab } from '@/components/tabs/assets-tab'
@@ -31,6 +32,7 @@ import { WhatsNewDialog } from '@/components/whats-new-dialog'
 import { useStudio } from '@/hooks/use-studio'
 import { useWhatsNew } from '@/hooks/use-whats-new'
 import { ONBOARDING_DISMISSED_VALUE, STORAGE_KEYS } from '@/lib/capture'
+import { displayKeyGlyph } from '@/lib/platform'
 import { shouldShowPermissionsOnboarding, systemAccessRows } from '@/lib/system-access'
 import { cn } from '@/lib/utils'
 
@@ -58,6 +60,8 @@ export function AppShell(): ReactElement {
   const [commandOpen, setCommandOpen] = useState(false)
   const [onboardingOpen, setOnboardingOpen] = useState(false)
   const whatsNew = useWhatsNew(runtimeInfo?.version)
+  const modKey = displayKeyGlyph('⌘', runtimeInfo?.platform)
+  const shiftKey = displayKeyGlyph('⇧', runtimeInfo?.platform)
 
   // Permissions onboarding gate: evaluated ONCE per launch, and only after the
   // backend has connected and real device enumeration arrived — before that
@@ -227,6 +231,7 @@ export function AppShell(): ReactElement {
           statusLabel={statusLabel}
           live={live}
           onOpenCommand={() => setCommandOpen(true)}
+          platform={runtimeInfo?.platform}
         />
 
         <main className="flex h-[calc(100vh-2.25rem)] flex-1 flex-col">
@@ -278,7 +283,7 @@ export function AppShell(): ReactElement {
             <Button size="sm" variant="ghost" onClick={() => setCommandOpen(true)}>
               Search
               <KbdGroup>
-                <Kbd>⌘</Kbd>
+                <Kbd>{modKey}</Kbd>
                 <Kbd>K</Kbd>
               </KbdGroup>
             </Button>
@@ -286,7 +291,7 @@ export function AppShell(): ReactElement {
             <Button size="sm" variant="ghost" onClick={() => void togglePreviewWindow()}>
               {previewWindow.open ? 'Close Preview' : 'Open Preview'}
               <KbdGroup>
-                <Kbd>⌘</Kbd>
+                <Kbd>{modKey}</Kbd>
                 <Kbd>P</Kbd>
               </KbdGroup>
             </Button>
@@ -305,8 +310,8 @@ export function AppShell(): ReactElement {
                 >
                   {notesWindow.open ? 'Close Notes' : 'Open Notes'}
                   <KbdGroup>
-                    <Kbd>⌘</Kbd>
-                    <Kbd>⇧</Kbd>
+                    <Kbd>{modKey}</Kbd>
+                    <Kbd>{shiftKey}</Kbd>
                     <Kbd>N</Kbd>
                   </KbdGroup>
                 </Button>
@@ -325,8 +330,8 @@ export function AppShell(): ReactElement {
                   <ChatCircle data-icon="inline-start" />
                   {commentsWindow.open ? 'Close Comments' : 'Open Comments'}
                   <KbdGroup>
-                    <Kbd>⌘</Kbd>
-                    <Kbd>⇧</Kbd>
+                    <Kbd>{modKey}</Kbd>
+                    <Kbd>{shiftKey}</Kbd>
                     <Kbd>J</Kbd>
                   </KbdGroup>
                 </Button>

--- a/apps/desktop/src/renderer/src/components/command-palette.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.tsx
@@ -13,6 +13,7 @@ import {
   CommandShortcut
 } from '@/components/ui/command'
 import { Kbd } from '@/components/ui/kbd'
+import { displayKeyGlyph } from '@/lib/platform'
 import {
   STUDIO_PANELS,
   WORKSPACE_TABS,
@@ -39,6 +40,8 @@ export function CommandPalette({
     commentsWindow,
     toggleCommentsWindow
   } = useStudio()
+  const modKey = displayKeyGlyph('⌘', runtimeInfo?.platform)
+  const shiftKey = displayKeyGlyph('⇧', runtimeInfo?.platform)
   const { setTheme } = useTheme()
 
   const run = (action: () => void | Promise<void>): void => {
@@ -68,7 +71,10 @@ export function CommandPalette({
                 {tab.label}
                 {digit ? (
                   <CommandShortcut className="tracking-normal">
-                    <Kbd>⌘{digit}</Kbd>
+                    <Kbd>
+                      {modKey}
+                      {digit}
+                    </Kbd>
                   </CommandShortcut>
                 ) : null}
               </CommandItem>
@@ -91,7 +97,10 @@ export function CommandPalette({
                 {panel.label}
                 {digit ? (
                   <CommandShortcut className="tracking-normal">
-                    <Kbd>⌘{digit}</Kbd>
+                    <Kbd>
+                      {modKey}
+                      {digit}
+                    </Kbd>
                   </CommandShortcut>
                 ) : null}
               </CommandItem>
@@ -129,7 +138,10 @@ export function CommandPalette({
               <ChatCircle className="size-4" />
               {commentsWindow.open ? 'Close comments window' : 'Open comments window'}
               <CommandShortcut className="tracking-normal">
-                <Kbd>⌘⇧J</Kbd>
+                <Kbd>
+                  {modKey}
+                  {shiftKey}J
+                </Kbd>
               </CommandShortcut>
             </CommandItem>
           ) : null}

--- a/apps/desktop/src/renderer/src/components/live-chat-rail.tsx
+++ b/apps/desktop/src/renderer/src/components/live-chat-rail.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from 'react'
 import { LiveChatPanel } from '@/components/live-chat-panel'
 import { Button } from '@/components/ui/button'
 import { Kbd } from '@/components/ui/kbd'
+import { displayKeyGlyph } from '@/lib/platform'
 import type { LiveChatSnapshot } from '../../../shared/backend'
 
 // The chat rail is live while streaming and can stay mounted after stop while
@@ -18,7 +19,8 @@ export function LiveChatRail({
   windowOpen,
   onPopOut,
   highlightedId = null,
-  onHighlight
+  onHighlight,
+  platform
 }: {
   snapshot: LiveChatSnapshot
   onClearLocal: () => void
@@ -27,13 +29,15 @@ export function LiveChatRail({
   onPopOut: () => void | Promise<void>
   highlightedId?: string | null
   onHighlight?: (message: import('../../../shared/backend').LiveChatMessage) => void
+  platform?: string
 }): ReactElement {
+  const modKey = displayKeyGlyph('⌘', platform)
   return (
     <aside className="flex w-80 shrink-0 flex-col gap-3 rounded-panel border bg-muted/20 p-4">
       <div className="flex items-center gap-2">
         <ChatCircle className="size-4 shrink-0 text-muted-foreground" weight="duotone" />
         <span className="flex-1 text-sm font-medium">Live chat</span>
-        <Kbd>⌘J</Kbd>
+        <Kbd>{modKey}J</Kbd>
         <Button
           aria-label={windowOpen ? 'Bring comments back into the app' : 'Open comments in a window'}
           aria-keyshortcuts="Meta+Shift+J"

--- a/apps/desktop/src/renderer/src/components/obs-import-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/obs-import-dialog.tsx
@@ -216,7 +216,7 @@ export function ObsImportDialog({
           </div>
         ) : discovery ? (
           <p className="text-sm text-muted-foreground">
-            No OBS Studio installation with scene collections was found on this Mac.
+            No OBS Studio installation with scene collections was found on this device.
           </p>
         ) : (
           <p className="text-sm text-muted-foreground">Looking for OBS Studio…</p>

--- a/apps/desktop/src/renderer/src/components/permissions-onboarding-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/permissions-onboarding-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { useStudio } from '@/hooks/use-studio'
+import { isWindowsPlatform, osSettingsName } from '@/lib/platform'
 import { systemAccessRows, type SystemAccessRow } from '@/lib/system-access'
 
 // Permissions-only onboarding: the ONE thing a fresh install needs is macOS
@@ -34,7 +35,8 @@ export function PermissionsOnboardingDialog({
     refreshBackend,
     openSystemPermission,
     sampleAudioMeter,
-    canSampleAudio
+    canSampleAudio,
+    runtimeInfo
   } = useStudio()
   const [pending, setPending] = useState<'camera' | 'microphone' | null>(null)
 
@@ -59,8 +61,11 @@ export function PermissionsOnboardingDialog({
     return () => window.removeEventListener('focus', onFocus)
   }, [open, refreshBackend])
 
-  const rows = systemAccessRows({ deviceList, audioMeter })
+  const rows = systemAccessRows({ deviceList, audioMeter, platform: runtimeInfo?.platform })
   const allGranted = rows.every((row) => row.state === 'granted')
+  const isWindows = isWindowsPlatform(runtimeInfo?.platform)
+  const deviceNoun = isWindows ? 'PC' : 'Mac'
+  const settingsName = osSettingsName(runtimeInfo?.platform)
 
   // Camera/microphone support a native in-place prompt on first use. The mic
   // chip derives from the audio-meter probe, so a fresh grant is proven by
@@ -95,10 +100,11 @@ export function PermissionsOnboardingDialog({
           <div className="flex items-center gap-3">
             <img alt="Videorc" className="size-14 object-contain" src={logoUrl} />
             <div className="flex flex-col gap-1">
-              <DialogTitle>Let Videorc capture your Mac</DialogTitle>
+              <DialogTitle>Let Videorc capture your {deviceNoun}</DialogTitle>
               <DialogDescription>
-                macOS asks once per permission. Grant what you need — you can change any of this
-                later in Settings.
+                {isWindows
+                  ? `Turn on camera and microphone access in ${settingsName}. You can change any of this later in Settings.`
+                  : 'macOS asks once per permission. Grant what you need — you can change any of this later in Settings.'}
               </DialogDescription>
             </div>
           </div>
@@ -118,7 +124,7 @@ export function PermissionsOnboardingDialog({
 
         <DialogFooter className="items-center sm:justify-between">
           <span className="text-xs text-muted-foreground">
-            Recordings stay on this Mac. Cloud AI only runs after you opt in.
+            Recordings stay on this {deviceNoun}. Cloud AI only runs after you opt in.
           </span>
           <Button onClick={onComplete}>
             {allGranted ? 'Continue' : 'Continue without granting'}

--- a/apps/desktop/src/renderer/src/components/preview-stage.tsx
+++ b/apps/desktop/src/renderer/src/components/preview-stage.tsx
@@ -383,7 +383,7 @@ function previewSupervisorDisplay(
         detail:
           supervisor.lastError ??
           previewPermissionMessage(supervisor.permissionStatus) ??
-          'macOS permission is required before this source can preview.',
+          'Permission is required before this source can preview.',
         tone: 'warn'
       }
     case 'failed':
@@ -433,7 +433,7 @@ function previewPermissionMessage(
     case 'camera-required':
       return 'Camera permission is required for camera sources.'
     case 'unknown':
-      return 'macOS permission is required before this source can preview.'
+      return 'Permission is required before this source can preview.'
     case 'ok':
       return null
   }

--- a/apps/desktop/src/renderer/src/components/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar.tsx
@@ -6,6 +6,7 @@ import { AccountMenu } from '@/components/account-menu'
 import { type StatusDotTone } from '@/components/status-dot'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Kbd, KbdGroup } from '@/components/ui/kbd'
+import { displayKeyGlyph } from '@/lib/platform'
 import { useUpdater } from '@/hooks/use-updater'
 import { updateChip } from '@/lib/update-ui'
 import {
@@ -24,6 +25,7 @@ function NavRow({
   isActive,
   triggerId,
   shortcutDigit,
+  modKey,
   onClick
 }: {
   icon: Icon
@@ -31,6 +33,7 @@ function NavRow({
   isActive: boolean
   triggerId: string
   shortcutDigit?: string
+  modKey: string
   onClick: () => void
 }): ReactElement {
   return (
@@ -52,7 +55,12 @@ function NavRow({
         className={cn('size-4 shrink-0', isActive && 'text-primary')}
       />
       <span className="flex-1 truncate text-left">{label}</span>
-      {shortcutDigit ? <Kbd>⌘{shortcutDigit}</Kbd> : null}
+      {shortcutDigit ? (
+        <Kbd>
+          {modKey}
+          {shortcutDigit}
+        </Kbd>
+      ) : null}
     </button>
   )
 }
@@ -125,7 +133,8 @@ export function Sidebar({
   statusTone,
   statusLabel,
   live,
-  onOpenCommand
+  onOpenCommand,
+  platform
 }: {
   active: WorkspaceTab
   activeStudioPanel: StudioPanel | null
@@ -136,9 +145,11 @@ export function Sidebar({
   statusLabel: string
   live: boolean
   onOpenCommand: () => void
+  platform?: string
 }): ReactElement {
   const tabsIn = (group: string): typeof WORKSPACE_TABS =>
     WORKSPACE_TABS.filter((tab) => tab.group === group)
+  const modKey = displayKeyGlyph('⌘', platform)
 
   return (
     <aside className="flex w-56 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
@@ -176,7 +187,7 @@ export function Sidebar({
           <MagnifyingGlass className="size-4 shrink-0" />
           <span className="flex-1 text-left">Search</span>
           <KbdGroup>
-            <Kbd>⌘</Kbd>
+            <Kbd>{modKey}</Kbd>
             <Kbd>K</Kbd>
           </KbdGroup>
         </button>
@@ -190,6 +201,7 @@ export function Sidebar({
               isActive={active === tab.id}
               triggerId={tab.id}
               shortcutDigit={shortcutDigitFor(tab.id)}
+              modKey={modKey}
               onClick={() => onSelect(tab.id)}
             />
           ))}
@@ -205,6 +217,7 @@ export function Sidebar({
               isActive={activeStudioPanel === panel.id}
               triggerId={panel.legacyTabId}
               shortcutDigit={shortcutDigitFor(panel.id)}
+              modKey={modKey}
               onClick={() => onSelectStudioPanel(panel.id)}
             />
           ))}
@@ -220,6 +233,7 @@ export function Sidebar({
               isActive={active === tab.id}
               triggerId={tab.id}
               shortcutDigit={shortcutDigitFor(tab.id)}
+              modKey={modKey}
               onClick={() => onSelect(tab.id)}
             />
           ))}
@@ -240,6 +254,7 @@ export function Sidebar({
                 isActive={active === tab.id}
                 triggerId={tab.id}
                 shortcutDigit={shortcutDigitFor(tab.id)}
+                modKey={modKey}
                 onClick={() => onSelect(tab.id)}
               />
             ))}

--- a/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
@@ -117,7 +117,7 @@ export function AudioMixer(): ReactElement {
             <span className="flex min-w-0 flex-col">
               <span className="truncate text-sm font-medium">{systemAudio.name}</span>
               <span className="truncate text-xs text-muted-foreground">
-                Pending native macOS adapter
+                Pending native system-audio adapter
               </span>
             </span>
           </span>

--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -63,7 +63,8 @@ export function SettingsTab({
     refreshBackend,
     openSystemPermission,
     exportSupportBundle,
-    supportBundleExportPending
+    supportBundleExportPending,
+    runtimeInfo
   } = useStudio()
   const { openStudioPanel } = useWorkspaceNav()
   const { theme, setTheme } = useTheme()
@@ -114,7 +115,7 @@ export function SettingsTab({
     return () => window.removeEventListener('focus', onFocus)
   }, [refreshBackend])
 
-  const accessRows = systemAccessRows({ deviceList, audioMeter })
+  const accessRows = systemAccessRows({ deviceList, audioMeter, platform: runtimeInfo?.platform })
 
   const createOutputDirectory = async (): Promise<void> => {
     if (!outputDirectory) {

--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -39,6 +39,7 @@ import type { DirectoryFacts, UpdateStatus } from '@/lib/backend'
 import { isActiveRecordingState } from '@/lib/format'
 import { recordingQuality, streamingSummary } from '@/lib/studio-session-view'
 import { shortcutsByGroup } from '@/lib/shortcuts'
+import { displayKeyGlyphs, osSettingsName } from '@/lib/platform'
 import { systemAccessRows } from '@/lib/system-access'
 import { isUpdateInstallable } from '@/lib/update-ui'
 
@@ -302,7 +303,7 @@ export function SettingsTab({
         </PanelSection>
 
         <PanelSection
-          description="What macOS lets Videorc capture right now."
+          description={`What ${osSettingsName(runtimeInfo?.platform)} lets Videorc capture right now.`}
           icon={LockKey}
           title="System access"
           action={
@@ -361,8 +362,8 @@ export function SettingsTab({
               Set up permissions
             </Button>
             <p className="text-xs text-muted-foreground">
-              Grants live in macOS System Settings → Privacy &amp; Security. After changing one,
-              come back here — rows refresh automatically.
+              Grants live in {osSettingsName(runtimeInfo?.platform)}. After changing one, come back
+              here — rows refresh automatically.
             </p>
           </div>
         </PanelSection>
@@ -373,7 +374,7 @@ export function SettingsTab({
       <div className="grid items-start gap-5 lg:grid-cols-2">
         <div className="flex flex-col gap-5">
           <PanelSection
-            description="How Videorc looks and behaves on this Mac."
+            description="How Videorc looks and behaves on this device."
             icon={PaintBrush}
             title="Appearance & behavior"
           >
@@ -447,7 +448,7 @@ export function SettingsTab({
                   >
                     <span className="flex-1 truncate text-muted-foreground">{entry.label}</span>
                     <KbdGroup>
-                      {entry.keys.map((key, index) => (
+                      {displayKeyGlyphs(entry.keys, runtimeInfo?.platform).map((key, index) => (
                         <Kbd key={`${entry.id}-${index}`}>{key}</Kbd>
                       ))}
                     </KbdGroup>

--- a/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
@@ -429,7 +429,13 @@ export function SourcesTab(): ReactElement {
                             tone: 'warn',
                             hint: 'The mic opened but did not send audio frames.'
                           }
-                        : null
+                        : audioMeter?.status === 'unavailable'
+                          ? {
+                              label: 'Meter unavailable',
+                              tone: 'neutral',
+                              hint: 'The live level meter is not available on this platform yet. Recording audio is unaffected.'
+                            }
+                          : null
               }
             />
           </span>

--- a/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
@@ -385,7 +385,7 @@ export function SourcesTab(): ReactElement {
 
       <PanelSection
         className="lg:col-span-2"
-        description="Native CoreAudio meter with manual source gain. No automatic processing is applied."
+        description="Live input meter with manual source gain. No automatic processing is applied."
         icon={Waveform}
         title="Microphone mixer"
       >

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -63,7 +63,7 @@ export function StudioTab(): ReactElement {
   } = studio
 
   const active = isSessionTransportActive(recording.state)
-  const previewHealth = studioHealth(diagnosticStats, active)
+  const previewHealth = studioHealth(diagnosticStats, active, studio.runtimeInfo?.platform)
   const banner = studioBlocker(studio)
   const liveStreamCompatibility = videoProfileCompatibility({
     ...captureConfig,

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -298,6 +298,7 @@ export function StudioTab(): ReactElement {
           onClose={() => setChatRailOpen(false)}
           onHighlight={studio.toggleCommentHighlight}
           onPopOut={studio.toggleCommentsWindow}
+          platform={studio.runtimeInfo?.platform}
         />
       ) : null}
     </div>

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -3529,8 +3529,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           state: 'unavailable',
           source: 'unavailable',
           transport: 'unavailable',
-          message:
-            permissionStatus.message ?? 'macOS permission is required before preview can run.'
+          message: permissionStatus.message ?? 'Permission is required before preview can run.'
         })
         return
       }

--- a/apps/desktop/src/renderer/src/lib/ai-readiness.ts
+++ b/apps/desktop/src/renderer/src/lib/ai-readiness.ts
@@ -50,7 +50,7 @@ export function cloudAiReadiness({
       return disabled(
         'session-expired',
         'Videorc session expired',
-        'Your sign-in expired on this Mac — sign in again to use cloud AI.'
+        'Your sign-in expired on this device — sign in again to use cloud AI.'
       )
     }
     return disabled('error', 'Cloud AI unavailable', error)

--- a/apps/desktop/src/renderer/src/lib/platform.test.ts
+++ b/apps/desktop/src/renderer/src/lib/platform.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  appPlatform,
+  displayKeyGlyph,
+  displayKeyGlyphs,
+  isWindowsPlatform,
+  osSettingsName
+} from './platform'
+
+describe('appPlatform', () => {
+  it('classifies known platforms and defaults unknown to other', () => {
+    expect(appPlatform('darwin')).toBe('darwin')
+    expect(appPlatform('win32')).toBe('win32')
+    expect(appPlatform('linux')).toBe('other')
+    expect(appPlatform(undefined)).toBe('other')
+  })
+})
+
+describe('osSettingsName', () => {
+  it('names the OS settings app per platform', () => {
+    expect(osSettingsName('darwin')).toBe('System Settings')
+    expect(osSettingsName('win32')).toBe('Windows Settings')
+  })
+})
+
+describe('displayKeyGlyph', () => {
+  it('keeps mac glyphs on macOS', () => {
+    expect(displayKeyGlyph('⌘', 'darwin')).toBe('⌘')
+    expect(displayKeyGlyph('⇧', 'darwin')).toBe('⇧')
+  })
+
+  it('translates modifier glyphs to Windows names', () => {
+    expect(displayKeyGlyph('⌘', 'win32')).toBe('Ctrl')
+    expect(displayKeyGlyph('⇧', 'win32')).toBe('Shift')
+    expect(displayKeyGlyph('⌥', 'win32')).toBe('Alt')
+  })
+
+  it('passes plain keys through unchanged on every platform', () => {
+    expect(displayKeyGlyph('K', 'win32')).toBe('K')
+    expect(displayKeyGlyph('5', 'win32')).toBe('5')
+  })
+
+  it('translates a full key sequence', () => {
+    expect(displayKeyGlyphs(['⌘', '⇧', 'J'], 'win32')).toEqual(['Ctrl', 'Shift', 'J'])
+    expect(displayKeyGlyphs(['⌘', '1'], 'darwin')).toEqual(['⌘', '1'])
+  })
+})
+
+describe('isWindowsPlatform', () => {
+  it('is true only for win32', () => {
+    expect(isWindowsPlatform('win32')).toBe(true)
+    expect(isWindowsPlatform('darwin')).toBe(false)
+    expect(isWindowsPlatform(undefined)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/platform.ts
+++ b/apps/desktop/src/renderer/src/lib/platform.ts
@@ -1,0 +1,37 @@
+// Renderer-side platform awareness. The main process reports the real
+// platform through runtimeInfo.platform ('darwin' | 'win32' | 'linux' | …);
+// components read it to pick OS-correct copy, permission flows, and keyboard
+// glyphs. Defaults to 'darwin' only as a pre-runtimeInfo boot fallback — the
+// value is replaced the moment runtimeInfo arrives.
+
+export type AppPlatform = 'darwin' | 'win32' | 'other'
+
+export function appPlatform(platform: string | undefined): AppPlatform {
+  if (platform === 'darwin') {
+    return 'darwin'
+  }
+  if (platform === 'win32') {
+    return 'win32'
+  }
+  return 'other'
+}
+
+export function isMacPlatform(platform: string | undefined): boolean {
+  return appPlatform(platform) === 'darwin'
+}
+
+export function isWindowsPlatform(platform: string | undefined): boolean {
+  return appPlatform(platform) === 'win32'
+}
+
+/** Human name for the OS Settings app, for permission copy. */
+export function osSettingsName(platform: string | undefined): string {
+  switch (appPlatform(platform)) {
+    case 'darwin':
+      return 'System Settings'
+    case 'win32':
+      return 'Windows Settings'
+    default:
+      return 'system settings'
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/platform.ts
+++ b/apps/desktop/src/renderer/src/lib/platform.ts
@@ -35,3 +35,26 @@ export function osSettingsName(platform: string | undefined): string {
       return 'system settings'
   }
 }
+
+// macOS uses ⌘ (Cmd) as the primary modifier; Windows/Linux use Ctrl. The
+// keydown handlers already accept `metaKey || ctrlKey`, so only the DISPLAYED
+// glyph needs translating. Shortcut data is authored with mac glyphs
+// (shortcuts.ts) and rendered through this map.
+const NON_MAC_KEY_GLYPHS: Record<string, string> = {
+  '⌘': 'Ctrl',
+  '⌥': 'Alt',
+  '⇧': 'Shift'
+}
+
+/** Translates a single displayed key glyph for the platform (⌘ → Ctrl, etc.). */
+export function displayKeyGlyph(glyph: string, platform: string | undefined): string {
+  if (appPlatform(platform) === 'darwin') {
+    return glyph
+  }
+  return NON_MAC_KEY_GLYPHS[glyph] ?? glyph
+}
+
+/** Translates every glyph in a key sequence (shortcuts.ts `keys` arrays). */
+export function displayKeyGlyphs(keys: readonly string[], platform: string | undefined): string[] {
+  return keys.map((key) => displayKeyGlyph(key, platform))
+}

--- a/apps/desktop/src/renderer/src/lib/studio-health.test.ts
+++ b/apps/desktop/src/renderer/src/lib/studio-health.test.ts
@@ -99,4 +99,32 @@ describe('studioHealth', () => {
       value: 'Idle'
     })
   })
+
+  // Windows: the CPU compositor and image-polling preview are the intended
+  // paths, not degradations — the badge must read healthy, never "Degraded"
+  // or "Fallback" (the tester-reported false alarms).
+  it('reads healthy for the CPU compositor on Windows', () => {
+    expect(
+      studioHealth(
+        stats({ compositorBackend: 'cpu', compositorCpuFallbackFrames: 42 }),
+        true,
+        'win32'
+      )
+    ).toMatchObject({ tone: 'good', value: 'Live' })
+  })
+
+  it('does not warn on image polling / proof surface on Windows', () => {
+    expect(
+      studioHealth(stats({ previewTransport: 'latest-jpeg-polling' }), true, 'win32')
+    ).toMatchObject({ tone: 'good', value: 'Live' })
+    expect(
+      studioHealth(stats({ previewTransport: 'electron-proof-surface' }), true, 'win32')
+    ).toMatchObject({ tone: 'good', value: 'Live' })
+  })
+
+  it('still degrades on a genuine macOS Metal fallback', () => {
+    expect(studioHealth(stats({ compositorBackend: 'cpu-fallback' }), true, 'darwin').tone).toBe(
+      'error'
+    )
+  })
 })

--- a/apps/desktop/src/renderer/src/lib/studio-health.ts
+++ b/apps/desktop/src/renderer/src/lib/studio-health.ts
@@ -40,10 +40,22 @@ const PREVIEW_PRESENT_BUDGET_P99_MS = 150
  * F1) owns truthful preview-path health with self-healing; the Studio badge
  * only reports states a user can act on.
  */
-export function studioHealth(stats: StudioHealthInput, active: boolean): StudioHealth {
+export function studioHealth(
+  stats: StudioHealthInput,
+  active: boolean,
+  platform?: string
+): StudioHealth {
+  // Off macOS there is no Metal GPU compositor and no native preview surface,
+  // so the CPU compositor ('cpu') and image-polling preview ARE the intended
+  // paths — they must read healthy. Only macOS's 'cpu-fallback' (Metal asked
+  // for, not obtained) is a real degradation. The backend already reports
+  // 'cpu' vs 'cpu-fallback' per platform; this guard also protects the
+  // frame-count fast path (which counts both) and the transport check.
+  const nativePreviewExpected = platform === undefined || platform === 'darwin'
+
   if (
     stats.compositorBackend === 'cpu-fallback' ||
-    (active && stats.compositorCpuFallbackFrames > 0)
+    (active && nativePreviewExpected && stats.compositorCpuFallbackFrames > 0)
   ) {
     return {
       tone: 'error',
@@ -56,11 +68,13 @@ export function studioHealth(stats: StudioHealthInput, active: boolean): StudioH
 
   // A fallback transport is the dominant, stable state, so surface it before borderline latency.
   // Otherwise the badge flaps between "Fallback" and "Lagging" while the preview sits on the
-  // polling path and its present latency oscillates around the budget.
+  // polling path and its present latency oscillates around the budget. On platforms without a
+  // native surface, polling is not a fallback — it is the preview path — so it stays quiet.
   if (
-    stats.previewTransport === 'latest-jpeg-polling' ||
-    stats.previewTransport === 'mjpeg-stream' ||
-    stats.previewTransport === 'electron-proof-surface'
+    nativePreviewExpected &&
+    (stats.previewTransport === 'latest-jpeg-polling' ||
+      stats.previewTransport === 'mjpeg-stream' ||
+      stats.previewTransport === 'electron-proof-surface')
   ) {
     return {
       tone: 'warn',

--- a/apps/desktop/src/renderer/src/lib/system-access.test.ts
+++ b/apps/desktop/src/renderer/src/lib/system-access.test.ts
@@ -139,7 +139,8 @@ describe('systemAccessRows', () => {
         { id: 'screen:screencapturekit:1', kind: 'screen', status: 'available' },
         { kind: 'camera', status: 'permission-required' }
       ]),
-      audioMeter: null
+      audioMeter: null,
+      platform: 'darwin'
     })
     expect(rows.map((row) => row.id)).toEqual(['screen-recording', 'camera', 'microphone'])
     expect(rows[0].state).toBe('granted')
@@ -147,5 +148,38 @@ describe('systemAccessRows', () => {
     expect(rows[1].detail).toMatch(/System Settings/)
     expect(rows[2].state).toBe('first-use')
     expect(rows[2].detail).toMatch(/mic check/)
+  })
+
+  it('omits the Screen Recording row on Windows (no per-app screen permission)', () => {
+    const rows = systemAccessRows({
+      deviceList: devices([
+        { id: 'screen:gdigrab:desktop', kind: 'screen', status: 'available' },
+        { kind: 'camera', status: 'available' }
+      ]),
+      audioMeter: { status: 'ready' },
+      platform: 'win32'
+    })
+    expect(rows.map((row) => row.id)).toEqual(['camera', 'microphone'])
+    // No "macOS" / "System Settings" wording leaks to Windows users.
+    for (const row of rows) {
+      expect(row.detail).not.toMatch(/macOS|System Settings/)
+    }
+  })
+
+  it('does not wedge onboarding open on a healthy Windows machine', () => {
+    // Windows: camera available (granted), mic meter ready (granted), no screen
+    // row — the dialog must be satisfiable, unlike the old screencapturekit +
+    // CoreAudio-only derivation that left it permanently first-use.
+    const rows = systemAccessRows({
+      deviceList: devices([
+        { id: 'screen:gdigrab:desktop', kind: 'screen', status: 'available' },
+        { kind: 'camera', status: 'available' }
+      ]),
+      audioMeter: { status: 'ready' },
+      platform: 'win32'
+    })
+    expect(
+      shouldShowPermissionsOnboarding({ rows, dismissed: false, backendReady: true })
+    ).toBe(false)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/system-access.test.ts
+++ b/apps/desktop/src/renderer/src/lib/system-access.test.ts
@@ -178,8 +178,8 @@ describe('systemAccessRows', () => {
       audioMeter: { status: 'ready' },
       platform: 'win32'
     })
-    expect(
-      shouldShowPermissionsOnboarding({ rows, dismissed: false, backendReady: true })
-    ).toBe(false)
+    expect(shouldShowPermissionsOnboarding({ rows, dismissed: false, backendReady: true })).toBe(
+      false
+    )
   })
 })

--- a/apps/desktop/src/renderer/src/lib/system-access.ts
+++ b/apps/desktop/src/renderer/src/lib/system-access.ts
@@ -1,10 +1,16 @@
 import type { AudioMeterResult, Device, DeviceList } from '@/lib/backend'
+import { appPlatform, osSettingsName, type AppPlatform } from '@/lib/platform'
 
 // ST3 (Settings rework): live permission states for the System access rows.
 // Derived from the SAME signals the rest of the app already trusts (device
 // enumeration statuses + the audio meter probe) — never from guesses. When
-// macOS genuinely won't tell us until first use, we say so instead of faking
+// the OS genuinely won't tell us until first use, we say so instead of faking
 // a green chip.
+//
+// Platform matters here: macOS TCC reports denied camera/mic as
+// permission-required, so "enumerated" implies "granted"; Windows exposes no
+// such per-device denial in the device list and has NO per-app screen
+// permission at all, so the derivation and the row set differ by platform.
 
 export type SystemAccessState = 'granted' | 'not-granted' | 'first-use' | 'device-issue'
 
@@ -63,49 +69,62 @@ export function microphoneAccessState(audioMeter: AudioMeterResult | null): Syst
   if (audioMeter.status === 'ready' || audioMeter.status === 'silent') {
     return 'granted'
   }
+  // 'unavailable' (no capture backend on this OS yet) and anything unknown
+  // fall through to first-use rather than a scary red chip.
   return 'first-use'
 }
 
 export function systemAccessRows({
   deviceList,
-  audioMeter
+  audioMeter,
+  platform
 }: {
   deviceList: DeviceList
   audioMeter: AudioMeterResult | null
+  platform?: string
 }): SystemAccessRow[] {
-  const screen = screenAccessState(deviceList)
+  const os = appPlatform(platform)
   const camera = cameraAccessState(deviceList)
   const microphone = microphoneAccessState(audioMeter)
 
-  return [
-    {
+  const rows: SystemAccessRow[] = []
+
+  // Windows has no per-app screen-capture permission — the desktop is always
+  // capturable — so the Screen Recording row only exists on macOS.
+  if (os !== 'win32') {
+    const screen = screenAccessState(deviceList)
+    rows.push({
       id: 'screen-recording',
       label: 'Screen Recording',
       purpose: 'Capture displays and app windows.',
       state: screen,
-      detail: accessDetail(screen, 'screen capture')
-    },
-    {
-      id: 'camera',
-      label: 'Camera',
-      purpose: 'Camera overlay in your scenes.',
-      state: camera,
-      detail: accessDetail(camera, 'the camera')
-    },
-    {
-      id: 'microphone',
-      label: 'Microphone',
-      purpose: 'Voice audio and live captions.',
-      state: microphone,
-      detail:
-        microphone === 'device-issue'
-          ? (audioMeter?.message ??
-            'The microphone opened but did not send frames. Try the fallback input or another mic.')
-          : microphone === 'first-use'
-            ? 'Checked when you run a mic check or start a session.'
-            : accessDetail(microphone, 'the microphone')
-    }
-  ]
+      detail: accessDetail(screen, 'screen capture', os)
+    })
+  }
+
+  rows.push({
+    id: 'camera',
+    label: 'Camera',
+    purpose: 'Camera overlay in your scenes.',
+    state: camera,
+    detail: accessDetail(camera, 'the camera', os)
+  })
+
+  rows.push({
+    id: 'microphone',
+    label: 'Microphone',
+    purpose: 'Voice audio and live captions.',
+    state: microphone,
+    detail:
+      microphone === 'device-issue'
+        ? (audioMeter?.message ??
+          'The microphone opened but did not send frames. Try the fallback input or another mic.')
+        : microphone === 'first-use'
+          ? 'Checked when you run a mic check or start a session.'
+          : accessDetail(microphone, 'the microphone', os)
+  })
+
+  return rows
 }
 
 // Permissions onboarding gate: the dialog exists ONLY to collect grants, so it
@@ -130,17 +149,20 @@ export function shouldShowPermissionsOnboarding({
   return rows.some((row) => row.state !== 'granted' && row.state !== 'device-issue')
 }
 
-function accessDetail(state: SystemAccessState, subject: string): string {
+function accessDetail(state: SystemAccessState, subject: string, os: AppPlatform): string {
+  const settings = osSettingsName(os === 'other' ? undefined : os)
   switch (state) {
     case 'granted':
       return 'Permission granted.'
     case 'not-granted':
       // The packaged-app nuance from the 0.9.1 incident: a missing grant is
-      // fixed in System Settings; a missing ENTITLEMENT can't be — but 0.9.2+
-      // ships the entitlements, so System Settings is the right pointer.
-      return `macOS is blocking ${subject} — grant access in System Settings.`
+      // fixed in the OS Settings; a missing ENTITLEMENT can't be — but 0.9.2+
+      // ships the entitlements, so Settings is the right pointer.
+      return `Your ${settings} is blocking ${subject} — grant access there.`
     case 'first-use':
-      return 'macOS reports this on first use.'
+      return os === 'win32'
+        ? `Grant ${subject} in ${settings} if it is turned off.`
+        : `${settings} reports this on first use.`
     case 'device-issue':
       return 'The device opened but did not send audio frames.'
   }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1084,7 +1084,7 @@ export type PreviewTransport =
  * internally, so this is the requested backend; the final-file codec/encoder tag is the
  * corroborating output-side signal. */
 export type EncodeBackend = 'software-x264' | 'hardware-videotoolbox' | 'hardware-mediafoundation'
-export type CompositorBackend = 'metal' | 'cpu-fallback'
+export type CompositorBackend = 'metal' | 'cpu' | 'cpu-fallback'
 
 /** Cumulative request counts for the HTTP image-polling preview transports. A native
  * preview never fetches these, so a session in which they climb is not actually native. */

--- a/apps/desktop/src/shared/native-preview-host-driver.ts
+++ b/apps/desktop/src/shared/native-preview-host-driver.ts
@@ -121,11 +121,18 @@ export function realSurfaceInvalidActivationMessage(
 
 export function proofSurfaceCompositorMessage(
   status: PreviewSurfaceCompositorUpdateParams,
-  realSurfaceFallbackReason?: string
+  realSurfaceFallbackReason?: string,
+  platform?: string
 ): string | undefined {
+  // On macOS the browser-window surface is a diagnostic PROOF path standing in
+  // for the native CAMetalLayer; off macOS image polling is simply the preview
+  // transport, so the "proof / falling back" framing is wrong and alarming.
+  const nativeSurfaceExpected = platform === undefined || platform === 'darwin'
   const proofMessage =
     status.state === 'live'
-      ? 'Electron proof preview surface is displaying compositor output.'
+      ? nativeSurfaceExpected
+        ? 'Electron proof preview surface is displaying compositor output.'
+        : 'Preview is displaying compositor output.'
       : status.message
   return realSurfaceFallbackReason
     ? `${realSurfaceFallbackReason} ${proofMessage ?? ''}`.trim()

--- a/crates/videorc-backend/src/audio.rs
+++ b/crates/videorc-backend/src/audio.rs
@@ -933,7 +933,13 @@ fn start_platform_audio_source(
     _device_id: u32,
     _settings: AudioProcessingSettings,
 ) -> Result<NativeAudioSource> {
-    bail!("Native microphone capture is only implemented on macOS");
+    // The live meter samples the native capture ring, which only the CoreAudio
+    // backend fills today. Recording audio on Windows still works (the dshow
+    // mic leg runs inside ffmpeg, not this path) — only the in-app level meter
+    // is pending its own Windows capture source. Phrase it as a not-yet, not a
+    // macOS-only defect, so the mic UI does not read as broken. Must NOT
+    // contain "permission"/"unauthor" (permission_or_unavailable keys on that).
+    bail!("Live microphone metering is not available on this platform yet.");
 }
 
 #[cfg(target_os = "windows")]

--- a/crates/videorc-backend/src/camera_capture.rs
+++ b/crates/videorc-backend/src/camera_capture.rs
@@ -319,12 +319,18 @@ mod windows_native {
     fn device_from_activate(activate: &IMFActivate, index: u32) -> Device {
         let friendly_name = mf_string(activate, &MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME)
             .unwrap_or_else(|| format!("Camera {}", index + 1));
-        let capture_name = mf_string(
+        let symbolic_link = mf_string(
             activate,
             &MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
-        )
-        .map(|symbolic_link| format!("@{symbolic_link}"))
-        .unwrap_or_else(|| friendly_name.clone());
+        );
+        // The capture name is what ffmpeg's dshow demuxer receives as
+        // `-i video=<name>`. dshow's device selector is the DirectShow FRIENDLY
+        // NAME, not the MediaFoundation symbolic link — feeding it the MF
+        // symbolic link (`@\\?\usb#...#{mf-guid}`) made dshow report "Could not
+        // find video device" and the preview produced zero frames (the Windows
+        // tester "camera granted but not working" report). The symbolic link
+        // stays in the detail for support triage, not as the ffmpeg arg.
+        let capture_name = friendly_name.clone();
         Device {
             id: windows_dshow_camera_device_id(&capture_name),
             name: friendly_name.clone(),
@@ -332,7 +338,7 @@ mod windows_native {
             status: DeviceStatus::Available,
             detail: Some(windows_media_foundation_camera_detail(
                 &friendly_name,
-                &capture_name,
+                symbolic_link.as_deref().unwrap_or(&capture_name),
             )),
             width: None,
             height: None,

--- a/crates/videorc-backend/src/capture_input.rs
+++ b/crates/videorc-backend/src/capture_input.rs
@@ -139,6 +139,19 @@ pub fn append_windows_screen_video_input(
 }
 
 pub fn append_windows_dshow_video_input(args: &mut Vec<String>, device_name: &str, fps: u32) {
+    append_windows_dshow_video_input_opts(args, device_name, Some(fps));
+}
+
+/// dshow video input with an OPTIONAL requested framerate. Passing `None`
+/// drops `-framerate`, letting dshow negotiate the device's default format —
+/// the retry path for cameras whose default format does not match an exact
+/// requested rate (a common zero-frames cause: dshow rejects `-framerate 30`
+/// on a webcam that only offers, say, MJPEG@25 and never starts).
+pub fn append_windows_dshow_video_input_opts(
+    args: &mut Vec<String>,
+    device_name: &str,
+    fps: Option<u32>,
+) {
     args.extend([
         "-fflags".to_string(),
         "nobuffer".to_string(),
@@ -152,11 +165,11 @@ pub fn append_windows_dshow_video_input(args: &mut Vec<String>, device_name: &st
         "16".to_string(),
         "-f".to_string(),
         "dshow".to_string(),
-        "-framerate".to_string(),
-        fps.to_string(),
-        "-i".to_string(),
-        format!("video={device_name}"),
     ]);
+    if let Some(fps) = fps {
+        args.extend(["-framerate".to_string(), fps.to_string()]);
+    }
+    args.extend(["-i".to_string(), format!("video={device_name}")]);
 }
 
 /// Appends the session's microphone input. The native-FIFO arm is
@@ -406,6 +419,18 @@ mod tests {
                 "video=USB Camera",
             ])
         );
+    }
+
+    #[test]
+    fn windows_dshow_camera_input_omits_framerate_for_default_format_retry() {
+        let mut args = Vec::new();
+        append_windows_dshow_video_input_opts(&mut args, "USB Camera", None);
+
+        // The retry path must not pass -framerate (dshow negotiates the
+        // device default), but everything else stays identical.
+        assert!(!args.iter().any(|arg| arg == "-framerate"));
+        assert_eq!(args.last().map(String::as_str), Some("video=USB Camera"));
+        assert!(args.windows(2).any(|pair| pair == ["-f", "dshow"]));
     }
 
     #[test]

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -1248,7 +1248,10 @@ async fn run_synthetic_compositor_loop(
                     )
                         .await;
                 let fallback_frame_age_ms = published.fallback_frame_age_ms;
-                if published.compositor_backend == CompositorBackend::CpuFallback {
+                if matches!(
+                    published.compositor_backend,
+                    CompositorBackend::CpuFallback | CompositorBackend::Cpu
+                ) {
                     cpu_fallback_frames = cpu_fallback_frames.saturating_add(1);
                 }
                 if is_repeated_compositor_frame(previous_fingerprint, published.fingerprint) {
@@ -2511,7 +2514,15 @@ async fn publish_compositor_frame(
         screen_frame.as_ref(),
         published_at,
     );
-    let mut compositor_backend = CompositorBackend::CpuFallback;
+    // Default to the platform-appropriate CPU state: on macOS, not reaching
+    // the Metal path is a genuine fallback (kept honest with a reason below);
+    // off macOS there is no Metal backend to fall back FROM, so the CPU
+    // compositor is the expected path and must not read as degraded.
+    let mut compositor_backend = if cfg!(target_os = "macos") {
+        CompositorBackend::CpuFallback
+    } else {
+        CompositorBackend::Cpu
+    };
     let mut compositor_fallback_reason = None;
     let mut pixel_format = CompositorPixelFormat::yuv420p_cpu_buffer();
     let mut export_handle = CompositorFrameExportHandle::default();
@@ -2556,7 +2567,14 @@ async fn publish_compositor_frame(
                 compositor_backend = CompositorBackend::Metal;
             }
             Err(reason) => {
-                compositor_fallback_reason = Some(reason);
+                // On macOS a Metal miss is a real degradation worth surfacing;
+                // off macOS the CPU compositor IS the path, so the "why not
+                // Metal" reason is noise (backend already set to Cpu above).
+                if cfg!(target_os = "macos") {
+                    compositor_fallback_reason = Some(reason);
+                } else {
+                    let _ = reason;
+                }
                 let mut store = frame_store
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -1105,13 +1105,28 @@ fn windows_camera_preview_ffmpeg_args(
     height: u32,
     fps: u32,
 ) -> Vec<String> {
+    windows_camera_preview_ffmpeg_args_opts(config, width, height, fps, Some(fps))
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_camera_preview_ffmpeg_args_opts(
+    config: &NativeCameraPreviewConfig,
+    width: u32,
+    height: u32,
+    fps: u32,
+    request_fps: Option<u32>,
+) -> Vec<String> {
     let mut args = vec![
         "-hide_banner".to_string(),
         "-loglevel".to_string(),
         "warning".to_string(),
         "-nostdin".to_string(),
     ];
-    crate::capture_input::append_windows_dshow_video_input(&mut args, &config.unique_id, fps);
+    crate::capture_input::append_windows_dshow_video_input_opts(
+        &mut args,
+        &config.unique_id,
+        request_fps,
+    );
     args.extend([
         "-an".to_string(),
         "-vf".to_string(),
@@ -1269,7 +1284,70 @@ mod windows {
             ));
             return;
         };
-        let args = windows_camera_preview_ffmpeg_args(&config, width, height, fps);
+
+        // One stop signal shared across attempts; a per-attempt killer reacts
+        // to it (the read loop unblocks when the ffmpeg child is killed).
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        {
+            let stop_flag = Arc::clone(&stop_flag);
+            thread::spawn(move || {
+                let _ = stop_rx.recv();
+                stop_flag.store(true, Ordering::Release);
+            });
+        }
+
+        // Attempt with the requested framerate first; if the device never
+        // produces a frame (dshow can reject an exact `-framerate` a webcam
+        // does not offer), retry once letting dshow negotiate its default
+        // format. This is the second half of the zero-frames fix (the first is
+        // using the dshow friendly name rather than the MF symbolic link).
+        let attempts = [Some(fps), None];
+        for (attempt_index, request_fps) in attempts.into_iter().enumerate() {
+            if stop_flag.load(Ordering::Acquire) {
+                return;
+            }
+            let last_attempt = attempt_index + 1 == attempts.len();
+            match run_windows_camera_preview_attempt(
+                &config,
+                &shared,
+                &startup_tx,
+                &stop_flag,
+                width,
+                height,
+                fps,
+                frame_len,
+                request_fps,
+                last_attempt,
+            ) {
+                CameraPreviewAttempt::ProducedFrames | CameraPreviewAttempt::Stopped => return,
+                CameraPreviewAttempt::FailedBeforeFirstFrame => {
+                    // Retry the next attempt (or, if this was the last, the
+                    // Failed status was already sent by the attempt).
+                }
+            }
+        }
+    }
+
+    enum CameraPreviewAttempt {
+        ProducedFrames,
+        Stopped,
+        FailedBeforeFirstFrame,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_windows_camera_preview_attempt(
+        config: &NativeCameraPreviewConfig,
+        shared: &Arc<StdMutex<PreviewCameraShared>>,
+        startup_tx: &std_mpsc::Sender<NativeCameraStartup>,
+        stop_flag: &Arc<AtomicBool>,
+        width: u32,
+        height: u32,
+        fps: u32,
+        frame_len: usize,
+        request_fps: Option<u32>,
+        last_attempt: bool,
+    ) -> CameraPreviewAttempt {
+        let args = windows_camera_preview_ffmpeg_args_opts(config, width, height, fps, request_fps);
         let mut command = Command::new(&config.ffmpeg_path);
         command
             .args(&args)
@@ -1280,32 +1358,38 @@ mod windows {
         let mut child = match spawn_owned_std(&mut command) {
             Ok(child) => child,
             Err(error) => {
-                let _ = startup_tx.send(NativeCameraStartup::Failed(format!(
-                    "Could not start {} for Windows camera preview: {error}",
-                    config.ffmpeg_path
-                )));
-                return;
+                if last_attempt {
+                    let _ = startup_tx.send(NativeCameraStartup::Failed(format!(
+                        "Could not start {} for Windows camera preview: {error}",
+                        config.ffmpeg_path
+                    )));
+                }
+                return CameraPreviewAttempt::FailedBeforeFirstFrame;
             }
         };
         let Some(mut stdout) = child.stdout.take() else {
             let _ = child.kill();
-            let _ = startup_tx.send(NativeCameraStartup::Failed(
-                "Windows camera preview did not expose FFmpeg stdout.".to_string(),
-            ));
-            return;
+            if last_attempt {
+                let _ = startup_tx.send(NativeCameraStartup::Failed(
+                    "Windows camera preview did not expose FFmpeg stdout.".to_string(),
+                ));
+            }
+            return CameraPreviewAttempt::FailedBeforeFirstFrame;
         };
         let stderr = collect_stderr(child.stderr.take());
         let child = Arc::new(StdMutex::new(child));
         let done = Arc::new(AtomicBool::new(false));
-        let stop_thread = spawn_stop_killer(Arc::clone(&child), Arc::clone(&done), stop_rx);
+        let killer =
+            spawn_stop_flag_killer(Arc::clone(&child), Arc::clone(&done), Arc::clone(stop_flag));
 
         let mut startup_sent = false;
         let mut buffer = vec![0; frame_len];
+        let mut outcome = CameraPreviewAttempt::FailedBeforeFirstFrame;
         loop {
             match stdout.read_exact(&mut buffer) {
                 Ok(()) => {
                     publish_bgra_frame(
-                        &shared,
+                        shared,
                         width,
                         height,
                         std::mem::replace(&mut buffer, vec![0; frame_len]),
@@ -1326,10 +1410,17 @@ mod windows {
                             ),
                         });
                         startup_sent = true;
+                        outcome = CameraPreviewAttempt::ProducedFrames;
                     }
                 }
                 Err(error) => {
-                    if !startup_sent {
+                    if startup_sent {
+                        // Ran and then ended (stop, unplug, or EOF); the caller
+                        // must not retry a preview that already went live.
+                        outcome = CameraPreviewAttempt::ProducedFrames;
+                    } else if stop_flag.load(Ordering::Acquire) {
+                        outcome = CameraPreviewAttempt::Stopped;
+                    } else if last_attempt {
                         let _ = startup_tx.send(NativeCameraStartup::Failed(format!(
                             "Windows FFmpeg camera preview ended before the first frame: {error}{}",
                             stderr_suffix(&stderr)
@@ -1345,7 +1436,8 @@ mod windows {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .wait();
-        let _ = stop_thread.join();
+        let _ = killer.join();
+        outcome
     }
 
     fn bgra_frame_len(width: u32, height: u32) -> Option<usize> {
@@ -1369,24 +1461,21 @@ mod windows {
         bytes
     }
 
-    fn spawn_stop_killer(
+    fn spawn_stop_flag_killer(
         child: Arc<StdMutex<Child>>,
         done: Arc<AtomicBool>,
-        stop_rx: std_mpsc::Receiver<()>,
+        stop_flag: Arc<AtomicBool>,
     ) -> thread::JoinHandle<()> {
         thread::spawn(move || {
             while !done.load(Ordering::Acquire) {
-                match stop_rx.recv_timeout(Duration::from_millis(100)) {
-                    Ok(()) => {
-                        let _ = child
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner())
-                            .kill();
-                        return;
-                    }
-                    Err(std_mpsc::RecvTimeoutError::Timeout) => {}
-                    Err(std_mpsc::RecvTimeoutError::Disconnected) => return,
+                if stop_flag.load(Ordering::Acquire) {
+                    let _ = child
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .kill();
+                    return;
                 }
+                thread::sleep(Duration::from_millis(50));
             }
         })
     }

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1032,12 +1032,19 @@ pub enum EncodeBackend {
     HardwareMediaFoundation,
 }
 
-/// Which compositor rendered the active shared-compositor frame. OBS-parity acceptance
-/// requires the Metal path; CPU fallback is kept honest with a reason and count.
+/// Which compositor rendered the active shared-compositor frame.
+///
+/// - `Metal`: the GPU path (macOS OBS-parity target).
+/// - `Cpu`: the CPU compositor as the EXPECTED path — platforms without a
+///   Metal backend (Windows/Linux) have no GPU compositor to fall back from,
+///   so this is normal, not a degradation, and carries no fallback reason.
+/// - `CpuFallback`: macOS asked for Metal and could not get it — a real
+///   degradation, kept honest with a reason and count.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum CompositorBackend {
     Metal,
+    Cpu,
     CpuFallback,
 }
 

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -4074,6 +4074,7 @@ fn append_h264_encoding_args_for_platform(
 fn compositor_backend_label(backend: Option<CompositorBackend>) -> &'static str {
     match backend {
         Some(CompositorBackend::Metal) => "metal",
+        Some(CompositorBackend::Cpu) => "cpu",
         Some(CompositorBackend::CpuFallback) => "cpu-fallback",
         None => "unknown",
     }


### PR DESCRIPTION
Fixes the batch of Windows tester-reported errors. Seven symptoms → four root causes; five slices, each committed separately.

## What was wrong and what changed

**Permissions threw and onboarding wedged (S1).** Every permission button funneled through `assertPermissionShortcutSupported`, which threw `only available on macOS` off-darwin — so the tester's `Error invoking remote method 'system:open-permissions'`. And the chips derived from macOS TCC invariants (screencapturekit-only screen check, CoreAudio-only mic), leaving screen + mic permanently "first-use" so the onboarding dialog wedged open on every fresh Windows install with buttons that threw.
- `ms-settings:privacy-webcam` / `privacy-microphone` deep links; no per-app screen pane on Windows (there is no such OS permission).
- `getMediaAccessStatus` on Windows (supported) instead of mac-only `askForMediaAccess`.
- `system-access` drops the Screen Recording row on Windows, handles the `unavailable` meter status, and uses per-OS copy — onboarding is now satisfiable on Windows.

**"Camera granted but not working" / "produced no frames" (S2).** Two bugs: the dshow selector was the MediaFoundation symbolic link (`@\\?\usb#...#{mf-guid}`), which ffmpeg's dshow demuxer rejects — it wants the DirectShow friendly name; and there was no format negotiation. The recording startup gate then correctly refused with "produced no frames." Now: capture name is the friendly name (symbolic link kept in device detail), and the preview runner retries once without `-framerate` (dshow default format) when the first attempt yields no frame, keeping ffmpeg stderr. Fixes both preview and record (shared decode).

**Mic "not working" (S3).** The live meter samples the CoreAudio ring, which has no Windows backend, so it leaked "only implemented on macOS" and sat dead at 0%. Recording audio is unaffected (the dshow mic runs inside ffmpeg). Now: honest not-yet copy + a neutral "Meter unavailable" chip. The live Windows capture meter needs device-name plumbing + on-box verification — tracked as the remaining S3 item.

**False "Metal compositor unavailable" / "falling back to image polling / Electron proof" (S4).** The CPU compositor and image-polling preview ARE the intended paths off macOS, but the health model treated both as macOS degradations — a permanent "Degraded" badge and scary warnings for normal operation. Added a `cpu` compositor backend (expected) distinct from macOS `cpu-fallback` (real degradation); studio health + the native-preview present policy + proof-surface copy now read healthy / quiet on Windows. macOS behavior unchanged, with a regression guard.

**"Mac" everywhere (S5).** ⌘ glyphs (handlers already accept Ctrl — display only) and ~20 strings said "Mac"/"macOS"/"System Settings"/"CoreAudio". Added `lib/platform.ts` (`displayKeyGlyph` ⌘→Ctrl, `osSettingsName`); the shortcut table is translated at every render site; strings are platform-aware or neutral.

## Validation
- `cargo fmt --check --all`, `cargo test -p videorc-backend`, `cargo clippy -p videorc-backend -- -D warnings` — green
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter @videorc/desktop test` (503 passed) — green
- `pnpm check:windows` — exit 0 (the Windows cross-compile)
- New tests: runtime-info + system-access platform matrix, platform.ts glyphs, studio-health Windows cases + macOS regression guard, dshow no-framerate retry arg builder.

The Windows gates + installer CI jobs on this PR are the real check; the tester's next run on the installer artifact is on-box acceptance (CI runners have no camera/mic). Plan: `plans/planned/2026-07-09 - Videorc Windows Tester Feedback Fix Plan.md` in the vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop UI now shows platform-appropriate keyboard shortcuts and OS Settings wording on both macOS and Windows.
  * Windows permission screens now include the correct app settings links and updated guidance.

* **Bug Fixes**
  * Improved native preview and media-permission behavior across platforms, reducing repeated fallback messages on Windows.
  * Fixed permission and preview status messages to use more general device-based wording.
  * Updated audio and microphone status messages to better reflect current availability and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->