### PR TITLE
Don't alarm on an unpublished update feed (Windows latest.yml 404)

### DIFF
--- a/apps/desktop/src/main/updater-status.test.ts
+++ b/apps/desktop/src/main/updater-status.test.ts
@@ -3,10 +3,32 @@ import { describe, expect, it } from 'vitest'
 import {
   BACKGROUND_RECHECK_INTERVAL_MS,
   clampPercent,
+  isMissingUpdateFeedError,
   shouldAutoDownload,
   shouldBackgroundRecheck,
   updateStatusFromEvent
 } from './updater-status'
+
+describe('isMissingUpdateFeedError', () => {
+  it('treats an unpublished feed (no channel / 404 manifest) as benign', () => {
+    // The exact shape electron-updater throws for a Windows client hitting a
+    // macOS-only feed (the tester report).
+    expect(
+      isMissingUpdateFeedError(
+        'Cannot find channel "latest.yml" update info: HttpError: 404 "method: GET url: https://www.videorc.com/api/updates/latest.yml"'
+      )
+    ).toBe(true)
+    expect(isMissingUpdateFeedError('HttpError: 404 latest-mac.yml')).toBe(true)
+    expect(isMissingUpdateFeedError('Cannot find channel')).toBe(true)
+  })
+
+  it('does not swallow real errors', () => {
+    expect(isMissingUpdateFeedError('net::ERR_INTERNET_DISCONNECTED')).toBe(false)
+    expect(isMissingUpdateFeedError('sha512 checksum mismatch')).toBe(false)
+    // A 404 mid-download of a package is a real failure, not a missing manifest.
+    expect(isMissingUpdateFeedError('HttpError: 404 Videorc-0.9.25-win-x64.exe')).toBe(false)
+  })
+})
 
 describe('updater status mapping', () => {
   it('maps each lifecycle event to its matching status', () => {

--- a/apps/desktop/src/main/updater-status.ts
+++ b/apps/desktop/src/main/updater-status.ts
@@ -14,6 +14,30 @@ export type UpdaterEvent =
   | { type: 'error'; message: string }
   | { type: 'unsupported' }
 
+// electron-updater surfaces an unpublished feed — no `latest*.yml` for this
+// build's platform/channel — as a 404 / "Cannot find channel" error. That is
+// not a failure the user can act on: it means no update channel is published
+// for this build yet (e.g. a Windows build before its release feed goes live).
+// Classify it so the updater can degrade to the benign 'unsupported' state
+// instead of showing an alarming "Couldn't check for updates: … 404" message.
+// Once the feed publishes, the same check resolves to available/not-available
+// with no code change.
+export function isMissingUpdateFeedError(message: string): boolean {
+  const normalized = message.toLowerCase()
+  if (normalized.includes('cannot find channel')) {
+    return true
+  }
+  // A 404 specifically on the update-info manifest (latest.yml / latest-mac.yml
+  // / latest-linux.yml), not an unrelated 404 mid-download.
+  return (
+    normalized.includes('404') &&
+    (normalized.includes('latest.yml') ||
+      normalized.includes('latest-mac.yml') ||
+      normalized.includes('latest-linux.yml') ||
+      normalized.includes('update info'))
+  )
+}
+
 // electron-updater can report a percent slightly outside 0–100 (or NaN before the
 // first chunk); normalise it so the progress bar never overflows.
 export function clampPercent(percent: number): number {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -7,6 +7,7 @@ import type { UpdateStatus } from '../shared/backend'
 import { safeConsole } from './safe-console'
 import {
   BACKGROUND_RECHECK_INTERVAL_MS,
+  isMissingUpdateFeedError,
   shouldAutoDownload,
   shouldBackgroundRecheck,
   updateStatusFromEvent
@@ -34,6 +35,17 @@ let listenersAttached = false
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+// A caught updater failure becomes the benign 'unsupported' state when it is
+// just an unpublished feed (no channel for this platform yet); otherwise it is
+// a real, user-facing error.
+function setStatusFromUpdaterError(message: string): void {
+  setStatus(
+    updateStatusFromEvent(
+      isMissingUpdateFeedError(message) ? { type: 'unsupported' } : { type: 'error', message }
+    )
+  )
 }
 
 function setStatus(next: UpdateStatus): void {
@@ -88,7 +100,7 @@ function attachUpdaterListeners(): void {
     const message = errorMessage(error)
     // Update failures are non-fatal.
     safeConsole.warn(`[auto-update] error: ${message}`)
-    setStatus(updateStatusFromEvent({ type: 'error', message }))
+    setStatusFromUpdaterError(message)
   })
 }
 
@@ -163,7 +175,7 @@ export function registerUpdaterIpc(mainWindowGetter: MainWindowGetter): void {
     } catch (error) {
       const message = errorMessage(error)
       safeConsole.warn(`[auto-update] check failed: ${message}`)
-      setStatus(updateStatusFromEvent({ type: 'error', message }))
+      setStatusFromUpdaterError(message)
       return currentStatus
     }
   })
@@ -178,7 +190,7 @@ export function registerUpdaterIpc(mainWindowGetter: MainWindowGetter): void {
       return currentStatus
     } catch (error) {
       const message = errorMessage(error)
-      setStatus(updateStatusFromEvent({ type: 'error', message }))
+      setStatusFromUpdaterError(message)
       return currentStatus
     }
   })

--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -511,7 +511,8 @@ function UpdateControl({
     case 'unsupported':
       return (
         <p className="text-xs text-muted-foreground">
-          Updates apply to the installed app — not to development builds.
+          Automatic updates aren’t available for this build yet. Grab new versions from the
+          downloads page.
         </p>
       )
     case 'checking':


### PR DESCRIPTION
## The report

A Windows tester saw this on launch:

> Couldn't check for updates: Cannot find channel "latest.yml" update info: HttpError: 404 … url: https://www.videorc.com/api/updates/latest.yml

## Cause

The electron-updater feed (`www.videorc.com/api/updates`) serves **macOS only** — the route maps every request to `updates/macos/` and its allowlist accepts only `latest-mac.yml` / `.zip` shapes. A Windows client requests `latest.yml`, which 404s. electron-updater surfaced that missing channel as a hard **error**, so a scary "Couldn't check for updates" message showed on every launch.

## Fix (this PR)

An unpublished feed is not a user-actionable failure — it means no update channel is published for this build's platform yet. This PR classifies that signature and degrades gracefully:

- `isMissingUpdateFeedError` matches the `Cannot find channel` / 404-manifest (`latest.yml` / `latest-mac.yml` / `latest-linux.yml`) shape — but **not** a 404 mid-download of a package (a real failure).
- The background check, manual check, and download error paths map it to the benign **`unsupported`** state instead of `error`. When the Windows feed later goes live, the same check resolves to available/not-available with **no further code change**.
- The `unsupported` copy is generalized from "development builds" to "Automatic updates aren't available for this build yet — grab new versions from the downloads page," which is truthful for both dev builds and a packaged Windows build with no feed.

## Validation
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter @videorc/desktop test` (505 passed) — green
- New tests pin the classifier on the exact tester error string and guard against swallowing real failures.

## Follow-up (NOT in this PR — release infra, tracked)

Actual Windows update **delivery** additionally needs:
1. **videorc-web**: extend the feed route (`handleMacosUpdateFeed`) to serve `updates/windows/` and accept Windows file shapes (`latest.yml`, `.exe`, `.exe.blockmap`).
2. **Windows release-upload pipeline**: publish signed Windows artifacts to R2 under `updates/windows/` (the release scripts are macOS-only today — B5 in the Windows remaining-work plan).

Until then, testers update by downloading the installer from the latest CI run / downloads page — this PR just makes the app say so calmly instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Update checks and downloads now handle missing or unpublished update feeds more gracefully, showing an unsupported/available-soon state instead of a hard error.
  - Related updater failures are still reported as errors when they’re caused by real issues like network problems or corrupted downloads.
  - Improved the message shown when automatic updates aren’t available for a build, with a clearer prompt to visit the downloads page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->