### PR TITLE
Fix Windows microphone/camera permission flow

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -127,6 +127,8 @@ import type {
   PreviewSurfaceSceneState,
   PreviewSurfaceSceneUpdateParams,
   PreviewSurfaceStatus,
+  MediaAccessSnapshot,
+  MediaAccessStatus,
   PreviewPermissionStatus,
   PreviewSupervisorState,
   SceneSource,
@@ -7032,6 +7034,26 @@ async function requestMediaAccessIfNeeded(pane: SystemPermissionPane): Promise<b
   }
 }
 
+// The OS's real camera/mic access state. getMediaAccessStatus is supported on
+// macOS AND Windows (only askForMediaAccess is mac-only), so this is the honest
+// signal the renderer chips read on Windows — where the audio meter has no
+// capture backend and the camera enumerates regardless of the privacy toggle.
+function readMediaAccessStatus(pane: 'camera' | 'microphone'): MediaAccessStatus {
+  try {
+    return systemPreferences.getMediaAccessStatus(pane) as MediaAccessStatus
+  } catch (error) {
+    logBackend('warn', `Could not read ${pane} access status: ${errorMessage(error)}`)
+    return 'unknown'
+  }
+}
+
+function mediaAccessSnapshot(): MediaAccessSnapshot {
+  return {
+    camera: readMediaAccessStatus('camera'),
+    microphone: readMediaAccessStatus('microphone')
+  }
+}
+
 async function restartBackend(reason: string): Promise<void> {
   if (backendRestartInProgress) {
     return backendRestartInProgress
@@ -7488,6 +7510,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('system:request-media-access', (_event, pane: 'camera' | 'microphone') =>
     requestMediaAccessNative(pane)
   )
+  ipcMain.handle('system:media-access-status', () => mediaAccessSnapshot())
   ipcMain.handle('system:reveal-permission-target', () => revealPermissionTarget())
   ipcMain.handle('system:reveal-path', (_event, targetPath: string) => revealPath(targetPath))
   // OBS setup import (O1): read-only discovery over OBS Studio's config files.

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -172,6 +172,7 @@ const api: VideorcApi = {
     ipcRenderer.invoke('preview-surface:destroy', generation),
   getNativePreviewSurfaceStatus: () => ipcRenderer.invoke('preview-surface:status'),
   openSystemPermissions: (pane) => ipcRenderer.invoke('system:open-permissions', pane),
+  getMediaAccessStatus: () => ipcRenderer.invoke('system:media-access-status'),
   requestMediaAccess: (pane) => ipcRenderer.invoke('system:request-media-access', pane),
   revealPermissionTarget: () => ipcRenderer.invoke('system:reveal-permission-target'),
   revealPath: (path) => ipcRenderer.invoke('system:reveal-path', path),

--- a/apps/desktop/src/renderer/src/components/app-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/app-shell.tsx
@@ -42,6 +42,7 @@ export function AppShell(): ReactElement {
     wsStatus,
     deviceList,
     audioMeter,
+    mediaAccess,
     recording,
     runtimeInfo,
     entitlements,
@@ -77,11 +78,16 @@ export function AppShell(): ReactElement {
     }
     onboardingEvaluatedRef.current = true
     const dismissed = localStorage.getItem(STORAGE_KEYS.onboarding) !== null
-    const rows = systemAccessRows({ deviceList, audioMeter, platform: runtimeInfo?.platform })
+    const rows = systemAccessRows({
+      deviceList,
+      audioMeter,
+      platform: runtimeInfo?.platform,
+      mediaAccess
+    })
     if (shouldShowPermissionsOnboarding({ rows, dismissed, backendReady })) {
       setOnboardingOpen(true)
     }
-  }, [audioMeter, backendReady, deviceList, runtimeInfo?.platform])
+  }, [audioMeter, backendReady, deviceList, mediaAccess, runtimeInfo?.platform])
 
   // Studio control pages are ordinary tabs grouped under "Studio" in the sidebar.
   const openStudioPanel = useCallback((panel: StudioPanel) => {

--- a/apps/desktop/src/renderer/src/components/permissions-onboarding-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/permissions-onboarding-dialog.tsx
@@ -36,7 +36,8 @@ export function PermissionsOnboardingDialog({
     openSystemPermission,
     sampleAudioMeter,
     canSampleAudio,
-    runtimeInfo
+    runtimeInfo,
+    mediaAccess
   } = useStudio()
   const [pending, setPending] = useState<'camera' | 'microphone' | null>(null)
 
@@ -61,7 +62,12 @@ export function PermissionsOnboardingDialog({
     return () => window.removeEventListener('focus', onFocus)
   }, [open, refreshBackend])
 
-  const rows = systemAccessRows({ deviceList, audioMeter, platform: runtimeInfo?.platform })
+  const rows = systemAccessRows({
+    deviceList,
+    audioMeter,
+    platform: runtimeInfo?.platform,
+    mediaAccess
+  })
   const allGranted = rows.every((row) => row.state === 'granted')
   const isWindows = isWindowsPlatform(runtimeInfo?.platform)
   const deviceNoun = isWindows ? 'PC' : 'Mac'
@@ -114,6 +120,7 @@ export function PermissionsOnboardingDialog({
           {rows.map((row) => (
             <PermissionRow
               key={row.id}
+              isWindows={isWindows}
               pending={pending === row.id}
               row={row}
               onEnable={() => void enableMedia(row.id as 'camera' | 'microphone')}
@@ -121,6 +128,14 @@ export function PermissionsOnboardingDialog({
             />
           ))}
         </div>
+
+        {isWindows ? (
+          <p className="text-xs text-muted-foreground">
+            Videorc runs as a desktop app, so it won’t appear by name in {settingsName}. In each
+            privacy page, turn on the main access toggle and “Let desktop apps access your camera /
+            microphone.”
+          </p>
+        ) : null}
 
         <DialogFooter className="items-center sm:justify-between">
           <span className="text-xs text-muted-foreground">
@@ -147,11 +162,13 @@ async function waitFor(condition: () => boolean, timeoutMs = 10_000): Promise<vo
 
 function PermissionRow({
   row,
+  isWindows,
   pending,
   onEnable,
   onOpenSettings
 }: {
   row: SystemAccessRow
+  isWindows: boolean
   pending: boolean
   onEnable: () => void
   onOpenSettings: () => void
@@ -159,7 +176,11 @@ function PermissionRow({
   // Screen Recording has no native prompt API — System Settings is the only
   // door. Camera/mic get the in-place prompt while undetermined; once macOS
   // has said no, only System Settings can flip it (TCC never re-asks).
-  const canEnableInPlace = row.id !== 'screen-recording' && row.state === 'first-use'
+  //
+  // Windows has NO in-place prompt at all (askForMediaAccess is macOS-only), so
+  // an "Enable" button there was a dead no-op (the tester's "clicking Enable
+  // does nothing") — every row opens Settings instead.
+  const canEnableInPlace = !isWindows && row.id !== 'screen-recording' && row.state === 'first-use'
   const action =
     row.state === 'granted' || row.state === 'device-issue' ? null : canEnableInPlace ? (
       <Button disabled={pending} size="xs" variant="outline" onClick={onEnable}>

--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -61,6 +61,7 @@ export function SettingsTab({
     captureConfig,
     deviceList,
     audioMeter,
+    mediaAccess,
     refreshBackend,
     openSystemPermission,
     exportSupportBundle,
@@ -116,7 +117,12 @@ export function SettingsTab({
     return () => window.removeEventListener('focus', onFocus)
   }, [refreshBackend])
 
-  const accessRows = systemAccessRows({ deviceList, audioMeter, platform: runtimeInfo?.platform })
+  const accessRows = systemAccessRows({
+    deviceList,
+    audioMeter,
+    platform: runtimeInfo?.platform,
+    mediaAccess
+  })
 
   const createOutputDirectory = async (): Promise<void> => {
     if (!outputDirectory) {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -81,6 +81,7 @@ import type {
   Device,
   DeviceList,
   EntitlementsSnapshot,
+  MediaAccessSnapshot,
   ExportPublishPackResult,
   FileAssessment,
   GateStatus,
@@ -471,6 +472,8 @@ export type StudioContextValue = {
   setSelectedSceneSourceId: Dispatch<SetStateAction<string | null>>
   audioMeter: AudioMeterResult | null
   audioMeterLoading: boolean
+  /** Real OS camera/mic access status (null before the first read). */
+  mediaAccess: MediaAccessSnapshot | null
   // ai + jobs
   aiConsent: boolean
   setAiConsent: Dispatch<SetStateAction<boolean>>
@@ -1225,6 +1228,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const [selectedSceneSourceId, setSelectedSceneSourceId] = useState<string | null>(null)
   const [audioMeter, setAudioMeter] = useState<AudioMeterResult | null>(null)
   const [audioMeterLoading, setAudioMeterLoading] = useState(false)
+  // The OS's real camera/mic access state (Electron getMediaAccessStatus).
+  // On Windows this is what makes the permission chips truthful — the audio
+  // meter has no capture backend there, so it can't report mic permission.
+  const [mediaAccess, setMediaAccess] = useState<MediaAccessSnapshot | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [aiConsent, setAiConsent] = useState(false)
   const [aiRunningSessionId, setAiRunningSessionId] = useState<string | null>(null)
@@ -2925,6 +2932,35 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     sceneEditMode,
     settings.ffmpegPath
   ])
+
+  // Real OS camera/mic access status (Electron getMediaAccessStatus, over IPC —
+  // independent of the backend socket). Refresh on mount and whenever the window
+  // regains focus, since grants flip in the OS Settings while we're backgrounded
+  // — the same trigger the Settings/onboarding chips already use.
+  useEffect(() => {
+    const bridge = window.videorc?.getMediaAccessStatus
+    if (!bridge) {
+      return
+    }
+    let cancelled = false
+    const refresh = (): void => {
+      void bridge()
+        .then((snapshot) => {
+          if (!cancelled) {
+            setMediaAccess(snapshot)
+          }
+        })
+        .catch(() => {
+          // Non-fatal: the chips fall back to the meter/enumeration derivation.
+        })
+    }
+    refresh()
+    window.addEventListener('focus', refresh)
+    return () => {
+      cancelled = true
+      window.removeEventListener('focus', refresh)
+    }
+  }, [])
 
   useEffect(() => {
     if (!client || wsStatus !== 'connected' || sceneEditMode) {
@@ -6278,6 +6314,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       setSelectedSceneSourceId,
       audioMeter,
       audioMeterLoading,
+      mediaAccess,
       aiConsent,
       setAiConsent,
       aiRunningSessionId,
@@ -6452,6 +6489,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       setSelectedSceneSourceId,
       audioMeter,
       audioMeterLoading,
+      mediaAccess,
       aiConsent,
       setAiConsent,
       aiRunningSessionId,

--- a/apps/desktop/src/renderer/src/lib/system-access.test.ts
+++ b/apps/desktop/src/renderer/src/lib/system-access.test.ts
@@ -4,6 +4,7 @@ import type { AudioMeterResult, DeviceList } from '@/lib/backend'
 
 import {
   cameraAccessState,
+  mediaAccessToState,
   microphoneAccessState,
   screenAccessState,
   shouldShowPermissionsOnboarding,
@@ -181,5 +182,33 @@ describe('systemAccessRows', () => {
     expect(shouldShowPermissionsOnboarding({ rows, dismissed: false, backendReady: true })).toBe(
       false
     )
+  })
+
+  it('derives Windows camera/mic from the real OS access status, not the meter', () => {
+    // The tester's exact case: mic meter is 'unavailable' (no Windows backend)
+    // and the camera enumerates, but the OS says microphone is denied. The chip
+    // must reflect the OS, not sit on a misleading "first use".
+    const rows = systemAccessRows({
+      deviceList: devices([{ kind: 'camera', status: 'available' }]),
+      audioMeter: { status: 'unavailable' },
+      platform: 'win32',
+      mediaAccess: { camera: 'granted', microphone: 'denied' }
+    })
+    const mic = rows.find((row) => row.id === 'microphone')
+    const camera = rows.find((row) => row.id === 'camera')
+    expect(camera?.state).toBe('granted')
+    expect(mic?.state).toBe('not-granted')
+    // Windows guidance points at the umbrella toggle and says the app isn't listed.
+    expect(mic?.detail).toMatch(/Let desktop apps access your microphone/)
+    expect(mic?.detail).toMatch(/isn.t listed by name/)
+  })
+
+  it('mediaAccessToState maps OS statuses to chip states', () => {
+    expect(mediaAccessToState('granted')).toBe('granted')
+    expect(mediaAccessToState('denied')).toBe('not-granted')
+    expect(mediaAccessToState('restricted')).toBe('not-granted')
+    expect(mediaAccessToState('not-determined')).toBe('first-use')
+    expect(mediaAccessToState('unknown')).toBe('first-use')
+    expect(mediaAccessToState(undefined)).toBe('first-use')
   })
 })

--- a/apps/desktop/src/renderer/src/lib/system-access.ts
+++ b/apps/desktop/src/renderer/src/lib/system-access.ts
@@ -1,4 +1,4 @@
-import type { AudioMeterResult, Device, DeviceList } from '@/lib/backend'
+import type { AudioMeterResult, Device, DeviceList, MediaAccessStatus } from '@/lib/backend'
 import { appPlatform, osSettingsName, type AppPlatform } from '@/lib/platform'
 
 // ST3 (Settings rework): live permission states for the System access rows.
@@ -74,18 +74,47 @@ export function microphoneAccessState(audioMeter: AudioMeterResult | null): Syst
   return 'first-use'
 }
 
+// Maps the OS's real getMediaAccessStatus to a chip state. This is the truthful
+// source on Windows, where the audio meter has no capture backend and the
+// camera enumerates regardless of the privacy toggle, so the meter/enumeration
+// derivations above would leave both stuck on "first-use" (the tester's stuck
+// mic chip). 'denied'/'restricted' → the desktop-apps toggle is off.
+export function mediaAccessToState(status: MediaAccessStatus | undefined): SystemAccessState {
+  switch (status) {
+    case 'granted':
+      return 'granted'
+    case 'denied':
+    case 'restricted':
+      return 'not-granted'
+    default:
+      // 'not-determined' | 'unknown' | undefined
+      return 'first-use'
+  }
+}
+
 export function systemAccessRows({
   deviceList,
   audioMeter,
-  platform
+  platform,
+  mediaAccess
 }: {
   deviceList: DeviceList
   audioMeter: AudioMeterResult | null
   platform?: string
+  mediaAccess?: { camera: MediaAccessStatus; microphone: MediaAccessStatus } | null
 }): SystemAccessRow[] {
   const os = appPlatform(platform)
-  const camera = cameraAccessState(deviceList)
-  const microphone = microphoneAccessState(audioMeter)
+  // On Windows the OS access status is the honest signal (see mediaAccessToState);
+  // macOS keeps its TCC-aware enumeration/meter derivation, which already
+  // distinguishes denied from first-use.
+  const camera =
+    os === 'win32' && mediaAccess
+      ? mediaAccessToState(mediaAccess.camera)
+      : cameraAccessState(deviceList)
+  const microphone =
+    os === 'win32' && mediaAccess
+      ? mediaAccessToState(mediaAccess.microphone)
+      : microphoneAccessState(audioMeter)
 
   const rows: SystemAccessRow[] = []
 
@@ -151,6 +180,12 @@ export function shouldShowPermissionsOnboarding({
 
 function accessDetail(state: SystemAccessState, subject: string, os: AppPlatform): string {
   const settings = osSettingsName(os === 'other' ? undefined : os)
+  if (os === 'win32' && (state === 'not-granted' || state === 'first-use')) {
+    // Windows gates desktop (non-Store) apps behind a single umbrella toggle
+    // and does NOT list them by name — the tester was hunting for "Videorc" in
+    // a list where it can never appear. Point at the two real levers instead.
+    return `In ${settings} → Privacy & security → ${windowsPrivacyPageName(subject)}, turn on access and “Let desktop apps access your ${windowsDeviceNoun(subject)}”. Videorc is a desktop app, so it isn’t listed by name.`
+  }
   switch (state) {
     case 'granted':
       return 'Permission granted.'
@@ -160,10 +195,16 @@ function accessDetail(state: SystemAccessState, subject: string, os: AppPlatform
       // ships the entitlements, so Settings is the right pointer.
       return `Your ${settings} is blocking ${subject} — grant access there.`
     case 'first-use':
-      return os === 'win32'
-        ? `Grant ${subject} in ${settings} if it is turned off.`
-        : `${settings} reports this on first use.`
+      return `${settings} reports this on first use.`
     case 'device-issue':
       return 'The device opened but did not send audio frames.'
   }
+}
+
+function windowsPrivacyPageName(subject: string): string {
+  return subject.includes('camera') ? 'Camera' : 'Microphone'
+}
+
+function windowsDeviceNoun(subject: string): string {
+  return subject.includes('camera') ? 'camera' : 'microphone'
 }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1870,6 +1870,15 @@ export interface DiagnosticStats {
 export type HealthLevel = 'info' | 'warn' | 'error'
 export type SystemPermissionPane = 'privacy' | 'screen-recording' | 'camera' | 'microphone'
 
+// Mirrors Electron systemPreferences.getMediaAccessStatus return values, plus
+// 'unknown' for platforms/errors where it cannot be read.
+export type MediaAccessStatus = 'not-determined' | 'granted' | 'denied' | 'restricted' | 'unknown'
+
+export interface MediaAccessSnapshot {
+  camera: MediaAccessStatus
+  microphone: MediaAccessStatus
+}
+
 export interface HealthEvent {
   id: string
   sessionId?: string
@@ -2435,6 +2444,11 @@ export interface VideorcApi {
   destroyNativePreviewSurface: (generation?: number) => Promise<PreviewSurfaceStatus>
   getNativePreviewSurfaceStatus: () => Promise<PreviewSurfaceStatus>
   openSystemPermissions: (pane?: SystemPermissionPane) => Promise<void>
+  /** The OS's real camera/microphone access state (Electron
+   * getMediaAccessStatus — supported on macOS AND Windows). Lets the UI show a
+   * truthful chip on Windows, where the audio meter has no capture backend and
+   * would otherwise leave the mic stuck on "checked on first use". */
+  getMediaAccessStatus: () => Promise<MediaAccessSnapshot>
   /** Fire the native macOS grant prompt in place (no System Settings jump).
    * `restarted` is true only when a fresh grant restarted the capture backend
    * — callers probing a device right after must wait for reconnect first. */


### PR DESCRIPTION
## The report (Windows tester)

- Clicking **Enable** for the microphone did nothing — no prompt, no request.
- The settings deep link opened **Privacy → Microphone**, but **Videorc never appears in the list**, so there was no way to grant access.

## Root cause

Two real Windows facts the flow ignored:

1. **No renderer code read the real OS permission.** The mic chip was derived from the audio meter — which has no Windows capture backend — so it sat on "checked on first use" forever, and the **"Enable" button fired `askForMediaAccess`, a macOS-only API**, so on Windows it was a dead no-op.
2. **Windows does not list unpackaged desktop apps by name** in the Camera/Microphone privacy pages. Desktop (non-Store) apps are governed by a single **"Let desktop apps access your microphone"** umbrella toggle plus the master access toggle. The tester was hunting for "Videorc" in a list where it can never appear.

## Fix

- **Backend**: new `system:media-access-status` IPC returns the real `getMediaAccessStatus` for camera + mic (supported on **Windows and macOS**; only `askForMediaAccess` is mac-only), wrapped to degrade to `unknown`. Preload bridge + shared `MediaAccessSnapshot` type. `use-studio` fetches it on mount and on window focus (grants flip in Settings while backgrounded).
- **Chips are truthful on Windows**: camera/mic derive from that OS status (`granted` → granted, `denied`/`restricted` → not-granted, else first-use) instead of the unavailable meter / bare enumeration. The Windows detail copy names the two real levers and says the app isn't listed by name.
- **Onboarding**: no dead in-place "Enable" on Windows — every row opens Settings, and a visible note explains the desktop-apps umbrella toggle.
- **macOS unchanged**: the `askForMediaAccess` prompt and TCC-aware enumeration are untouched, guarded by tests.

## Validation
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter @videorc/desktop test` (505 passed), `pnpm build` — green
- New tests: Windows derivation from OS status (the tester's exact "meter unavailable + mic denied" case), `mediaAccessToState` mapping, and the desktop-apps guidance copy.

The Windows gates CI job on this PR is the on-box compile check; the tester confirming they can now reach a granted state (via the umbrella toggle) is the acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OS camera and microphone access detection in the desktop app.
  * Updated permission panels and settings to show media access status and clearer guidance, including Windows-specific help and settings shortcuts.

* **Bug Fixes**
  * Improved permission state accuracy on Windows by using the system’s real media access status.
  * Added safer handling when access status can’t be read, so the app falls back gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->