### PR TITLE
Fix Windows recording blocked by macOS-only camera cadence gate

### DIFF
--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -3687,6 +3687,11 @@ const RECORDING_CAMERA_CADENCE_READY_TIMEOUT: Duration = Duration::from_millis(3
 const RECORDING_CAMERA_CADENCE_READY_POLL: Duration = Duration::from_millis(25);
 const RECORDING_CAMERA_CADENCE_FRAME_INTERVAL_FACTOR: f64 = 2.1;
 const RECORDING_CAMERA_CADENCE_MAX_FRAME_AGE_MS: u64 = 250;
+// The FFmpeg/dshow callback cadence (Windows) is jitterier than AVFoundation's
+// sample-PTS cadence, so its readiness budget is more generous: the compositor
+// absorbs occasional camera hitches, and frame freshness already proves the
+// stream is live. ~140ms p95 at 30fps still catches a genuinely stalled camera.
+const RECORDING_CAMERA_CADENCE_CALLBACK_BUDGET_FACTOR: f64 = 2.0;
 const RECORDING_ENCODER_BRIDGE_SOURCE_READY_TIMEOUT: Duration = Duration::from_millis(750);
 const RECORDING_ENCODER_BRIDGE_SOURCE_READY_POLL: Duration = Duration::from_millis(25);
 
@@ -3814,7 +3819,12 @@ async fn await_recording_camera_cadence_ready(
             )
         };
 
-        if camera_cadence_ready(sample_pts_gap_p95_ms, frame_age_ms, threshold_ms) {
+        if camera_cadence_ready(
+            sample_pts_gap_p95_ms,
+            callback_gap_p95_ms,
+            frame_age_ms,
+            threshold_ms,
+        ) {
             let _ = emit_health_event(
                 state,
                 Some(session_id),
@@ -3855,11 +3865,31 @@ async fn await_recording_camera_cadence_ready(
 
 fn camera_cadence_ready(
     sample_pts_gap_p95_ms: Option<f64>,
+    callback_gap_p95_ms: Option<f64>,
     frame_age_ms: Option<u64>,
     threshold_ms: f64,
 ) -> bool {
-    sample_pts_gap_p95_ms.is_some_and(|gap| gap.is_finite() && gap <= threshold_ms)
-        && frame_age_ms.is_some_and(|age| age <= RECORDING_CAMERA_CADENCE_MAX_FRAME_AGE_MS)
+    let frames_fresh =
+        frame_age_ms.is_some_and(|age| age <= RECORDING_CAMERA_CADENCE_MAX_FRAME_AGE_MS);
+    if !frames_fresh {
+        return false;
+    }
+
+    match sample_pts_gap_p95_ms.filter(|gap| gap.is_finite()) {
+        // macOS AVFoundation native capture reports per-sample presentation
+        // timestamps, so we gate on that precise cadence.
+        Some(gap) => gap <= threshold_ms,
+        // The FFmpeg-fed path (Windows dshow) delivers raw frames with no
+        // per-sample PTS, so `sample_pts_gap` is never measured — the old gate
+        // could never pass and blocked every recording. The compositor reads
+        // the frame store on its own clock and repeats the last frame across a
+        // camera hitch, so readiness here is a SUSTAINED, fresh stream: a
+        // measured callback cadence within a lenient budget (dshow jitter runs
+        // higher than AVFoundation) plus a recent frame (checked above).
+        None => callback_gap_p95_ms.is_some_and(|gap| {
+            gap.is_finite() && gap <= threshold_ms * RECORDING_CAMERA_CADENCE_CALLBACK_BUDGET_FACTOR
+        }),
+    }
 }
 
 fn camera_cadence_ready_threshold_ms(target_fps: u32) -> f64 {
@@ -9713,11 +9743,60 @@ mod tests {
         let threshold = camera_cadence_ready_threshold_ms(30);
 
         assert!(threshold > 69.0 && threshold < 71.0);
-        assert!(camera_cadence_ready(Some(33.3), Some(40), threshold));
-        assert!(camera_cadence_ready(Some(66.7), Some(40), threshold));
-        assert!(!camera_cadence_ready(Some(83.3), Some(40), threshold));
-        assert!(!camera_cadence_ready(Some(33.3), Some(300), threshold));
-        assert!(!camera_cadence_ready(None, Some(40), threshold));
+        // macOS AVFoundation path: gated on the per-sample PTS cadence.
+        assert!(camera_cadence_ready(
+            Some(33.3),
+            Some(30.0),
+            Some(40),
+            threshold
+        ));
+        assert!(camera_cadence_ready(
+            Some(66.7),
+            Some(30.0),
+            Some(40),
+            threshold
+        ));
+        assert!(!camera_cadence_ready(
+            Some(83.3),
+            Some(30.0),
+            Some(40),
+            threshold
+        ));
+        assert!(!camera_cadence_ready(
+            Some(33.3),
+            Some(30.0),
+            Some(300),
+            threshold
+        ));
+    }
+
+    #[test]
+    fn camera_cadence_guard_falls_back_to_callback_cadence_without_sample_pts() {
+        // The Windows FFmpeg/dshow path reports no per-sample PTS, so the gate
+        // must not require it — otherwise recording is blocked forever (the
+        // tester's "cadence did not settle, sample PTS p95 n/a"). It falls back
+        // to a fresh, sustained callback cadence within a lenient budget.
+        let threshold = camera_cadence_ready_threshold_ms(30);
+
+        // The exact tester numbers: no sample PTS, callback p95 76.9ms, age 37ms.
+        assert!(camera_cadence_ready(None, Some(76.9), Some(37), threshold));
+        // A truly stalled camera (callback p95 far over the lenient budget) or
+        // stale frames still block.
+        assert!(!camera_cadence_ready(
+            None,
+            Some(200.0),
+            Some(37),
+            threshold
+        ));
+        assert!(!camera_cadence_ready(
+            None,
+            Some(76.9),
+            Some(300),
+            threshold
+        ));
+        // No frames and no callback cadence at all is not ready.
+        assert!(!camera_cadence_ready(None, None, Some(40), threshold));
+        assert!(!camera_cadence_ready(None, Some(76.9), None, threshold));
     }
 
     #[test]


### PR DESCRIPTION
## The report (Windows tester)

> Recording startup blocked before encoding: camera sample PTS cadence did not settle (sample PTS p95 **n/a**, threshold 70ms, callback p95 76.9ms, frame age 37ms).

Recording never started — the camera source could not clear the startup readiness gate. (The tester also saw "Pending native system-audio adapter", which is just the honest placeholder for the not-yet-implemented desktop-audio loopback feature — not a bug, and not the blocker.)

## Cause

The camera cadence gate (`camera_cadence_ready`) hard-required `sample_pts_gap_p95_ms` — a per-sample presentation-timestamp metric that **only the macOS AVFoundation native capture produces**. The Windows FFmpeg/dshow preview publishes raw BGRA frames over a pipe with no per-sample PTS, so that metric is always `None` ("p95 n/a"), the gate could never pass, and every recording timed out at the 3-second barrier. The Windows path *does* report the other two signals (callback p95 76.9ms, frame age 37ms) — the gate just wasn't looking at them.

## Fix

`camera_cadence_ready` now branches on metric availability:
- **sample PTS present (macOS)** → gate on that precise cadence, unchanged.
- **sample PTS absent (Windows FFmpeg path)** → fall back to a fresh, sustained stream: a measured callback cadence within a lenient budget (dshow jitter runs higher than AVFoundation, so 2× the frame-interval threshold — ~140ms p95 at 30fps) plus a recent frame. The compositor reads the frame store on its own clock and repeats the last frame across a hitch, so this still produces a correct recording. A truly stalled camera (no callback cadence, stale frames, or p95 far over budget) still blocks.

The tester's exact numbers now pass. macOS behavior is untouched.

## Validation
- `cargo fmt --check --all`, `cargo test -p videorc-backend` (872 pass), `cargo clippy -p videorc-backend -- -D warnings` — green
- `pnpm check:windows` — exit 0 (Windows cross-compile)
- New test covers the Windows callback fallback (the tester's 76.9ms / 37ms case) plus the still-block stall cases; the macOS sample-PTS test stays.

The Windows gates CI job on this PR is the on-box compile check; the tester recording successfully is the acceptance (CI runners have no camera).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording start checks so camera readiness is evaluated more reliably across different platforms.
  * Recording now better distinguishes between fresh frames and stable capture timing, reducing cases where recording could begin too early or be delayed unnecessarily.
  * Added support for systems that don’t provide frame timing details, with a fallback that uses callback timing to determine readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->