### PR TITLE
docs: add Contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ on the shape before you invest in a PR. Read [AGENTS.md](AGENTS.md) before
 touching recording or native-preview code — those areas have non-negotiable
 verification gates.
 
+## Contributors
+
+- **[TheOrcDev](https://github.com/TheOrcDev)** — founder & lead developer
+
+<p align="center">
+  <a href="https://github.com/TheOrcDev/videorc/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=TheOrcDev/videorc" alt="Contributors" />
+  </a>
+</p>
+
 ## License
 
 Code: [AGPL-3.0](LICENSE). Brand: the Videorc name, logo, and app icon are not


### PR DESCRIPTION
Adds a **Contributors** section to the README.

- Explicitly lists TheOrcDev as the first contributor (founder & lead developer).
- Includes the dynamic [contrib.rocks](https://contrib.rocks) image so the list will automatically update as more people contribute.

This is a documentation-only change.

## Changes
- New `## Contributors` section between "Contributing" and "License"
- Founder listed first in a clean bullet list
- Auto-updating contributors graphic

## Verification
- Docs-only; no code, tests, or product behavior changes.