### PR TITLE
docs: update TheOrcDev title to Warchief

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ verification gates.
 
 ## Contributors
 
-- **[TheOrcDev](https://github.com/TheOrcDev)** — founder & lead developer
+- **[TheOrcDev](https://github.com/TheOrcDev)** — Warchief
 
 <p align="center">
   <a href="https://github.com/TheOrcDev/videorc/graphs/contributors">


### PR DESCRIPTION
Swaps the plain 'founder & lead developer' line for something more orcish and cool: **Warchief**.

This keeps the tone fun and on-brand for Videorc.