### PR TITLE
Fix blank preview on broken-GPU Windows (Insider): opaque surface + GPU fallback

### DIFF
--- a/apps/desktop/src/main/gpu-fallback.test.ts
+++ b/apps/desktop/src/main/gpu-fallback.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GPU_CRASH_PERSIST_THRESHOLD,
+  decideGpuFallback,
+  gpuFallbackStatePath,
+  isGpuCrashReason,
+  readGpuFallbackState,
+  shouldPersistGpuFallback,
+  writeGpuFallbackState,
+  type GpuFallbackState
+} from './gpu-fallback'
+
+const persisted: GpuFallbackState = {
+  disableHardwareAcceleration: true,
+  reason: 'gpu-process-crashes',
+  crashCount: 2,
+  updatedAt: '2026-07-09T00:00:00.000Z'
+}
+
+describe('decideGpuFallback', () => {
+  it('honors the explicit escape hatch every launch', () => {
+    expect(decideGpuFallback({ env: { VIDEORC_DISABLE_GPU: '1' }, persisted: null })).toEqual({
+      disable: true,
+      source: 'env',
+      clearPersisted: false
+    })
+  })
+
+  it('applies a persisted crash fallback on the next launch', () => {
+    expect(decideGpuFallback({ env: {}, persisted })).toEqual({
+      disable: true,
+      source: 'persisted',
+      clearPersisted: false
+    })
+  })
+
+  it('VIDEORC_FORCE_GPU overrides and clears the persisted flag', () => {
+    expect(decideGpuFallback({ env: { VIDEORC_FORCE_GPU: '1' }, persisted })).toEqual({
+      disable: false,
+      source: 'none',
+      clearPersisted: true
+    })
+    // Nothing persisted → nothing to clear.
+    expect(decideGpuFallback({ env: { VIDEORC_FORCE_GPU: '1' }, persisted: null })).toEqual({
+      disable: false,
+      source: 'none',
+      clearPersisted: false
+    })
+  })
+
+  it('defaults to hardware acceleration', () => {
+    expect(decideGpuFallback({ env: {}, persisted: null })).toEqual({
+      disable: false,
+      source: 'none',
+      clearPersisted: false
+    })
+  })
+})
+
+describe('crash counting', () => {
+  it('persists only after repeated crashes (first crash can be a fluke)', () => {
+    expect(shouldPersistGpuFallback(1)).toBe(false)
+    expect(shouldPersistGpuFallback(GPU_CRASH_PERSIST_THRESHOLD)).toBe(true)
+  })
+
+  it('counts only genuine crash reasons, never clean shutdowns', () => {
+    expect(isGpuCrashReason('crashed')).toBe(true)
+    expect(isGpuCrashReason('launch-failed')).toBe(true)
+    expect(isGpuCrashReason('abnormal-exit')).toBe(true)
+    expect(isGpuCrashReason('oom')).toBe(true)
+    expect(isGpuCrashReason('clean-exit')).toBe(false)
+    expect(isGpuCrashReason('killed')).toBe(false)
+  })
+})
+
+describe('state persistence', () => {
+  it('round-trips through the injected store', () => {
+    let written = ''
+    writeGpuFallbackState(gpuFallbackStatePath('/data'), persisted, {
+      writeFile: (_path, contents) => {
+        written = contents
+      },
+      makeDir: () => undefined
+    })
+    const roundTripped = readGpuFallbackState('/data/gpu-fallback.json', {
+      readFile: () => written
+    })
+    expect(roundTripped).toEqual(persisted)
+  })
+
+  it('treats missing or corrupt state as no fallback (never blocks startup)', () => {
+    expect(
+      readGpuFallbackState('/data/gpu-fallback.json', {
+        readFile: () => {
+          throw new Error('ENOENT')
+        }
+      })
+    ).toBeNull()
+    expect(readGpuFallbackState('/data/gpu-fallback.json', { readFile: () => 'not json' })).toBe(
+      null
+    )
+    expect(readGpuFallbackState('/data/gpu-fallback.json', { readFile: () => '{"x":1}' })).toBe(
+      null
+    )
+  })
+})

--- a/apps/desktop/src/main/gpu-fallback.ts
+++ b/apps/desktop/src/main/gpu-fallback.ts
@@ -1,0 +1,132 @@
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+// GPU fallback policy for machines where the Chromium GPU process is broken
+// (seen on Windows Insider builds: the app only boots with GPU flags and
+// window compositing silently fails). Two entry points:
+//
+//   • VIDEORC_DISABLE_GPU=1 — explicit user escape hatch, honored every launch.
+//   • Automatic: repeated GPU-process crashes in one launch persist a flag in
+//     userData, and the NEXT launch disables hardware acceleration before
+//     app.ready. VIDEORC_FORCE_GPU=1 overrides and clears the persisted flag.
+//
+// Everything here is pure/injected so the policy is unit-testable; index.ts
+// wires it to app.disableHardwareAcceleration() and child-process-gone.
+
+/** GPU-process crashes in ONE launch before we persist the fallback. The first
+ * crash can be a fluke Chromium recovers from; a second means the GPU path is
+ * genuinely unreliable on this machine. */
+export const GPU_CRASH_PERSIST_THRESHOLD = 2
+
+export interface GpuFallbackState {
+  disableHardwareAcceleration: boolean
+  reason: string
+  crashCount: number
+  updatedAt: string
+}
+
+export function gpuFallbackStatePath(userDataDir: string): string {
+  return join(userDataDir, 'gpu-fallback.json')
+}
+
+export function shouldPersistGpuFallback(crashCount: number): boolean {
+  return crashCount >= GPU_CRASH_PERSIST_THRESHOLD
+}
+
+/** child-process-gone reasons that indicate a genuinely broken GPU process —
+ * clean shutdowns must not count toward the fallback. */
+export function isGpuCrashReason(reason: string): boolean {
+  switch (reason) {
+    case 'crashed':
+    case 'abnormal-exit':
+    case 'launch-failed':
+    case 'integrity-failure':
+    case 'oom':
+      return true
+    default:
+      return false
+  }
+}
+
+export interface GpuFallbackDecision {
+  disable: boolean
+  /** Human-readable source of the decision, for logs / runtime info. */
+  source: 'env' | 'persisted' | 'none'
+  /** True when VIDEORC_FORCE_GPU=1 asked us to clear a persisted fallback. */
+  clearPersisted: boolean
+}
+
+export function decideGpuFallback({
+  env,
+  persisted
+}: {
+  env: Partial<Pick<NodeJS.ProcessEnv, 'VIDEORC_DISABLE_GPU' | 'VIDEORC_FORCE_GPU'>>
+  persisted: GpuFallbackState | null
+}): GpuFallbackDecision {
+  if (env.VIDEORC_FORCE_GPU === '1') {
+    return { disable: false, source: 'none', clearPersisted: persisted !== null }
+  }
+  if (env.VIDEORC_DISABLE_GPU === '1') {
+    return { disable: true, source: 'env', clearPersisted: false }
+  }
+  if (persisted?.disableHardwareAcceleration) {
+    return { disable: true, source: 'persisted', clearPersisted: false }
+  }
+  return { disable: false, source: 'none', clearPersisted: false }
+}
+
+export interface GpuFallbackStore {
+  readFile?: (path: string) => string
+  writeFile?: (path: string, contents: string) => void
+  makeDir?: (path: string) => void
+  removeFile?: (path: string) => void
+}
+
+export function readGpuFallbackState(
+  path: string,
+  { readFile = (target) => readFileSync(target, 'utf8') }: GpuFallbackStore = {}
+): GpuFallbackState | null {
+  try {
+    const parsed = JSON.parse(readFile(path)) as unknown
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as GpuFallbackState).disableHardwareAcceleration === 'boolean'
+    ) {
+      const state = parsed as Partial<GpuFallbackState>
+      return {
+        disableHardwareAcceleration: state.disableHardwareAcceleration === true,
+        reason: typeof state.reason === 'string' ? state.reason : 'unknown',
+        crashCount: typeof state.crashCount === 'number' ? state.crashCount : 0,
+        updatedAt: typeof state.updatedAt === 'string' ? state.updatedAt : ''
+      }
+    }
+    return null
+  } catch {
+    // Missing or unreadable state means no fallback — never block startup.
+    return null
+  }
+}
+
+export function writeGpuFallbackState(
+  path: string,
+  state: GpuFallbackState,
+  {
+    writeFile = (target, contents) => writeFileSync(target, contents),
+    makeDir = (target) => mkdirSync(target, { recursive: true })
+  }: GpuFallbackStore = {}
+): void {
+  makeDir(dirname(path))
+  writeFile(path, `${JSON.stringify(state, null, 2)}\n`)
+}
+
+export function clearGpuFallbackState(
+  path: string,
+  { removeFile = (target) => rmSync(target, { force: true }) }: GpuFallbackStore = {}
+): void {
+  try {
+    removeFile(path)
+  } catch {
+    // Best-effort: a stale flag only re-disables acceleration, never worse.
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -57,6 +57,15 @@ import {
   permissionUrlForPane
 } from './runtime-info'
 import { requestMediaAccessWithRestart, type MediaAccessResult } from './media-access'
+import {
+  clearGpuFallbackState,
+  decideGpuFallback,
+  gpuFallbackStatePath,
+  isGpuCrashReason,
+  readGpuFallbackState,
+  shouldPersistGpuFallback,
+  writeGpuFallbackState
+} from './gpu-fallback'
 import { createMediaPermissionGrantWatcher } from './system-permission-watch'
 import { PreviewSupervisorModel } from './preview-supervisor'
 import {
@@ -311,6 +320,57 @@ if (remoteDebugPortOverride) {
 if (process.env.VIDEORC_SMOKE_DISABLE_ELECTRON_GPU === '1') {
   app.commandLine.appendSwitch('disable-gpu')
 }
+// GPU fallback (Windows Insider incident: broken Chromium GPU process boots
+// only with GPU flags and composites transparent windows as BLANK). Must run
+// before app.ready: VIDEORC_DISABLE_GPU=1 is the explicit user hatch, a
+// persisted gpu-fallback.json (written after repeated GPU crashes, below)
+// self-heals the next launch, and VIDEORC_FORCE_GPU=1 overrides + clears it.
+const gpuFallbackFile = gpuFallbackStatePath(app.getPath('userData'))
+const gpuFallbackDecision = decideGpuFallback({
+  env: process.env,
+  persisted: readGpuFallbackState(gpuFallbackFile)
+})
+if (gpuFallbackDecision.clearPersisted) {
+  clearGpuFallbackState(gpuFallbackFile)
+}
+if (gpuFallbackDecision.disable) {
+  app.disableHardwareAcceleration()
+}
+let gpuProcessCrashCount = 0
+let gpuFallbackPersistedThisLaunch = false
+app.on('child-process-gone', (_event, details) => {
+  // Every abnormal child exit is worth a support-bundle line; GPU crashes
+  // additionally drive the persisted software-rendering fallback.
+  if (details.type !== 'GPU' || !isGpuCrashReason(details.reason)) {
+    if (details.reason !== 'clean-exit' && details.reason !== 'killed') {
+      logBackend(
+        'warn',
+        `Chromium ${details.type} process gone (${details.reason}, exit ${details.exitCode ?? 'n/a'}).`
+      )
+    }
+    return
+  }
+  gpuProcessCrashCount += 1
+  logBackend(
+    'warn',
+    `GPU process crashed (${details.reason}, ${gpuProcessCrashCount} this launch). Repeated crashes switch Videorc to software rendering on the next launch.`
+  )
+  if (!gpuFallbackDecision.disable && !gpuFallbackPersistedThisLaunch) {
+    if (shouldPersistGpuFallback(gpuProcessCrashCount)) {
+      gpuFallbackPersistedThisLaunch = true
+      writeGpuFallbackState(gpuFallbackFile, {
+        disableHardwareAcceleration: true,
+        reason: 'gpu-process-crashes',
+        crashCount: gpuProcessCrashCount,
+        updatedAt: new Date().toISOString()
+      })
+      logBackend(
+        'warn',
+        'GPU process is unreliable on this machine — Videorc will use software rendering from the next launch (set VIDEORC_FORCE_GPU=1 to undo).'
+      )
+    }
+  }
+})
 // Keep the detached preview window live while it sits behind the main window.
 // A scene change is made in the main window, so the preview is occluded at that
 // moment — and macOS/Chromium stops compositing a fully-occluded window, which
@@ -3395,7 +3455,13 @@ async function createNativePreviewSurfaceWindow(generation: number): Promise<voi
       // it and moves with it like one app.
       parent: previewWindow ?? mainWindow,
       frame: false,
-      transparent: true,
+      // Transparency requires the GPU compositor on Windows — with a broken
+      // GPU process (Windows Insider builds) a transparent window composites
+      // NOTHING and the preview reads as a blank canvas even though the <img>
+      // polling underneath is fully software-safe. Off macOS the surface is
+      // opaque over a solid dark base; macOS keeps transparency (its real
+      // preview path is the CAMetalLayer helper anyway).
+      transparent: isMac,
       focusable: false,
       skipTaskbar: true,
       hasShadow: false,
@@ -3404,7 +3470,7 @@ async function createNativePreviewSurfaceWindow(generation: number): Promise<voi
       // user-movable and never a click target.
       movable: false,
       show: false,
-      backgroundColor: '#00000000',
+      backgroundColor: isMac ? '#00000000' : '#101014',
       ...appWindowIconOptions(),
       webPreferences: {
         sandbox: true,
@@ -7088,6 +7154,7 @@ async function runtimeInfo(): Promise<RuntimeInfo> {
     arch: process.arch,
     osRelease: release(),
     gpuInfo,
+    hardwareAccelerationDisabled: gpuFallbackDecision.disable,
     env: process.env
   })
 }

--- a/apps/desktop/src/main/runtime-info.ts
+++ b/apps/desktop/src/main/runtime-info.ts
@@ -27,6 +27,7 @@ export interface RuntimeInfoInput {
   arch?: string
   osRelease?: string
   gpuInfo?: unknown
+  hardwareAccelerationDisabled?: boolean
   env: Partial<
     Pick<
       NodeJS.ProcessEnv,
@@ -84,6 +85,7 @@ export function buildRuntimeInfo({
   arch = process.arch,
   osRelease = release(),
   gpuInfo,
+  hardwareAccelerationDisabled = false,
   env
 }: RuntimeInfoInput): RuntimeInfo {
   const targetPath = permissionTargetPath(execPath)
@@ -96,6 +98,7 @@ export function buildRuntimeInfo({
     arch,
     osRelease,
     gpuDevices: normalizeRuntimeGpuDevices(gpuInfo),
+    hardwareAccelerationDisabled,
     isPackaged,
     permissionTargetName: isPackaged ? 'Videorc' : 'Electron',
     permissionTargetPath: targetPath,

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -2160,6 +2160,10 @@ export interface RuntimeInfo {
   arch: string
   osRelease: string
   gpuDevices: RuntimeGpuDevice[]
+  /** True when Videorc is running with hardware acceleration disabled — via
+   * VIDEORC_DISABLE_GPU=1 or the persisted GPU-crash fallback. Surfaced so
+   * support bundles name the active graphics mode. */
+  hardwareAccelerationDisabled: boolean
   isPackaged: boolean
   permissionTargetName: string
   permissionTargetPath: string


### PR DESCRIPTION
Fix blank preview on broken-GPU Windows (Insider): opaque surface + GPU fallback

A Windows Insider tester reported the app boots only with
--disable-gpu-sandbox and the preview area is a blank canvas. The preview
draw path is already GPU-independent (plain <img> elements polling PNG over
HTTP from the backend) — the blank came from the ONE GPU dependency in the
chain: the proof-surface BrowserWindow was created transparent:true on every
platform, and transparent windows on Windows require the GPU compositor. A
dead GPU process composites the window as nothing, silently.

- Proof surface is opaque off macOS (solid dark base; the <img> layers paint
  on top). macOS keeps transparency — values there are bit-identical to
  before.
- VIDEORC_DISABLE_GPU=1 escape hatch -> app.disableHardwareAcceleration()
  before ready; VIDEORC_FORCE_GPU=1 overrides and clears the persisted
  fallback. (The old smoke-only flag stays.)
- Automatic self-heal: child-process-gone counts genuine GPU-process crashes;
  at >=2 in one launch a gpu-fallback.json is persisted in userData and the
  NEXT launch runs with hardware acceleration disabled. Policy is a pure,
  unit-tested module (gpu-fallback.ts).
- Observability: abnormal Chromium child exits land in the backend log ring
  (-> support bundle) and runtimeInfo gains hardwareAccelerationDisabled, so
  the active graphics mode is diagnosable remotely.

The tester's webRTC theory was a red herring: no webRTC, canvas, or <video>
exists anywhere in the preview path.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>