### PR TITLE
Fix Windows recording reliability

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -87,7 +87,15 @@ mac:
 # Windows 11 x64. Unsigned for now (internal testing); Authenticode signing is
 # Phase 5. The .exe backend and the windows-x64 ffmpeg dir override the
 # top-level (macOS) extraResources paths. See docs/windows-port-plan.md.
+#
+# signAndEditExecutable:false skips winCodeSign/rcedit. On Windows without
+# Developer Mode (or admin), extracting winCodeSign fails on unused macOS
+# dylib symlinks ("Cannot create symbolic link : A required privilege is not
+# held by the client"). Safe while we ship unsigned; re-enable for Authenticode
+# / icon resource editing and require Developer Mode or an elevated extract.
+# https://github.com/electron-userland/electron-builder/issues/8149
 win:
+  signAndEditExecutable: false
   icon: build-resources/icon.ico
   extraResources:
     # Host-target build: `pnpm package:backend` on the Windows box puts the

--- a/crates/videorc-backend/src/audio.rs
+++ b/crates/videorc-backend/src/audio.rs
@@ -998,12 +998,21 @@ mod windows_native {
     fn device_from_activate(activate: &IMFActivate, index: u32) -> Device {
         let friendly_name = mf_string(activate, &MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME)
             .unwrap_or_else(|| format!("Microphone {}", index + 1));
-        let capture_name = mf_string(
+        let symbolic_link = mf_string(
             activate,
             &MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_AUDCAP_SYMBOLIC_LINK,
-        )
-        .map(|symbolic_link| format!("@{symbolic_link}"))
-        .unwrap_or_else(|| friendly_name.clone());
+        );
+        // Same trap as the Windows camera path (camera_capture.rs): dshow's
+        // selector is the DirectShow FRIENDLY NAME (`audio=Microphone (...)`),
+        // not the MediaFoundation MMDEVAPI symbolic link. Encoding
+        // `@\\?\SWD#MMDEVAPI#...` into the device id made FFmpeg exit
+        // immediately at session start with:
+        //   Could not find audio only device with name [@\\?\SWD#MMDEVAPI#...]
+        //   Error opening input files: I/O error
+        //   FFmpeg exited with exit code: 0xfffffffb
+        // which the user sees as "recording starts then stops". Keep the
+        // symbolic link in detail for support bundles only.
+        let capture_name = friendly_name.clone();
         Device {
             id: windows_dshow_microphone_device_id(&capture_name),
             name: friendly_name.clone(),
@@ -1011,7 +1020,11 @@ mod windows_native {
             status: DeviceStatus::Available,
             detail: Some(windows_media_foundation_microphone_detail(
                 &friendly_name,
-                &capture_name,
+                symbolic_link
+                    .as_deref()
+                    .map(|link| format!("@{link}"))
+                    .as_deref()
+                    .unwrap_or(&capture_name),
             )),
             width: None,
             height: None,
@@ -1444,6 +1457,8 @@ mod tests {
 
     #[test]
     fn describes_windows_mediafoundation_microphone_detail() {
+        // Detail may still mention a symbolic link for support triage; the
+        // dshow capture name (device id payload) is the friendly name.
         assert_eq!(
             windows_media_foundation_microphone_detail(
                 "Microphone Array",
@@ -1454,6 +1469,14 @@ mod tests {
         assert_eq!(
             windows_media_foundation_microphone_detail("Microphone Array", "Microphone Array"),
             "Windows MediaFoundation microphone. Recording uses dshow device `Microphone Array`."
+        );
+        // Round-trip the id with the friendly name FFmpeg dshow accepts.
+        assert_eq!(
+            parse_windows_dshow_microphone_id(&windows_dshow_microphone_device_id(
+                "Microphone (HD Pro Webcam C920)"
+            ))
+            .as_deref(),
+            Some("Microphone (HD Pro Webcam C920)")
         );
     }
 

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -3682,7 +3682,21 @@ const MICROPHONE_WARMUP_TIMEOUT: Duration = Duration::from_millis(1500);
 const RECORDING_STARTUP_BARRIER_TIMEOUT: Duration = Duration::from_millis(2500);
 /// Consecutive target-resolution real-source compositor frames required before encoding.
 const RECORDING_STARTUP_BARRIER_MIN_FRAMES: u32 = 3;
+/// How many frame intervals the startup barrier allows between consecutive
+/// accepted compositor publishes. macOS Metal stays near the interval; Windows
+/// CPU compose + dshow delivery routinely lands 100–180ms gaps at session start
+/// (on-box: 130ms then 172ms over earlier 71ms/150ms budgets), so non-macOS uses
+/// a looser factor (~200ms at 30fps) plus a floor. Stalled pipelines still fail
+/// at multi-hundred-ms.
+#[cfg(target_os = "macos")]
 const RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR: f64 = 2.1;
+#[cfg(not(target_os = "macos"))]
+const RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR: f64 = 6.0;
+/// Windows compose/dshow startup gaps are often wall-clock-bound rather than
+/// pure multiples of the target frame interval; keep a hard floor so 60fps
+/// sessions do not inherit an unrealistically tight cadence budget.
+#[cfg(not(target_os = "macos"))]
+const RECORDING_STARTUP_CADENCE_MIN_FRAME_GAP: Duration = Duration::from_millis(200);
 const RECORDING_CAMERA_CADENCE_READY_TIMEOUT: Duration = Duration::from_millis(3000);
 const RECORDING_CAMERA_CADENCE_READY_POLL: Duration = Duration::from_millis(25);
 const RECORDING_CAMERA_CADENCE_FRAME_INTERVAL_FACTOR: f64 = 2.1;
@@ -3899,7 +3913,15 @@ fn camera_cadence_ready_threshold_ms(target_fps: u32) -> f64 {
 fn recording_startup_frame_gap_budget(target_fps: u32) -> Duration {
     let frame_interval_ms =
         1000.0 / f64::from(target_fps.max(1)) * RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR;
-    Duration::from_millis(frame_interval_ms.ceil() as u64)
+    let budget = Duration::from_millis(frame_interval_ms.ceil() as u64);
+    #[cfg(not(target_os = "macos"))]
+    {
+        return budget.max(RECORDING_STARTUP_CADENCE_MIN_FRAME_GAP);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        budget
+    }
 }
 
 fn optional_ms(value: Option<f64>) -> String {
@@ -4073,7 +4095,18 @@ fn append_h264_encoding_args_for_platform(
                 "1".to_string(),
             ]);
         }
-        FfmpegH264Platform::Windows => {}
+        FfmpegH264Platform::Windows => {
+            // Keep the low-delay Media Foundation profile, but let the encoder
+            // select an available implementation. Forcing hardware encoding
+            // makes h264_mf fail outright on systems without a compatible
+            // hardware MFT.
+            args.extend([
+                "-rate_control".to_string(),
+                "ld_vbr".to_string(),
+                "-scenario".to_string(),
+                "live_streaming".to_string(),
+            ]);
+        }
         FfmpegH264Platform::Other => {
             args.extend([
                 "-preset".to_string(),
@@ -4871,6 +4904,11 @@ fn append_bridge_recording_input_args(
     let video_input_index = next_input_index;
     match video_output {
         EncoderBridgeVideoOutput::RawYuv420p => {
+            // rawvideo carries pixels only—there are no per-frame timestamps to
+            // preserve. `-use_wallclock_as_timestamps` therefore collapses or
+            // otherwise retimes FIFO input on Windows. Keep the declared CFR
+            // timestamps and require the selected encoder to sustain the output
+            // cadence instead.
             args.extend([
                 "-f".to_string(),
                 "rawvideo".to_string(),
@@ -7700,14 +7738,33 @@ mod tests {
 
     #[test]
     fn recording_startup_frame_gap_budget_scales_with_target_fps() {
-        assert_eq!(
-            recording_startup_frame_gap_budget(30),
-            Duration::from_millis(71)
-        );
-        assert_eq!(
-            recording_startup_frame_gap_budget(60),
-            Duration::from_millis(36)
-        );
+        #[cfg(target_os = "macos")]
+        {
+            // 2.1 × 33.3ms ≈ 70 → 71ms ceil
+            assert_eq!(
+                recording_startup_frame_gap_budget(30),
+                Duration::from_millis(71)
+            );
+            assert_eq!(
+                recording_startup_frame_gap_budget(60),
+                Duration::from_millis(36)
+            );
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            // 6.0 × 33.3ms = 200ms — covers on-box Windows 172ms compose gaps
+            assert_eq!(
+                recording_startup_frame_gap_budget(30),
+                Duration::from_millis(200)
+            );
+            // 6.0 × 16.7ms ≈ 100ms, but the 200ms floor wins (gaps are wall-clock).
+            assert_eq!(
+                recording_startup_frame_gap_budget(60),
+                Duration::from_millis(200)
+            );
+            // The exact tester numbers that used to fail under the 71ms/150ms budgets.
+            assert!(recording_startup_frame_gap_budget(30) > Duration::from_millis(172));
+        }
     }
 
     fn base_params(record_enabled: bool, stream_enabled: bool) -> StartSessionParams {
@@ -8848,6 +8905,15 @@ mod tests {
             input_arg_value(&args, &fifo_path.display().to_string(), "-framerate"),
             Some("30")
         );
+        assert_eq!(
+            input_arg_value(
+                &args,
+                &fifo_path.display().to_string(),
+                "-use_wallclock_as_timestamps"
+            ),
+            None,
+            "rawvideo carries no per-frame timestamps, so it must retain its declared CFR timeline"
+        );
         assert!(!input_has_arg(
             &args,
             "sine=frequency=880:sample_rate=48000",
@@ -8911,6 +8977,7 @@ mod tests {
             input_arg_value(&args, &fifo_path.display().to_string(), "-framerate"),
             Some("30")
         );
+
         assert!(!input_has_arg(
             &args,
             &fifo_path.display().to_string(),

--- a/crates/videorc-backend/src/screen_capture.rs
+++ b/crates/videorc-backend/src/screen_capture.rs
@@ -1,4 +1,3 @@
-use std::sync::mpsc;
 use std::time::Duration;
 
 use crate::protocol::{Device, DeviceKind, DeviceStatus};

--- a/docs/windows-dev-loop.md
+++ b/docs/windows-dev-loop.md
@@ -104,6 +104,37 @@ Learned on-box 2026-07-08; encoded in `scripts/lib/app-launcher.mjs`:
 - Derive `ffprobe` from a configured ffmpeg path with `.exe` awareness
   (`resolveSiblingFfprobe` in `scripts/smoke-recording-session.mjs`), and use
   `basename()` instead of `split('/')` for path math (`recording-analyzer.mjs`).
+- Do **not** write package scripts as `VAR=1 node script.mjs` — pnpm on Windows
+  runs those through `cmd.exe`, which treats `VAR=1` as a command name
+  (`'VAR' is not recognized…`). Prefer CLI flags (e.g.
+  `node scripts/smoke-packaged-app.mjs --require-bundled-ffmpeg`) or set env in
+  the parent Node `spawn({ env })`.
+
+## electron-builder winCodeSign / symlink privilege
+
+Packaging used to pull the legacy `winCodeSign` tool bundle (for rcedit /
+signtool). That archive contains macOS dylib **symlinks**. On Windows without
+**Developer Mode** (or an elevated shell), 7-Zip fails with:
+
+```text
+ERROR: Cannot create symbolic link : A required privilege is not held by the client.
+... winCodeSign\...\darwin\10.12\lib\libcrypto.dylib
+```
+
+Unsigned local packages set `win.signAndEditExecutable: false` in
+`apps/desktop/electron-builder.yml` so packaging never downloads that bundle.
+When Authenticode signing / exe resource editing is re-enabled, either:
+
+1. Turn on **Settings → System → For developers → Developer Mode**, then clear
+   the broken cache and rebuild:
+
+   ```powershell
+   Remove-Item "$env:LOCALAPPDATA\electron-builder\Cache\winCodeSign" -Recurse -Force -ErrorAction SilentlyContinue
+   pnpm --filter @videorc/desktop package
+   ```
+
+2. Or run the first package once from an **Administrator** PowerShell so the
+   extract can create those links.
 
 ## FFmpeg pin rot
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "smoke:screens": "node scripts/smoke-screens-app.mjs",
     "smoke:multistream": "node scripts/smoke-multistream-app.mjs",
     "smoke:packaged": "node scripts/smoke-packaged-app.mjs",
-    "smoke:packaged:bundled": "VIDEORC_SMOKE_REQUIRE_BUNDLED_FFMPEG=1 node scripts/smoke-packaged-app.mjs",
+    "smoke:packaged:bundled": "node scripts/smoke-packaged-app.mjs --require-bundled-ffmpeg",
     "smoke:packaged:native-preview": "VIDEORC_SMOKE_PACKAGED_APP=1 VIDEORC_EXPECT_NATIVE_METAL_PREVIEW=1 node scripts/smoke-preview-surface-app.mjs",
     "smoke:packaged:release": "pnpm smoke:packaged:bundled && pnpm smoke:packaged:native-preview",
     "smoke:local-gates:windows": "node scripts/smoke-local-gates-windows.mjs",

--- a/scripts/smoke-packaged-app.mjs
+++ b/scripts/smoke-packaged-app.mjs
@@ -13,6 +13,12 @@ import { runBackendRecordingSmoke } from './smoke-recording-session.mjs'
 
 const repoRoot = resolve(import.meta.dirname, '..')
 assertPackagedSmokePlatform()
+// Prefer a CLI flag over `VAR=1 node …` so the script works under Windows cmd
+// (pnpm runs package scripts through cmd.exe, which does not understand Unix env
+// prefixes). Env still works on POSIX shells and when gates inject it via spawn.
+if (process.argv.includes('--require-bundled-ffmpeg')) {
+  process.env.VIDEORC_SMOKE_REQUIRE_BUNDLED_FFMPEG = '1'
+}
 const appExecutable = process.env.VIDEORC_PACKAGED_APP_EXECUTABLE
   ? resolve(repoRoot, process.env.VIDEORC_PACKAGED_APP_EXECUTABLE)
   : defaultPackagedAppExecutable({ repoRoot })


### PR DESCRIPTION
## Summary
- fix Windows DirectShow microphone selection and recording startup cadence
- retain Media Foundation low-delay settings without forcing unavailable hardware encoding
- make Windows packaged-smoke FFmpeg requirements shell-compatible

## Verification
- cargo test -p videorc-backend (777 passed)
- pnpm smoke:dev (all layouts passed; A/V skew 0–15ms)

## Note
pnpm smoke:recording-studio reached its imported-screen stage but that harness currently fails on Windows because smoke-screens-app.mjs spawns bare pnpm (ENOENT).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows packaging reliability and added a safer packaging path for some systems.
  * Smoke tests can now explicitly verify the app is using the bundled media components.

* **Bug Fixes**
  * Windows microphone handling now preserves more user-friendly device identifiers.
  * Recording startup timing and encoding defaults were adjusted for more consistent behavior across platforms.

* **Documentation**
  * Added Windows troubleshooting guidance for packaging and symlink-related setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->