### PR TITLE
Repair CI after PR #59: macOS mpsc import + Windows needless_return

### DIFF
--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -3914,9 +3914,11 @@ fn recording_startup_frame_gap_budget(target_fps: u32) -> Duration {
     let frame_interval_ms =
         1000.0 / f64::from(target_fps.max(1)) * RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR;
     let budget = Duration::from_millis(frame_interval_ms.ceil() as u64);
+    // Exactly one arm survives cfg-stripping and becomes the tail expression;
+    // `return` here would trip clippy::needless_return on that platform.
     #[cfg(not(target_os = "macos"))]
     {
-        return budget.max(RECORDING_STARTUP_CADENCE_MIN_FRAME_GAP);
+        budget.max(RECORDING_STARTUP_CADENCE_MIN_FRAME_GAP)
     }
     #[cfg(target_os = "macos")]
     {

--- a/crates/videorc-backend/src/screen_capture.rs
+++ b/crates/videorc-backend/src/screen_capture.rs
@@ -240,12 +240,16 @@ fn utf16_z(value: &[u16]) -> Option<String> {
 mod macos {
     use super::*;
     use block2::RcBlock;
+    // Scoped here (not at the top of the file) so the Windows arm never sees
+    // an unused import — PR #59 deleted the top-level `use std::sync::mpsc`
+    // as apparently-unused and broke the macOS build.
     use objc2_core_graphics::{
         CGDirectDisplayID, CGDisplayCopyDisplayMode, CGDisplayMode, CGPreflightScreenCaptureAccess,
         CGRequestScreenCaptureAccess,
     };
     use objc2_foundation::{NSError, NSString};
     use objc2_screen_capture_kit::{SCShareableContent, SCWindow};
+    use std::sync::mpsc;
 
     enum ShareableContentResult {
         Devices(Vec<Device>),


### PR DESCRIPTION
PR #59 landed with red CI on both platforms:

1. **macOS build broken** (E0433): it deleted `use std::sync::mpsc` from `screen_capture.rs` as apparently-unused — but the import is consumed only inside the `cfg(macos)` ScreenCaptureKit module. Restored **scoped inside the macos module**, so neither platform ever sees it as unused again.
2. **Windows clippy** `needless_return` in the new cfg-branched `recording_startup_frame_gap_budget` — both arms are tail expressions now (the established devices.rs cfg pattern).

Validation: `cargo test -p videorc-backend` (all suites) + `cargo clippy -- -D warnings` green on macOS; the Windows gates job on this PR proves the clippy side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up internal code structure and import placement for platform-specific logic.
  * Simplified a conditional expression to use a more idiomatic form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->