### PR TITLE
Release 0.9.26-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.26-beta.1.md
+++ b/changelog/0.9.26-beta.1.md
@@ -1,0 +1,36 @@
+---
+version: 0.9.26-beta.1
+date: 2026-07-10
+channel: beta
+title: Audio and video stay in sync — plus a sturdier preview
+summary: Long recordings and streams no longer drift out of sync over time, the preview is more reliable while you move, resize, and switch scenes, and Windows testers get a big batch of capture fixes.
+highlights:
+  - Fixed the slow audio/video drift where sound fell further behind the longer you recorded or streamed — timelines now stay true to the clock from start to finish.
+  - The preview was rebuilt on a sturdier foundation — it now keeps up smoothly when you drag or resize the window, switch scenes, or move between displays, without flashing stale frames.
+  - Windows (tester builds) — camera and microphone permission prompts work properly, recording is more reliable, and the blank preview on some GPUs is fixed.
+---
+
+## Your recordings stay in sync, start to finish
+
+Some long recordings and streams slowly drifted: the audio fell a little
+further behind every minute, so an hour-long session could end noticeably out
+of sync. The cause was in how Videorc scheduled video frames — under load it
+quietly compressed the video timeline while the audio stayed true. That
+scheduling is fixed: video time now always matches real time, so audio and
+video line up at minute one and at minute sixty.
+
+## A sturdier preview
+
+The live preview got a rebuilt foundation on macOS. It now lives directly
+inside the app window instead of being glued on top of it, which means it
+keeps up smoothly when you drag the window around, resize it, change display
+scale, or switch scenes — and it holds the last good picture instead of
+flashing stale or empty frames while a new scene loads.
+
+## Windows tester builds
+
+For everyone testing Videorc on Windows: camera and microphone permission
+prompts now open the right Windows settings and no longer wedge the app,
+cameras are detected more reliably, recording start/stop is more robust, and
+the blank preview some GPUs showed is fixed. Keyboard hints now show Ctrl
+instead of Mac symbols too.


### PR DESCRIPTION
## Summary

Release prep for 0.9.26-beta.1:
- Bump `apps/desktop/package.json` to 0.9.26 (triggers electron-updater)
- Add `changelog/0.9.26-beta.1.md` (validated with `pnpm changelog:check`)

## What ships since 0.9.25

- Progressive A/V drift fix — absolute bridge schedule (#57)
- macOS preview rebuilt in-process, atomic and latest-wins (#61)
- Windows tester batch: permissions, camera, mic, recording reliability, GPU-fallback preview (#47–#51, #59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)