### PR TITLE
Record the 0.9.26-beta.1 release (build, upload, feed, announce)

### DIFF
--- a/docs/releases/0.9.26.md
+++ b/docs/releases/0.9.26.md
@@ -1,0 +1,67 @@
+# Videorc 0.9.26 Beta 1
+
+Videorc 0.9.26 ships the progressive A/V drift fix (plan 026 core), the
+rebuilt in-process macOS native preview, and the Windows tester feedback
+batch. First release announced as "audio stays in sync, start to finish".
+
+## Scope
+
+- **Progressive A/V drift fix** (PR #57, plan 026 S1+S2+S3-core) — the
+  bridge writer's per-tick re-anchor silently deleted overrun time from
+  the video timeline (macOS VT path) and the Windows raw-yuv fresh-frame
+  wait paced the loop below target fps; both stamped exact-CFR PTS, so
+  video time compressed against wall-true audio (0.6–0.8s/min on macOS,
+  ~7.8% on the first Windows recording). Now: absolute schedule
+  (`next_frame_at += interval` only), zero-wait catch-up repeats, and
+  explicit counted ≥2s stall gaps (`schedule_skipped_ms` diagnostic).
+- **macOS preview root fix** (PR #61) — production preview moved from a
+  helper-process `NSWindow` overlay to an in-process Rust N-API
+  `CAMetalLayer` in Electron's view hierarchy; main is the sole placement
+  owner with bounded latest-wins placement/presentation lanes; scene
+  switching is backend-owned, source-ready, monotonic, last-intent-wins;
+  previous good pixels held until the winner is presentable.
+- **Windows tester batch** (PRs #47–#51, #59, #60) — permissions open
+  ms-settings and never wedge, camera dshow friendly-name + format
+  retry, honest mic copy, platform-truthful health (Cpu vs CpuFallback),
+  ⌘→Ctrl glyph sweep, benign unsupported update feed (no 404 alarm),
+  macOS-only camera cadence gate no longer blocks Windows recording,
+  opaque surface + GPU fallback for broken-GPU blank preview, recording
+  reliability fixes, CI repair.
+
+## Release status
+
+- [x] All feature PRs merged via protected `main`; release prep PR
+      https://github.com/TheOrcDev/videorc/pull/63.
+- [x] Built from a tree identical to `origin/main` post-merge (tree hash
+      `a545255c` verified equal between the squash-merged main and the
+      built branch).
+- [x] Signed + notarized (DMG stapled); `release:validate:macos` PASS
+      (codesign, Gatekeeper, stapler, bundled-secret gates); ffmpeg
+      capability probe passed in `package:preflight:macos`.
+- [x] Uploaded to R2, all 8 objects verified (versioned DMG + sha256 +
+      release.json, stable latest/release.json, feed yml + zip +
+      blockmap, changelog.json); feed serves `version: 0.9.26` through
+      the www redirect; `/api/changelog` serves `0.9.26-beta.1`
+      (27 entries valid).
+- [x] Discord announced (dry-run previewed first, single post).
+
+## Verification
+
+- All gates green on prep PR #63 (Rust test+clippy+fmt, JS
+  format+lint+tests, Windows gates, Windows installer artifact).
+- Feature-PR evidence: PR #57 carried the 60s slow-compositor red
+  harness (±100ms wall-clock invariant), smoke:dev all-layout recording
+  PASS at 52ms A/V skew; PR #61 carried recording-studio aggregate
+  stages 1–18, packaged all-layout recordings (52ms skew), and packaged
+  native preview at 60.4 FPS / 19ms p95.
+
+## Pending owner acceptance
+
+- [ ] Update to 0.9.26 and record a long session (10+ min): audio stays
+      in sync end-to-end; video duration matches audio duration.
+- [ ] By-eye preview checks from PR #61's checklist: drag, dock,
+      focus/click, resize/display-scale, rapid scene-switch, and
+      during-recording behavior.
+- [ ] Windows tester re-records on the next installer artifact:
+      audio in sync, `encoderBridgeScheduleSkippedMs` ~0.
+- [ ] Confirm the signed-in download page shows 0.9.26.


### PR DESCRIPTION
Internal release record for 0.9.26-beta.1: build/sign/notarize, R2 upload (all objects verified), feed verified serving 0.9.26 through the www redirect, Discord announced. Owner acceptance checklist pending inside the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)