### PR TITLE
Live session bug batch: preview-proof false errors, fallback mics, dead comments visibility, instant backgrounds, real-time mic meter

### DIFF
--- a/apps/desktop/src/main/native-preview-scene-authority.test.ts
+++ b/apps/desktop/src/main/native-preview-scene-authority.test.ts
@@ -59,7 +59,7 @@ describe('native preview compositor scene authority', () => {
     ).toBe(false)
   })
 
-  it('requires an attached in-process present of the committed revision', () => {
+  it('requires an attached in-process present at or beyond the committed revision', () => {
     const status = {
       state: 'live',
       transport: 'native-surface',
@@ -75,6 +75,28 @@ describe('native preview compositor scene authority', () => {
     expect(
       nativePreviewStatusProvesSceneRevision(
         { ...status, nativePreviewHostKind: 'proof-surface', nativePreviewHostAttached: false },
+        12
+      )
+    ).toBe(false)
+  })
+
+  it('accepts a newer presented revision as proof of a superseded commit', () => {
+    const status = {
+      state: 'live',
+      transport: 'native-surface',
+      backing: 'cametal-layer',
+      sourcePixelsPresent: true,
+      nativePreviewHostKind: 'in-process',
+      nativePreviewHostAttached: true,
+      nativePreviewPresentedSceneRevision: 13
+    } as PreviewSurfaceStatus
+
+    // Latest-wins presentation may skip an intermediate committed revision and
+    // land directly on a newer one; the older commit is proven, not stale.
+    expect(nativePreviewStatusProvesSceneRevision(status, 12)).toBe(true)
+    expect(
+      nativePreviewStatusProvesSceneRevision(
+        { ...status, nativePreviewPresentedSceneRevision: undefined },
         12
       )
     ).toBe(false)

--- a/apps/desktop/src/renderer/src/components/comments-destination-status.test.ts
+++ b/apps/desktop/src/renderer/src/components/comments-destination-status.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   CommentsDestinationStatus,
-  commentsDestinationSummary
+  commentsDestinationSummary,
+  providerBadgeTitle
 } from '@/components/comments-destination-status'
 import type { LiveChatProviderState, StreamPlatform } from '@/lib/backend'
 
@@ -56,6 +57,20 @@ describe('comments destination status', () => {
         sendTargets: []
       })
     ).toBe('No writable destinations · Twitch reconnect to send · X receive-only')
+  })
+
+  it('names the bound account so a wrong-channel manual stream is visible', () => {
+    expect(providerBadgeTitle(provider('twitch', { message: '', accountLabel: 'OrcDev' }))).toBe(
+      'Reading chat as OrcDev.'
+    )
+    expect(
+      providerBadgeTitle(
+        provider('twitch', { message: 'twitch connected', accountLabel: 'OrcDev' })
+      )
+    ).toBe('twitch connected — Reading chat as OrcDev.')
+    expect(providerBadgeTitle(provider('twitch', { message: 'twitch connected' }))).toBe(
+      'twitch connected'
+    )
   })
 
   it('renders provider and failure status with the shared badge contract', () => {

--- a/apps/desktop/src/renderer/src/components/comments-destination-status.tsx
+++ b/apps/desktop/src/renderer/src/components/comments-destination-status.tsx
@@ -63,6 +63,18 @@ function providerStatusLabel(provider: LiveChatProviderState): string {
   return providerStateLabel(provider.state)
 }
 
+// Chat binds to the linked account's channel, not to wherever the stream key
+// points. On a manual-RTMP stream of a different channel that reads the wrong
+// chat with a green "Connected" badge — name the bound account so the
+// mismatch is at least visible.
+export function providerBadgeTitle(provider: LiveChatProviderState): string {
+  const identity = provider.accountLabel ? `Reading chat as ${provider.accountLabel}.` : ''
+  if (provider.message && identity) {
+    return `${provider.message} — ${identity}`
+  }
+  return provider.message || identity
+}
+
 export function commentsDestinationSummary({
   providers,
   sendTargets,
@@ -166,7 +178,7 @@ export function CommentsDestinationStatus({
       {providers.map((provider) => (
         <Badge
           key={provider.id}
-          title={provider.message}
+          title={providerBadgeTitle(provider)}
           variant={providerBadgeVariant(provider.state)}
         >
           <span aria-hidden className="size-1.5 shrink-0 rounded-full bg-current" />

--- a/apps/desktop/src/renderer/src/components/live-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/live-chat-panel.tsx
@@ -5,7 +5,14 @@ import { CHAT_PLATFORM_LABELS, ChatPlatformIcon } from '@/components/chat-platfo
 import { CommentRow, commentHighlightPresentationForMessage } from '@/components/comment-row'
 import { CommentsDestinationStatus } from '@/components/comments-destination-status'
 import { Button } from '@/components/ui/button'
-import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle
+} from '@/components/ui/empty'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
@@ -18,6 +25,7 @@ import type {
 import {
   LIVE_CHAT_PLATFORMS,
   MAX_RENDERED_LIVE_CHAT_MESSAGES,
+  chatNeedsConnectionAction,
   filterMessagesByPlatform,
   liveChatEmptyMessage,
   nextUnreadCount,
@@ -185,6 +193,24 @@ export function LiveChatPanel({
                 <EmptyTitle className="text-sm">No comments yet</EmptyTitle>
                 <EmptyDescription className="text-xs">{emptyMessage}</EmptyDescription>
               </EmptyHeader>
+              {chatNeedsConnectionAction(snapshot.providers) ? (
+                <EmptyContent>
+                  <Button
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                    onClick={() =>
+                      window.dispatchEvent(
+                        new CustomEvent('videorc:navigate-workspace', {
+                          detail: { tab: 'streaming' }
+                        })
+                      )
+                    }
+                  >
+                    Open Livestream settings
+                  </Button>
+                </EmptyContent>
+              ) : null}
             </Empty>
           )}
         </ScrollArea>

--- a/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
@@ -5,16 +5,18 @@ import { PanelSection } from '@/components/panel-section'
 import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import { useWorkspaceNav } from '@/components/workspace-nav'
+import { useMicLevelMeter, type MicLevelMeter } from '@/hooks/use-mic-level-meter'
 import { useStudio } from '@/hooks/use-studio'
 import { formatDb } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
 /**
- * Audio mixer (SD4 + post-0.9.4 fix F7). During a LIVE session the meter moves
- * on its own: the backend derives a live level from the mic frames the session
- * already captures (diagnostics.stats stream — no extra device open, no idle
- * loop, the idle-perf baseline holds). While idle, the meter stays on-demand
- * (Check level, one 700ms device sample) — the same model Sources uses.
+ * Audio mixer (SD4 + post-0.9.4 fix F7 + 2026-07-10 live-meter fix). The
+ * VISUAL meter runs on a renderer WebAudio analyser at display rate, driven
+ * imperatively (use-mic-level-meter) — instant response with peak hold, both
+ * idle and in-session. The backend stays the capture/health authority: its
+ * 1 Hz `micLiveLevel` and the on-demand 700 ms "Check level" sample remain
+ * the fallback whenever the analyser cannot open the selected device.
  * System audio shows its honest "unavailable — pending native adapter" state;
  * real capture is Phase-2 (F3).
  */
@@ -32,16 +34,23 @@ export function AudioMixer(): ReactElement {
   const { openStudioPanel } = useWorkspaceNav()
 
   const muted = captureConfig.audio.microphoneMuted
+  const micMeter = useMicLevelMeter({
+    deviceName: selectedMicrophone?.name,
+    enabled: Boolean(selectedMicrophone),
+    muted
+  })
   const liveLevel =
     typeof diagnosticStats?.micLiveLevel === 'number' ? diagnosticStats.micLiveLevel : null
   const hasReading = audioMeter !== null && typeof audioMeter.level === 'number'
   const level = liveLevel ?? (hasReading ? (audioMeter?.level ?? 0) : 0)
   const dbLabel =
-    liveLevel !== null && typeof diagnosticStats?.micLivePeakDb === 'number'
-      ? formatDb(diagnosticStats.micLivePeakDb)
-      : audioMeter && typeof audioMeter.peakDb === 'number'
-        ? formatDb(audioMeter.peakDb)
-        : formatDb(captureConfig.audio.microphoneGainDb)
+    micMeter.active && micMeter.peakDb !== null
+      ? formatDb(micMeter.peakDb)
+      : liveLevel !== null && typeof diagnosticStats?.micLivePeakDb === 'number'
+        ? formatDb(diagnosticStats.micLivePeakDb)
+        : audioMeter && typeof audioMeter.peakDb === 'number'
+          ? formatDb(audioMeter.peakDb)
+          : formatDb(captureConfig.audio.microphoneGainDb)
   const systemAudio = deviceList.devices.find((device) => device.kind === 'system-audio')
 
   return (
@@ -89,11 +98,12 @@ export function AudioMixer(): ReactElement {
         </div>
         <div className="flex items-center gap-2">
           <MeterBar
-            level={level}
+            level={micMeter.active ? null : level}
+            live={micMeter.active ? micMeter : undefined}
             muted={muted}
-            status={liveLevel !== null ? 'ready' : audioMeter?.status}
+            status={micMeter.active || liveLevel !== null ? 'ready' : audioMeter?.status}
           />
-          {liveLevel !== null ? (
+          {micMeter.active || liveLevel !== null ? (
             <span className="shrink-0 text-xs text-muted-foreground">Live</span>
           ) : (
             <Button
@@ -130,14 +140,18 @@ export function AudioMixer(): ReactElement {
 
 function MeterBar({
   level,
+  live,
   status,
   muted
 }: {
-  level: number
+  /** Static level for the fallback paths; null while the analyser drives the bar. */
+  level: number | null
+  /** When set, fill width and peak marker are written imperatively at rAF rate. */
+  live?: Pick<MicLevelMeter, 'fillRef' | 'peakRef'>
   status?: string
   muted: boolean
 }): ReactElement {
-  const pct = Math.min(100, Math.max(0, Math.round(level * 100)))
+  const pct = level === null ? 0 : Math.min(100, Math.max(0, Math.round(level * 100)))
   const tone = muted
     ? 'bg-muted-foreground/40'
     : status === 'ready'
@@ -146,11 +160,27 @@ function MeterBar({
         ? 'bg-warning'
         : 'bg-muted-foreground/40'
   return (
-    <span className="h-2 min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
+    <span className="relative h-2 min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
       <span
-        className={cn('block h-full rounded-full transition-[width] duration-100', tone)}
-        style={{ width: `${pct}%` }}
+        ref={live?.fillRef}
+        // The analyser's own ballistics animate the live bar; a CSS width
+        // transition would smear every frame. Keep it only on the 1 Hz
+        // fallback paths so their jumps stay readable.
+        className={cn(
+          'block h-full rounded-full',
+          !live && 'transition-[width] duration-100',
+          tone
+        )}
+        style={live ? undefined : { width: `${pct}%` }}
       />
+      {live ? (
+        <span
+          ref={live.peakRef}
+          aria-hidden
+          className="absolute top-0 h-full w-0.5 rounded-full bg-foreground/70"
+          style={{ left: 0, opacity: 0 }}
+        />
+      ) : null}
     </span>
   )
 }

--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -34,6 +34,7 @@ import {
   buildCaptureSources,
   buildMicrophoneSources,
   capturePickerDevices,
+  microphonePickerDevices,
   layoutPresetNeedsCamera,
   layoutPresetNeedsScreen
 } from '@/lib/capture'
@@ -117,7 +118,7 @@ export function QuickSettings(): ReactElement {
 
   const captureDevices = capturePickerDevices(deviceList.devices)
   const cameras = deviceList.devices.filter((device) => device.kind === 'camera')
-  const microphones = deviceList.devices.filter((device) => device.kind === 'microphone')
+  const microphones = microphonePickerDevices(deviceList.devices)
   const selectedCaptureId = captureConfig.sources.screenId ?? captureConfig.sources.windowId
   const hasCamera = Boolean(captureConfig.sources.cameraId)
   const hasScreen = Boolean(selectedCaptureId)

--- a/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
@@ -31,6 +31,7 @@ import {
   buildCaptureSources,
   buildMicrophoneSources,
   capturePickerDevices,
+  microphonePickerDevices,
   audioSyncCalibrationState,
   normalizeMicrophoneSyncOffsetMs,
   parseAudioSyncRecommendationJson,
@@ -131,7 +132,7 @@ export function SourcesTab(): ReactElement {
     : null
   const captureDevices = capturePickerDevices(deviceList.devices)
   const cameras = deviceList.devices.filter((device) => device.kind === 'camera')
-  const microphones = deviceList.devices.filter((device) => device.kind === 'microphone')
+  const microphones = microphonePickerDevices(deviceList.devices)
   const hasCapturePermissionRequired = captureDevices.some(
     (device) => device.status === 'permission-required'
   )

--- a/apps/desktop/src/renderer/src/hooks/use-mic-level-meter.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-mic-level-meter.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import {
+  INITIAL_METER_BALLISTICS,
+  advanceMeterBallistics,
+  amplitudeToDb,
+  dbToMeterLevel,
+  matchMicrophoneDeviceId,
+  samplesRmsAndPeak,
+  type MeterBallisticsState
+} from '@/lib/mic-meter'
+
+const PEAK_DB_LABEL_INTERVAL_MS = 250
+
+export type MicLevelMeter = {
+  /** Attach the meter fill element; its width is driven imperatively at rAF rate. */
+  fillRef: (element: HTMLSpanElement | null) => void
+  /** Attach the peak-hold marker element; its left offset is driven imperatively. */
+  peakRef: (element: HTMLSpanElement | null) => void
+  /** True while the WebAudio analyser is metering the selected device. */
+  active: boolean
+  /** Peak dBFS for the text label, throttled to ~4Hz of React state. */
+  peakDb: number | null
+}
+
+/**
+ * Real-time mic meter (2026-07-10 report: the mixer bar moved once a second
+ * and barely at all). The VISUAL runs on a renderer-side WebAudio analyser at
+ * display rate, writing element styles directly — React state, the 1 Hz
+ * telemetry commit throttle, and the backend diagnostics tick are all
+ * bypassed. The backend's `micLiveLevel` stays the capture/health authority
+ * and the mixer's fallback when the analyser cannot run (permission denied,
+ * exclusive-mode device): shared-mode capture means this analyser coexists
+ * with the backend's CoreAudio/dshow session capture.
+ */
+export function useMicLevelMeter(input: {
+  /** Backend name of the selected microphone; matched to WebAudio by label. */
+  deviceName: string | undefined
+  enabled: boolean
+  /** Backend mute is applied at capture gain; the analyser sees pre-mute signal. */
+  muted: boolean
+}): MicLevelMeter {
+  const { deviceName, enabled, muted } = input
+  const [active, setActive] = useState(false)
+  const [peakDb, setPeakDb] = useState<number | null>(null)
+  const fillElementRef = useRef<HTMLSpanElement | null>(null)
+  const peakElementRef = useRef<HTMLSpanElement | null>(null)
+  const mutedRef = useRef(muted)
+  mutedRef.current = muted
+
+  const fillRef = useCallback((element: HTMLSpanElement | null) => {
+    fillElementRef.current = element
+  }, [])
+  const peakRef = useCallback((element: HTMLSpanElement | null) => {
+    peakElementRef.current = element
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) {
+      setActive(false)
+      setPeakDb(null)
+      return
+    }
+
+    let disposed = false
+    let frame = 0
+    let stream: MediaStream | null = null
+    let context: AudioContext | null = null
+
+    const stopStream = (): void => {
+      stream?.getTracks().forEach((track) => track.stop())
+      stream = null
+    }
+
+    const start = async (): Promise<void> => {
+      const media = navigator.mediaDevices
+      if (!media?.getUserMedia) {
+        return
+      }
+      const inputs = (await media.enumerateDevices().catch(() => []))
+        .filter((device) => device.kind === 'audioinput')
+        .map((device) => ({ deviceId: device.deviceId, label: device.label }))
+      const deviceId = matchMicrophoneDeviceId(deviceName, inputs)
+      stream = await media.getUserMedia({
+        audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+        video: false
+      })
+      if (disposed) {
+        stopStream()
+        return
+      }
+      context = new AudioContext()
+      const analyser = context.createAnalyser()
+      // 2048 samples ≈ 43 ms at 48 kHz: a meaningful RMS window that still
+      // refreshes completely between display frames.
+      analyser.fftSize = 2048
+      context.createMediaStreamSource(stream).connect(analyser)
+      const samples = new Float32Array(analyser.fftSize)
+      let ballistics: MeterBallisticsState = INITIAL_METER_BALLISTICS
+      let lastFrameAt = performance.now()
+      let lastLabelAt = 0
+      setActive(true)
+
+      const tick = (): void => {
+        if (disposed) {
+          return
+        }
+        const now = performance.now()
+        const elapsedMs = Math.min(100, now - lastFrameAt)
+        lastFrameAt = now
+        analyser.getFloatTimeDomainData(samples)
+        const { rms, peak } = samplesRmsAndPeak(samples)
+        const target = mutedRef.current ? 0 : dbToMeterLevel(amplitudeToDb(rms))
+        ballistics = advanceMeterBallistics(ballistics, target, elapsedMs, now)
+        const fill = fillElementRef.current
+        if (fill) {
+          fill.style.width = `${(ballistics.level * 100).toFixed(1)}%`
+        }
+        const marker = peakElementRef.current
+        if (marker) {
+          marker.style.left = `calc(${(ballistics.peakLevel * 100).toFixed(1)}% - 2px)`
+          marker.style.opacity = mutedRef.current || ballistics.peakLevel <= 0.001 ? '0' : '1'
+        }
+        if (now - lastLabelAt >= PEAK_DB_LABEL_INTERVAL_MS) {
+          lastLabelAt = now
+          setPeakDb(mutedRef.current ? null : amplitudeToDb(peak))
+        }
+        frame = requestAnimationFrame(tick)
+      }
+      frame = requestAnimationFrame(tick)
+    }
+
+    void start().catch(() => {
+      // Permission denied or the device is exclusively held: the mixer falls
+      // back to the backend-sampled meter. A passive meter must never toast.
+      if (!disposed) {
+        setActive(false)
+      }
+    })
+
+    return () => {
+      disposed = true
+      cancelAnimationFrame(frame)
+      stopStream()
+      void context?.close().catch(() => undefined)
+      setActive(false)
+      setPeakDb(null)
+    }
+  }, [deviceName, enabled])
+
+  return { fillRef, peakRef, active, peakDb }
+}

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -75,6 +75,7 @@ import {
   layoutTransactionFailureReconciliation,
   layoutTransactionProofDisposition,
   layoutTransactionUnprovenSeverity,
+  liveBackgroundCommitDecision,
   NativePreviewPresentationProofError,
   shouldReloadSceneFromCaptureConfig
 } from '@/lib/layout-transaction-policy'
@@ -3792,7 +3793,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   }, [client])
 
   const requestLayoutTransaction = useCallback(
-    (layout: LayoutSettings) => {
+    (layout: LayoutSettings, options?: { pendingIndicator?: boolean }) => {
       const sessionActive = isActiveRecordingState(recordingRef.current.state)
       if (!client || wsStatus !== 'connected') {
         toast.error('Backend socket is not connected — layout unchanged.')
@@ -3802,7 +3803,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       const intentId = Math.max(layoutIntentIdRef.current + 1, Date.now())
       layoutIntentIdRef.current = intentId
       layoutIntentAwaitingProofRef.current = intentId
-      setLayoutSwitchPending(layout.layoutPreset)
+      // Background-only commits keep the same preset; flashing the layout
+      // controls into "Switching…" for them reads as an unrelated change.
+      if (options?.pendingIndicator !== false) {
+        setLayoutSwitchPending(layout.layoutPreset)
+      }
 
       void (async () => {
         try {
@@ -3922,6 +3927,30 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       wsStatus
     ]
   )
+
+  // Instant background apply while live (2026-07-10 report: clicking an asset
+  // only changed the local registry — the stream kept the old background until
+  // the next layout-preset change re-committed the scene). Idle stays with the
+  // debounced scene reload effect; an active session commits through the same
+  // layout-transaction machinery (scene revision, latest-wins, proof).
+  // Fingerprint by VALUE: the registry memo yields a new object on unrelated
+  // edits (rename, import into an inactive slot) which must not commit.
+  const liveBackgroundFingerprintRef = useRef<string | null>(null)
+  const activeSceneBackgroundFingerprint = useMemo(
+    () => JSON.stringify(activeSceneBackground ?? null),
+    [activeSceneBackground]
+  )
+  useEffect(() => {
+    const decision = liveBackgroundCommitDecision({
+      sessionActive: isActiveRecordingState(recording.state),
+      armedFingerprint: liveBackgroundFingerprintRef.current,
+      fingerprint: activeSceneBackgroundFingerprint
+    })
+    liveBackgroundFingerprintRef.current = decision.next
+    if (decision.commit) {
+      requestLayoutTransaction(captureConfigRef.current.layout, { pendingIndicator: false })
+    }
+  }, [activeSceneBackgroundFingerprint, recording.state, requestLayoutTransaction])
 
   const applyLayoutPatch = useCallback(
     (patch: Partial<LayoutSettings>) => {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -192,8 +192,10 @@ import {
   applyLiveChatMessages,
   applyLiveChatProviderStatus,
   applyLiveChatSnapshot,
+  chatSetupToastWarnings,
   reconcileLiveChatRecovery
 } from '@/lib/live-chat-view'
+import { CHAT_PLATFORM_LABELS } from '@/components/chat-platform-icon'
 import {
   buildNativePreviewCompositorUpdateParams,
   compositorStatusHasRenderedSceneRevision,
@@ -1071,6 +1073,38 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     if (!client) return
     await client.request('liveChat.clearLocal')
   }, [client])
+  // A silently empty Comments feed must never be the only signal that chat
+  // setup failed at go-live (2026-07-10: Twitch chat needed a reconnect and
+  // the failure lived only in a backend warn log). Toast each broken
+  // destination once per session, with a jump to the Livestream tab.
+  const chatSetupWarnedRef = useRef<{ sessionId?: string; warned: Set<string> }>({
+    warned: new Set()
+  })
+  useEffect(() => {
+    const sessionId = liveChatSnapshot.sessionId
+    if (!sessionId) {
+      return
+    }
+    if (chatSetupWarnedRef.current.sessionId !== sessionId) {
+      chatSetupWarnedRef.current = { sessionId, warned: new Set() }
+    }
+    for (const warning of chatSetupToastWarnings(liveChatSnapshot.providers)) {
+      if (chatSetupWarnedRef.current.warned.has(warning.id)) {
+        continue
+      }
+      chatSetupWarnedRef.current.warned.add(warning.id)
+      toast.warning(`${CHAT_PLATFORM_LABELS[warning.platform]} comments are not connected`, {
+        description: warning.message,
+        action: {
+          label: 'Open Livestream',
+          onClick: () =>
+            window.dispatchEvent(
+              new CustomEvent(WORKSPACE_NAVIGATE_EVENT, { detail: { tab: 'streaming' } })
+            )
+        }
+      })
+    }
+  }, [liveChatSnapshot])
   // Live captions: status + transcript driven by captions.* events; the mic
   // audio itself never reaches the renderer (the Rust backend uploads chunks).
   const [captionsStatus, setCaptionsStatus] = useState<CaptionsStatus>({ state: 'idle' })

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -74,6 +74,8 @@ import {
   layoutTransactionBackendSnapshotIsStable,
   layoutTransactionFailureReconciliation,
   layoutTransactionProofDisposition,
+  layoutTransactionUnprovenSeverity,
+  NativePreviewPresentationProofError,
   shouldReloadSceneFromCaptureConfig
 } from '@/lib/layout-transaction-policy'
 import {
@@ -301,6 +303,10 @@ const NATIVE_PREVIEW_COMPOSITOR_POLL_INTERVAL_MS = 1000 / 60
 const NATIVE_PREVIEW_COMPOSITOR_TIMING_SAMPLE_LIMIT = 900
 const NATIVE_PREVIEW_SCENE_FRAME_WAIT_TIMEOUT_MS = 750
 const NATIVE_PREVIEW_SCENE_FRAME_WAIT_INTERVAL_MS = 33
+// The native surface presents latest-wins on a busy GPU while streaming; its
+// presented-revision readback routinely needs more than the 750 ms compositor
+// frame window. Budget it separately, below the 5 s live output proof.
+const NATIVE_PREVIEW_SCENE_PROOF_WAIT_TIMEOUT_MS = 3000
 const LIVE_LAYOUT_PROOF_WAIT_TIMEOUT_MS = 5000
 const LIVE_LAYOUT_PROOF_WAIT_INTERVAL_MS = 100
 
@@ -367,7 +373,7 @@ async function waitForNativePreviewSurfaceSceneRevision(
     return null
   }
 
-  const deadline = Date.now() + NATIVE_PREVIEW_SCENE_FRAME_WAIT_TIMEOUT_MS
+  const deadline = Date.now() + NATIVE_PREVIEW_SCENE_PROOF_WAIT_TIMEOUT_MS
   let lastStatus: PreviewSurfaceStatus | null = null
   while (Date.now() < deadline) {
     try {
@@ -3639,7 +3645,15 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         return false
       }
       const previewWindowState = await window.videorc?.getPreviewWindowState?.()
-      if (nativePreviewSurfaceEnabled && previewWindowState?.open) {
+      // While the preview is hidden (dialog overlay, minimized, fullscreen,
+      // scrolled away) the host benign-skips presents, so a presented-revision
+      // proof can never arrive. The compositor proof above already covered the
+      // commit; do not demand a proof the surface is not allowed to produce.
+      const surfaceCanPresent =
+        previewWindowState?.open === true &&
+        previewWindowState.visible &&
+        previewWindowState.dockHiddenReason == null
+      if (nativePreviewSurfaceEnabled && surfaceCanPresent) {
         const proofOwner = nativePreviewSceneProofPresentationOwner({
           mainPumpActive: mainPumpActiveRef.current,
           statusReaderAvailable: Boolean(window.videorc?.getNativePreviewSurfaceStatus),
@@ -3653,7 +3667,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
               ? await window.videorc.updateNativePreviewSurfaceCompositor(compositorStatus)
               : null
         if (!surfaceStatus) {
-          throw new Error(
+          throw new NativePreviewPresentationProofError(
             `Native preview could not verify committed scene revision ${status.sceneRevision}.`
           )
         }
@@ -3662,7 +3676,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           surfaceStatus.nativePreviewHostKind !== 'proof-surface' &&
           !nativePreviewStatusProvesSceneRevision(surfaceStatus, status.sceneRevision)
         ) {
-          throw new Error(
+          throw new NativePreviewPresentationProofError(
             `Native preview did not present committed scene revision ${status.sceneRevision}.`
           )
         }
@@ -3803,6 +3817,20 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           if (disposition === 'apply-unproven') {
             const detail =
               proofError instanceof Error ? proofError.message : 'Presentation proof timed out.'
+            if (layoutTransactionUnprovenSeverity(proofError) === 'presentation-warning') {
+              // The commit and the recording/streaming output proof already
+              // passed; only the preview window's presented-revision readback
+              // missed. Keep it diagnostic — a destructive error here reads as
+              // a session failure while everything the viewer sees is correct.
+              console.warn(
+                `Layout committed at revision ${status.sceneRevision}; native preview presentation proof was not observed. ${detail}`
+              )
+              toast.warning('Preview verification lagged behind the layout change', {
+                description:
+                  'The layout was applied and the output is unaffected. If the preview looks stale, close and reopen it.'
+              })
+              return
+            }
             reportError(
               new Error(
                 `Layout committed at revision ${status.sceneRevision}, but preview proof was not observed. The controls were reconciled to the backend commit. ${detail}`

--- a/apps/desktop/src/renderer/src/lib/capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.test.ts
@@ -17,6 +17,7 @@ import {
   hasSelectedScreenSource,
   isCapturePickerDevice,
   isNativeCaptureDevice,
+  microphonePickerDevices,
   isScreenCaptureKitCaptureDevice,
   isSelectableCaptureDevice,
   layoutPresetNeedsCamera,
@@ -349,6 +350,66 @@ describe('reconcileSourceSelection', () => {
     expect(next.screenName).toBeUndefined()
     expect(next.windowId).toBeUndefined()
     expect(next.windowName).toBeUndefined()
+  })
+})
+
+describe('microphone picker and fallback migration', () => {
+  const nativeMicrophone: Device = {
+    id: 'microphone:coreaudio:42',
+    name: 'Shure MV7+',
+    kind: 'microphone',
+    status: 'available'
+  }
+  const avfoundationMicrophone: Device = {
+    id: 'microphone:avfoundation:2',
+    name: 'Shure MV7+',
+    kind: 'microphone',
+    status: 'available'
+  }
+
+  it('hides avfoundation microphone rows whenever a native row exists', () => {
+    expect(microphonePickerDevices([avfoundationMicrophone, nativeMicrophone])).toEqual([
+      nativeMicrophone
+    ])
+  })
+
+  it('keeps avfoundation microphones only when they are the sole rows', () => {
+    expect(microphonePickerDevices([avfoundationMicrophone])).toEqual([avfoundationMicrophone])
+  })
+
+  it('never defaults a fresh profile to an avfoundation fallback microphone', () => {
+    // Older backends listed the avfoundation duplicate FIRST, which made
+    // microphones[0] a broken "Fallback - X" default on fresh profiles.
+    const next = reconcileSourceSelection({}, [avfoundationMicrophone, nativeMicrophone])
+
+    expect(next.microphoneId).toBe('microphone:coreaudio:42')
+    expect(next.microphoneName).toBe('Shure MV7+')
+  })
+
+  it('migrates a persisted fallback microphone selection to its native device', () => {
+    const next = reconcileSourceSelection(
+      {
+        microphoneId: 'microphone:avfoundation:2',
+        microphoneName: 'Fallback - Shure MV7+'
+      },
+      [nativeMicrophone]
+    )
+
+    expect(next.microphoneId).toBe('microphone:coreaudio:42')
+    expect(next.microphoneName).toBe('Shure MV7+')
+  })
+
+  it('keeps a persisted avfoundation selection when no native input exists', () => {
+    const next = reconcileSourceSelection(
+      {
+        microphoneId: 'microphone:avfoundation:2',
+        microphoneName: 'Shure MV7+'
+      },
+      [avfoundationMicrophone]
+    )
+
+    expect(next.microphoneId).toBe('microphone:avfoundation:2')
+    expect(next.microphoneName).toBe('Shure MV7+')
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -1292,6 +1292,30 @@ function isAvFoundationScreenSourceId(sourceId: string | undefined): boolean {
   return sourceId?.startsWith('screen:avfoundation:') === true
 }
 
+export function isAvFoundationMicrophoneId(sourceId: string | undefined): boolean {
+  return sourceId?.startsWith('microphone:avfoundation:') === true
+}
+
+// Older builds published every avfoundation microphone as a selectable
+// "Fallback - X" duplicate of its CoreAudio device; the prefix survives in
+// persisted selections and must map back to the native device name.
+const FALLBACK_MICROPHONE_NAME_PREFIX = 'Fallback - '
+
+function nativeMicrophoneNameFor(name: string | undefined): string | undefined {
+  return name?.startsWith(FALLBACK_MICROPHONE_NAME_PREFIX)
+    ? name.slice(FALLBACK_MICROPHONE_NAME_PREFIX.length)
+    : name
+}
+
+// Mirrors the backend picker rule (and guards against older backends that
+// still list them): avfoundation microphones are the internal silent-mic
+// retry path and are only selectable when no native input row exists at all.
+export function microphonePickerDevices(devices: Device[]): Device[] {
+  const microphones = devices.filter((device) => device.kind === 'microphone')
+  const nativeMicrophones = microphones.filter((device) => !isAvFoundationMicrophoneId(device.id))
+  return nativeMicrophones.length > 0 ? nativeMicrophones : microphones
+}
+
 const SCREEN_CAPTUREKIT_STATUS_IDS = new Set([
   'screen:screencapturekit-permission',
   'screen:screencapturekit-unavailable',
@@ -1439,8 +1463,8 @@ export function reconcileSourceSelection(
   const cameras = devices.filter(
     (device) => device.kind === 'camera' && device.status === 'available'
   )
-  const microphones = devices.filter(
-    (device) => device.kind === 'microphone' && device.status === 'available'
+  const microphones = microphonePickerDevices(devices).filter(
+    (device) => device.status === 'available'
   )
 
   // Auto-defaulting must never grab a window: with Screen Recording denied the
@@ -1479,9 +1503,22 @@ export function reconcileSourceSelection(
 
   const selectedCamera =
     findRememberedSource(nextSources.cameraId, nextSources.cameraName, cameras) ?? cameras[0]
+  // Migrate selections persisted onto the retired "Fallback - X" avfoundation
+  // rows: drop the synthetic id when native rows exist and match the native
+  // device by its unprefixed name instead of re-pinning the broken fallback.
+  const nativeMicrophoneAvailable = microphones.some(
+    (device) => !isAvFoundationMicrophoneId(device.id)
+  )
+  const rememberedMicrophoneId =
+    nativeMicrophoneAvailable && isAvFoundationMicrophoneId(nextSources.microphoneId)
+      ? undefined
+      : nextSources.microphoneId
   const selectedMicrophone =
-    findRememberedSource(nextSources.microphoneId, nextSources.microphoneName, microphones) ??
-    microphones[0]
+    findRememberedSource(
+      rememberedMicrophoneId,
+      nativeMicrophoneNameFor(nextSources.microphoneName),
+      microphones
+    ) ?? microphones[0]
 
   const cameraIdentity = sourceIdentityFor(selectedCamera)
   nextSources.cameraId = cameraIdentity.id

--- a/apps/desktop/src/renderer/src/lib/layout-transaction-policy.test.ts
+++ b/apps/desktop/src/renderer/src/lib/layout-transaction-policy.test.ts
@@ -6,6 +6,7 @@ import {
   layoutTransactionFailureReconciliation,
   layoutTransactionProofDisposition,
   layoutTransactionUnprovenSeverity,
+  liveBackgroundCommitDecision,
   NativePreviewPresentationProofError,
   shouldReloadSceneFromCaptureConfig
 } from './layout-transaction-policy'
@@ -39,6 +40,33 @@ describe('layout transaction policy', () => {
         proofSucceeded: false
       })
     ).toBe('ignore-stale')
+  })
+
+  it('live-commits a background change only after the session armed the watcher', () => {
+    // Idle: never commit, stay disarmed.
+    expect(
+      liveBackgroundCommitDecision({
+        sessionActive: false,
+        armedFingerprint: 'a',
+        fingerprint: 'b'
+      })
+    ).toEqual({ next: null, commit: false })
+    // Session rising edge: start params already carry the background — arm only.
+    expect(
+      liveBackgroundCommitDecision({
+        sessionActive: true,
+        armedFingerprint: null,
+        fingerprint: 'a'
+      })
+    ).toEqual({ next: 'a', commit: false })
+    // Unchanged value (registry edited an inactive slot): no commit.
+    expect(
+      liveBackgroundCommitDecision({ sessionActive: true, armedFingerprint: 'a', fingerprint: 'a' })
+    ).toEqual({ next: 'a', commit: false })
+    // The visible background actually changed while live: commit once.
+    expect(
+      liveBackgroundCommitDecision({ sessionActive: true, armedFingerprint: 'a', fingerprint: 'b' })
+    ).toEqual({ next: 'b', commit: true })
   })
 
   it('downgrades a preview-only presentation miss to a warning', () => {

--- a/apps/desktop/src/renderer/src/lib/layout-transaction-policy.test.ts
+++ b/apps/desktop/src/renderer/src/lib/layout-transaction-policy.test.ts
@@ -5,6 +5,8 @@ import {
   layoutTransactionBackendSnapshotIsStable,
   layoutTransactionFailureReconciliation,
   layoutTransactionProofDisposition,
+  layoutTransactionUnprovenSeverity,
+  NativePreviewPresentationProofError,
   shouldReloadSceneFromCaptureConfig
 } from './layout-transaction-policy'
 
@@ -37,6 +39,25 @@ describe('layout transaction policy', () => {
         proofSucceeded: false
       })
     ).toBe('ignore-stale')
+  })
+
+  it('downgrades a preview-only presentation miss to a warning', () => {
+    expect(
+      layoutTransactionUnprovenSeverity(
+        new NativePreviewPresentationProofError(
+          'Native preview did not present committed scene revision 7.'
+        )
+      )
+    ).toBe('presentation-warning')
+  })
+
+  it('keeps output-proof failures at error severity', () => {
+    expect(
+      layoutTransactionUnprovenSeverity(
+        new Error('Live layout switch did not reach the active recording/streaming output')
+      )
+    ).toBe('output-error')
+    expect(layoutTransactionUnprovenSeverity(undefined)).toBe('output-error')
   })
 
   it('reconciles commit A when superseding intent B fails after scene events were suppressed', () => {

--- a/apps/desktop/src/renderer/src/lib/layout-transaction-policy.ts
+++ b/apps/desktop/src/renderer/src/lib/layout-transaction-policy.ts
@@ -29,6 +29,27 @@ export function layoutTransactionProofDisposition(input: {
   return input.proofSucceeded ? 'apply-proven' : 'apply-unproven'
 }
 
+// A backend commit whose recording/streaming output proof passed but whose
+// native preview presented-revision readback missed is a preview-only fault:
+// the session output is already proven and the controls are reconciled to the
+// commit, so it must not be raised as a destructive error.
+export class NativePreviewPresentationProofError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NativePreviewPresentationProofError'
+  }
+}
+
+export type LayoutTransactionUnprovenSeverity = 'output-error' | 'presentation-warning'
+
+export function layoutTransactionUnprovenSeverity(
+  proofError: unknown
+): LayoutTransactionUnprovenSeverity {
+  return proofError instanceof NativePreviewPresentationProofError
+    ? 'presentation-warning'
+    : 'output-error'
+}
+
 export type LayoutTransactionFailureReconciliation<T> = {
   source: 'backend-truth' | 'latest-commit'
   snapshot: T

--- a/apps/desktop/src/renderer/src/lib/layout-transaction-policy.ts
+++ b/apps/desktop/src/renderer/src/lib/layout-transaction-policy.ts
@@ -29,6 +29,25 @@ export function layoutTransactionProofDisposition(input: {
   return input.proofSucceeded ? 'apply-proven' : 'apply-unproven'
 }
 
+// Instant background apply while live: commit only when a session is active,
+// only after the session's own start armed the watcher (start params already
+// carry the background), and only when the resolved background VALUE changed —
+// the registry yields new objects on unrelated edits (rename, import into an
+// inactive slot) which must not commit.
+export function liveBackgroundCommitDecision(input: {
+  sessionActive: boolean
+  armedFingerprint: string | null
+  fingerprint: string
+}): { next: string | null; commit: boolean } {
+  if (!input.sessionActive) {
+    return { next: null, commit: false }
+  }
+  if (input.armedFingerprint === null || input.armedFingerprint === input.fingerprint) {
+    return { next: input.fingerprint, commit: false }
+  }
+  return { next: input.fingerprint, commit: true }
+}
+
 // A backend commit whose recording/streaming output proof passed but whose
 // native preview presented-revision readback missed is a preview-only fault:
 // the session output is already proven and the controls are reconciled to the

--- a/apps/desktop/src/renderer/src/lib/live-chat-view.test.ts
+++ b/apps/desktop/src/renderer/src/lib/live-chat-view.test.ts
@@ -6,6 +6,8 @@ import {
   applyLiveChatMessage,
   applyLiveChatMessages,
   applyLiveChatProviderStatus,
+  chatNeedsConnectionAction,
+  chatSetupToastWarnings,
   emptyLiveChatSnapshot,
   filterMessagesByPlatform,
   liveChatEmptyMessage,
@@ -49,6 +51,45 @@ function provider(
     message
   }
 }
+
+describe('chat setup warnings', () => {
+  it('warns for failed and missing-scope destinations with their message', () => {
+    const failed: LiveChatProviderState = {
+      ...provider(
+        'twitch',
+        'Twitch live chat unavailable: Reconnect Twitch to enable live comments.'
+      ),
+      state: 'failed',
+      read: 'failed',
+      write: 'failed'
+    }
+    const missingScope: LiveChatProviderState = {
+      ...provider('twitch', 'Reconnect Twitch to send.', 'twitch-2'),
+      write: 'missing-scope'
+    }
+
+    expect(chatSetupToastWarnings([failed, missingScope]).map((warning) => warning.id)).toEqual([
+      'twitch',
+      'twitch-2'
+    ])
+    expect(chatSetupToastWarnings([failed])[0].message).toContain('Reconnect Twitch')
+  })
+
+  it('never warns for healthy or documented receive-only destinations', () => {
+    const healthy = provider('twitch', '')
+    const xReceiveOnly = provider('x', 'X live chat is receive-only.')
+    const xUnavailable: LiveChatProviderState = {
+      ...provider('x', 'Manual RTMP has no native X broadcast context.', 'x-manual'),
+      read: 'unavailable',
+      write: 'read-only'
+    }
+
+    expect(chatSetupToastWarnings([healthy, xReceiveOnly, xUnavailable])).toEqual([])
+    // The unavailable state still deserves the Comments empty-state CTA.
+    expect(chatNeedsConnectionAction([xUnavailable])).toBe(true)
+    expect(chatNeedsConnectionAction([healthy, xReceiveOnly])).toBe(false)
+  })
+})
 
 describe('live-chat-view', () => {
   it('sorts messages chronologically by receivedAt', () => {

--- a/apps/desktop/src/renderer/src/lib/live-chat-view.ts
+++ b/apps/desktop/src/renderer/src/lib/live-chat-view.ts
@@ -127,6 +127,33 @@ function providerNeedsAction(provider: LiveChatProviderState): boolean {
   return providerStatePriority(provider) < 4
 }
 
+export type ChatSetupWarning = {
+  id: string
+  platform: StreamPlatform
+  message: string
+}
+
+/**
+ * Destinations whose comments are broken or need a reconnect — never the
+ * documented receive-only/unavailable states. These warrant a go-live toast:
+ * a silently empty Comments feed must never be the first (or only) signal
+ * that chat setup failed (2026-07-10 live-session report).
+ */
+export function chatSetupToastWarnings(providers: LiveChatProviderState[]): ChatSetupWarning[] {
+  return providers
+    .filter((provider) => providerStatePriority(provider) <= 1)
+    .map((provider) => ({
+      id: provider.id,
+      platform: provider.platform,
+      message: provider.message || 'Live comments are unavailable for this destination.'
+    }))
+}
+
+/** True when some destination's comments could be fixed by (re)connecting an account. */
+export function chatNeedsConnectionAction(providers: LiveChatProviderState[]): boolean {
+  return providers.some((provider) => providerStatePriority(provider) <= 2)
+}
+
 export function liveChatEmptyMessage(
   snapshot: Pick<LiveChatSnapshot, 'providers'>,
   noProviderMessage = 'Connect YouTube, Twitch, or X to read live comments.'

--- a/apps/desktop/src/renderer/src/lib/mic-meter.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-meter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_METER_BALLISTICS,
+  INITIAL_METER_BALLISTICS,
+  MIC_METER_FLOOR_DB,
+  advanceMeterBallistics,
+  amplitudeToDb,
+  dbToMeterLevel,
+  matchMicrophoneDeviceId,
+  samplesRmsAndPeak
+} from './mic-meter'
+
+describe('mic meter math', () => {
+  it('computes rms and peak over a buffer', () => {
+    const { rms, peak } = samplesRmsAndPeak(new Float32Array([0, 0.5, -0.5, 0]))
+    expect(peak).toBe(0.5)
+    expect(rms).toBeCloseTo(Math.sqrt(0.125), 5)
+    expect(samplesRmsAndPeak(new Float32Array([]))).toEqual({ rms: 0, peak: 0 })
+  })
+
+  it('maps amplitude to dBFS with a hard floor', () => {
+    expect(amplitudeToDb(1)).toBe(0)
+    expect(amplitudeToDb(0.1)).toBeCloseTo(-20, 5)
+    expect(amplitudeToDb(0)).toBe(MIC_METER_FLOOR_DB)
+    expect(dbToMeterLevel(0)).toBe(1)
+    expect(dbToMeterLevel(MIC_METER_FLOOR_DB)).toBe(0)
+    expect(dbToMeterLevel(-30)).toBeCloseTo(0.5, 5)
+  })
+
+  it('rises fast on attack and falls slower on decay', () => {
+    const attacked = advanceMeterBallistics(INITIAL_METER_BALLISTICS, 1, 16, 0)
+    // One 16ms frame with a 15ms attack tau covers most of the distance.
+    expect(attacked.level).toBeGreaterThan(0.6)
+
+    const decayed = advanceMeterBallistics(attacked, 0, 16, 16)
+    // The same frame length on the 350ms decay tau barely moves the bar.
+    expect(decayed.level).toBeGreaterThan(attacked.level * 0.9)
+    expect(decayed.level).toBeLessThan(attacked.level)
+  })
+
+  it('holds the peak marker before letting it decay toward the bar', () => {
+    const spiked = advanceMeterBallistics(INITIAL_METER_BALLISTICS, 0.8, 16, 0)
+    expect(spiked.peakLevel).toBe(0.8)
+    expect(spiked.peakHeldUntilMs).toBe(DEFAULT_METER_BALLISTICS.peakHoldMs)
+
+    // Still inside the hold window: the peak must not move.
+    const held = advanceMeterBallistics(spiked, 0, 16, 100)
+    expect(held.peakLevel).toBe(0.8)
+
+    // After the hold window it decays toward the (lower) bar level.
+    const released = advanceMeterBallistics(held, 0, 200, spiked.peakHeldUntilMs + 1)
+    expect(released.peakLevel).toBeLessThan(0.8)
+    expect(released.peakLevel).toBeGreaterThanOrEqual(released.level)
+  })
+
+  it('matches the backend device to a WebAudio input by label', () => {
+    const inputs = [
+      { deviceId: 'default', label: 'Default - Shure MV7+' },
+      { deviceId: 'a', label: 'Shure MV7+' },
+      { deviceId: 'b', label: 'MacBook Pro Microphone' }
+    ]
+    expect(matchMicrophoneDeviceId('Shure MV7+', inputs)).toBe('a')
+    expect(matchMicrophoneDeviceId('MacBook Pro Microphone', inputs)).toBe('b')
+    // Containment either way covers vendor suffix differences.
+    expect(matchMicrophoneDeviceId('Pro Microphone', [inputs[2]])).toBe('b')
+    expect(matchMicrophoneDeviceId('Elgato Wave:3', inputs)).toBeUndefined()
+    expect(matchMicrophoneDeviceId(undefined, inputs)).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/mic-meter.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-meter.ts
@@ -1,0 +1,130 @@
+// Pure math for the live microphone meter: dBFS mapping, broadcast-style
+// ballistics (fast attack, slower decay, peak hold), and backend-device →
+// WebAudio device matching by label. No WebAudio, no DOM — unit-testable.
+// The WebAudio side lives in hooks/use-mic-level-meter.ts.
+
+export const MIC_METER_FLOOR_DB = -60
+
+export function samplesRmsAndPeak(samples: Float32Array): { rms: number; peak: number } {
+  if (samples.length === 0) {
+    return { rms: 0, peak: 0 }
+  }
+  let sumSquares = 0
+  let peak = 0
+  for (const sample of samples) {
+    const magnitude = Math.abs(sample)
+    if (magnitude > peak) {
+      peak = magnitude
+    }
+    sumSquares += sample * sample
+  }
+  return { rms: Math.sqrt(sumSquares / samples.length), peak }
+}
+
+export function amplitudeToDb(amplitude: number): number {
+  if (amplitude <= 0) {
+    return MIC_METER_FLOOR_DB
+  }
+  return Math.max(MIC_METER_FLOOR_DB, 20 * Math.log10(amplitude))
+}
+
+/** Linear-in-dB meter position over the floor..0 dBFS window, clamped to 0..1. */
+export function dbToMeterLevel(db: number, floorDb: number = MIC_METER_FLOOR_DB): number {
+  return Math.min(1, Math.max(0, (db - floorDb) / -floorDb))
+}
+
+export type MeterBallisticsState = {
+  /** Smoothed bar position (0..1). */
+  level: number
+  /** Peak-hold marker position (0..1). */
+  peakLevel: number
+  /** Timestamp (ms) until which the held peak may not decay. */
+  peakHeldUntilMs: number
+}
+
+export const INITIAL_METER_BALLISTICS: MeterBallisticsState = {
+  level: 0,
+  peakLevel: 0,
+  peakHeldUntilMs: 0
+}
+
+export type MeterBallisticsOptions = {
+  attackMs: number
+  decayMs: number
+  peakHoldMs: number
+  peakDecayMs: number
+}
+
+export const DEFAULT_METER_BALLISTICS: MeterBallisticsOptions = {
+  // Fast rise so a spoken syllable registers on the next frame; slower fall so
+  // the bar reads as motion instead of flicker (broadcast PPM-ish feel).
+  attackMs: 15,
+  decayMs: 350,
+  peakHoldMs: 1200,
+  peakDecayMs: 600
+}
+
+function approach(current: number, target: number, elapsedMs: number, tauMs: number): number {
+  if (tauMs <= 0) {
+    return target
+  }
+  return current + (target - current) * (1 - Math.exp(-elapsedMs / tauMs))
+}
+
+export function advanceMeterBallistics(
+  state: MeterBallisticsState,
+  targetLevel: number,
+  elapsedMs: number,
+  nowMs: number,
+  options: MeterBallisticsOptions = DEFAULT_METER_BALLISTICS
+): MeterBallisticsState {
+  const target = Math.min(1, Math.max(0, targetLevel))
+  const rising = target > state.level
+  const level = approach(
+    state.level,
+    target,
+    elapsedMs,
+    rising ? options.attackMs : options.decayMs
+  )
+
+  let peakLevel = state.peakLevel
+  let peakHeldUntilMs = state.peakHeldUntilMs
+  if (target >= peakLevel) {
+    peakLevel = target
+    peakHeldUntilMs = nowMs + options.peakHoldMs
+  } else if (nowMs >= peakHeldUntilMs) {
+    peakLevel = Math.max(level, approach(peakLevel, level, elapsedMs, options.peakDecayMs))
+  }
+  return { level, peakLevel, peakHeldUntilMs }
+}
+
+function normalizeDeviceName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+/**
+ * Match the backend's selected microphone (CoreAudio/dshow name) to a WebAudio
+ * input by label: exact normalized match first, then containment either way.
+ * Returns undefined when nothing matches — callers fall back to the default
+ * input rather than metering a device the user did not select.
+ */
+export function matchMicrophoneDeviceId(
+  backendName: string | undefined,
+  inputs: { deviceId: string; label: string }[]
+): string | undefined {
+  if (!backendName) {
+    return undefined
+  }
+  const wanted = normalizeDeviceName(backendName)
+  if (!wanted) {
+    return undefined
+  }
+  const exact = inputs.find((input) => normalizeDeviceName(input.label) === wanted)
+  if (exact) {
+    return exact.deviceId
+  }
+  return inputs.find((input) => {
+    const label = normalizeDeviceName(input.label)
+    return label.length > 0 && (label.includes(wanted) || wanted.includes(label))
+  })?.deviceId
+}

--- a/apps/desktop/src/shared/native-preview-scene-authority.ts
+++ b/apps/desktop/src/shared/native-preview-scene-authority.ts
@@ -34,7 +34,13 @@ export function nativePreviewStatusProvesSceneRevision(
     status.sourcePixelsPresent === true &&
     status.nativePreviewHostKind !== 'proof-surface' &&
     status.nativePreviewHostAttached === true &&
-    status.nativePreviewPresentedSceneRevision === sceneRevision
+    typeof status.nativePreviewPresentedSceneRevision === 'number' &&
+    // Presentation is latest-wins: under rapid commits the surface may skip an
+    // intermediate revision and present a newer one. A presented revision at or
+    // above the awaited one proves the awaited commit was satisfied or
+    // superseded by newer committed truth; only an older presented revision
+    // means the surface is stale.
+    status.nativePreviewPresentedSceneRevision >= sceneRevision
   )
 }
 

--- a/crates/videorc-backend/src/devices.rs
+++ b/crates/videorc-backend/src/devices.rs
@@ -88,6 +88,11 @@ async fn list_macos_devices(ffmpeg_path: &str) -> DeviceList {
                 devices.extend(screens);
             }
 
+            devices.extend(avfoundation_microphone_picker_devices(
+                &av_devices,
+                native_microphone_available,
+            ));
+
             for device in av_devices {
                 match device.kind {
                     AvFoundationDeviceKind::Video => {
@@ -113,10 +118,10 @@ async fn list_macos_devices(ffmpeg_path: &str) -> DeviceList {
                             });
                         }
                     }
-                    AvFoundationDeviceKind::Audio => devices.push(avfoundation_microphone_device(
-                        &device,
-                        native_microphone_available,
-                    )),
+                    // Audio rows are handled by avfoundation_microphone_picker_devices
+                    // above; they are hidden entirely while a native CoreAudio
+                    // input is available.
+                    AvFoundationDeviceKind::Audio => {}
                 }
             }
         }
@@ -636,26 +641,37 @@ fn db_to_level(db: f64) -> f64 {
     ((db + 60.0) / 60.0).clamp(0.0, 1.0)
 }
 
-fn avfoundation_microphone_device(
-    device: &AvFoundationDevice,
+// FFmpeg avfoundation microphones duplicate every CoreAudio input and exist
+// as the internal silent-mic retry path: recording resolves their index by
+// name at session time (find_avfoundation_microphone_index_for_native_name),
+// never through picker rows. Publishing them while a native input was
+// available doubled every microphone in the picker and made a broken
+// "Fallback - X" row the fresh-profile default, so they are listed only when
+// no native CoreAudio input can be selected at all.
+fn avfoundation_microphone_picker_devices(
+    av_devices: &[AvFoundationDevice],
     native_microphone_available: bool,
-) -> Device {
+) -> Vec<Device> {
+    if native_microphone_available {
+        return Vec::new();
+    }
+    av_devices
+        .iter()
+        .filter(|device| device.kind == AvFoundationDeviceKind::Audio)
+        .map(avfoundation_microphone_device)
+        .collect()
+}
+
+fn avfoundation_microphone_device(device: &AvFoundationDevice) -> Device {
     Device {
         id: format!("microphone:avfoundation:{}", device.index),
-        name: if native_microphone_available {
-            format!("Fallback - {}", device.name)
-        } else {
-            device.name.clone()
-        },
+        name: device.name.clone(),
         kind: DeviceKind::Microphone,
         status: DeviceStatus::Available,
-        detail: Some(if native_microphone_available {
-            "FFmpeg avfoundation fallback; use this if the native CoreAudio input opens but does not send frames."
-                .to_string()
-        } else {
+        detail: Some(
             "FFmpeg avfoundation fallback; native CoreAudio probe did not return an available input."
-                .to_string()
-        }),
+                .to_string(),
+        ),
         width: None,
         height: None,
     }
@@ -748,42 +764,48 @@ mod tests {
     }
 
     #[test]
-    fn avfoundation_microphone_is_exposed_as_fallback_when_native_exists() {
-        let device = avfoundation_microphone_device(
-            &AvFoundationDevice {
+    fn avfoundation_microphones_are_hidden_from_picker_when_native_exists() {
+        let av_devices = vec![
+            AvFoundationDevice {
+                index: 0,
+                name: "FaceTime HD Camera".to_string(),
+                kind: AvFoundationDeviceKind::Video,
+            },
+            AvFoundationDevice {
                 index: 2,
                 name: "MacBook Pro Microphone".to_string(),
                 kind: AvFoundationDeviceKind::Audio,
             },
-            true,
-        );
+        ];
 
-        assert_eq!(device.id, "microphone:avfoundation:2");
-        assert_eq!(device.name, "Fallback - MacBook Pro Microphone");
-        assert_eq!(device.status, DeviceStatus::Available);
-        assert!(
-            device
-                .detail
-                .as_deref()
-                .unwrap_or_default()
-                .contains("does not send frames")
-        );
+        // With a native CoreAudio input available, no avfoundation microphone
+        // may reach the picker; the silent-mic retry path resolves the ffmpeg
+        // index by name at session time instead.
+        assert!(avfoundation_microphone_picker_devices(&av_devices, true).is_empty());
     }
 
     #[test]
-    fn avfoundation_microphone_keeps_plain_label_when_native_is_unavailable() {
-        let device = avfoundation_microphone_device(
-            &AvFoundationDevice {
+    fn avfoundation_microphones_are_listed_plain_when_native_is_unavailable() {
+        let av_devices = vec![
+            AvFoundationDevice {
+                index: 0,
+                name: "FaceTime HD Camera".to_string(),
+                kind: AvFoundationDeviceKind::Video,
+            },
+            AvFoundationDevice {
                 index: 2,
                 name: "MacBook Pro Microphone".to_string(),
                 kind: AvFoundationDeviceKind::Audio,
             },
-            false,
-        );
+        ];
 
-        assert_eq!(device.name, "MacBook Pro Microphone");
+        let devices = avfoundation_microphone_picker_devices(&av_devices, false);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].id, "microphone:avfoundation:2");
+        assert_eq!(devices[0].name, "MacBook Pro Microphone");
+        assert_eq!(devices[0].status, DeviceStatus::Available);
         assert!(
-            device
+            devices[0]
                 .detail
                 .as_deref()
                 .unwrap_or_default()

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -590,8 +590,12 @@ fn layout_apply_status(
     status: SceneCommitStatus,
     message: Option<String>,
 ) -> LiveLayoutApplyStatus {
-    let presentation_proven =
-        status.compositor_status.frame_scene_revision == Some(status.scene_revision);
+    // Rendering is latest-wins: a frame at or beyond the committed revision
+    // proves this commit was satisfied or superseded by newer committed truth.
+    let presentation_proven = status
+        .compositor_status
+        .frame_scene_revision
+        .is_some_and(|revision| revision >= status.scene_revision);
     LiveLayoutApplyStatus {
         applied: true,
         mode: mode.to_string(),

--- a/scripts/smoke-source-reconciliation.mjs
+++ b/scripts/smoke-source-reconciliation.mjs
@@ -36,7 +36,7 @@ try {
     loadCaptureConfig,
     persistableCaptureConfig,
     reconcileSourceSelection,
-    sourceSelectionChangeMessages,
+    sourceSelectionChangeEvents,
     STORAGE_KEYS
   } = require(tempModule)
   assert.equal(typeof reconcileSourceSelection, 'function')
@@ -90,11 +90,17 @@ try {
     microphoneName: 'Podcast Mic',
     testPattern: false
   })
-  assert.deepEqual(sourceSelectionChangeMessages(loaded.sources, reloadedSources), [
-    'Capture source "Built-in Display" was restored by name because its system ID changed.',
-    'Camera "FaceTime HD Camera" was restored by name because its system ID changed.',
-    'Microphone "Podcast Mic" was restored by name because its system ID changed.'
-  ])
+  assert.deepEqual(
+    sourceSelectionChangeEvents(loaded.sources, reloadedSources).map((event) => ({
+      sourceKind: event.sourceKind,
+      reason: event.reason
+    })),
+    [
+      { sourceKind: 'capture', reason: 'restored-by-name' },
+      { sourceKind: 'camera', reason: 'restored-by-name' },
+      { sourceKind: 'microphone', reason: 'restored-by-name' }
+    ]
+  )
 
   localStorage.setItem(
     STORAGE_KEYS.captureConfig,
@@ -190,14 +196,18 @@ try {
     microphoneName: 'Podcast Mic'
   })
   assert.deepEqual(
-    sourceSelectionChangeMessages(
+    sourceSelectionChangeEvents(
       missingSources,
       reconcileSourceSelection(missingSources, devices)
-    ),
+    ).map((event) => ({
+      sourceKind: event.sourceKind,
+      reason: event.reason,
+      nextName: event.nextName
+    })),
     [
-      'Capture source "Missing Display" is unavailable, so Videorc selected "Built-in Display".',
-      'Camera "Missing Camera" is unavailable, so Videorc selected "FaceTime HD Camera".',
-      'Microphone "Missing Mic" is unavailable, so Videorc selected "Podcast Mic".'
+      { sourceKind: 'capture', reason: 'unavailable-selected', nextName: 'Built-in Display' },
+      { sourceKind: 'camera', reason: 'unavailable-selected', nextName: 'FaceTime HD Camera' },
+      { sourceKind: 'microphone', reason: 'unavailable-selected', nextName: 'Podcast Mic' }
     ]
   )
 
@@ -225,8 +235,31 @@ try {
     }
   )
 
+  // Zombie "Fallback - X" avfoundation microphone rows (pre-0.9.27 backends)
+  // must never win the default, and selections persisted onto them must
+  // migrate to the matching native CoreAudio device by unprefixed name.
+  const fallbackMicDevices = [
+    device('microphone:avfoundation:2', 'Shure MV7+', 'microphone'),
+    device('microphone:coreaudio:shure', 'Shure MV7+', 'microphone')
+  ]
+  const migratedFromFallback = reconcileSourceSelection(
+    { microphoneId: 'microphone:avfoundation:2', microphoneName: 'Fallback - Shure MV7+' },
+    fallbackMicDevices
+  )
+  assert.equal(migratedFromFallback.microphoneId, 'microphone:coreaudio:shure')
+  assert.equal(migratedFromFallback.microphoneName, 'Shure MV7+')
+
+  const freshDefaultMic = reconcileSourceSelection({}, fallbackMicDevices)
+  assert.equal(freshDefaultMic.microphoneId, 'microphone:coreaudio:shure')
+
+  const avfoundationOnly = reconcileSourceSelection(
+    { microphoneId: 'microphone:avfoundation:2', microphoneName: 'Shure MV7+' },
+    [device('microphone:avfoundation:2', 'Shure MV7+', 'microphone')]
+  )
+  assert.equal(avfoundationOnly.microphoneId, 'microphone:avfoundation:2')
+
   console.log(
-    'Source reconciliation smoke OK - persisted IDs, name rematch, and fallback behavior verified.'
+    'Source reconciliation smoke OK - persisted IDs, name rematch, fallback behavior, and fallback-mic migration verified.'
   )
 } finally {
   await rm(tempDir, { recursive: true, force: true })


### PR DESCRIPTION
Fixes the five bugs from the owner's 2026-07-10 live session on 0.9.26 (plan: vault `2026-07-10 - Videorc Live Session Bug Batch Fix Plan`). One commit per fix, ordered F2 → F1 → F4 → F3 → F5.

## F2 — False-positive "preview proof was not observed" error toasts
The proof contract introduced with the preview rebuild (#61) required a strict `===` match on the native surface's presented scene revision within 750 ms, while presentation is latest-wins — presenting a **newer** committed revision was scored as failure, and commits made while the preview is hidden behind a dialog can never present at all. Users got destructive error toasts while everything visibly worked.
- Matcher accepts presented revision `>=` committed (shared TS + backend `presentation_proven` mirror in `live_layout.rs`).
- Native-surface proof gets its own 3 s budget; skipped entirely while the surface cannot present (hidden/minimized/overlay-open) — the compositor output proof still gates.
- Preview-only presentation misses downgrade to a warning toast + console diagnostic; output-proof failures stay errors.

## F1 — Zombie "Fallback - X" microphone rows; broken fallback was the default
macOS published every FFmpeg-avfoundation mic as a selectable duplicate **ahead of** the native CoreAudio rows, so fresh profiles defaulted to a broken fallback input (silent for aggregate/virtual devices, mute dropped, mono), and the choice persisted by id **and** name.
- Backend lists avfoundation mics only when no native input exists; the internal silent-mic auto-retry is unaffected (resolves its ffmpeg index by name at session time).
- Renderer mirrors the rule in both pickers + `reconcileSourceSelection`, and migrates persisted "Fallback - X" selections to the native device by name.
- Repaired `scripts/smoke-source-reconciliation.mjs` (imported the removed `sourceSelectionChangeMessages`; this was also breaking `smoke:local-gates` on clean main) and added fallback-mic fixtures.

## F4 — Twitch comments silently dead while live
The 0.9.26 session predates #62, where chat-setup failures were warn-log-only. #62 added typed destination rows; this closes the remaining visibility gaps so an empty feed is never the only signal:
- Go-live warning toast (once per destination per session) when a destination's chat failed or needs a reconnect, with an "Open Livestream" action. Documented receive-only/unavailable states never toast.
- Comments empty state gains an "Open Livestream settings" CTA when a destination is fixable by (re)connecting.
- Destination badge tooltip names the bound account ("Reading chat as X.") — chat binds to the linked account's channel, not to wherever a manual stream key points.

**Owner triage for the 2026-07-10 session:** export a support bundle and search `Twitch live chat unavailable` — most likely remedy is reconnecting Twitch in the Livestream tab so the token carries `user:read:chat`.

## F3 — Clicking a background asset now applies to the live scene instantly
Clicking only mutated the renderer-local registry; nothing committed it during an active session, so the stream kept the old background until a layout-preset change re-committed the scene. A `StudioProvider` effect now watches the resolved background **value** and commits through the existing `requestLayoutTransaction` machinery (scene revisions, intent latest-wins, proof — no second writer). Arm-on-session-start and value-fingerprint rules are a pure tested helper; background-only commits skip the "Switching…" flash. Also covers style sliders and Remove-from-scene. Depends on F2 (more commits per session must not toast).

## F5 — Real-time mic meter
The bar was fed one instantaneous single-buffer peak per second (1 Hz backend tick × 1 Hz renderer throttle, no ballistics, 100 ms CSS transition) and existed only while recording. The visual now runs on a renderer WebAudio analyser: selected device matched by label, ~43 ms RMS window at display rate, 15 ms attack / 350 ms decay with a 1.2 s peak-hold marker, driven imperatively via refs (no React state in the path). Works idle and in-session, honors mute, and falls back to the backend meter when the analyser can't open the device. Backend `micLiveLevel` remains the capture/health authority.

## Verification
- `pnpm typecheck` / `pnpm lint` / `pnpm format:check` — PASS
- `pnpm --filter @videorc/desktop test` — 82 files / 652 tests PASS
- `pnpm test:scripts` — PASS; `pnpm build` — PASS
- `cargo fmt --check --all` / `cargo clippy -p videorc-backend -- -D warnings` / `cargo test -p videorc-backend` — 946 tests PASS
- `pnpm smoke:live-chat-fake-providers` — PASS (375 messages, fan-out matrix, snapshot recovery)
- `node scripts/smoke-source-reconciliation.mjs` — PASS (incl. new fallback-mic migration fixtures)
- `pnpm probe:preview-lifecycle` — PASS (100 toggle cycles)
- `pnpm smoke:preview-scene-commit` — **BLOCKED on this host**: the isolated worktree's freshly installed Electron binary has no camera TCC grant ("No camera device available to select"). Needs a run from a granted checkout; the proof-semantics changes are covered by the updated `native-preview-scene-authority` / `layout-transaction-policy` unit suites.

## By-eye acceptance (owner)
- Rapid layout/background changes while streaming: no error toasts; genuine output failures still error.
- Fresh profile: mic defaults to a real device; a profile stuck on "Fallback - X" migrates on launch.
- Twitch stream with a stale account: pre-live warning toast + Comments CTA instead of a silent empty feed.
- Asset click while live changes the stream background immediately.
- Mic meter reacts syllable-by-syllable while idle and while live; peak marker holds ~1 s; mute zeroes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)