### PR TITLE
Record the 0.9.27-beta.1 release (build, upload, feed, announce)

### DIFF
--- a/.claude/skills/videorc-release/SKILL.md
+++ b/.claude/skills/videorc-release/SKILL.md
@@ -119,3 +119,9 @@ commit + push (via a PR — `main` is branch-protected since 2026-07-07).
   `max-age=60`; a long / `immutable` cache serves an expired 403.
 - **Notarization is a network round-trip to Apple** — the build sits for minutes
   near the end; that's normal, not a hang.
+- **Don't source env via `. <(grep …)` under `/bin/bash`** — macOS ships bash
+  3.2, where sourcing from process substitution silently loads NOTHING; the
+  0.9.27 upload failed with "Release upload S3 endpoint URL must be a valid
+  HTTP(S) URL" because `VIDEORC_DOWNLOAD_S3_*` never entered the environment
+  (zsh handles it fine, which hides the bug when testing interactively).
+  Write the grep output to a temp file and `.` that file instead.

--- a/docs/releases/0.9.27.md
+++ b/docs/releases/0.9.27.md
@@ -1,0 +1,85 @@
+# Videorc 0.9.27 Beta 1
+
+Videorc 0.9.27 ships the live-session bug batch: five fixes from the
+owner's 2026-07-10 live stream on 0.9.26, plus the comments unification
+(PR #62) that merged just after the 0.9.26 build was cut.
+
+## Scope
+
+- **Live session bug batch** (PR #65, plan: vault
+  `2026-07-10 - Videorc Live Session Bug Batch Fix Plan`):
+  - false-positive "preview proof was not observed" destructive toasts
+    (PR #61's proof contract vs latest-wins presentation; `>=` matcher,
+    3s native proof budget, skip-while-hidden, warning severity for
+    preview-only misses);
+  - zombie "Fallback - X" avfoundation microphone picker rows that
+    doubled every mic and made a broken fallback the fresh-profile
+    default (backend hides them while a native input exists; persisted
+    fallback selections migrate by name);
+  - silently dead comments feed (go-live warning toast per broken
+    destination with an Open Livestream action, Comments empty-state
+    connect CTA, destination badge names the bound account);
+  - background assets now apply to the live scene instantly through the
+    existing layout-transaction machinery;
+  - real-time mic meter: renderer WebAudio analyser at display rate
+    with attack/decay ballistics and peak hold; backend stays health
+    authority.
+- **Comments unification** (PR #62, plan 033): per-destination
+  read/write truth, correlated send fan-out, lag-proof event relay,
+  backend-authoritative highlight, live/history modes — merged to main
+  after 0.9.26 was built, so it ships here.
+
+## Release status
+
+- [x] Feature PRs merged via protected `main` (#62, #65); release prep
+      PR https://github.com/TheOrcDev/videorc/pull/67.
+- [x] Built from a worktree at `origin/main` post-merge (`766de10f`).
+- [x] Signed + notarized (DMG stapled); `release:validate:macos` PASS
+      (codesign, Gatekeeper, stapler, bundled-secret gates incl. the X
+      OAuth1 consumer pair); ffmpeg capability probe passed in
+      `package:preflight:macos`.
+- [x] Uploaded to R2, all 8 objects verified (versioned DMG + sha256 +
+      release.json, stable latest/release.json, feed yml + zip +
+      blockmap, changelog.json); feed serves `version: 0.9.27` through
+      the www redirect; `/api/changelog` serves `0.9.27-beta.1`
+      (28 entries valid).
+- [x] Discord announced (dry-run previewed first, single post).
+
+## Verification
+
+- All gates green on prep PR #67 and feature PR #65 (Rust
+  test+clippy+fmt, JS format+lint+tests, Windows gates, Windows
+  installer artifact).
+- Feature-PR evidence (PR #65): 652 desktop tests, 946 backend tests,
+  `smoke:live-chat-fake-providers` PASS (375 messages, fan-out matrix,
+  snapshot recovery), repaired `smoke-source-reconciliation` PASS with
+  new fallback-mic migration fixtures, `probe:preview-lifecycle` PASS
+  (100 cycles). `smoke:preview-scene-commit` was blocked in the
+  isolated build worktree (its fresh Electron binary has no camera TCC
+  grant) — rerun from a granted checkout below.
+
+## Release-process note
+
+The runbook's inline `. <(grep …)` env sourcing silently loads nothing
+under macOS `/bin/bash` 3.2 — the first upload attempt failed with
+"Release upload S3 endpoint URL must be a valid HTTP(S) URL" because
+`VIDEORC_DOWNLOAD_S3_*` never made it into the environment. Fixed by
+sourcing through a temp file; the release skill now warns about this.
+
+## Pending owner acceptance
+
+- [ ] Update to 0.9.27; rapid layout/background changes while streaming
+      produce no error toasts.
+- [ ] Fresh-profile check: mic picker lists each device once and
+      defaults to a real device; a profile stuck on "Fallback - X"
+      migrates on launch.
+- [ ] Click a background asset while live: scene changes immediately,
+      no layout switch.
+- [ ] Mic meter reacts syllable-by-syllable idle and live; peak marker
+      holds ~1s; mute zeroes it.
+- [ ] Reconnect Twitch in the Livestream tab, then stream: comments
+      arrive; with a broken account, the go-live warning toast and
+      Comments CTA appear instead of a silent feed.
+- [ ] Run `pnpm smoke:preview-scene-commit` from a camera-granted
+      checkout.
+- [ ] Confirm the signed-in download page shows 0.9.27.


### PR DESCRIPTION
Release record for 0.9.27-beta.1 (live session bug batch #65 + comments unification #62; prep PR #67). Feed verified serving 0.9.27 through the www redirect; changelog live; Discord announced. Also adds the bash-3.2 `. <(grep …)` env-sourcing gotcha to the release skill — it silently loaded nothing and failed the first upload attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Videorc 0.9.27 Beta 1, covering live-session fixes, unified comments, validation results, and pending verification items.
  * Documented a macOS release procedure workaround to prevent upload failures caused by missing environment variables.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->