### PR TITLE
Remove docked preview chrome: borderless frame, no transport label, solid buttons

### DIFF
--- a/apps/desktop/src/renderer/src/components/preview-stage.tsx
+++ b/apps/desktop/src/renderer/src/components/preview-stage.tsx
@@ -118,13 +118,15 @@ function DockedPreviewFrame({
     title: previewSupervisorDisplay(true, supervisor, previewSurfaceStatus).title,
     detail: previewSupervisorDisplay(true, supervisor, previewSurfaceStatus).detail
   }
-  const transportLabel = previewTransportLabel(supervisor.transport, supervisor.backing)
   const showPermissionAction = supervisor.lifecycleState === 'permission-required'
   const aspectRatio = previewAspectRatio(aspect)
 
   return (
+    // No border and no panel rounding here: the native surface is a separate
+    // window glued over the slot with square corners — CSS cannot clip it, so
+    // any rounded frame leaves a dark corner wedge peeking around the video.
     <div
-      className={cn('flex w-full flex-col overflow-hidden rounded-panel border', className)}
+      className={cn('flex w-full flex-col overflow-hidden', className)}
       data-videorc-preview-card
       data-videorc-preview-docked
     >
@@ -143,30 +145,25 @@ function DockedPreviewFrame({
           <span className="text-xs text-[#A1A1AA]">{status.detail}</span>
         </div>
       </div>
-      <div className="flex items-center justify-between gap-2 border-t px-3 py-1.5">
-        <span className="text-xs text-muted-foreground">
-          {transportLabel ?? 'Preview docked in the app'}
-        </span>
-        <div className="flex items-center gap-1">
-          {showPermissionAction && onOpenPermissions ? (
-            <Button size="sm" variant="outline" onClick={onOpenPermissions}>
-              Open permissions
-            </Button>
-          ) : null}
-          <Button
-            data-videorc-preview-pop-out
-            size="sm"
-            title="Pop the preview out into its own window"
-            variant="ghost"
-            onClick={onPopOut}
-          >
-            <ArrowSquareOut className="size-4" />
-            Pop out
+      <div className="flex items-center justify-end gap-1.5 px-3 py-1.5">
+        {showPermissionAction && onOpenPermissions ? (
+          <Button size="sm" variant="outline" onClick={onOpenPermissions}>
+            Open permissions
           </Button>
-          <Button size="sm" variant="ghost" onClick={onClose}>
-            Close
-          </Button>
-        </div>
+        ) : null}
+        <Button
+          data-videorc-preview-pop-out
+          size="sm"
+          title="Pop the preview out into its own window"
+          variant="secondary"
+          onClick={onPopOut}
+        >
+          <ArrowSquareOut className="size-4" />
+          Pop out
+        </Button>
+        <Button size="sm" variant="secondary" onClick={onClose}>
+          Close
+        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
The docked preview drew a `rounded-panel border` frame, but the native CAMetalLayer surface is a separate square-cornered window that CSS cannot clip — the rounded corners left an ugly dark wedge peeking around the video (owner screenshot, 2026-07-10). 

- Docked frame is now borderless and square-cornered so the native surface sits flush.
- Footer drops the "Native preview" transport label (buttons right-aligned).
- Pop out / Close are now `variant="secondary"` solid buttons instead of ghost, per owner request.

Probe selectors (`data-videorc-dock-slot`, `data-videorc-preview-pop-out`) are unchanged; the `smoke:preview-surface` badge assertion targets the detached window, not this footer. Verified: typecheck, eslint, prettier, 652 desktop tests. Docked-state visual is an owner by-eye check (docked preview needs a live app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the docked preview frame with a cleaner, unclipped appearance.
  * Reworked preview controls into a compact, right-aligned toolbar.
  * Added a conditional “Open permissions” action.
  * Updated “Pop out” and “Close” controls with a more prominent secondary style.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->