### PR TITLE
Fix Windows recording and poster reliability

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -340,6 +340,7 @@ nativeTheme.themeSource = 'dark'
 type GlassVibrancyMaterial = NonNullable<Parameters<BrowserWindow['setVibrancy']>[0]>
 const isMac = process.platform === 'darwin'
 const isWindows = process.platform === 'win32'
+const mainWindowSandboxEnabled = !isWindows
 const glassVibrancyEnabled = process.env.VIDEORC_GLASS_VIBRANCY !== '0'
 const glassVibrancyRaw = process.env.VIDEORC_GLASS_VIBRANCY
 const glassVibrancyMaterial: GlassVibrancyMaterial =
@@ -981,7 +982,7 @@ function createWindow(): void {
     ...appWindowIconOptions(),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: true,
+      sandbox: mainWindowSandboxEnabled,
       contextIsolation: true,
       nodeIntegration: false,
       backgroundThrottling: false

--- a/crates/videorc-backend/src/ffmpeg_work.rs
+++ b/crates/videorc-backend/src/ffmpeg_work.rs
@@ -31,6 +31,7 @@ struct FfmpegWorkState {
     capture_active: bool,
     finalizing_active: bool,
     maintenance_running: bool,
+    priority_maintenance_waiting: usize,
     maintenance_cancel_generation: u64,
     maintenance_cancel_requested: bool,
 }
@@ -100,15 +101,10 @@ impl FfmpegWorkCoordinator {
         if state.finalizing_active {
             return Err(MaintenanceDeferral::FinalizingActive);
         }
-        if state.maintenance_running {
+        if state.maintenance_running || state.priority_maintenance_waiting > 0 {
             return Err(MaintenanceDeferral::MaintenanceRunning);
         }
-        state.maintenance_running = true;
-        state.maintenance_cancel_requested = false;
-        Ok(MaintenancePermit {
-            coordinator: self.clone(),
-            generation: state.maintenance_cancel_generation,
-        })
+        Ok(self.begin_maintenance_locked(&mut state))
     }
 
     pub async fn begin_maintenance_when_idle(self: &Arc<Self>) -> MaintenancePermit {
@@ -117,6 +113,42 @@ impl FfmpegWorkCoordinator {
                 Ok(permit) => return permit,
                 Err(_) => self.notify.notified().await,
             }
+        }
+    }
+
+    /// Wait for the next idle maintenance slot ahead of background maintenance.
+    /// This is for short, user-visible work such as poster extraction. Capture
+    /// and finalization still take precedence.
+    pub async fn begin_priority_maintenance_when_idle(self: &Arc<Self>) -> MaintenancePermit {
+        let mut waiter = PriorityMaintenanceWaiter::new(self.clone());
+        loop {
+            let notified = {
+                let mut state = self.state.lock().expect("ffmpeg work state poisoned");
+                if !state.capture_active
+                    && state.capture_waiting == 0
+                    && !state.finalizing_active
+                    && !state.maintenance_running
+                {
+                    state.priority_maintenance_waiting =
+                        state.priority_maintenance_waiting.saturating_sub(1);
+                    waiter.registered = false;
+                    return self.begin_maintenance_locked(&mut state);
+                }
+                self.notify.notified()
+            };
+            notified.await;
+        }
+    }
+
+    fn begin_maintenance_locked(
+        self: &Arc<Self>,
+        state: &mut FfmpegWorkState,
+    ) -> MaintenancePermit {
+        state.maintenance_running = true;
+        state.maintenance_cancel_requested = false;
+        MaintenancePermit {
+            coordinator: self.clone(),
+            generation: state.maintenance_cancel_generation,
         }
     }
 
@@ -164,6 +196,45 @@ impl FfmpegWorkCoordinator {
             state.maintenance_cancel_requested = false;
         }
         self.notify.notify_waiters();
+    }
+}
+
+struct PriorityMaintenanceWaiter {
+    coordinator: Arc<FfmpegWorkCoordinator>,
+    registered: bool,
+}
+
+impl PriorityMaintenanceWaiter {
+    fn new(coordinator: Arc<FfmpegWorkCoordinator>) -> Self {
+        {
+            let mut state = coordinator
+                .state
+                .lock()
+                .expect("ffmpeg work state poisoned");
+            state.priority_maintenance_waiting += 1;
+        }
+        Self {
+            coordinator,
+            registered: true,
+        }
+    }
+}
+
+impl Drop for PriorityMaintenanceWaiter {
+    fn drop(&mut self) {
+        if !self.registered {
+            return;
+        }
+        {
+            let mut state = self
+                .coordinator
+                .state
+                .lock()
+                .expect("ffmpeg work state poisoned");
+            state.priority_maintenance_waiting =
+                state.priority_maintenance_waiting.saturating_sub(1);
+        }
+        self.coordinator.notify.notify_waiters();
     }
 }
 
@@ -350,5 +421,28 @@ mod tests {
             MaintenanceDeferral::CaptureActive
         );
         drop(capture);
+    }
+
+    #[tokio::test]
+    async fn priority_maintenance_runs_before_waiting_background_maintenance() {
+        let coordinator = Arc::new(FfmpegWorkCoordinator::new());
+        let finalizing = coordinator.begin_finalizing();
+        let background = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.begin_maintenance_when_idle().await }
+        });
+        tokio::task::yield_now().await;
+        let priority = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.begin_priority_maintenance_when_idle().await }
+        });
+        tokio::task::yield_now().await;
+
+        drop(finalizing);
+        let priority_permit = priority.await.unwrap();
+        assert!(!background.is_finished());
+
+        drop(priority_permit);
+        drop(background.await.unwrap());
     }
 }

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -45,7 +45,10 @@ use crate::protocol::{
     SceneSourceKind, SourceSelection,
 };
 use crate::scene::{scene_from_capture_config, validate_scene_background};
-use crate::screen_capture::{parse_screencapturekit_display_id, parse_screencapturekit_window_id};
+use crate::screen_capture::{
+    is_windows_gdigrab_desktop_screen_id, parse_screencapturekit_display_id,
+    parse_screencapturekit_window_id, parse_windows_dxgi_output_index,
+};
 use crate::state::AppState;
 
 const WARM_SOURCE_START_TIMEOUT: Duration = Duration::from_secs(5);
@@ -234,18 +237,8 @@ pub fn preset_selection_blocker(params: &SceneConfigParams) -> Option<String> {
     );
     let camera_selected = params.sources.camera_id.is_some();
     let screen_selected = params.sources.test_pattern
-        || params
-            .sources
-            .screen_id
-            .as_deref()
-            .and_then(parse_screencapturekit_display_id)
-            .is_some()
-        || params
-            .sources
-            .window_id
-            .as_deref()
-            .and_then(parse_screencapturekit_window_id)
-            .is_some();
+        || screen_source_is_native(params.sources.screen_id.as_deref())
+        || window_source_is_native(params.sources.window_id.as_deref());
     if needs_camera && !camera_selected {
         return Some(format!(
             "Layout preset {preset:?} needs a camera, but no camera is selected. Pick a camera, then switch."
@@ -262,6 +255,26 @@ pub fn preset_selection_blocker(params: &SceneConfigParams) -> Option<String> {
         ));
     }
     None
+}
+
+fn screen_source_is_native(screen_id: Option<&str>) -> bool {
+    let Some(screen_id) = screen_id else {
+        return false;
+    };
+    if parse_screencapturekit_display_id(screen_id).is_some() {
+        return true;
+    }
+    if parse_windows_dxgi_output_index(screen_id).is_some() {
+        return true;
+    }
+    is_windows_gdigrab_desktop_screen_id(screen_id)
+}
+
+fn window_source_is_native(window_id: Option<&str>) -> bool {
+    let Some(window_id) = window_id else {
+        return false;
+    };
+    parse_screencapturekit_window_id(window_id).is_some()
 }
 
 async fn source_liveness(state: &AppState, target_sources: &SourceSelection) -> SourceLiveness {
@@ -1356,6 +1369,23 @@ mod tests {
             preset_selection_blocker(&legacy_screen)
                 .is_some_and(|message| message.contains("native screen"))
         );
+
+        let windows_screen = config(LayoutPreset::ScreenOnly, false, false);
+        assert_eq!(
+            preset_selection_blocker(&windows_screen),
+            Some(
+                "Layout preset ScreenOnly needs a screen or window, but none is selected. Pick one, then switch."
+                    .to_string()
+            )
+        );
+
+        let mut windows_dxgi = config(LayoutPreset::ScreenOnly, false, false);
+        windows_dxgi.sources.screen_id = Some("screen:dxgi:00000000000003f1:2".to_string());
+        assert_eq!(preset_selection_blocker(&windows_dxgi), None);
+
+        let mut windows_gdigrab = config(LayoutPreset::ScreenOnly, false, false);
+        windows_gdigrab.sources.screen_id = Some("screen:gdigrab:desktop".to_string());
+        assert_eq!(preset_selection_blocker(&windows_gdigrab), None);
     }
 
     #[test]

--- a/crates/videorc-backend/src/posters.rs
+++ b/crates/videorc-backend/src/posters.rs
@@ -77,7 +77,14 @@ pub async fn ensure_session_poster(
     {
         return false;
     }
-    let _maintenance = state.ffmpeg_work.begin_maintenance_when_idle().await;
+    let _maintenance = state
+        .ffmpeg_work
+        .begin_priority_maintenance_when_idle()
+        .await;
+    // Another request may have generated this poster while we waited.
+    if output.exists() {
+        return true;
+    }
     let mut command = tokio::process::Command::new(ffmpeg_path);
     command
         .args(poster_extract_args(

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -159,6 +159,11 @@ const SCREEN_OVERLAY_FIFO_WRITE_RETRY: std::time::Duration = std::time::Duration
 const POST_RECORDING_GATE_IDLE_DELAY: Duration = Duration::from_secs(30);
 const POST_RECORDING_FAST_ASSESSMENT_TIMEOUT: Duration = Duration::from_secs(60);
 const POST_RECORDING_REPAIR_TIMEOUT: Duration = Duration::from_secs(180);
+// Raw compositor frames arrive over a live FIFO alongside live device audio.
+// FFmpeg needs a dedicated demux thread for that input; without one, Windows
+// dshow polling can leave the named-pipe reader idle until its buffer fills,
+// blocking the bridge and starving both recording and preview.
+const ENCODER_BRIDGE_RAW_VIDEO_INPUT_QUEUE_FRAMES: u32 = 16;
 const ENCODER_BRIDGE_VIDEO_OUTPUT_ENV: &str = "VIDEORC_ENCODER_BRIDGE_VIDEO_OUTPUT";
 
 #[derive(Debug)]
@@ -2783,6 +2788,19 @@ async fn monitor_session(
             } else {
                 None
             };
+            // The Library describes the media file, not how long the record
+            // button was active. A stalled encoder can produce a much shorter
+            // timeline than wall time, so persist the probed finalized duration
+            // and retain elapsed time only as a fallback when probing fails.
+            let duration_ms = match mp4_path.as_ref().or(output_path.as_ref()) {
+                Some(final_path) => crate::session_ops::probe_duration_ms(
+                    &monitored_recording.ffmpeg_path,
+                    final_path,
+                )
+                .await
+                .or(duration_ms),
+                None => duration_ms,
+            };
             let _ = state.database.finish_session(
                 &session_id,
                 "completed",
@@ -5001,6 +5019,8 @@ fn append_bridge_recording_input_args(
             // timestamps and require the selected encoder to sustain the output
             // cadence instead.
             args.extend([
+                "-thread_queue_size".to_string(),
+                ENCODER_BRIDGE_RAW_VIDEO_INPUT_QUEUE_FRAMES.to_string(),
                 "-f".to_string(),
                 "rawvideo".to_string(),
                 "-pix_fmt".to_string(),
@@ -9057,6 +9077,15 @@ mod tests {
         assert_eq!(
             input_arg_value(&args, &fifo_path.display().to_string(), "-framerate"),
             Some("30")
+        );
+        assert_eq!(
+            input_arg_value(
+                &args,
+                &fifo_path.display().to_string(),
+                "-thread_queue_size"
+            ),
+            Some("16"),
+            "live raw video must have its own demux queue when device audio is also active"
         );
         assert_eq!(
             input_arg_value(

--- a/crates/videorc-backend/src/session_ops.rs
+++ b/crates/videorc-backend/src/session_ops.rs
@@ -89,7 +89,7 @@ fn import_destination(output_directory: &Path, source: &Path) -> PathBuf {
     first_free_duplicate_path(&base)
 }
 
-async fn probe_duration_ms(ffmpeg_path: &str, file: &Path) -> Option<i64> {
+pub(crate) async fn probe_duration_ms(ffmpeg_path: &str, file: &Path) -> Option<i64> {
     let ffprobe = crate::ffmpeg::ffprobe_path_for(ffmpeg_path);
     let mut command = tokio::process::Command::new(ffprobe);
     command


### PR DESCRIPTION
## Summary
- include the Windows sandbox and screen preset handling from petercr/videorc#1
- prevent Windows raw-video FIFO starvation when DShow audio is active
- persist finalized media duration instead of record-button wall time
- prioritize poster extraction ahead of background quality maintenance

## Verification
- cargo fmt --check --all
- git diff --check
- packaged Windows app builds and launches (reported locally)

Long-running Rust and Windows recording-studio gates were left for follow-up on the Windows host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows support for selecting native screens and windows.
  * Session durations now more accurately reflect finalized media files.
  * Reduced recording and preview deadlocks during raw video processing.
  * Prevented duplicate poster extraction when concurrent requests overlap.
  * Ensured priority maintenance tasks run ahead of background maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->