### PR TITLE
feat: rebuild live captions reliability and styles

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -169,6 +169,7 @@ import type {
   BackendConnection,
   BackendLogEvent,
   CameraShape,
+  CaptionWindowSnapshot,
   CaptionsUpdate,
   CaptionsWindowState,
   CommentHighlightCommand,
@@ -249,6 +250,13 @@ let captionsWindowLastFrame: Electron.Rectangle | null = null
 let captionsWindowAlwaysOnTop = false
 let captionsWindowClosing = false
 let latestCaptionLines: CaptionsUpdate[] = []
+let latestCaptionSnapshot: CaptionWindowSnapshot = {
+  lines: [],
+  status: { state: 'idle' },
+  styleId: 'classic',
+  position: 'bottom',
+  textSize: 'm'
+}
 let nativePreviewSurfaceCompositorUpdateInFlight: Promise<PreviewSurfaceStatus> | null = null
 let nativePreviewSurfaceCompositorRequestSerial = 0
 const nativePreviewSurfaceMutationQueue = new NativePreviewMutationQueue()
@@ -1647,8 +1655,8 @@ function notesWindowHtml(document: NotesDocument): string {
 
 // FX6: app shortcuts died while an aux window (Notes/Comments) held key focus
 // — the forwarding above only listens on the main window. Aux windows forward
-// the exact same chords: ⌘1–9/⌘, focus main and navigate; ⌘⇧N/⌘⇧J toggle the
-// aux windows. Nothing else is intercepted (typing in Notes stays untouched).
+// the exact same chords: ⌘1–9/⌘, focus main and navigate; ⌘⇧N/⌘⇧J/⌘⇧C toggle
+// the aux windows. Nothing else is intercepted (typing in Notes stays untouched).
 function attachAuxWindowShortcuts(window: BrowserWindow): void {
   window.webContents.on('before-input-event', (event, input) => {
     if (input.type !== 'keyDown' || input.alt || !(input.meta || input.control)) {
@@ -1669,6 +1677,13 @@ function attachAuxWindowShortcuts(window: BrowserWindow): void {
           closeCommentsWindow()
         } else {
           void openCommentsWindow()
+        }
+      } else if (key === 'c') {
+        event.preventDefault()
+        if (captionsWindowIsOpen()) {
+          closeCaptionsWindow()
+        } else {
+          void openCaptionsWindow()
         }
       }
       return
@@ -9465,10 +9480,20 @@ app.whenReady().then(async () => {
   )
   // Same relay shape as comments: the main renderer owns the backend WS and
   // pushes its caption-line buffer; main caches it for the window's first paint.
+  ipcMain.handle('captions-window:push-snapshot', (_event, snapshot: CaptionWindowSnapshot) => {
+    latestCaptionSnapshot = snapshot
+    latestCaptionLines = Array.isArray(snapshot.lines) ? snapshot.lines : []
+    if (captionsWindow && !captionsWindow.webContents.isDestroyed()) {
+      captionsWindow.webContents.send('captions-window:snapshot', latestCaptionSnapshot)
+    }
+  })
+  ipcMain.handle('captions-window:get-snapshot', () => latestCaptionSnapshot)
   ipcMain.handle('captions-window:push-lines', (_event, lines: CaptionsUpdate[]) => {
     latestCaptionLines = Array.isArray(lines) ? lines : []
+    latestCaptionSnapshot = { ...latestCaptionSnapshot, lines: latestCaptionLines }
     if (captionsWindow && !captionsWindow.webContents.isDestroyed()) {
       captionsWindow.webContents.send('captions-window:lines', latestCaptionLines)
+      captionsWindow.webContents.send('captions-window:snapshot', latestCaptionSnapshot)
     }
   })
   ipcMain.handle('captions-window:get-lines', () => latestCaptionLines)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -9,6 +9,7 @@ import type {
   CommentsClearCommand,
   CommentsSendCommand,
   CommentsViewSnapshot,
+  CaptionWindowSnapshot,
   CaptionsUpdate,
   CaptionsWindowState,
   CommentsSnapshotDelta,
@@ -157,6 +158,14 @@ const api: VideorcApi = {
       callback(state)
     ipcRenderer.on('captions-window:state', listener)
     return () => ipcRenderer.removeListener('captions-window:state', listener)
+  },
+  pushCaptionSnapshot: (snapshot) => ipcRenderer.invoke('captions-window:push-snapshot', snapshot),
+  getCaptionSnapshot: () => ipcRenderer.invoke('captions-window:get-snapshot'),
+  onCaptionSnapshot: (callback) => {
+    const listener = (_event: Electron.IpcRendererEvent, snapshot: CaptionWindowSnapshot): void =>
+      callback(snapshot)
+    ipcRenderer.on('captions-window:snapshot', listener)
+    return () => ipcRenderer.removeListener('captions-window:snapshot', listener)
   },
   pushCaptionLines: (lines) => ipcRenderer.invoke('captions-window:push-lines', lines),
   getCaptionLines: () => ipcRenderer.invoke('captions-window:get-lines'),

--- a/apps/desktop/src/renderer/captions/main.tsx
+++ b/apps/desktop/src/renderer/captions/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 
 import { CaptionsReader } from '@/components/captions-reader'
 import { AppErrorBoundary } from '@/components/error-boundary'
-import type { CaptionsUpdate } from '@/lib/backend'
+import type { CaptionWindowSnapshot } from '@/lib/backend'
 import '@/styles.css'
 
 // Long-lived second window: drop React's dev perf-track measures, which buffer
@@ -27,29 +27,39 @@ if (import.meta.env.DEV && localStorage.getItem('videorc.reactPerfTrack') !== '1
 // The window's data comes from the main renderer through the main-process
 // relay: seed from the cached caption lines, then follow live pushes.
 function CaptionsWindowApp(): ReactElement {
-  const [lines, setLines] = useState<CaptionsUpdate[]>([])
+  const [snapshot, setSnapshot] = useState<CaptionWindowSnapshot>({
+    lines: [],
+    status: { state: 'idle' },
+    styleId: 'classic',
+    position: 'bottom',
+    textSize: 'm'
+  })
   const [alwaysOnTop, setAlwaysOnTop] = useState(false)
   useEffect(() => {
     void window.videorc
-      ?.getCaptionLines?.()
-      .then((initial) => initial && setLines(initial))
+      ?.getCaptionSnapshot?.()
+      .then((initial) => initial && setSnapshot(initial))
       .catch(() => {})
     void window.videorc
       ?.getCaptionsWindowState?.()
       .then((state) => state && setAlwaysOnTop(state.alwaysOnTop))
       .catch(() => {})
-    const offLines = window.videorc?.onCaptionLines?.((next) => setLines(next))
+    const offSnapshot = window.videorc?.onCaptionSnapshot?.((next) => setSnapshot(next))
     const offState = window.videorc?.onCaptionsWindowState?.((state) =>
       setAlwaysOnTop(state.alwaysOnTop)
     )
     return () => {
-      offLines?.()
+      offSnapshot?.()
       offState?.()
     }
   }, [])
   return (
     <CaptionsReader
-      lines={lines}
+      lines={snapshot.lines}
+      position={snapshot.position}
+      status={snapshot.status}
+      styleId={snapshot.styleId}
+      textSize={snapshot.textSize}
       alwaysOnTop={alwaysOnTop}
       onToggleAlwaysOnTop={() => void window.videorc?.setCaptionsWindowAlwaysOnTop?.(!alwaysOnTop)}
     />

--- a/apps/desktop/src/renderer/src/backendClient.test.ts
+++ b/apps/desktop/src/renderer/src/backendClient.test.ts
@@ -89,6 +89,7 @@ describe('BackendClient request lifetime', () => {
 
   it('rejects and clears every request owned by a closed socket', async () => {
     const { client, socket } = await connectedClient()
+    expect(client.connected).toBe(true)
     const first = client.request('scene.get')
     const second = client.request('diagnostics.stats')
     const firstRejection = expect(first).rejects.toThrow('Backend connection closed.')
@@ -98,6 +99,7 @@ describe('BackendClient request lifetime', () => {
 
     await Promise.all([firstRejection, secondRejection])
     expect(client.pendingRequestCount).toBe(0)
+    expect(client.connected).toBe(false)
   })
 
   it('clears timeout and cancellation hooks after a response', async () => {

--- a/apps/desktop/src/renderer/src/backendClient.ts
+++ b/apps/desktop/src/renderer/src/backendClient.ts
@@ -51,6 +51,10 @@ export class BackendClient {
     return this.pending.size
   }
 
+  get connected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN
+  }
+
   connect(): Promise<void> {
     if (this.ws?.readyState === WebSocket.OPEN) {
       return Promise.resolve()

--- a/apps/desktop/src/renderer/src/components/app-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/app-shell.tsx
@@ -34,6 +34,9 @@ const AiTab = lazy(async () => ({ default: (await import('@/components/tabs/ai-t
 const AssetsTab = lazy(async () => ({
   default: (await import('@/components/tabs/assets-tab')).AssetsTab
 }))
+const CaptionsTab = lazy(async () => ({
+  default: (await import('@/components/tabs/captions-tab')).CaptionsTab
+}))
 const DiagnosticsTab = lazy(async () => ({
   default: (await import('@/components/tabs/diagnostics-tab')).DiagnosticsTab
 }))
@@ -114,7 +117,8 @@ export function AppShell(): ReactElement {
     commentsWindowOpen,
     openCommentsWindow,
     closeCommentsWindow,
-    toggleCommentsWindow
+    toggleCommentsWindow,
+    toggleCaptionsWindow
   } = useStudioShell()
   const [active, setActive] = useState<WorkspaceTab>('studio')
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
@@ -207,6 +211,10 @@ export function AppShell(): ReactElement {
         event.preventDefault()
         void toggleCommentsWindow()
       }
+      if (event.key.toLowerCase() === 'c' && event.shiftKey && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        void toggleCaptionsWindow()
+      }
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
@@ -217,6 +225,7 @@ export function AppShell(): ReactElement {
     runtimeInfo?.commentsWindowEnabled,
     runtimeInfo?.notesWindowEnabled,
     toggleCommentsWindow,
+    toggleCaptionsWindow,
     togglePreviewWindow
   ])
 
@@ -314,6 +323,7 @@ export function AppShell(): ReactElement {
                 {active === 'layouts' ? <LayoutTab /> : null}
                 {active === 'assets' ? <AssetsTab /> : null}
                 {active === 'live' ? <StreamingTab /> : null}
+                {active === 'captions' ? <CaptionsTab /> : null}
                 {active === 'recording' ? <RecordingTab /> : null}
                 {active === 'library' ? <LibraryTab onOpenInAi={openInAi} /> : null}
                 {active === 'ai' ? (

--- a/apps/desktop/src/renderer/src/components/captions-reader.test.ts
+++ b/apps/desktop/src/renderer/src/components/captions-reader.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { CAPTION_STYLE_IDS, captionStyleDefinition } from '@/lib/caption-overlay'
+
+import { captionReaderAppearance } from './captions-reader'
+
+describe('captionReaderAppearance', () => {
+  it.each(CAPTION_STYLE_IDS)('projects the shared %s registry entry', (styleId) => {
+    const definition = captionStyleDefinition(styleId)
+    const appearance = captionReaderAppearance(styleId)
+
+    expect(appearance.style).toMatchObject({
+      backgroundColor: definition.plate === 'none' ? 'transparent' : definition.backgroundColor,
+      borderRadius: `${definition.radiusFactor}em`,
+      color: definition.textColor,
+      fontWeight: definition.fontWeight,
+      textAlign: definition.align
+    })
+    expect(appearance.className.includes('w-full')).toBe(definition.wide)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/captions-reader.tsx
+++ b/apps/desktop/src/renderer/src/components/captions-reader.tsx
@@ -1,8 +1,10 @@
 import { PushPin } from '@phosphor-icons/react'
-import { useEffect, useRef, type ReactElement } from 'react'
+import { useEffect, useRef, type CSSProperties, type ReactElement } from 'react'
 
 import { Button } from '@/components/ui/button'
-import type { CaptionsUpdate } from '@/lib/backend'
+import type { CaptionStyleId, CaptionsStatus, CaptionsUpdate } from '@/lib/backend'
+import { captionStyleDefinition } from '@/lib/caption-overlay'
+import { latestFinalCaptionText } from '@/lib/captions-ui'
 import { cn } from '@/lib/utils'
 
 /**
@@ -12,10 +14,18 @@ import { cn } from '@/lib/utils'
  */
 export function CaptionsReader({
   lines,
+  status = { state: 'idle' },
+  styleId = 'classic',
+  position = 'bottom',
+  textSize = 'm',
   alwaysOnTop = false,
   onToggleAlwaysOnTop
 }: {
   lines: CaptionsUpdate[]
+  status?: CaptionsStatus
+  styleId?: CaptionStyleId
+  position?: 'top' | 'bottom'
+  textSize?: 's' | 'm' | 'l'
   alwaysOnTop?: boolean
   onToggleAlwaysOnTop?: () => void
 }): ReactElement {
@@ -30,13 +40,30 @@ export function CaptionsReader({
   }, [lines])
 
   const recent = lines.slice(-8)
+  const latestFinal = latestFinalCaptionText(lines)
+  const statusLabel = readerStatusLabel(status)
+  const latestTextClass = textSize === 's' ? 'text-xl' : textSize === 'l' ? 'text-4xl' : 'text-3xl'
+  const readerAppearance = captionReaderAppearance(styleId)
 
   return (
     <div className="flex h-screen flex-col bg-background text-foreground">
       {/* The whole drag bar moves the window (hiddenInset titlebar); the
           controls opt back out of the drag region. */}
       <header className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border px-3 [-webkit-app-region:drag]">
-        <span className="text-xs font-medium text-subtle">Live captions</span>
+        <span className="flex items-center gap-2 text-xs font-medium text-subtle">
+          Live captions
+          <span className="flex items-center gap-1.5 text-muted-foreground">
+            <span
+              className={cn(
+                'size-1.5 rounded-full bg-muted-foreground',
+                (status.state === 'listening' || status.state === 'live') && 'bg-success',
+                (status.state === 'reconnecting' || status.state === 'degraded') && 'bg-warning',
+                (status.state === 'blocked' || status.state === 'error') && 'bg-destructive'
+              )}
+            />
+            {statusLabel}
+          </span>
+        </span>
         {onToggleAlwaysOnTop ? (
           <Button
             aria-label="Keep this window on top"
@@ -52,8 +79,10 @@ export function CaptionsReader({
       </header>
 
       <div
-        aria-live="polite"
-        className="flex flex-1 flex-col justify-end gap-2 overflow-y-auto px-5 py-4"
+        className={cn(
+          'flex flex-1 flex-col gap-2 overflow-y-auto px-5 py-4',
+          position === 'top' ? 'justify-start' : 'justify-end'
+        )}
         ref={feedRef}
       >
         {recent.length === 0 ? (
@@ -62,21 +91,86 @@ export function CaptionsReader({
             transcribe your microphone during a session.
           </p>
         ) : (
-          recent.map((line, index) => (
-            <p
-              className={cn(
-                'text-2xl leading-snug',
-                index === recent.length - 1
-                  ? 'font-medium text-foreground'
-                  : 'text-muted-foreground'
-              )}
-              key={`${line.sessionClientId}-${line.seq}`}
-            >
-              {line.text}
-            </p>
-          ))
+          recent.map((line, index) => {
+            const latest = index === recent.length - 1
+            return (
+              <p
+                className={cn(
+                  'leading-snug transition-colors',
+                  latest ? latestTextClass : 'text-xl text-muted-foreground',
+                  latest && 'font-semibold text-foreground',
+                  latest && line.kind === 'partial' && 'text-muted-foreground',
+                  latest && readerAppearance.className
+                )}
+                key={`${line.sessionClientId}-${line.seq}`}
+                style={
+                  latest
+                    ? { ...readerAppearance.style, opacity: line.kind === 'partial' ? 0.72 : 1 }
+                    : undefined
+                }
+              >
+                {line.text}
+              </p>
+            )
+          })
         )}
       </div>
+      <span aria-live="polite" className="sr-only">
+        {latestFinal ? `Final caption: ${latestFinal}` : ''}
+      </span>
     </div>
   )
+}
+
+/** CSS projection of the shared canvas style registry for the detached reader. */
+export function captionReaderAppearance(styleId: CaptionStyleId): {
+  className: string
+  style: CSSProperties
+} {
+  const definition = captionStyleDefinition(styleId)
+  const hasPlate = definition.plate !== 'none'
+  return {
+    className: cn(
+      hasPlate && 'border border-white/10 shadow-xl',
+      definition.plate === 'glass' && 'backdrop-blur-xl',
+      definition.wide && 'w-full'
+    ),
+    style: {
+      backgroundColor: hasPlate ? definition.backgroundColor : 'transparent',
+      borderRadius: `${definition.radiusFactor}em`,
+      color: definition.textColor,
+      fontWeight: definition.fontWeight,
+      padding: hasPlate
+        ? `${definition.paddingYFactor}em ${definition.paddingXFactor}em`
+        : undefined,
+      textAlign: definition.align,
+      textShadow: '0 2px 3px rgba(0, 0, 0, 0.58)',
+      WebkitTextStroke:
+        definition.strokeColor && definition.strokeWidthFactor
+          ? `${Math.max(1, definition.strokeWidthFactor * 14)}px ${definition.strokeColor}`
+          : undefined
+    }
+  }
+}
+
+function readerStatusLabel(status: CaptionsStatus): string {
+  switch (status.state) {
+    case 'listening':
+    case 'live':
+      return 'Listening'
+    case 'starting':
+      return 'Starting'
+    case 'reconnecting':
+      return 'Reconnecting'
+    case 'degraded':
+      return 'Higher delay'
+    case 'blocked':
+      return 'Blocked'
+    case 'error':
+      return 'Error'
+    case 'ready':
+      return 'Ready'
+    default:
+      return 'Idle'
+  }
 }

--- a/apps/desktop/src/renderer/src/components/captions/caption-preview.tsx
+++ b/apps/desktop/src/renderer/src/components/captions/caption-preview.tsx
@@ -1,0 +1,123 @@
+import { Eye } from '@phosphor-icons/react'
+import { useEffect, useMemo, useState, type ReactElement } from 'react'
+
+import { PanelSection } from '@/components/panel-section'
+import { Badge } from '@/components/ui/badge'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { useStudioCore } from '@/hooks/use-studio'
+import { renderCaptionCueFramePng } from '@/lib/caption-overlay'
+import { cn } from '@/lib/utils'
+
+type PreviewBackdrop = 'dark' | 'light' | 'motion'
+
+const PREVIEW_WIDTH = 960
+const SAMPLE_CAPTION = 'Your words become clear, live captions.'
+
+export function CaptionPreview(): ReactElement {
+  const { captionLines, captureConfig } = useStudioCore()
+  const [backdrop, setBackdrop] = useState<PreviewBackdrop>('motion')
+  const [overlayUrl, setOverlayUrl] = useState<string | null>(null)
+  const latest = captionLines.at(-1)
+  const text = latest?.text.trim() || SAMPLE_CAPTION
+  const aspect = captureConfig.video.width / Math.max(1, captureConfig.video.height)
+  const previewHeight = Math.max(360, Math.round(PREVIEW_WIDTH / aspect))
+  const isSample = !latest
+
+  useEffect(() => {
+    let cancelled = false
+    void renderCaptionCueFramePng({
+      text,
+      canvasWidth: PREVIEW_WIDTH,
+      canvasHeight: previewHeight,
+      styleId: captureConfig.captions.styleId,
+      position: captureConfig.captions.position,
+      textSize: captureConfig.captions.textSize
+    })
+      .then((png) => {
+        if (!cancelled) setOverlayUrl(png ? `data:image/png;base64,${png}` : null)
+      })
+      .catch(() => {
+        if (!cancelled) setOverlayUrl(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [captureConfig.captions, previewHeight, text])
+
+  const backdropClass = useMemo(
+    () =>
+      backdrop === 'light'
+        ? 'bg-[linear-gradient(135deg,#f4f4f5_0%,#d4d4d8_45%,#a1a1aa_100%)]'
+        : backdrop === 'dark'
+          ? 'bg-[linear-gradient(135deg,#09090b_0%,#27272a_55%,#18181b_100%)]'
+          : 'bg-[radial-gradient(circle_at_25%_20%,#64748b_0%,transparent_32%),radial-gradient(circle_at_78%_70%,#7c3aed_0%,transparent_30%),linear-gradient(135deg,#0f172a,#334155)]',
+    [backdrop]
+  )
+
+  return (
+    <PanelSection
+      action={
+        <Badge variant={isSample ? 'secondary' : 'success'}>{isSample ? 'Sample' : 'Live'}</Badge>
+      }
+      className="lg:sticky lg:top-4"
+      description="The selected style at your current video aspect ratio."
+      icon={Eye}
+      title="Caption preview"
+    >
+      <div
+        aria-label={`${captionStyleLabel(captureConfig.captions.styleId)} caption preview: ${text}`}
+        className={cn(
+          'relative aspect-video w-full overflow-hidden rounded-panel border border-border shadow-inner',
+          backdropClass
+        )}
+        role="img"
+        style={{ aspectRatio: `${PREVIEW_WIDTH} / ${previewHeight}` }}
+      >
+        <div
+          aria-hidden
+          className="absolute inset-0 opacity-35 [background-image:linear-gradient(90deg,transparent_49%,rgba(255,255,255,0.08)_50%,transparent_51%)] [background-size:8rem_100%]"
+        />
+        {overlayUrl ? (
+          <img alt="" aria-hidden className="absolute inset-0 size-full" src={overlayUrl} />
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{text}</p>
+          <p className="text-xs text-muted-foreground">
+            {captureConfig.video.width} × {captureConfig.video.height} ·{' '}
+            {captureConfig.captions.position === 'top' ? 'Top' : 'Bottom'}
+          </p>
+        </div>
+        <ToggleGroup
+          aria-label="Preview background"
+          size="sm"
+          type="single"
+          value={backdrop}
+          variant="outline"
+          onValueChange={(value) => {
+            if (value === 'dark' || value === 'light' || value === 'motion') setBackdrop(value)
+          }}
+        >
+          <ToggleGroupItem value="dark">Dark</ToggleGroupItem>
+          <ToggleGroupItem value="light">Light</ToggleGroupItem>
+          <ToggleGroupItem value="motion">Mixed</ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+    </PanelSection>
+  )
+}
+
+function captionStyleLabel(styleId: string): string {
+  switch (styleId) {
+    case 'classic':
+      return 'Classic'
+    case 'lower-third':
+      return 'Lower third'
+    case 'high-contrast':
+      return 'High contrast'
+    default:
+      return 'Glass'
+  }
+}

--- a/apps/desktop/src/renderer/src/components/captions/captions-controls.tsx
+++ b/apps/desktop/src/renderer/src/components/captions/captions-controls.tsx
@@ -1,0 +1,523 @@
+import {
+  ArrowClockwise,
+  ArrowSquareOut,
+  ClosedCaptioning,
+  Microphone,
+  WarningCircle
+} from '@phosphor-icons/react'
+import type { ReactElement } from 'react'
+import { toast } from 'sonner'
+
+import { PanelSection } from '@/components/panel-section'
+import { StatusBadge, type StatusTone } from '@/components/status-badge'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldTitle
+} from '@/components/ui/field'
+import { Kbd, KbdGroup } from '@/components/ui/kbd'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { useStudioCore } from '@/hooks/use-studio'
+import type { CaptionStyleId, CaptionsStatus } from '@/lib/backend'
+import {
+  CAPTION_STYLE_IDS,
+  captionStyleDefinition,
+  type CaptionPosition,
+  type CaptionTextSize
+} from '@/lib/caption-overlay'
+import {
+  captionStripLines,
+  captionsStatusIsActive,
+  latestFinalCaptionText
+} from '@/lib/captions-ui'
+import type { CaptionBurnTarget, CaptionsCaptureSettings } from '@/lib/capture'
+import { cloudAiUploadGate } from '@/lib/entitlement-ui'
+import { cn } from '@/lib/utils'
+
+const LANGUAGES = [
+  { id: 'auto', label: 'Auto-detect' },
+  { id: 'en', label: 'English' },
+  { id: 'es', label: 'Spanish' },
+  { id: 'fr', label: 'French' },
+  { id: 'de', label: 'German' },
+  { id: 'pt', label: 'Portuguese' },
+  { id: 'it', label: 'Italian' }
+] as const
+
+type CaptionStatusPresentation = {
+  value: string
+  tone: StatusTone
+  detail: string
+}
+
+function captionsStatusPresentation(
+  status: CaptionsStatus,
+  enabled: boolean,
+  sessionActive: boolean
+): CaptionStatusPresentation {
+  if (!enabled) {
+    return { value: 'Off', tone: 'neutral', detail: 'Enable captions to arm them for a session.' }
+  }
+  switch (status.state) {
+    case 'starting':
+      return { value: 'Starting', tone: 'neutral', detail: 'Connecting to transcription…' }
+    case 'listening':
+    case 'live':
+      return { value: 'Listening', tone: 'good', detail: 'Microphone speech is being transcribed.' }
+    case 'reconnecting':
+      return { value: 'Reconnecting', tone: 'warn', detail: 'Trying to restore live captions.' }
+    case 'degraded':
+      return {
+        value: 'Higher delay',
+        tone: 'warn',
+        detail: status.message ?? 'Captions are continuing with a longer delay.'
+      }
+    case 'blocked':
+      return {
+        value: 'Blocked',
+        tone: 'error',
+        detail: status.message ?? 'Captions need attention before they can start.'
+      }
+    case 'error':
+      return {
+        value: 'Error',
+        tone: 'error',
+        detail: status.message ?? 'Captions stopped unexpectedly.'
+      }
+    case 'ready':
+      return {
+        value: 'Ready',
+        tone: 'good',
+        detail: sessionActive
+          ? 'Ready to listen for microphone speech.'
+          : 'Starts with your next session.'
+      }
+    default:
+      return {
+        value: sessionActive ? 'Waiting' : 'Armed',
+        tone: 'neutral',
+        detail: sessionActive
+          ? 'Waiting for the caption service.'
+          : 'Starts with your next session.'
+      }
+  }
+}
+
+function burnTargetFromChecks(stream: boolean, recording: boolean): CaptionBurnTarget {
+  if (stream && recording) return 'both'
+  if (stream) return 'stream'
+  if (recording) return 'recording'
+  return 'off'
+}
+
+function StyleSwatch({ styleId }: { styleId: CaptionStyleId }): ReactElement {
+  const style = captionStyleDefinition(styleId)
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'relative flex h-12 w-full items-end overflow-hidden rounded-lg bg-gradient-to-br from-slate-500 via-slate-700 to-slate-950 p-2',
+        style.align === 'center' ? 'justify-center' : 'justify-start'
+      )}
+    >
+      <span
+        className={cn(
+          'line-clamp-1 max-w-full px-2 py-1 text-[8px] leading-none tracking-tight text-white',
+          style.fontWeight === 700 ? 'font-bold' : 'font-semibold',
+          style.plate === 'none' && '[text-shadow:0_1px_2px_rgb(0_0_0),0_0_1px_rgb(0_0_0)]',
+          style.plate === 'glass' && 'rounded-md border border-white/10 bg-black/70 shadow-lg',
+          style.plate === 'band' && 'w-full rounded-sm bg-black/85 text-left',
+          style.plate === 'solid' && 'rounded-sm bg-black'
+        )}
+      >
+        Make every word count
+      </span>
+    </span>
+  )
+}
+
+function OutputCheckbox({
+  id,
+  checked,
+  disabled,
+  title,
+  description,
+  onCheckedChange
+}: {
+  id: string
+  checked: boolean
+  disabled: boolean
+  title: string
+  description: string
+  onCheckedChange: (checked: boolean) => void
+}): ReactElement {
+  return (
+    <Field data-disabled={disabled || undefined} orientation="horizontal">
+      <Checkbox
+        id={id}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={(value) => onCheckedChange(value === true)}
+      />
+      <FieldContent>
+        <FieldLabel htmlFor={id}>{title}</FieldLabel>
+        <FieldDescription>{description}</FieldDescription>
+      </FieldContent>
+    </Field>
+  )
+}
+
+export function CaptionsControls(): ReactElement {
+  const {
+    aiQuota,
+    captionLines,
+    captionsCommandPending,
+    captionsStatus,
+    captionsWindow,
+    captureConfig,
+    entitlements,
+    isSessionActive,
+    setCaptureConfig,
+    startCaptions,
+    toggleCaptionsWindow
+  } = useStudioCore()
+  const captions = captureConfig.captions
+  const gate = cloudAiUploadGate(entitlements)
+  const runtimeActive = captionsStatusIsActive(captionsStatus)
+  const status = captionsStatusPresentation(captionsStatus, captions.enabled, isSessionActive)
+  const lines = captionStripLines(captionLines)
+  const finalAnnouncement = latestFinalCaptionText(captionLines)
+  const streamChecked = captions.burnTarget === 'stream' || captions.burnTarget === 'both'
+  const recordingChecked = captions.burnTarget === 'recording' || captions.burnTarget === 'both'
+  const canEnable = gate.allowed || captions.enabled
+  const showRetry =
+    captions.enabled &&
+    isSessionActive &&
+    (captionsStatus.state === 'blocked' || captionsStatus.state === 'error')
+
+  const patchCaptions = (
+    patch: Partial<CaptionsCaptureSettings>,
+    bumpStyleRevision = false
+  ): void => {
+    setCaptureConfig((current) => {
+      const changed = Object.entries(patch).some(
+        ([key, value]) => current.captions[key as keyof CaptionsCaptureSettings] !== value
+      )
+      if (!changed) return current
+      return {
+        ...current,
+        captions: {
+          ...current.captions,
+          ...patch,
+          styleRevision: bumpStyleRevision
+            ? current.captions.styleRevision + 1
+            : current.captions.styleRevision
+        }
+      }
+    })
+  }
+
+  const retry = (): void => {
+    void startCaptions(captions.language).catch((error: unknown) => {
+      toast.error('Live captions could not start', {
+        description: error instanceof Error ? error.message : 'The caption service is unavailable.'
+      })
+    })
+  }
+
+  return (
+    <PanelSection
+      action={<StatusBadge tone={status.tone} value={status.value} />}
+      description="Transcribe your microphone during a recording or livestream."
+      icon={ClosedCaptioning}
+      title="Live captions"
+    >
+      <FieldGroup>
+        <Field orientation="horizontal">
+          <FieldContent>
+            <FieldTitle>Enable live captions</FieldTitle>
+            <FieldDescription>
+              Starts automatically with your next session. Turn this off at any time to stop audio
+              upload.
+            </FieldDescription>
+          </FieldContent>
+          <Switch
+            aria-label="Enable live captions"
+            checked={captions.enabled}
+            disabled={captionsCommandPending || !canEnable}
+            onCheckedChange={(enabled) => patchCaptions({ enabled })}
+          />
+        </Field>
+
+        {!gate.allowed ? (
+          <Alert variant="warning">
+            <WarningCircle weight="fill" />
+            <AlertTitle>Premium captions</AlertTitle>
+            <AlertDescription>
+              {gate.reason}
+              {gate.upgradeUrl ? (
+                <Button
+                  className="ml-2 h-auto p-0 align-baseline"
+                  size="xs"
+                  variant="link"
+                  onClick={() => openExternalUrl(gate.upgradeUrl as string)}
+                >
+                  View Premium
+                </Button>
+              ) : null}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex flex-col gap-3 rounded-row border border-border bg-muted/20 p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2 text-sm">
+              <Microphone className="size-4 shrink-0 text-muted-foreground" weight="duotone" />
+              <span className="font-medium">Microphone</span>
+              <span className="text-muted-foreground">
+                · {captionsStatus.transport === 'realtime' ? 'Realtime' : 'Live transcription'}
+              </span>
+            </div>
+            {typeof (captionsStatus.remainingSeconds ?? aiQuota?.monthly.remaining) === 'number' ? (
+              <span className="text-xs text-muted-foreground">
+                {captionsStatus.remainingSeconds !== undefined
+                  ? `${Math.max(0, Math.ceil(captionsStatus.remainingSeconds / 60))} min left`
+                  : `${aiQuota?.monthly.remaining ?? 0} credits left`}
+              </span>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-xs text-muted-foreground">{status.detail}</p>
+            {showRetry ? (
+              <Button disabled={captionsCommandPending} size="xs" variant="outline" onClick={retry}>
+                <ArrowClockwise data-icon="inline-start" />
+                Retry
+              </Button>
+            ) : null}
+          </div>
+        </div>
+
+        <Field>
+          <FieldContent>
+            <FieldTitle>Style</FieldTitle>
+            <FieldDescription>
+              Appearance updates live without restarting captions.
+            </FieldDescription>
+          </FieldContent>
+          <ToggleGroup
+            aria-label="Caption style"
+            className="grid w-full grid-cols-2 gap-2"
+            type="single"
+            value={captions.styleId}
+            variant="outline"
+            onValueChange={(value) => {
+              if (CAPTION_STYLE_IDS.includes(value as CaptionStyleId)) {
+                patchCaptions({ styleId: value as CaptionStyleId }, true)
+              }
+            }}
+          >
+            {CAPTION_STYLE_IDS.map((styleId) => {
+              const definition = captionStyleDefinition(styleId)
+              return (
+                <ToggleGroupItem
+                  aria-label={definition.label}
+                  className="h-auto min-w-0 flex-col items-stretch gap-2 overflow-hidden rounded-row p-2 text-left whitespace-normal data-[state=on]:border-primary/50 data-[state=on]:bg-primary/10"
+                  key={styleId}
+                  value={styleId}
+                >
+                  <StyleSwatch styleId={styleId} />
+                  <span className="min-w-0 whitespace-normal">
+                    <span className="block text-xs font-medium">{definition.label}</span>
+                    <span className="mt-0.5 block break-words text-[11px] leading-snug whitespace-normal text-muted-foreground">
+                      {definition.description}
+                    </span>
+                  </span>
+                </ToggleGroupItem>
+              )
+            })}
+          </ToggleGroup>
+        </Field>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field>
+            <FieldLabel>Position</FieldLabel>
+            <ToggleGroup
+              aria-label="Caption position"
+              className="w-full"
+              type="single"
+              value={captions.position}
+              variant="outline"
+              onValueChange={(value) => {
+                if (value === 'top' || value === 'bottom') {
+                  patchCaptions({ position: value as CaptionPosition }, true)
+                }
+              }}
+            >
+              <ToggleGroupItem className="flex-1" value="bottom">
+                Bottom
+              </ToggleGroupItem>
+              <ToggleGroupItem className="flex-1" value="top">
+                Top
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </Field>
+          <Field>
+            <FieldLabel>Text size</FieldLabel>
+            <ToggleGroup
+              aria-label="Caption text size"
+              className="w-full"
+              type="single"
+              value={captions.textSize}
+              variant="outline"
+              onValueChange={(value) => {
+                if (value === 's' || value === 'm' || value === 'l') {
+                  patchCaptions({ textSize: value as CaptionTextSize }, true)
+                }
+              }}
+            >
+              <ToggleGroupItem className="flex-1" value="s">
+                Small
+              </ToggleGroupItem>
+              <ToggleGroupItem className="flex-1" value="m">
+                Medium
+              </ToggleGroupItem>
+              <ToggleGroupItem className="flex-1" value="l">
+                Large
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </Field>
+        </div>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="caption-language">Spoken language</FieldLabel>
+            <FieldDescription>
+              {isSessionActive
+                ? 'Language is locked until the next session.'
+                : 'Auto-detect works for most conversations.'}
+            </FieldDescription>
+          </FieldContent>
+          <Select
+            disabled={isSessionActive}
+            value={captions.language}
+            onValueChange={(language) => patchCaptions({ language })}
+          >
+            <SelectTrigger className="w-full" id="caption-language">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {LANGUAGES.map((language) => (
+                  <SelectItem key={language.id} value={language.id}>
+                    {language.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldTitle>Show captions in</FieldTitle>
+            <FieldDescription>
+              {isSessionActive
+                ? 'Output routing is locked until the next session.'
+                : 'Choose livestream burn-in and whether to create a captioned recording copy.'}
+            </FieldDescription>
+          </FieldContent>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <OutputCheckbox
+              checked={streamChecked}
+              description="Visible to livestream viewers."
+              disabled={isSessionActive}
+              id="captions-output-stream"
+              title="Livestream"
+              onCheckedChange={(checked) =>
+                patchCaptions({ burnTarget: burnTargetFromChecks(checked, recordingChecked) })
+              }
+            />
+            <OutputCheckbox
+              checked={recordingChecked}
+              description="Visible in the captioned recording copy."
+              disabled={isSessionActive}
+              id="captions-output-recording"
+              title="Recording"
+              onCheckedChange={(checked) =>
+                patchCaptions({ burnTarget: burnTargetFromChecks(streamChecked, checked) })
+              }
+            />
+          </div>
+        </Field>
+
+        {(runtimeActive || lines.length > 0) && (
+          <div className="flex min-h-16 flex-col justify-end gap-1.5 rounded-row border border-border bg-muted/15 p-3">
+            {lines.length === 0 ? (
+              <span className="text-sm text-muted-foreground">Listening…</span>
+            ) : (
+              lines.map((line) => (
+                <p
+                  className={cn(
+                    'text-sm leading-6',
+                    line.kind === 'partial' ? 'text-muted-foreground' : 'text-foreground'
+                  )}
+                  key={`${line.sessionClientId}-${line.seq}`}
+                >
+                  {line.text}
+                </p>
+              ))
+            )}
+          </div>
+        )}
+        <span aria-live="polite" className="sr-only">
+          {finalAnnouncement}
+        </span>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+          <p className="max-w-md text-xs text-muted-foreground">
+            While enabled, microphone audio is sent to Videorc’s transcription provider only during
+            an active session.
+          </p>
+          <Button
+            disabled={!captionsWindow.enabled && !captionsWindow.open}
+            size="sm"
+            variant="outline"
+            onClick={() => void toggleCaptionsWindow()}
+          >
+            <ArrowSquareOut data-icon="inline-start" />
+            {captionsWindow.open ? 'Close reader' : 'Open reader'}
+            <KbdGroup className="ml-1">
+              <Kbd>⌘</Kbd>
+              <Kbd>⇧</Kbd>
+              <Kbd>C</Kbd>
+            </KbdGroup>
+          </Button>
+        </div>
+      </FieldGroup>
+    </PanelSection>
+  )
+}
+
+function openExternalUrl(url: string): void {
+  const opener = window.videorc?.openOAuthUrl
+  if (opener) {
+    void opener(url)
+    return
+  }
+  window.open(url, '_blank', 'noopener,noreferrer')
+}

--- a/apps/desktop/src/renderer/src/components/command-palette.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.tsx
@@ -1,4 +1,12 @@
-import { ChatCircle, Desktop, Moon, Stop, Sun, VideoCamera } from '@phosphor-icons/react'
+import {
+  ChatCircle,
+  ClosedCaptioning,
+  Desktop,
+  Moon,
+  Stop,
+  Sun,
+  VideoCamera
+} from '@phosphor-icons/react'
 import { useTheme } from 'next-themes'
 import type { ReactElement } from 'react'
 
@@ -32,8 +40,15 @@ export function CommandPalette({
   onOpenChange: (open: boolean) => void
 }): ReactElement {
   const { setActive, openStudioPanel } = useWorkspaceNav()
-  const { runtimeInfo, startSession, stopSession, commentsWindow, toggleCommentsWindow } =
-    useStudioCore()
+  const {
+    runtimeInfo,
+    startSession,
+    stopSession,
+    commentsWindow,
+    toggleCommentsWindow,
+    captionsWindow,
+    toggleCaptionsWindow
+  } = useStudioCore()
   const { recording } = useStudioRecordingState()
   const modKey = displayKeyGlyph('⌘', runtimeInfo?.platform)
   const shiftKey = displayKeyGlyph('⇧', runtimeInfo?.platform)
@@ -136,6 +151,21 @@ export function CommandPalette({
                 <Kbd>
                   {modKey}
                   {shiftKey}J
+                </Kbd>
+              </CommandShortcut>
+            </CommandItem>
+          ) : null}
+          {captionsWindow.enabled || captionsWindow.open ? (
+            <CommandItem
+              value="Toggle captions reader"
+              onSelect={() => run(() => toggleCaptionsWindow())}
+            >
+              <ClosedCaptioning className="size-4" />
+              {captionsWindow.open ? 'Close captions reader' : 'Open captions reader'}
+              <CommandShortcut className="tracking-normal">
+                <Kbd>
+                  {modKey}
+                  {shiftKey}C
                 </Kbd>
               </CommandShortcut>
             </CommandItem>

--- a/apps/desktop/src/renderer/src/components/go-live-dialog.test.ts
+++ b/apps/desktop/src/renderer/src/components/go-live-dialog.test.ts
@@ -2,7 +2,11 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 
-import { GoLiveCommentsStatus, GoLiveDestinationSummary } from './go-live-dialog'
+import {
+  GoLiveCaptionsStatus,
+  GoLiveCommentsStatus,
+  GoLiveDestinationSummary
+} from './go-live-dialog'
 
 describe('Go Live comments status', () => {
   it('states that native X comments attach after publish and remain receive-only', () => {
@@ -44,5 +48,48 @@ describe('Go Live comments status', () => {
     expect(markup).toContain('Ready · 2 comment limitations')
     expect(markup).toContain('data-variant="warning"')
     expect(markup).not.toContain('data-variant="destructive"')
+  })
+})
+
+describe('Go Live captions status', () => {
+  it('shows a compact ready transport row', () => {
+    const markup = renderToStaticMarkup(
+      createElement(GoLiveCaptionsStatus, {
+        pending: false,
+        readiness: {
+          kind: 'ready',
+          blocksStart: false,
+          title: 'Captions ready',
+          description: 'Realtime microphone transcription is ready.',
+          transport: 'realtime'
+        },
+        onContinueWithoutCaptions: () => {}
+      })
+    )
+
+    expect(markup).toContain('Captions')
+    expect(markup).toContain('Realtime microphone transcription is ready.')
+    expect(markup).toContain('data-variant="success"')
+    expect(markup).not.toContain('Continue without captions')
+  })
+
+  it('offers an explicit one-session bypass when deployment readiness is unavailable', () => {
+    const markup = renderToStaticMarkup(
+      createElement(GoLiveCaptionsStatus, {
+        pending: false,
+        readiness: {
+          kind: 'blocked',
+          blocksStart: true,
+          title: 'Captions unavailable',
+          description: 'Videorc could not verify live-caption readiness for this deployment.',
+          transport: null
+        },
+        onContinueWithoutCaptions: () => {}
+      })
+    )
+
+    expect(markup).toContain('Continue without captions')
+    expect(markup).toContain('deployment')
+    expect(markup).toContain('data-variant="warning"')
   })
 })

--- a/apps/desktop/src/renderer/src/components/go-live-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/go-live-dialog.tsx
@@ -1,4 +1,4 @@
-import { Broadcast, CheckCircle, WarningCircle } from '@phosphor-icons/react'
+import { Broadcast, CheckCircle, ClosedCaptioning, WarningCircle } from '@phosphor-icons/react'
 import type { ReactElement } from 'react'
 
 import { Badge } from '@/components/ui/badge'
@@ -31,6 +31,7 @@ import type {
   StreamPrivacy
 } from '@/lib/backend'
 import { type EntitlementUiGate } from '@/lib/entitlement-ui'
+import type { GoLiveCaptionsReadiness } from '@/lib/captions-preflight'
 
 // The Go Live confirmation flow: review destinations + metadata, resolve any
 // error-severity blockers, then start the livestream. Extracted from StudioTab
@@ -43,10 +44,12 @@ export function GoLiveConfirmationDialog({
   preflight,
   entitlementGate,
   draft,
+  captionsReadiness,
   onPatchDraft,
   onCancel,
   onConfirm,
   onContinuePartial,
+  onContinueWithoutCaptions,
   onResolveBlocker
 }: {
   open: boolean
@@ -55,10 +58,12 @@ export function GoLiveConfirmationDialog({
   preflight: ReturnType<typeof useStudioCore>['goLivePreflight']
   entitlementGate: EntitlementUiGate
   draft: ReturnType<typeof useStudioCore>['streamMetadataDraft']
+  captionsReadiness: GoLiveCaptionsReadiness
   onPatchDraft: ReturnType<typeof useStudioCore>['patchStreamMetadataDraft']
   onCancel: () => void
   onConfirm: () => void
   onContinuePartial: () => void
+  onContinueWithoutCaptions: () => void
   onResolveBlocker: (targetId: string, resolution: 'disable' | 'manual-rtmp') => void
 }): ReactElement {
   const entitlementBlocker = entitlementGate.allowed ? null : entitlementGate
@@ -71,11 +76,15 @@ export function GoLiveConfirmationDialog({
     !preflight?.issues.some((issue) => issue.message === entitlementBlocker.reason)
       ? 1
       : 0
-  const issueCount = errorCount + entitlementIssueCount
+  const captionsIssueCount = captionsReadiness.blocksStart ? 1 : 0
+  const issueCount = errorCount + entitlementIssueCount + captionsIssueCount
   // "Resolve before going live" means exactly that: error-severity issues keep
   // the confirm button locked until resolved (disable the destination, switch
   // it to Manual RTMP, or fix it in the Streaming tab).
-  const blocked = Boolean(entitlementBlocker) || (preflight ? !preflight.valid : false)
+  const blocked =
+    Boolean(entitlementBlocker) ||
+    captionsReadiness.blocksStart ||
+    (preflight ? !preflight.valid : false)
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
@@ -110,6 +119,14 @@ export function GoLiveConfirmationDialog({
                 />
               </Field>
             </div>
+
+            {captionsReadiness.kind !== 'disabled' ? (
+              <GoLiveCaptionsStatus
+                pending={pending}
+                readiness={captionsReadiness}
+                onContinueWithoutCaptions={onContinueWithoutCaptions}
+              />
+            ) : null}
 
             <Field>
               <div className="flex flex-wrap items-center justify-between gap-2">
@@ -246,7 +263,10 @@ export function GoLiveConfirmationDialog({
             Cancel
           </Button>
           {partialSetup ? (
-            <Button disabled={pending || Boolean(entitlementBlocker)} onClick={onContinuePartial}>
+            <Button
+              disabled={pending || Boolean(entitlementBlocker) || captionsReadiness.blocksStart}
+              onClick={onContinuePartial}
+            >
               <Broadcast data-icon="inline-start" weight="fill" />
               {pending ? 'Starting…' : 'Continue With Ready'}
             </Button>
@@ -259,6 +279,51 @@ export function GoLiveConfirmationDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+export function GoLiveCaptionsStatus({
+  readiness,
+  pending,
+  onContinueWithoutCaptions
+}: {
+  readiness: GoLiveCaptionsReadiness
+  pending: boolean
+  onContinueWithoutCaptions: () => void
+}): ReactElement {
+  const blocked = readiness.kind === 'blocked'
+  const ready = readiness.kind === 'ready'
+  return (
+    <div
+      className={
+        blocked
+          ? 'flex flex-col gap-2 rounded-row border border-warning/35 bg-warning/10 p-3'
+          : 'flex flex-col gap-2 rounded-row border border-border bg-muted/25 p-3'
+      }
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <ClosedCaptioning className="size-4 text-muted-foreground" weight="duotone" />
+          Captions
+        </div>
+        <Badge variant={ready ? 'success' : blocked ? 'warning' : 'secondary'}>
+          {ready ? <CheckCircle data-icon="inline-start" weight="fill" /> : null}
+          {readiness.title.replace(/^Captions\s*/i, '')}
+        </Badge>
+      </div>
+      <p className="text-sm text-muted-foreground">{readiness.description}</p>
+      {blocked ? (
+        <Button
+          className="w-fit"
+          disabled={pending}
+          size="sm"
+          variant="outline"
+          onClick={onContinueWithoutCaptions}
+        >
+          Continue without captions
+        </Button>
+      ) : null}
+    </div>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -9,8 +9,7 @@ import {
   SpeakerSlash,
   type Icon
 } from '@phosphor-icons/react'
-import { useState, type ReactElement, type ReactNode } from 'react'
-import { toast } from 'sonner'
+import type { ReactElement, ReactNode } from 'react'
 
 import { SourceSelect } from '@/components/source-select'
 import { Button } from '@/components/ui/button'
@@ -27,7 +26,7 @@ import { Switch } from '@/components/ui/switch'
 import { useWorkspaceNav } from '@/components/workspace-nav'
 import { useStudioCore } from '@/hooks/use-studio'
 import { recordingQuality } from '@/lib/studio-session-view'
-import type { LayoutPreset } from '@/lib/backend'
+import type { CaptionsStatus, LayoutPreset } from '@/lib/backend'
 import { cloudAiUploadGate } from '@/lib/entitlement-ui'
 import {
   buildCameraSources,
@@ -63,6 +62,33 @@ function resolutionKey(width: number, height: number): string {
   return `${width}x${height}`
 }
 
+function compactCaptionsStatus(
+  status: CaptionsStatus,
+  enabled: boolean,
+  sessionActive: boolean,
+  premiumAllowed: boolean
+): string {
+  switch (status.state) {
+    case 'starting':
+      return 'Starting…'
+    case 'listening':
+    case 'live':
+      return sessionActive ? 'Live' : 'Waiting for session'
+    case 'reconnecting':
+      return 'Reconnecting…'
+    case 'degraded':
+      return 'Higher delay'
+    case 'blocked':
+      return 'Blocked'
+    case 'error':
+      return 'Error'
+    case 'ready':
+      return 'Ready'
+    default:
+      return enabled ? 'Armed' : premiumAllowed ? 'Off' : 'Premium'
+  }
+}
+
 const TRIGGER_CLASS =
   'flex w-full items-center gap-2 rounded-row border bg-background px-2.5 py-1.5 text-sm transition-colors hover:bg-accent data-[state=open]:bg-accent'
 
@@ -88,33 +114,15 @@ export function QuickSettings(): ReactElement {
     isSessionActive,
     entitlements,
     captionsStatus,
-    startCaptions,
-    stopCaptions,
+    captionsCommandPending,
     wsStatus
   } = useStudioCore()
   // Q6 (plan 022): before the backend reports devices, selects say "Finding
   // devices…" instead of rendering blank.
   const discoveryPending = wsStatus !== 'connected'
   const { openStudioPanel } = useWorkspaceNav()
-  const [captionsPending, setCaptionsPending] = useState(false)
   const captionsGate = cloudAiUploadGate(entitlements)
-  const captionsLive = captionsStatus.state === 'live' || captionsStatus.state === 'degraded'
-  const toggleCaptions = async (next: boolean): Promise<void> => {
-    setCaptionsPending(true)
-    try {
-      if (next) {
-        await startCaptions()
-      } else {
-        await stopCaptions()
-      }
-    } catch (error) {
-      toast.error('Live captions', {
-        description: error instanceof Error ? error.message : 'Could not update live captions.'
-      })
-    } finally {
-      setCaptionsPending(false)
-    }
-  }
+  const captionsEnabled = captureConfig.captions.enabled
 
   const captureDevices = capturePickerDevices(deviceList.devices)
   const cameras = deviceList.devices.filter((device) => device.kind === 'camera')
@@ -302,23 +310,26 @@ export function QuickSettings(): ReactElement {
       <QuickCard icon={ClosedCaptioning} label="Captions">
         <div className="flex items-center justify-between gap-2 rounded-row border bg-background px-2.5 py-1.5">
           <span className="min-w-0 flex-1 truncate text-sm font-medium">
-            {captionsStatus.state === 'degraded'
-              ? 'Reconnecting…'
-              : captionsLive
-                ? isSessionActive
-                  ? 'Live'
-                  : 'Waiting for session'
-                : captionsGate.allowed
-                  ? 'Off'
-                  : 'Premium'}
+            {compactCaptionsStatus(
+              captionsStatus,
+              captionsEnabled,
+              isSessionActive,
+              captionsGate.allowed
+            )}
           </span>
           <Switch
             aria-label="Enable live captions"
-            checked={captionsLive}
-            disabled={captionsPending || (!captionsLive && !captionsGate.allowed)}
-            onCheckedChange={(next) => void toggleCaptions(next)}
+            checked={captionsEnabled}
+            disabled={captionsCommandPending || (!captionsEnabled && !captionsGate.allowed)}
+            onCheckedChange={(enabled) =>
+              setCaptureConfig((current) => ({
+                ...current,
+                captions: { ...current.captions, enabled }
+              }))
+            }
           />
         </div>
+        <ManageLink onClick={() => openStudioPanel('captions')}>Manage captions</ManageLink>
       </QuickCard>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/tabs/captions-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/captions-tab.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react'
+
+import { CaptionPreview } from '@/components/captions/caption-preview'
+import { CaptionsControls } from '@/components/captions/captions-controls'
+
+export function CaptionsTab(): ReactElement {
+  return (
+    <div className="grid items-start gap-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(380px,0.8fr)]">
+      <CaptionPreview />
+      <CaptionsControls />
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
@@ -4,7 +4,6 @@ import {
   Broadcast,
   CaretDown,
   CheckCircle,
-  ClosedCaptioning,
   FloppyDisk,
   Gauge,
   LinkSimple,
@@ -20,10 +19,10 @@ import {
   type Icon
 } from '@phosphor-icons/react'
 import { useEffect, useMemo, useState, type ReactElement } from 'react'
-import { toast } from 'sonner'
 
 import { ListRow } from '@/components/list-row'
 import { PanelSection } from '@/components/panel-section'
+import { CaptionsControls } from '@/components/captions/captions-controls'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -72,12 +71,7 @@ import {
   streamOutputVideoSettings,
   videoProfileCompatibility
 } from '@/lib/capture'
-import { captionStripLines } from '@/lib/captions-ui'
-import {
-  cloudAiUploadGate,
-  streamingDestinationEnableGate,
-  type EntitlementUiGate
-} from '@/lib/entitlement-ui'
+import { streamingDestinationEnableGate, type EntitlementUiGate } from '@/lib/entitlement-ui'
 import { entitlementDisabledReason } from '@/lib/entitlements'
 import { streamKeyPlatformMismatch, streamKeyTailHint } from '@/lib/stream-key-format'
 import { cn } from '@/lib/utils'
@@ -271,203 +265,9 @@ export function StreamingTab(): ReactElement {
           streamVideo={streamVideo}
           targets={streaming.targets}
         />
-        <LiveCaptionsSection />
+        <CaptionsControls />
       </div>
     </div>
-  )
-}
-
-/**
- * Live captions (premium cloud AI): real-time mic speech-to-text via the
- * Videorc AI gateway. The Rust backend uploads ~3s mic chunks while enabled —
- * the consent line below states that plainly (AI privacy tone).
- */
-function LiveCaptionsSection(): ReactElement {
-  const {
-    entitlements,
-    captionsStatus,
-    captionLines,
-    startCaptions,
-    stopCaptions,
-    captionsWindow,
-    toggleCaptionsWindow,
-    isSessionActive,
-    captureConfig,
-    setCaptureConfig
-  } = useStudioCore()
-  const [pending, setPending] = useState(false)
-  const gate = cloudAiUploadGate(entitlements)
-  const active = captionsStatus.state === 'live' || captionsStatus.state === 'degraded'
-  const locked = !active && !gate.allowed
-  const lines = captionStripLines(captionLines)
-  const captions = captureConfig.captions
-  const patchCaptions = (patch: Partial<typeof captions>): void =>
-    setCaptureConfig((current) => ({
-      ...current,
-      captions: { ...current.captions, ...patch }
-    }))
-
-  const toggleCaptions = async (next: boolean): Promise<void> => {
-    setPending(true)
-    try {
-      if (next) {
-        await startCaptions()
-      } else {
-        await stopCaptions()
-      }
-    } catch (error) {
-      toast.error('Live captions', {
-        description: error instanceof Error ? error.message : 'Could not update live captions.'
-      })
-    } finally {
-      setPending(false)
-    }
-  }
-
-  return (
-    <PanelSection
-      description="Real-time speech-to-text from your microphone while you record or stream."
-      icon={ClosedCaptioning}
-      title="Live captions"
-    >
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center justify-between gap-3">
-          <span className="text-sm text-muted-foreground">
-            {active ? 'Captions are live' : 'Captions are off'}
-          </span>
-          <Switch
-            aria-label="Enable live captions"
-            checked={active}
-            disabled={pending || locked}
-            onCheckedChange={(next) => void toggleCaptions(next)}
-          />
-        </div>
-        {locked ? (
-          <div className="flex flex-wrap items-center gap-2 border-l-2 border-warning/50 pl-3 text-xs text-warning-foreground dark:text-warning">
-            <WarningCircle className="size-3.5 shrink-0" weight="fill" />
-            <span className="min-w-0 flex-1">{gate.allowed ? null : gate.reason}</span>
-            {!gate.allowed && gate.upgradeUrl ? (
-              <Button
-                className="h-auto px-0 text-xs"
-                size="xs"
-                variant="link"
-                onClick={() => openExternalUrl(gate.upgradeUrl as string)}
-              >
-                View Premium
-              </Button>
-            ) : null}
-          </div>
-        ) : (
-          <p className="text-xs text-muted-foreground">
-            While enabled, your microphone audio is sent to xAI through the Videorc AI gateway for
-            transcription. Captions appear a few seconds behind speech.
-          </p>
-        )}
-        {(captionsStatus.state === 'error' || captionsStatus.state === 'degraded') &&
-        captionsStatus.message ? (
-          <div className="flex items-start gap-2 border-l-2 border-warning/50 pl-3 text-xs text-warning-foreground dark:text-warning">
-            <WarningCircle className="mt-0.5 size-3.5 shrink-0" weight="fill" />
-            <span>{captionsStatus.message}</span>
-          </div>
-        ) : null}
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <span className="text-sm text-muted-foreground">Burn captions into</span>
-          <ToggleGroup
-            aria-label="Caption burn target"
-            size="sm"
-            type="single"
-            value={captions.burnTarget}
-            variant="outline"
-            disabled={locked}
-            onValueChange={(value) => {
-              if (
-                value === 'off' ||
-                value === 'stream' ||
-                value === 'recording' ||
-                value === 'both'
-              ) {
-                patchCaptions({ burnTarget: value })
-              }
-            }}
-          >
-            <ToggleGroupItem value="off">Off</ToggleGroupItem>
-            <ToggleGroupItem value="stream">Stream</ToggleGroupItem>
-            <ToggleGroupItem value="recording">Recording</ToggleGroupItem>
-            <ToggleGroupItem value="both">Both</ToggleGroupItem>
-          </ToggleGroup>
-        </div>
-        {captions.burnTarget !== 'off' ? (
-          <>
-            <p className="text-xs text-muted-foreground">
-              {captions.burnTarget === 'stream'
-                ? 'Viewers see a caption bar burned into the stream, a few seconds behind speech. Your recording stays clean and gets a perfectly-synced captioned copy after the session.'
-                : 'The live caption bar runs a few seconds behind speech, and that lag is burned in permanently. The recording also gets a perfectly-synced captioned copy after the session.'}
-            </p>
-            <div className="flex flex-wrap items-center gap-4">
-              <ToggleGroup
-                aria-label="Caption position"
-                size="sm"
-                type="single"
-                value={captions.position}
-                variant="outline"
-                onValueChange={(value) => {
-                  if (value === 'top' || value === 'bottom') {
-                    patchCaptions({ position: value })
-                  }
-                }}
-              >
-                <ToggleGroupItem value="bottom">Bottom</ToggleGroupItem>
-                <ToggleGroupItem value="top">Top</ToggleGroupItem>
-              </ToggleGroup>
-              <ToggleGroup
-                aria-label="Caption text size"
-                size="sm"
-                type="single"
-                value={captions.textSize}
-                variant="outline"
-                onValueChange={(value) => {
-                  if (value === 's' || value === 'm' || value === 'l') {
-                    patchCaptions({ textSize: value })
-                  }
-                }}
-              >
-                <ToggleGroupItem value="s">S</ToggleGroupItem>
-                <ToggleGroupItem value="m">M</ToggleGroupItem>
-                <ToggleGroupItem value="l">L</ToggleGroupItem>
-              </ToggleGroup>
-            </div>
-          </>
-        ) : null}
-        {active || lines.length > 0 ? (
-          <div aria-live="polite" className="flex min-h-16 flex-col justify-end gap-1.5">
-            {lines.length === 0 ? (
-              // No instructional copy while captions are on — the transcript
-              // area stays quiet until there is something to transcribe
-              // (post-0.9.4 fix batch F2).
-              isSessionActive ? (
-                <span className="text-sm text-muted-foreground">Listening…</span>
-              ) : null
-            ) : (
-              lines.map((line) => (
-                <p className="text-sm leading-6 text-foreground" key={line.seq}>
-                  {line.text}
-                </p>
-              ))
-            )}
-          </div>
-        ) : null}
-        {captionsWindow.enabled || captionsWindow.open ? (
-          <Button
-            className="w-fit"
-            size="sm"
-            variant="ghost"
-            onClick={() => void toggleCaptionsWindow()}
-          >
-            {captionsWindow.open ? 'Close captions window' : 'Open captions window'}
-          </Button>
-        ) : null}
-      </div>
-    </PanelSection>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -51,11 +51,13 @@ export function StudioTab(): ReactElement {
     goLiveConfirmationPending,
     goLivePartialSetup,
     goLivePreflight,
+    goLiveCaptionsReadiness,
     streamMetadataDraft,
     patchStreamMetadataDraft,
     cancelGoLiveConfirmation,
     confirmGoLive,
     continueGoLiveWithReadyDestinations,
+    continueGoLiveWithoutCaptions,
     resolveGoLiveBlocker
   } = studio
 
@@ -127,6 +129,7 @@ export function StudioTab(): ReactElement {
       <div className="min-w-0 flex-1">
         <GoLiveConfirmationDialog
           draft={streamMetadataDraft}
+          captionsReadiness={goLiveCaptionsReadiness}
           entitlementGate={goLiveEntitlement}
           open={goLiveConfirmationOpen}
           pending={goLiveConfirmationPending || startRequestPending}
@@ -135,6 +138,7 @@ export function StudioTab(): ReactElement {
           onCancel={cancelGoLiveConfirmation}
           onConfirm={() => void confirmGoLive()}
           onContinuePartial={() => void continueGoLiveWithReadyDestinations()}
+          onContinueWithoutCaptions={continueGoLiveWithoutCaptions}
           onPatchDraft={patchStreamMetadataDraft}
           onResolveBlocker={(targetId, resolution) =>
             void resolveGoLiveBlocker(targetId, resolution)

--- a/apps/desktop/src/renderer/src/components/workspace-nav.test.ts
+++ b/apps/desktop/src/renderer/src/components/workspace-nav.test.ts
@@ -11,9 +11,9 @@ import {
   type WorkspaceTab
 } from './workspace-nav'
 
-// Assets is a first-class Setup page at ⌘4. Settings moved onto ⌘8 (2026-06-24),
-// and AI + Health (Diagnostics) intentionally have no digit — both stay reachable
-// via ⌘K. These invariants guard the IA so a later edit can't silently drop a page,
+// Captions is a first-class Setup page at ⌘6. Settings keeps ⌘,, while Health
+// intentionally has no navigation key and stays reachable via ⌘K. These invariants
+// guard the IA so a later edit can't silently drop a page,
 // duplicate a shortcut, or rename a legacy trigger id that smokes/deep-links depend on.
 describe('workspace navigation', () => {
   it('registers Assets as a Setup panel between Scene and Destinations', () => {
@@ -22,6 +22,7 @@ describe('workspace navigation', () => {
       'layouts',
       'assets',
       'live',
+      'captions',
       'recording'
     ])
 
@@ -38,26 +39,28 @@ describe('workspace navigation', () => {
       sources: 'sources',
       layouts: 'layout',
       live: 'streaming',
+      captions: 'captions',
       recording: 'recording'
     })
   })
 
-  it('maps ⌘1–⌘9 to the workflow pages in sidebar order (AI ⌘8, Settings ⌘9)', () => {
+  it('maps the workflow pages in sidebar order (Captions ⌘6, Settings ⌘,)', () => {
     expect(WORKSPACE_SHORTCUTS.map((entry) => [entry.digit, entry.tab])).toEqual([
       ['1', 'studio'],
       ['2', 'sources'],
       ['3', 'layouts'],
       ['4', 'assets'],
       ['5', 'live'],
-      ['6', 'recording'],
-      ['7', 'library'],
-      ['8', 'ai'],
-      ['9', 'settings']
+      ['6', 'captions'],
+      ['7', 'recording'],
+      ['8', 'library'],
+      ['9', 'ai'],
+      [',', 'settings']
     ])
   })
 
-  it('puts Settings on ⌘9 and never duplicates a key', () => {
-    expect(shortcutDigitFor('settings')).toBe('9')
+  it('puts Settings on ⌘, and never duplicates a key', () => {
+    expect(shortcutDigitFor('settings')).toBe(',')
     expect(WORKSPACE_SHORTCUTS.filter((entry) => entry.tab === 'settings')).toHaveLength(1)
 
     const keys = WORKSPACE_SHORTCUTS.map((entry) => entry.digit)
@@ -80,10 +83,12 @@ describe('workspace navigation', () => {
     expect(WORKSPACE_SHORTCUTS).toHaveLength(reachable.length - noDigit.length)
   })
 
-  it('classifies Assets as a Studio panel and labels it', () => {
+  it('classifies Assets and Captions as Studio panels and labels them', () => {
     expect(isStudioPanel('assets')).toBe(true)
     expect(isStudioPanel('studio')).toBe(false)
     expect(isWorkspaceTab('assets')).toBe(true)
+    expect(isStudioPanel('captions')).toBe(true)
+    expect(workspaceTabLabel('captions')).toBe('Captions')
     expect(isWorkspaceTab('library')).toBe(true)
     expect(isWorkspaceTab('missing')).toBe(false)
     expect(workspaceTabLabel('assets')).toBe('Assets')

--- a/apps/desktop/src/renderer/src/components/workspace-nav.tsx
+++ b/apps/desktop/src/renderer/src/components/workspace-nav.tsx
@@ -1,5 +1,6 @@
 import {
   Broadcast,
+  ClosedCaptioning,
   FilmReel,
   GearSix,
   ImageSquare,
@@ -18,7 +19,7 @@ import { createContext, useContext } from 'react'
 // 2026-06-09, overriding the earlier push-rail idea). Sources is the single home for
 // every capture device — screen/window, camera, AND microphone — so changing what
 // gets captured never requires hunting across pages (UI rewrite plan, 2026-06-10).
-export type StudioPanel = 'sources' | 'layouts' | 'assets' | 'live' | 'recording'
+export type StudioPanel = 'sources' | 'layouts' | 'assets' | 'live' | 'captions' | 'recording'
 
 // Full pages: they replace the workspace content area.
 export type WorkspaceTab = 'studio' | StudioPanel | 'library' | 'ai' | 'diagnostics' | 'settings'
@@ -60,11 +61,12 @@ export const STUDIO_PANELS: StudioPanelMeta[] = [
   { id: 'layouts', label: 'Scene', icon: SquaresFour, legacyTabId: 'layout' },
   { id: 'assets', label: 'Assets', icon: ImageSquare, legacyTabId: 'assets' },
   { id: 'live', label: 'Livestream', icon: Broadcast, legacyTabId: 'streaming' },
+  { id: 'captions', label: 'Captions', icon: ClosedCaptioning, legacyTabId: 'captions' },
   { id: 'recording', label: 'Output', icon: Record, legacyTabId: 'recording' }
 ]
 
-// Page shortcuts in sidebar order. Studio + the Setup pages + Library take ⌘1–⌘7,
-// AI takes ⌘8, and Settings takes ⌘9. Health (Diagnostics) intentionally has NO
+// Page shortcuts in sidebar order. Studio + the Setup pages + Library take ⌘1–⌘8,
+// AI takes ⌘9, and Settings keeps the platform-standard ⌘,. Health intentionally has NO
 // digit — it stays reachable via ⌘K (and the account menu). The main process emits
 // the raw key ('1'–'9' or ',') and AppShell maps whatever is listed here.
 export const WORKSPACE_SHORTCUTS: { digit: string; tab: WorkspaceTab }[] = [
@@ -73,10 +75,11 @@ export const WORKSPACE_SHORTCUTS: { digit: string; tab: WorkspaceTab }[] = [
   { digit: '3', tab: 'layouts' },
   { digit: '4', tab: 'assets' },
   { digit: '5', tab: 'live' },
-  { digit: '6', tab: 'recording' },
-  { digit: '7', tab: 'library' },
-  { digit: '8', tab: 'ai' },
-  { digit: '9', tab: 'settings' }
+  { digit: '6', tab: 'captions' },
+  { digit: '7', tab: 'recording' },
+  { digit: '8', tab: 'library' },
+  { digit: '9', tab: 'ai' },
+  { digit: ',', tab: 'settings' }
 ]
 
 export function shortcutDigitFor(tab: WorkspaceTab): string | undefined {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -25,6 +25,7 @@ import { rendererCompositorUpdateWasAccepted } from '../../../shared/native-prev
 import { cloudAiReadiness } from '@/lib/ai-readiness'
 import {
   applyStoredManualStreamKeyResult,
+  auxiliaryStreamOutputVideoSettings,
   bridgeStreamingToLegacy,
   buildCameraSources,
   areEnabledStreamTargetsStartReady,
@@ -50,6 +51,7 @@ import {
   smokePreviewCompositorCaptureConfig,
   sourceSelectionChangeEvents,
   STORAGE_KEYS,
+  streamOutputVideosForTargets,
   streamOutputVideoSettings,
   videoProfileCompatibility,
   videoPresets,
@@ -96,6 +98,7 @@ import type {
   AiWorkflowResult,
   AutomaticSourceFallbackEvent,
   AudioMeterResult,
+  AudioProcessingUpdateResult,
   BackendConnection,
   BackendHealth,
   BackendLogEvent,
@@ -121,6 +124,7 @@ import type {
   CaptionsStatus,
   CaptionsUpdate,
   CaptionsWindowState,
+  CaptionStyleId,
   LiveChatSnapshot,
   NativePreviewHostCommand,
   NotesWindowState,
@@ -184,11 +188,26 @@ import { renderCaptionCueFramePng, renderCaptionOverlayPng } from '@/lib/caption
 import { renderCommentHighlightPng } from '@/lib/caption-overlay'
 import {
   appendCaptionLine,
+  captionDwellMs,
   captionLineAboveFloor,
+  captionLineIdentity,
+  captionOverlayKey,
+  captionOverlayTargetPlan,
   captionSessionFloor,
+  CaptionCueRenderGuard,
+  captionsStatusIsActive,
+  decideCaptionsRuntimeIntent,
   decideOverlayPush,
+  LatestWinsScheduler,
+  shouldCancelCaptionCueRender,
   type CaptionSessionFloor
 } from '@/lib/captions-ui'
+import {
+  captionRuntimeStartBlocked,
+  captionSessionOutputReadiness,
+  decideGoLiveCaptionsReadiness,
+  type GoLiveCaptionsReadiness
+} from '@/lib/captions-preflight'
 import { goLiveEntitlementGate, videoProfileEntitlementGate } from '@/lib/entitlement-ui'
 import { entitlementDisabledReason } from '@/lib/entitlements'
 import {
@@ -230,6 +249,11 @@ import { useBackgroundAssets } from '@/hooks/use-background-assets'
 import { buildStartSessionParams } from '@/lib/session-params'
 import { findDevice, isActiveRecordingState, mergeStreamHealth } from '@/lib/format'
 import {
+  activeAudioProcessingUpdateParams,
+  rejectedLiveAudioProcessingUpdate,
+  type LiveAudioProcessingValues
+} from '@/lib/live-audio-processing'
+import {
   loadValidatedPlatformAccountsOnIsolatedClient,
   StudioBootstrapGuard
 } from '@/lib/studio-bootstrap'
@@ -239,6 +263,22 @@ import {
 } from '@/lib/protected-overlay-windows'
 
 export type { GoLivePartialSetup, GoLiveSetupFailure } from '@/lib/go-live-flow'
+
+type CaptionOverlayWork = {
+  client: BackendClient
+  epoch: number
+  key: string
+  text: string
+  outputs: Array<{
+    target: 'primary' | 'auxiliary'
+    canvasWidth: number
+    canvasHeight: number
+  }>
+  styleId: CaptionStyleId
+  styleRevision: number
+  textSize: 's' | 'm' | 'l'
+  position: 'top' | 'bottom'
+}
 
 function openPremiumUpgradePage(): void {
   const opener = window.videorc?.openOAuthUrl
@@ -536,7 +576,8 @@ export type StudioContextValue = {
   /** Live captions (premium cloud AI): status + transcript lines from captions.* events. */
   captionsStatus: CaptionsStatus
   captionLines: CaptionsUpdate[]
-  startCaptions: () => Promise<void>
+  captionsCommandPending: boolean
+  startCaptions: (language?: string) => Promise<void>
   stopCaptions: () => Promise<void>
   captionsWindow: CaptionsWindowState
   openCaptionsWindow: () => Promise<void>
@@ -559,6 +600,8 @@ export type StudioContextValue = {
   goLiveConfirmationOpen: boolean
   goLiveConfirmationPending: boolean
   goLivePartialSetup: GoLivePartialSetup | null
+  goLiveCaptionsReadiness: GoLiveCaptionsReadiness
+  continueGoLiveWithoutCaptions: () => void
   // preview + audio
   previewUrl: string | null
   previewLoading: boolean
@@ -776,6 +819,7 @@ interface StudioShellContextValue {
   openCommentsWindow: () => Promise<void>
   closeCommentsWindow: () => Promise<void>
   toggleCommentsWindow: () => Promise<void>
+  toggleCaptionsWindow: () => Promise<void>
 }
 
 const StudioShellContext = createContext<StudioShellContextValue | null>(null)
@@ -1392,9 +1436,15 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       })
     }
   }, [liveChatSnapshot])
+  const [captureConfig, setCaptureConfig] = useState<CaptureConfig>(loadCaptureConfig)
   // Live captions: status + transcript driven by captions.* events; the mic
   // audio itself never reaches the renderer (the Rust backend uploads chunks).
   const [captionsStatus, setCaptionsStatus] = useState<CaptionsStatus>({ state: 'idle' })
+  const captionsStatusRevisionRef = useRef(0)
+  const commitCaptionsStatus = useCallback((status: CaptionsStatus): void => {
+    captionsStatusRevisionRef.current += 1
+    setCaptionsStatus(status)
+  }, [])
   const [captionLines, setCaptionLines] = useState<CaptionsUpdate[]>([])
   const captionLinesRef = useRef(captionLines)
   captionLinesRef.current = captionLines
@@ -1404,25 +1454,53 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   // responses can land seconds after the next recording began, and the
   // capture-epoch filter only guards the .srt/burn chunks, not these events.
   const captionSessionFloorRef = useRef<CaptionSessionFloor | null>(null)
-  const startCaptions = useCallback(async () => {
-    // F-022: both failure shapes must THROW so the toggle's error handler can
-    // toast — a missing client and a non-live status used to revert the switch
-    // silently.
-    if (!client) {
-      throw new Error('Backend is not connected — try again in a moment.')
-    }
-    setCaptionLines([])
-    const status = await client.request<CaptionsStatus>('captions.start')
-    setCaptionsStatus(status)
-    if (status.state !== 'live' && status.state !== 'degraded') {
-      throw new Error(status.message ?? `Live captions did not start (status: ${status.state}).`)
-    }
-  }, [client])
+  const [captionsCommandPending, setCaptionsCommandPending] = useState(false)
+  const captionsCommandTailRef = useRef<Promise<void>>(Promise.resolve())
+  const captionsCommandCountRef = useRef(0)
+  const runCaptionsCommand = useCallback(
+    (command: () => Promise<CaptionsStatus>): Promise<CaptionsStatus> => {
+      captionsCommandCountRef.current += 1
+      setCaptionsCommandPending(true)
+      const result = captionsCommandTailRef.current.catch(() => undefined).then(command)
+      captionsCommandTailRef.current = result.then(
+        () => undefined,
+        () => undefined
+      )
+      const finish = (): void => {
+        captionsCommandCountRef.current = Math.max(0, captionsCommandCountRef.current - 1)
+        if (captionsCommandCountRef.current === 0) setCaptionsCommandPending(false)
+      }
+      void result.then(finish, finish)
+      return result
+    },
+    []
+  )
+  const startCaptions = useCallback(
+    async (language = 'auto') => {
+      // F-022: both failure shapes must THROW so the toggle's error handler can
+      // toast — a missing client and a non-live status used to revert the switch
+      // silently.
+      if (!client) {
+        throw new Error('Backend is not connected — try again in a moment.')
+      }
+      setCaptionLines([])
+      const status = await runCaptionsCommand(() =>
+        client.request<CaptionsStatus>('captions.start', {
+          language: language === 'auto' ? undefined : language
+        })
+      )
+      commitCaptionsStatus(status)
+      if (!captionsStatusIsActive(status) && status.state !== 'ready') {
+        throw new Error(status.message ?? `Live captions did not start (status: ${status.state}).`)
+      }
+    },
+    [client, commitCaptionsStatus, runCaptionsCommand]
+  )
   const stopCaptions = useCallback(async () => {
     if (!client) return
-    const status = await client.request<CaptionsStatus>('captions.stop')
-    setCaptionsStatus(status)
-  }, [client])
+    const status = await runCaptionsCommand(() => client.request<CaptionsStatus>('captions.stop'))
+    commitCaptionsStatus(status)
+  }, [client, commitCaptionsStatus, runCaptionsCommand])
   // Detached captions window: same relay-via-main pattern as Comments — the
   // caption-line buffer is pushed to main, which caches + forwards it.
   const [captionsWindow, setCaptionsWindow] = useState<CaptionsWindowState>(idleCaptionsWindowState)
@@ -1445,12 +1523,26 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
   }, [])
   useEffect(() => {
-    void window.videorc?.pushCaptionLines?.(captionLines)
-  }, [captionLines])
+    void window.videorc?.pushCaptionSnapshot?.({
+      lines: captionLines,
+      status: captionsStatus,
+      styleId: captureConfig.captions.styleId,
+      position: captureConfig.captions.position,
+      textSize: captureConfig.captions.textSize
+    })
+  }, [captionLines, captionsStatus, captureConfig.captions])
   const openCaptionsWindow = useCallback(async () => {
-    await window.videorc?.pushCaptionLines?.(captionLines).catch(() => {})
+    await window.videorc
+      ?.pushCaptionSnapshot?.({
+        lines: captionLines,
+        status: captionsStatus,
+        styleId: captureConfig.captions.styleId,
+        position: captureConfig.captions.position,
+        textSize: captureConfig.captions.textSize
+      })
+      .catch(() => {})
     await window.videorc?.openCaptionsWindow?.()
-  }, [captionLines])
+  }, [captionLines, captionsStatus, captureConfig.captions])
   const closeCaptionsWindow = useCallback(async () => {
     await window.videorc?.closeCaptionsWindow?.()
   }, [])
@@ -1504,8 +1596,6 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       offClear?.()
     }
   }, [client])
-  const [captureConfig, setCaptureConfig] = useState<CaptureConfig>(loadCaptureConfig)
-
   // Backend-authoritative comment highlight. The renderer owns only the
   // temporary rasterization phase; `On stream` comes from the backend state.
   const [commentHighlightState, setCommentHighlightState] = useState<CommentHighlightState>({
@@ -1812,6 +1902,36 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const [goLiveConfirmationOpen, setGoLiveConfirmationOpen] = useState(false)
   const [goLiveConfirmationPending, setGoLiveConfirmationPending] = useState(false)
   const [goLivePartialSetup, setGoLivePartialSetup] = useState<GoLivePartialSetup | null>(null)
+  const [suppressCaptionsForSession, setSuppressCaptionsForSession] = useState(false)
+  const captionOutputReadiness = useMemo(() => {
+    const streamVideos = streamOutputVideosForTargets(
+      captureConfig.video,
+      captureConfig.streamEnabled ? captureConfig.streaming : undefined
+    ).map(({ video }) => video)
+    return captionSessionOutputReadiness({
+      burnTarget: captureConfig.captions.burnTarget,
+      recordEnabled: captureConfig.recordEnabled,
+      streamEnabled: captureConfig.streamEnabled,
+      recordingVideo: captureConfig.video,
+      streamVideos
+    })
+  }, [captureConfig])
+  const goLiveCaptionsReadiness = useMemo(
+    () =>
+      decideGoLiveCaptionsReadiness({
+        persistedEnabled: captureConfig.captions.enabled,
+        suppressForSession: suppressCaptionsForSession,
+        capabilities: aiCapabilities,
+        outputReadiness: captionOutputReadiness
+      }),
+    [
+      aiCapabilities,
+      captionOutputReadiness,
+      captureConfig.captions.enabled,
+      suppressCaptionsForSession
+    ]
+  )
+  const continueGoLiveWithoutCaptions = useCallback(() => setSuppressCaptionsForSession(true), [])
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [previewLoading, setPreviewLoading] = useState(false)
   const [previewLiveStatus, setPreviewLiveStatus] = useState<PreviewLiveStatus>({
@@ -1856,6 +1976,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   // the same session (fast assessment, then post-repair); one toast is enough.
   const qualityToastSessionsRef = useRef<Set<string>>(new Set())
   const captureConfigRef = useRef(captureConfig)
+  const liveAudioProcessingSyncRef = useRef<{
+    sessionId: string
+    lastApplied: LiveAudioProcessingValues
+    disabled: boolean
+    requestRevision: number
+  } | null>(null)
   const layoutIntentIdRef = useRef(Date.now())
   const layoutIntentAwaitingProofRef = useRef<number | null>(null)
   const latestLayoutTransactionCommitRef = useRef<LayoutTransactionSnapshot | null>(null)
@@ -2026,9 +2152,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         captureConfig,
         scene: sceneWithBackground,
         sceneEditMode,
-        settings
+        settings,
+        suppressCaptionsForSession
       }),
-    [captureConfig, sceneWithBackground, sceneEditMode, settings]
+    [captureConfig, sceneWithBackground, sceneEditMode, settings, suppressCaptionsForSession]
   )
 
   const reportError = useCallback((error: unknown) => {
@@ -2194,6 +2321,27 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     setRecording(status)
     syncFramePollingSuppressionRef.current?.()
   }, [])
+
+  // Smoke-only state hydration for harnesses that start a capture through a
+  // second backend client. It uses the same authoritative status query and
+  // reducer as normal bootstrap, without reloading the renderer mid-session.
+  useEffect(() => {
+    const smokeWindow = window as Window & {
+      __videorcSmokeHydrateRecordingStatus?: () => Promise<RecordingStatus>
+    }
+    if (!runtimeInfo?.previewSmokeMode || !client) {
+      delete smokeWindow.__videorcSmokeHydrateRecordingStatus
+      return
+    }
+    smokeWindow.__videorcSmokeHydrateRecordingStatus = async () => {
+      const status = await client.request<RecordingStatus>('recording.status')
+      applyRecordingStatus(status)
+      return status
+    }
+    return () => {
+      delete smokeWindow.__videorcSmokeHydrateRecordingStatus
+    }
+  }, [applyRecordingStatus, client, runtimeInfo?.previewSmokeMode])
 
   const queueNativePreviewSurfacePresentReport = useCallback(
     (activeClient: BackendClient, params: PreviewSurfacePresentParams) => {
@@ -3090,6 +3238,86 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     let liveChatRecovery: Promise<void> | null = null
     let liveChatRecoveryRetryTimer: number | null = null
     let commentHighlightRevision = 0
+    type CaptionCueRenderRequest = {
+      requestId: string
+      canvasWidth: number
+      canvasHeight: number
+      position: 'top' | 'bottom'
+      textSize: 's' | 'm' | 'l'
+      styleId?: import('@/lib/backend').CaptionStyleId
+      styleRevision?: number
+      blankSeq: number
+      cues: { seq: number; text: string }[]
+    }
+    const captionCueRenderGuard = new CaptionCueRenderGuard()
+    let captionCueRenderGeneration = captionCueRenderGuard.begin()
+    const captionCueRenderQueue: CaptionCueRenderRequest[] = []
+    let captionCueRenderWorkerActive = false
+    let captionCueRenderAbort: AbortController | null = null
+    const cancelCaptionCueRender = (): void => {
+      captionCueRenderGuard.cancel()
+      captionCueRenderGeneration = captionCueRenderGuard.begin()
+      captionCueRenderQueue.splice(0)
+      captionCueRenderAbort?.abort()
+      captionCueRenderAbort = null
+    }
+    const drainCaptionCueRenderQueue = async (): Promise<void> => {
+      if (captionCueRenderWorkerActive) return
+      captionCueRenderWorkerActive = true
+      try {
+        while (captionCueRenderQueue.length > 0) {
+          const request = captionCueRenderQueue.shift()
+          if (!request) continue
+          const cueRenderGeneration = captionCueRenderGeneration
+          const cueRenderAbort = new AbortController()
+          captionCueRenderAbort = cueRenderAbort
+          const jobs = [{ seq: request.blankSeq, text: '' }, ...request.cues]
+          for (const cue of jobs) {
+            if (
+              !generationIsCurrent() ||
+              cueRenderAbort.signal.aborted ||
+              !captionCueRenderGuard.isCurrent(cueRenderGeneration)
+            ) {
+              break
+            }
+            const pngBase64 = await renderCaptionCueFramePng({
+              text: cue.text,
+              canvasWidth: request.canvasWidth,
+              canvasHeight: request.canvasHeight,
+              position: request.position,
+              textSize: request.textSize,
+              styleId: request.styleId ?? 'glass'
+            })
+            if (
+              !pngBase64 ||
+              !generationIsCurrent() ||
+              cueRenderAbort.signal.aborted ||
+              !captionCueRenderGuard.isCurrent(cueRenderGeneration)
+            ) {
+              continue
+            }
+            try {
+              await nextClient.request(
+                'captions.cues.submit',
+                {
+                  requestId: request.requestId,
+                  seq: cue.seq,
+                  pngBase64
+                },
+                { signal: cueRenderAbort.signal }
+              )
+            } catch {
+              // Skip this cue; the backend watchdog handles incompleteness.
+            }
+          }
+          if (captionCueRenderAbort === cueRenderAbort) {
+            captionCueRenderAbort = null
+          }
+        }
+      } finally {
+        captionCueRenderWorkerActive = false
+      }
+    }
     type LiveChatRecoveryResult =
       | { kind: 'disposed' | 'superseded' }
       | {
@@ -3489,7 +3717,16 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           if (!disposed) reportError(error)
         })
       }),
-      nextClient.on('captions.status', (payload) => setCaptionsStatus(payload as CaptionsStatus)),
+      nextClient.on('captions.status', (payload) =>
+        commitCaptionsStatus(payload as CaptionsStatus)
+      ),
+      nextClient.on('captions.cleared', (payload) => {
+        if (shouldCancelCaptionCueRender((payload as { reason?: string }).reason)) {
+          cancelCaptionCueRender()
+        }
+        captionSessionFloorRef.current = null
+        setCaptionLines([])
+      }),
       nextClient.on('captions.update', (payload) =>
         setCaptionLines((current) =>
           captionLineAboveFloor(payload as CaptionsUpdate, captionSessionFloorRef.current)
@@ -3501,39 +3738,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       // per cue at finalize; render + submit sequentially, best-effort (the
       // backend watchdog degrades to SRT-only if we never finish).
       nextClient.on('captions.cues.render-request', (payload) => {
-        const request = payload as {
-          requestId: string
-          canvasWidth: number
-          canvasHeight: number
-          position: 'top' | 'bottom'
-          textSize: 's' | 'm' | 'l'
-          blankSeq: number
-          cues: { seq: number; text: string }[]
-        }
-        void (async () => {
-          const jobs = [{ seq: request.blankSeq, text: '' }, ...request.cues]
-          for (const cue of jobs) {
-            try {
-              const pngBase64 = await renderCaptionCueFramePng({
-                text: cue.text,
-                canvasWidth: request.canvasWidth,
-                canvasHeight: request.canvasHeight,
-                position: request.position,
-                textSize: request.textSize
-              })
-              if (!pngBase64) {
-                continue
-              }
-              await nextClient.request('captions.cues.submit', {
-                requestId: request.requestId,
-                seq: cue.seq,
-                pngBase64
-              })
-            } catch {
-              // Skip this cue; the backend watchdog handles incompleteness.
-            }
-          }
-        })()
+        captionCueRenderQueue.push(payload as CaptionCueRenderRequest)
+        void drainCaptionCueRenderQueue()
       }),
       nextClient.on('streamTargets.metadata.changed', (payload) => {
         bootstrapGuard.mark('streamMetadata')
@@ -3652,6 +3858,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         const ffmpegPath = settingsRef.current.ffmpegPath.trim() || undefined
         const bootstrapSnapshot = bootstrapGuard.snapshot()
         const commentHighlightRevisionAtBootstrapStart = commentHighlightRevision
+        const captionsStatusRevisionAtBootstrapStart = captionsStatusRevisionRef.current
         const [
           nextHealth,
           nextEntitlements,
@@ -3659,6 +3866,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           nextDevices,
           nextRecording,
           nextDiagnostics,
+          nextCaptionsStatus,
           nextLiveChat,
           nextCommentHighlight,
           nextPreview,
@@ -3678,6 +3886,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           bootstrapRequest<DeviceList>('devices.list', { ffmpegPath }),
           bootstrapRequest<RecordingStatus>('recording.status'),
           bootstrapRequest<DiagnosticStats>('diagnostics.stats'),
+          bootstrapRequest<CaptionsStatus>('captions.status.get'),
           bootstrapRequest<LiveChatSnapshot>('liveChat.status'),
           bootstrapRequest<CommentHighlightState>('comments.highlight.status'),
           bootstrapRequest<PreviewLiveStatus>('preview.live.status'),
@@ -3710,6 +3919,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         }
         if (bootstrapGuard.isCurrent(bootstrapSnapshot, 'diagnostics')) {
           setDiagnosticStats(nextDiagnostics)
+        }
+        if (captionsStatusRevisionRef.current === captionsStatusRevisionAtBootstrapStart) {
+          commitCaptionsStatus(nextCaptionsStatus)
         }
         if (bootstrapGuard.isCurrent(bootstrapSnapshot, 'previewLive')) {
           applyPreviewLiveStatus(nextPreview)
@@ -3859,12 +4071,17 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         if (!generationIsCurrent()) {
           return
         }
-        setWsStatus('failed')
+        // A bootstrap data request can fail while the established WebSocket
+        // remains healthy. Keep transport truth separate from snapshot health
+        // so captions and other live controls do not freeze behind a false
+        // "Backend offline" state.
+        setWsStatus(nextClient.connected ? 'connected' : 'failed')
         reportError(error)
       })
 
     return () => {
       disposed = true
+      cancelCaptionCueRender()
       bootstrapAbort.abort()
       liveChatMessageBatcher.dispose()
       if (liveChatRecoveryRetryTimer !== null) {
@@ -5639,18 +5856,311 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const isSessionActive =
     isActiveRecordingState(recording.state) || startRequestPending || stopRequestPending
 
+  // Every mic surface edits the same captureConfig. Mirror that one source of
+  // truth into the active backend-owned native audio session, scoped by the
+  // session id so a delayed update cannot mute/unmute the next capture.
+  useEffect(() => {
+    const params = activeAudioProcessingUpdateParams(
+      { state: recording.state, sessionId: recording.sessionId },
+      {
+        microphoneGainDb: captureConfig.audio.microphoneGainDb,
+        microphoneMuted: captureConfig.audio.microphoneMuted
+      }
+    )
+    if (!params) {
+      liveAudioProcessingSyncRef.current = null
+      return
+    }
+    if (!client || wsStatus !== 'connected') return
+
+    let sync = liveAudioProcessingSyncRef.current
+    if (!sync || sync.sessionId !== params.sessionId) {
+      sync = {
+        sessionId: params.sessionId,
+        lastApplied: {
+          microphoneGainDb: params.microphoneGainDb,
+          microphoneMuted: params.microphoneMuted
+        },
+        disabled: false,
+        requestRevision: 0
+      }
+      liveAudioProcessingSyncRef.current = sync
+    }
+
+    // Once this session proves it has no native post-controls path, keep every
+    // mic surface pinned to the last settings the backend actually accepted.
+    // A new capture session creates a fresh sync state and retries normally.
+    if (sync.disabled) {
+      if (
+        params.microphoneGainDb !== sync.lastApplied.microphoneGainDb ||
+        params.microphoneMuted !== sync.lastApplied.microphoneMuted
+      ) {
+        const rollback = sync.lastApplied
+        setCaptureConfig((current) => ({
+          ...current,
+          audio: { ...current.audio, ...rollback }
+        }))
+      }
+      return
+    }
+
+    sync.requestRevision += 1
+    const requestRevision = sync.requestRevision
+    const lastApplied = sync.lastApplied
+
+    const rejectCurrentRequest = (
+      result?: AudioProcessingUpdateResult
+    ): ReturnType<typeof rejectedLiveAudioProcessingUpdate> => {
+      const latest = liveAudioProcessingSyncRef.current
+      if (
+        !latest ||
+        latest.sessionId !== params.sessionId ||
+        latest.requestRevision !== requestRevision
+      ) {
+        return null
+      }
+      const rejection = rejectedLiveAudioProcessingUpdate({
+        recording: recordingRef.current,
+        current: captureConfigRef.current.audio,
+        requested: params,
+        result,
+        lastApplied
+      })
+      if (!rejection) return null
+
+      latest.disabled = rejection.disableForSession
+      setCaptureConfig((current) => {
+        const currentRejection = rejectedLiveAudioProcessingUpdate({
+          recording: recordingRef.current,
+          current: current.audio,
+          requested: params,
+          result,
+          lastApplied
+        })
+        if (!currentRejection) return current
+        return {
+          ...current,
+          audio: { ...current.audio, ...currentRejection.rollback }
+        }
+      })
+      return rejection
+    }
+
+    void client
+      .request<AudioProcessingUpdateResult>('audio.processing.update', params)
+      .then((result) => {
+        const latest = liveAudioProcessingSyncRef.current
+        if (
+          !latest ||
+          latest.sessionId !== params.sessionId ||
+          latest.requestRevision !== requestRevision ||
+          result.sessionId !== params.sessionId ||
+          recordingRef.current.sessionId !== params.sessionId ||
+          !['recording', 'streaming'].includes(recordingRef.current.state)
+        ) {
+          return
+        }
+        if (result.applied) {
+          latest.lastApplied = {
+            microphoneGainDb: result.microphoneGainDb,
+            microphoneMuted: result.microphoneMuted
+          }
+          return
+        }
+
+        const rejection = rejectCurrentRequest(result)
+        if (!rejection) return
+        reportError(new Error(rejection.message))
+      })
+      .catch((error) => {
+        const rejection = rejectCurrentRequest()
+        if (!rejection) return
+        const detail = error instanceof Error ? error.message : String(error)
+        reportError(new Error(`${rejection.message} ${detail}`))
+      })
+  }, [
+    client,
+    recording.sessionId,
+    recording.state,
+    captureConfig.audio.microphoneGainDb,
+    captureConfig.audio.microphoneMuted,
+    reportError,
+    wsStatus
+  ])
+
+  // Persisted consent is intent; the backend snapshot remains runtime truth.
+  // One attempt per capture/toggle/client edge prevents blocked/error states
+  // from spinning, while explicit retry edges deliberately try once again.
+  const captionsStartAttemptedRef = useRef(false)
+  const captionsStopAttemptedRef = useRef(false)
+  const captionsAttemptClientRef = useRef<BackendClient | null>(null)
+  const captionsAttemptScopeRef = useRef('')
+  const captionsCaptureActive = ['recording', 'streaming'].includes(recording.state)
+  const captionsAttemptScope = [
+    captureConfig.captions.enabled ? 'enabled' : 'disabled',
+    suppressCaptionsForSession ? 'suppressed' : 'normal',
+    captionsCaptureActive ? `capture:${recording.sessionId ?? 'unknown'}` : 'idle',
+    captureConfig.captions.language,
+    wsStatus
+  ].join(':')
+  useEffect(() => {
+    if (
+      captionsAttemptClientRef.current !== client ||
+      captionsAttemptScopeRef.current !== captionsAttemptScope
+    ) {
+      captionsAttemptClientRef.current = client
+      captionsAttemptScopeRef.current = captionsAttemptScope
+      captionsStartAttemptedRef.current = false
+      captionsStopAttemptedRef.current = false
+    }
+    if (!client || wsStatus !== 'connected' || captionsCommandPending) return
+    const action = decideCaptionsRuntimeIntent({
+      persistedEnabled: captureConfig.captions.enabled,
+      suppressForSession: suppressCaptionsForSession,
+      captureActive: captionsCaptureActive,
+      status: captionsStatus,
+      startAttempted: captionsStartAttemptedRef.current,
+      stopAttempted: captionsStopAttemptedRef.current
+    })
+    if (action === 'start') {
+      if (
+        captionRuntimeStartBlocked({
+          captureActive: captionsCaptureActive,
+          outputReadiness: captionOutputReadiness
+        })
+      ) {
+        setSuppressCaptionsForSession(true)
+        toast.error('Live captions cannot start in this session', {
+          id: 'captions-output-unsupported',
+          description:
+            captionOutputReadiness.description ??
+            'The active output configuration cannot carry caption pixels.'
+        })
+        return
+      }
+      captionsStartAttemptedRef.current = true
+      captionsStopAttemptedRef.current = false
+      void startCaptions(captureConfig.captions.language).catch((error: unknown) => {
+        toast.error('Live captions could not start', {
+          description:
+            error instanceof Error ? error.message : 'The caption service is unavailable.'
+        })
+      })
+    } else if (action === 'stop') {
+      captionsStartAttemptedRef.current = false
+      captionsStopAttemptedRef.current = true
+      void stopCaptions().catch(() => {})
+    }
+  }, [
+    captionsAttemptScope,
+    captionsCaptureActive,
+    captionsCommandPending,
+    captionOutputReadiness,
+    captionsStatus,
+    captureConfig.captions.enabled,
+    captureConfig.captions.language,
+    client,
+    startCaptions,
+    stopCaptions,
+    suppressCaptionsForSession,
+    wsStatus
+  ])
+
+  // A Go Live override survives confirmation and startup, then clears as soon
+  // as that attempted session returns to idle. Persisted consent never changes.
+  const suppressedCaptionSessionWasActiveRef = useRef(false)
+  useEffect(() => {
+    if (suppressCaptionsForSession && isSessionActive) {
+      suppressedCaptionSessionWasActiveRef.current = true
+      return
+    }
+    if (!isSessionActive && suppressedCaptionSessionWasActiveRef.current) {
+      suppressedCaptionSessionWasActiveRef.current = false
+      setSuppressCaptionsForSession(false)
+    }
+  }, [isSessionActive, suppressCaptionsForSession])
+
   useEffect(() => {
     if (aiConsent && !currentCloudAiReadiness.ready) {
       setAiConsent(false)
     }
   }, [aiConsent, currentCloudAiReadiness.ready])
 
-  // Burn-in driver: rasterize the newest caption line at the stream output
-  // width and push it to the backend overlay (stream leg only, A0). Cleared
-  // whenever burn-in/captions/session stop so the next session never starts
-  // with a stale bar.
-  const captionOverlayBusy = useRef(false)
+  // Burn-in driver: a serial latest-wins scheduler replaces the old boolean
+  // busy gate, which could permanently drop a final/style update that arrived
+  // during rasterization. One render may run and only the newest waits behind it.
   const captionOverlayPushedKey = useRef<string | null>(null)
+  const captionOverlayEpochRef = useRef(0)
+  const captionOverlayWorkActiveRef = useRef(false)
+  const captionOverlayExpiredLineRef = useRef<string | null>(null)
+  const captionOverlayWorkerRef = useRef<(work: CaptionOverlayWork) => Promise<void>>(
+    async () => {}
+  )
+  const captionOverlaySchedulerRef = useRef<LatestWinsScheduler<CaptionOverlayWork> | null>(null)
+  if (!captionOverlaySchedulerRef.current) {
+    captionOverlaySchedulerRef.current = new LatestWinsScheduler((work) =>
+      captionOverlayWorkerRef.current(work)
+    )
+  }
+  captionOverlayWorkerRef.current = async (work) => {
+    let pushed = false
+    for (const output of work.outputs) {
+      const pngBase64 = await renderCaptionOverlayPng({
+        text: work.text,
+        canvasWidth: output.canvasWidth,
+        textSize: work.textSize,
+        styleId: work.styleId
+      })
+      if (!pngBase64 || work.epoch !== captionOverlayEpochRef.current) return
+      await work.client.request('captions.overlay.set', {
+        pngBase64,
+        position: work.position,
+        target: output.target,
+        styleRevision: work.styleRevision
+      })
+      pushed = true
+    }
+    if (pushed && work.epoch === captionOverlayEpochRef.current) {
+      captionOverlayPushedKey.current = work.key
+    }
+  }
+
+  // The backend owns final-copy cue rendering after capture stops, so every
+  // live appearance revision is mirrored there as well as into overlay pixels.
+  useEffect(() => {
+    if (
+      !client ||
+      !isActiveRecordingState(recording.state) ||
+      !captureConfig.captions.enabled ||
+      suppressCaptionsForSession
+    ) {
+      return
+    }
+    void client
+      .request('captions.style.set', {
+        position: captureConfig.captions.position,
+        textSize: captureConfig.captions.textSize,
+        styleId: captureConfig.captions.styleId,
+        styleRevision: captureConfig.captions.styleRevision
+      })
+      .catch(() => {})
+  }, [
+    client,
+    recording.state,
+    captureConfig.captions.enabled,
+    captureConfig.captions.position,
+    captureConfig.captions.styleId,
+    captureConfig.captions.styleRevision,
+    captureConfig.captions.textSize,
+    suppressCaptionsForSession
+  ])
+
+  useEffect(() => {
+    captionOverlayEpochRef.current += 1
+    captionOverlaySchedulerRef.current?.clearPending()
+    captionOverlayPushedKey.current = null
+    captionOverlayWorkActiveRef.current = false
+  }, [client])
 
   // Capture-session rising edge: the caption strip/window and the burn bar
   // start EMPTY for every new video. The floor is recorded before the buffer
@@ -5663,7 +6173,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     if (isSessionActive && !captionSessionWasActiveRef.current) {
       const lines = captionLinesRef.current
       captionSessionFloorRef.current = captionSessionFloor(lines) ?? captionSessionFloorRef.current
+      captionOverlayEpochRef.current += 1
+      captionOverlaySchedulerRef.current?.clearPending()
       captionOverlayPushedKey.current = null
+      captionOverlayWorkActiveRef.current = false
+      captionOverlayExpiredLineRef.current = null
       if (lines.length > 0) {
         setCaptionLines([])
       }
@@ -5675,63 +6189,122 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     if (!client) {
       return
     }
-    const decision = decideOverlayPush({
-      burnIn: captureConfig.captions.burnTarget !== 'off',
-      captionsRunning: captionsStatus.state === 'live' || captionsStatus.state === 'degraded',
-      sessionActive: isSessionActive,
-      latest: captionLines.at(-1),
-      floor: captionSessionFloorRef.current,
-      pushedKey: captionOverlayPushedKey.current,
-      busy: captionOverlayBusy.current
-    })
-    if (decision.action === 'clear') {
-      captionOverlayPushedKey.current = null
-      void client.request('captions.overlay.clear').catch(() => {})
-      return
-    }
-    if (decision.action !== 'push') {
-      return
-    }
-    const latest = captionLines.at(-1)!
-    captionOverlayBusy.current = true
-    const streamVideo = streamOutputVideoSettings(
+    const latest = captionLines.at(-1)
+    const streamVideo = auxiliaryStreamOutputVideoSettings(
       captureConfig.video,
       captureConfig.streamEnabled ? captureConfig.streaming : undefined
     )
-    void renderCaptionOverlayPng({
-      text: latest.text,
-      canvasWidth: streamVideo.width,
-      textSize: captureConfig.captions.textSize
+    const outputs = captionOverlayTargetPlan({
+      burnTarget: captureConfig.captions.burnTarget,
+      recordEnabled: captureConfig.recordEnabled,
+      streamEnabled: captureConfig.streamEnabled,
+      recordingVideo: captureConfig.video,
+      streamVideo
     })
-      .then((pngBase64) => {
-        if (!pngBase64) {
-          return
-        }
-        return client
-          .request('captions.overlay.set', {
-            pngBase64,
-            position: captureConfig.captions.position
-          })
-          .then(() => {
-            captionOverlayPushedKey.current = decision.key
-          })
-      })
-      .catch(() => {
-        // Overlay pushes are best-effort; the next caption line retries.
-      })
-      .finally(() => {
-        captionOverlayBusy.current = false
-      })
+    const candidateKey = latest
+      ? outputs
+          .map((output) =>
+            captionOverlayKey(latest, {
+              styleId: captureConfig.captions.styleId,
+              styleRevision: captureConfig.captions.styleRevision,
+              position: captureConfig.captions.position,
+              textSize: captureConfig.captions.textSize,
+              canvasWidth: output.canvasWidth,
+              canvasHeight: output.canvasHeight,
+              outputLeg: output.target
+            })
+          )
+          .join('|')
+      : undefined
+    const burnIn = outputs.length > 0
+    const captionsRunning = captionsStatusIsActive(captionsStatus)
+    const decision = decideOverlayPush({
+      burnIn,
+      captionsRunning,
+      sessionActive: isSessionActive,
+      latest,
+      floor: captionSessionFloorRef.current,
+      pushedKey: captionOverlayPushedKey.current,
+      candidateKey,
+      expiredLineId: captionOverlayExpiredLineRef.current
+    })
+    if (
+      decision.action === 'clear' ||
+      ((!burnIn || !captionsRunning || !isSessionActive) && captionOverlayWorkActiveRef.current)
+    ) {
+      captionOverlayEpochRef.current += 1
+      captionOverlaySchedulerRef.current?.clearPending()
+      captionOverlayPushedKey.current = null
+      captionOverlayWorkActiveRef.current = false
+      void client
+        .request('captions.overlay.clear', {
+          styleRevision: captureConfig.captions.styleRevision
+        })
+        .catch(() => {})
+      return
+    }
+    if (decision.action !== 'push' || !latest || !decision.key) {
+      return
+    }
+    captionOverlayWorkActiveRef.current = true
+    captionOverlaySchedulerRef.current?.enqueue({
+      client,
+      epoch: captionOverlayEpochRef.current,
+      key: decision.key,
+      text: latest.text,
+      outputs: outputs.map((output) => ({
+        target: output.target,
+        canvasWidth: output.canvasWidth,
+        canvasHeight: output.canvasHeight
+      })),
+      styleId: captureConfig.captions.styleId,
+      styleRevision: captureConfig.captions.styleRevision,
+      textSize: captureConfig.captions.textSize,
+      position: captureConfig.captions.position
+    })
   }, [
     client,
     captionLines,
-    captionsStatus.state,
+    captionsStatus,
     isSessionActive,
     captureConfig.captions,
+    captureConfig.recordEnabled,
     captureConfig.video,
     captureConfig.streamEnabled,
     captureConfig.streaming
   ])
+
+  // Silence expiry belongs to the current line, not to a render attempt. Every
+  // partial refresh restarts the clock; finals dwell by readable text length.
+  const latestCaption = captionLines.at(-1)
+  useEffect(() => {
+    if (
+      !client ||
+      !latestCaption ||
+      !isSessionActive ||
+      captureConfig.captions.burnTarget === 'off'
+    ) {
+      return
+    }
+    const identity = captionLineIdentity(latestCaption)
+    captionOverlayExpiredLineRef.current = null
+    const dwellMs = latestCaption.kind === 'partial' ? 6000 : captionDwellMs(latestCaption.text)
+    const timer = window.setTimeout(() => {
+      const current = captionLinesRef.current.at(-1)
+      if (!current || captionLineIdentity(current) !== identity) return
+      captionOverlayExpiredLineRef.current = identity
+      captionOverlayEpochRef.current += 1
+      captionOverlaySchedulerRef.current?.clearPending()
+      captionOverlayPushedKey.current = null
+      captionOverlayWorkActiveRef.current = false
+      void client
+        .request('captions.overlay.clear', {
+          styleRevision: captureConfig.captions.styleRevision
+        })
+        .catch(() => {})
+    }, dwellMs)
+    return () => window.clearTimeout(timer)
+  }, [client, captureConfig.captions, isSessionActive, latestCaption])
 
   const renameScreen = useCallback(
     async (screenId: string, name: string) => {
@@ -6777,6 +7350,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     try {
       setLastError(null)
       setGoLivePartialSetup(null)
+      setSuppressCaptionsForSession(false)
       setGoLiveConfirmationPending(true)
       if (streamMetadataDraft) {
         const saved = await client.request<StreamMetadataDraft>(
@@ -6790,12 +7364,23 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         )
         setStreamMetadataValidation(validation)
       }
-      const preflight = await client.request<GoLivePreflight>(
-        'streamTargets.confirmation.validate',
-        {
+      const [preflight] = await Promise.all([
+        client.request<GoLivePreflight>('streamTargets.confirmation.validate', {
           streaming: captureConfig.streaming
-        }
-      )
+        }),
+        captureConfig.captions.enabled
+          ? client
+              .request<AiCapabilities>('ai.capabilities.get')
+              .then((capabilities) => {
+                setAiCapabilities(capabilities)
+                setAiReadinessError(null)
+              })
+              .catch((error: unknown) => {
+                setAiCapabilities(null)
+                setAiReadinessError(error instanceof Error ? error.message : String(error))
+              })
+          : Promise.resolve()
+      ])
       setGoLivePreflight(preflight)
       setGoLiveConfirmationOpen(true)
     } catch (error) {
@@ -6804,6 +7389,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       setGoLiveConfirmationPending(false)
     }
   }, [
+    captureConfig.captions.enabled,
     captureConfig.streaming,
     client,
     isSessionActive,
@@ -6834,6 +7420,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
     setGoLivePartialSetup(null)
     setGoLiveConfirmationOpen(false)
+    setSuppressCaptionsForSession(false)
   }, [
     completePreparedPlatformBroadcasts,
     goLiveConfirmationPending,
@@ -6843,6 +7430,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   const confirmGoLive = useCallback(async () => {
     if (!client || goLiveConfirmationPending || startRequestPending) {
+      return
+    }
+    if (goLiveCaptionsReadiness.blocksStart) {
+      toast.warning('Live captions are not ready.', {
+        description: goLiveCaptionsReadiness.description
+      })
       return
     }
 
@@ -6904,6 +7497,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     captureConfig.streaming,
     client,
     goLiveConfirmationPending,
+    goLiveCaptionsReadiness,
     prepareOauthTargetsForGoLive,
     reportError,
     runStartSession,
@@ -6912,6 +7506,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   ])
 
   const continueGoLiveWithReadyDestinations = useCallback(async () => {
+    if (goLiveCaptionsReadiness.blocksStart) {
+      toast.warning('Live captions are not ready.', {
+        description: goLiveCaptionsReadiness.description
+      })
+      return
+    }
     const decision = decideContinueGoLiveWithReadyDestinations({
       goLiveConfirmationPending,
       startRequestPending,
@@ -6934,6 +7534,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
   }, [
     goLiveConfirmationPending,
+    goLiveCaptionsReadiness,
     goLivePartialSetup,
     reportError,
     runStartSession,
@@ -7539,7 +8140,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       commentsWindowOpen: commentsWindow.open,
       openCommentsWindow,
       closeCommentsWindow,
-      toggleCommentsWindow
+      toggleCommentsWindow,
+      toggleCaptionsWindow
     }),
     [
       closeCommentsWindow,
@@ -7554,6 +8156,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       recording.state,
       runtimeInfo,
       toggleCommentsWindow,
+      toggleCaptionsWindow,
       togglePreviewWindow,
       wsStatus
     ]
@@ -7610,6 +8213,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       clearLiveChat,
       captionsStatus,
       captionLines,
+      captionsCommandPending,
       startCaptions,
       stopCaptions,
       captionsWindow,
@@ -7633,6 +8237,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       goLiveConfirmationOpen,
       goLiveConfirmationPending,
       goLivePartialSetup,
+      goLiveCaptionsReadiness,
+      continueGoLiveWithoutCaptions,
       previewUrl,
       previewLoading,
       nativePreviewSurfaceEnabled,
@@ -7773,6 +8379,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       clearLiveChat,
       captionsStatus,
       captionLines,
+      captionsCommandPending,
       startCaptions,
       stopCaptions,
       captionsWindow,
@@ -7796,6 +8403,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       goLiveConfirmationOpen,
       goLiveConfirmationPending,
       goLivePartialSetup,
+      goLiveCaptionsReadiness,
+      continueGoLiveWithoutCaptions,
       previewUrl,
       previewLoading,
       nativePreviewSurfaceEnabled,

--- a/apps/desktop/src/renderer/src/lib/caption-overlay.test.ts
+++ b/apps/desktop/src/renderer/src/lib/caption-overlay.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  CAPTION_STYLE_DEFINITIONS,
+  CAPTION_STYLE_IDS,
   captionBarMetrics,
   layoutCaptionBar,
   MAX_CAPTION_BAR_LINES,
@@ -19,6 +21,50 @@ describe('captionBarMetrics', () => {
     expect(captionBarMetrics(1920, 's').fontPx).toBe(38)
     // Tiny canvases never go below the readable floor.
     expect(captionBarMetrics(320, 's').fontPx).toBe(24)
+  })
+})
+
+describe('caption style registry', () => {
+  it('ships the four named presets from the product contract', () => {
+    expect(CAPTION_STYLE_IDS).toEqual(['classic', 'glass', 'lower-third', 'high-contrast'])
+    expect(CAPTION_STYLE_DEFINITIONS.classic.plate).toBe('none')
+    expect(CAPTION_STYLE_DEFINITIONS.glass.plate).toBe('glass')
+    expect(CAPTION_STYLE_DEFINITIONS['lower-third'].align).toBe('left')
+    expect(CAPTION_STYLE_DEFINITIONS['high-contrast'].backgroundColor).toBe('#050506')
+  })
+
+  it('gives lower third a wide band while keeping other styles content-sized', () => {
+    const lowerThird = layoutCaptionBar({
+      text: 'Hello',
+      canvasWidth: 1920,
+      textSize: 'm',
+      styleId: 'lower-third',
+      measure
+    })
+    const classic = layoutCaptionBar({
+      text: 'Hello',
+      canvasWidth: 1920,
+      textSize: 'm',
+      styleId: 'classic',
+      measure
+    })
+    expect(lowerThird?.barWidthPx).toBe(Math.floor(1920 * 0.92))
+    expect(classic!.barWidthPx).toBeLessThan(lowerThird!.barWidthPx)
+  })
+
+  it.each(CAPTION_STYLE_IDS)('lays out %s at horizontal and vertical output widths', (styleId) => {
+    for (const canvasWidth of [1080, 1920, 3840]) {
+      const layout = layoutCaptionBar({
+        text: 'Captions remain readable across every output shape.',
+        canvasWidth,
+        textSize: 'm',
+        styleId,
+        measure
+      })
+      expect(layout).not.toBeNull()
+      expect(layout!.barWidthPx).toBeLessThanOrEqual(canvasWidth)
+      expect(layout!.lines.length).toBeLessThanOrEqual(MAX_CAPTION_BAR_LINES)
+    }
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/caption-overlay.ts
+++ b/apps/desktop/src/renderer/src/lib/caption-overlay.ts
@@ -4,6 +4,7 @@
 // the canvas painter is a thin shell over it.
 
 import { commentHighlightPlatformBadge, layoutCommentHighlight } from '@/lib/comment-highlight'
+import type { CaptionStyleId } from '@/lib/backend'
 
 export type CaptionTextSize = 's' | 'm' | 'l'
 export type CaptionPosition = 'top' | 'bottom'
@@ -17,7 +18,102 @@ export interface CaptionBarMetrics {
   maxTextWidthPx: number
 }
 
+export interface CaptionStyleDefinition {
+  id: CaptionStyleId
+  label: string
+  description: string
+  plate: 'none' | 'glass' | 'band' | 'solid'
+  align: 'left' | 'center'
+  fontWeight: 600 | 700
+  maxWidthFraction: number
+  wide: boolean
+  lineHeightFactor: number
+  paddingXFactor: number
+  paddingYFactor: number
+  radiusFactor: number
+  backgroundColor: string
+  textColor: string
+  strokeColor?: string
+  strokeWidthFactor?: number
+}
+
+export const CAPTION_STYLE_DEFINITIONS: Record<CaptionStyleId, CaptionStyleDefinition> = {
+  classic: {
+    id: 'classic',
+    label: 'Classic',
+    description: 'Clean outlined subtitles that stay legible over any video.',
+    plate: 'none',
+    align: 'center',
+    fontWeight: 600,
+    maxWidthFraction: 0.88,
+    wide: false,
+    lineHeightFactor: 1.28,
+    paddingXFactor: 0.3,
+    paddingYFactor: 0.24,
+    radiusFactor: 0,
+    backgroundColor: 'transparent',
+    textColor: '#FFFFFF',
+    strokeColor: 'rgba(0, 0, 0, 0.96)',
+    strokeWidthFactor: 0.105
+  },
+  glass: {
+    id: 'glass',
+    label: 'Glass',
+    description: 'Videorc black glass with a polished edge and soft elevation.',
+    plate: 'glass',
+    align: 'center',
+    fontWeight: 600,
+    maxWidthFraction: 0.92,
+    wide: false,
+    lineHeightFactor: 1.32,
+    paddingXFactor: 0.72,
+    paddingYFactor: 0.4,
+    radiusFactor: 0.26,
+    backgroundColor: 'rgba(16, 16, 18, 0.78)',
+    textColor: '#F5F5F7'
+  },
+  'lower-third': {
+    id: 'lower-third',
+    label: 'Lower third',
+    description: 'A wide, left-aligned broadcast band for conversations.',
+    plate: 'band',
+    align: 'left',
+    fontWeight: 600,
+    maxWidthFraction: 0.92,
+    wide: true,
+    lineHeightFactor: 1.3,
+    paddingXFactor: 0.7,
+    paddingYFactor: 0.34,
+    radiusFactor: 0.12,
+    backgroundColor: 'rgba(13, 13, 15, 0.9)',
+    textColor: '#F5F5F7'
+  },
+  'high-contrast': {
+    id: 'high-contrast',
+    label: 'High contrast',
+    description: 'Opaque black and bold white for maximum readability.',
+    plate: 'solid',
+    align: 'center',
+    fontWeight: 700,
+    maxWidthFraction: 0.88,
+    wide: false,
+    lineHeightFactor: 1.4,
+    paddingXFactor: 0.62,
+    paddingYFactor: 0.42,
+    radiusFactor: 0.08,
+    backgroundColor: '#050506',
+    textColor: '#FFFFFF'
+  }
+}
+
+export const CAPTION_STYLE_IDS = Object.keys(CAPTION_STYLE_DEFINITIONS) as CaptionStyleId[]
+
+export function captionStyleDefinition(styleId: CaptionStyleId): CaptionStyleDefinition {
+  return CAPTION_STYLE_DEFINITIONS[styleId]
+}
+
 export interface CaptionBarLayout {
+  style: CaptionStyleDefinition
   metrics: CaptionBarMetrics
   lines: string[]
   barWidthPx: number
@@ -27,25 +123,23 @@ export interface CaptionBarLayout {
 export type TextMeasurer = (text: string, fontPx: number) => number
 
 const SIZE_FACTOR: Record<CaptionTextSize, number> = { s: 0.8, m: 1.0, l: 1.25 }
-/** The bar never exceeds this fraction of the video width. */
-const MAX_BAR_WIDTH_FRACTION = 0.92
 export const MAX_CAPTION_BAR_LINES = 2
 
 export function captionBarMetrics(
   canvasWidth: number,
-  textSize: CaptionTextSize
+  textSize: CaptionTextSize,
+  styleId: CaptionStyleId = 'glass'
 ): CaptionBarMetrics {
+  const style = captionStyleDefinition(styleId)
   const fontPx = Math.max(24, Math.round((canvasWidth / 40) * SIZE_FACTOR[textSize]))
-  const paddingXPx = Math.round(fontPx * 0.72)
+  const paddingXPx = Math.round(fontPx * style.paddingXFactor)
   return {
     fontPx,
-    lineHeightPx: Math.round(fontPx * 1.32),
+    lineHeightPx: Math.round(fontPx * style.lineHeightFactor),
     paddingXPx,
-    paddingYPx: Math.round(fontPx * 0.4),
-    // Panel-tier corners (videorc-design): ~13px at 1080p — a caption panel,
-    // never a pill button.
-    radiusPx: Math.round(fontPx * 0.26),
-    maxTextWidthPx: Math.floor(canvasWidth * MAX_BAR_WIDTH_FRACTION) - paddingXPx * 2
+    paddingYPx: Math.round(fontPx * style.paddingYFactor),
+    radiusPx: Math.round(fontPx * style.radiusFactor),
+    maxTextWidthPx: Math.floor(canvasWidth * style.maxWidthFraction) - paddingXPx * 2
   }
 }
 
@@ -89,20 +183,22 @@ export function layoutCaptionBar(params: {
   text: string
   canvasWidth: number
   textSize: CaptionTextSize
+  styleId?: CaptionStyleId
   measure: TextMeasurer
 }): CaptionBarLayout | null {
-  const metrics = captionBarMetrics(params.canvasWidth, params.textSize)
+  const style = captionStyleDefinition(params.styleId ?? 'glass')
+  const metrics = captionBarMetrics(params.canvasWidth, params.textSize, style.id)
   const lines = wrapCaptionText(params.text, metrics, params.measure)
   if (lines.length === 0) {
     return null
   }
   const widest = Math.max(...lines.map((line) => params.measure(line, metrics.fontPx)))
-  const barWidthPx = Math.min(
-    Math.ceil(widest) + metrics.paddingXPx * 2,
-    Math.floor(params.canvasWidth * MAX_BAR_WIDTH_FRACTION)
-  )
+  const maxBarWidth = Math.floor(params.canvasWidth * style.maxWidthFraction)
+  const barWidthPx = style.wide
+    ? maxBarWidth
+    : Math.min(Math.ceil(widest) + metrics.paddingXPx * 2, maxBarWidth)
   const barHeightPx = metrics.paddingYPx * 2 + metrics.lineHeightPx * lines.length
-  return { metrics, lines, barWidthPx, barHeightPx }
+  return { style, metrics, lines, barWidthPx, barHeightPx }
 }
 
 /** Vertical safe margin the compositor uses — mirrored for burned frames. */
@@ -139,70 +235,77 @@ export function captionBarFramePosition(params: {
 function paintCaptionBar(
   context: OffscreenCanvasRenderingContext2D,
   layout: CaptionBarLayout,
-  fontFor: (fontPx: number) => string,
+  fontFor: (fontPx: number, weight?: 600 | 700) => string,
   originX: number,
   originY: number
 ): void {
   const { metrics } = layout
-  // Glass panel over video (videorc-design solid fallback): translucent
-  // charcoal that FLOATS — soft elevation shadow, inner-top sheen, hairline
-  // ring — instead of a flat pill.
-  context.save()
-  context.shadowColor = 'rgba(0, 0, 0, 0.4)'
-  context.shadowBlur = metrics.fontPx * 0.45
-  context.shadowOffsetY = metrics.fontPx * 0.1
-  context.beginPath()
-  context.roundRect(originX, originY, layout.barWidthPx, layout.barHeightPx, metrics.radiusPx)
-  context.fillStyle = 'rgba(16, 16, 18, 0.78)'
-  context.fill()
-  context.restore()
+  const { style } = layout
+  if (style.plate !== 'none') {
+    context.save()
+    if (style.plate === 'glass') {
+      context.shadowColor = 'rgba(0, 0, 0, 0.4)'
+      context.shadowBlur = metrics.fontPx * 0.45
+      context.shadowOffsetY = metrics.fontPx * 0.1
+    }
+    context.beginPath()
+    context.roundRect(originX, originY, layout.barWidthPx, layout.barHeightPx, metrics.radiusPx)
+    context.fillStyle = style.backgroundColor
+    context.fill()
+    context.restore()
 
-  const sheen = context.createLinearGradient(0, originY, 0, originY + layout.barHeightPx)
-  sheen.addColorStop(0, 'rgba(255, 255, 255, 0.07)')
-  sheen.addColorStop(0.35, 'rgba(255, 255, 255, 0.015)')
-  sheen.addColorStop(1, 'rgba(255, 255, 255, 0)')
-  context.beginPath()
-  context.roundRect(originX, originY, layout.barWidthPx, layout.barHeightPx, metrics.radiusPx)
-  context.fillStyle = sheen
-  context.fill()
-
-  context.beginPath()
-  context.roundRect(
-    originX + 0.5,
-    originY + 0.5,
-    layout.barWidthPx - 1,
-    layout.barHeightPx - 1,
-    metrics.radiusPx
-  )
-  context.strokeStyle = 'rgba(255, 255, 255, 0.1)'
-  context.lineWidth = 1
-  context.stroke()
+    if (style.plate === 'glass') {
+      const sheen = context.createLinearGradient(0, originY, 0, originY + layout.barHeightPx)
+      sheen.addColorStop(0, 'rgba(255, 255, 255, 0.07)')
+      sheen.addColorStop(0.35, 'rgba(255, 255, 255, 0.015)')
+      sheen.addColorStop(1, 'rgba(255, 255, 255, 0)')
+      context.beginPath()
+      context.roundRect(originX, originY, layout.barWidthPx, layout.barHeightPx, metrics.radiusPx)
+      context.fillStyle = sheen
+      context.fill()
+      context.beginPath()
+      context.roundRect(
+        originX + 0.5,
+        originY + 0.5,
+        layout.barWidthPx - 1,
+        layout.barHeightPx - 1,
+        metrics.radiusPx
+      )
+      context.strokeStyle = 'rgba(255, 255, 255, 0.1)'
+      context.lineWidth = 1
+      context.stroke()
+    }
+  }
 
   // Crisp text with a whisper of shadow so it survives bright video.
   context.save()
-  context.shadowColor = 'rgba(0, 0, 0, 0.45)'
-  context.shadowBlur = metrics.fontPx * 0.08
+  context.shadowColor = 'rgba(0, 0, 0, 0.58)'
+  context.shadowBlur = metrics.fontPx * (style.plate === 'none' ? 0.12 : 0.08)
   context.shadowOffsetY = Math.max(1, Math.round(metrics.fontPx * 0.03))
-  context.font = fontFor(metrics.fontPx)
-  context.fillStyle = '#F5F5F7'
-  context.textAlign = 'center'
+  context.font = fontFor(metrics.fontPx, style.fontWeight)
+  context.fillStyle = style.textColor
+  context.textAlign = style.align
   context.textBaseline = 'middle'
+  const textX =
+    style.align === 'left' ? originX + metrics.paddingXPx : originX + layout.barWidthPx / 2
   layout.lines.forEach((line, index) => {
-    context.fillText(
-      line,
-      originX + layout.barWidthPx / 2,
-      originY + metrics.paddingYPx + metrics.lineHeightPx * (index + 0.5),
-      layout.barWidthPx - metrics.paddingXPx
-    )
+    const textY = originY + metrics.paddingYPx + metrics.lineHeightPx * (index + 0.5)
+    if (style.strokeColor && style.strokeWidthFactor) {
+      context.strokeStyle = style.strokeColor
+      context.lineWidth = Math.max(2, metrics.fontPx * style.strokeWidthFactor)
+      context.lineJoin = 'round'
+      context.strokeText(line, textX, textY, layout.barWidthPx - metrics.paddingXPx * 2)
+    }
+    context.fillText(line, textX, textY, layout.barWidthPx - metrics.paddingXPx * 2)
   })
   context.restore()
 }
 
-function canvasFont(fontPx: number): string {
-  return `600 ${fontPx}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`
+function canvasFont(fontPx: number, weight: 600 | 700 = 600): string {
+  return `${weight} ${fontPx}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`
 }
 
-function canvasMeasurer(): { measure: TextMeasurer } | null {
+function canvasMeasurer(styleId: CaptionStyleId = 'glass'): { measure: TextMeasurer } | null {
   const probe = new OffscreenCanvas(1, 1)
   const probeContext = probe.getContext('2d')
   if (!probeContext) {
@@ -210,7 +313,7 @@ function canvasMeasurer(): { measure: TextMeasurer } | null {
   }
   return {
     measure: (text, fontPx) => {
-      probeContext.font = canvasFont(fontPx)
+      probeContext.font = canvasFont(fontPx, captionStyleDefinition(styleId).fontWeight)
       return probeContext.measureText(text).width
     }
   }
@@ -236,12 +339,14 @@ export async function renderCaptionOverlayPng(params: {
   text: string
   canvasWidth: number
   textSize: CaptionTextSize
+  styleId?: CaptionStyleId
 }): Promise<string | null> {
-  const measurer = canvasMeasurer()
+  const styleId = params.styleId ?? 'glass'
+  const measurer = canvasMeasurer(styleId)
   if (!measurer) {
     return null
   }
-  const layout = layoutCaptionBar({ ...params, measure: measurer.measure })
+  const layout = layoutCaptionBar({ ...params, styleId, measure: measurer.measure })
   if (!layout) {
     return null
   }
@@ -266,6 +371,7 @@ export async function renderCaptionCueFramePng(params: {
   canvasHeight: number
   position: CaptionPosition
   textSize: CaptionTextSize
+  styleId?: CaptionStyleId
 }): Promise<string | null> {
   const canvas = new OffscreenCanvas(
     Math.max(2, params.canvasWidth),
@@ -276,7 +382,8 @@ export async function renderCaptionCueFramePng(params: {
     return null
   }
   if (params.text.trim().length > 0) {
-    const measurer = canvasMeasurer()
+    const styleId = params.styleId ?? 'glass'
+    const measurer = canvasMeasurer(styleId)
     if (!measurer) {
       return null
     }
@@ -284,6 +391,7 @@ export async function renderCaptionCueFramePng(params: {
       text: params.text,
       canvasWidth: params.canvasWidth,
       textSize: params.textSize,
+      styleId,
       measure: measurer.measure
     })
     if (layout) {

--- a/apps/desktop/src/renderer/src/lib/captions-preflight.test.ts
+++ b/apps/desktop/src/renderer/src/lib/captions-preflight.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AiCapabilities } from '@/lib/backend'
+
+import {
+  captionsEnabledForSession,
+  captionsSuppressedForSession,
+  captionRuntimeStartBlocked,
+  captionSessionOutputReadiness,
+  decideGoLiveCaptionsReadiness
+} from './captions-preflight'
+
+function capabilities(captions: AiCapabilities['captions']): AiCapabilities {
+  return { captions } as AiCapabilities
+}
+
+describe('decideGoLiveCaptionsReadiness', () => {
+  it('fails closed when an enabled client receives an older capabilities payload', () => {
+    const result = decideGoLiveCaptionsReadiness({
+      persistedEnabled: true,
+      suppressForSession: false,
+      capabilities: capabilities(undefined)
+    })
+
+    expect(result.kind).toBe('blocked')
+    expect(result.blocksStart).toBe(true)
+    expect(result.description).toContain('could not verify')
+  })
+
+  it('uses a deployment-safe reason when caption infrastructure is unavailable', () => {
+    const result = decideGoLiveCaptionsReadiness({
+      persistedEnabled: true,
+      suppressForSession: false,
+      capabilities: capabilities({
+        available: false,
+        preferredTransport: null,
+        reasonCode: 'captions-not-configured',
+        realtime: { available: false, configured: false, disabled: false, model: '' },
+        chunked: { available: false, configured: false, model: '' }
+      })
+    })
+
+    expect(result).toMatchObject({ kind: 'blocked', blocksStart: true, transport: null })
+    expect(result.description).toContain('deployment')
+  })
+
+  it('blocks Go Live when the monthly caption allowance is exhausted', () => {
+    const result = decideGoLiveCaptionsReadiness({
+      persistedEnabled: true,
+      suppressForSession: false,
+      capabilities: capabilities({
+        available: false,
+        preferredTransport: null,
+        reasonCode: 'captions-monthly-quota-exhausted',
+        monthlySecondsLimit: 180_000,
+        remainingSeconds: 0,
+        realtime: { available: true, configured: true, disabled: false, model: 'xai/realtime' },
+        chunked: { available: true, configured: true, model: 'xai/chunked' }
+      })
+    })
+
+    expect(result).toMatchObject({ kind: 'blocked', blocksStart: true, transport: null })
+    expect(result.description).toContain('allowance is exhausted')
+  })
+
+  it('reports the preferred ready transport', () => {
+    const result = decideGoLiveCaptionsReadiness({
+      persistedEnabled: true,
+      suppressForSession: false,
+      capabilities: capabilities({
+        available: true,
+        preferredTransport: 'realtime',
+        reasonCode: 'ready-realtime',
+        realtime: {
+          available: true,
+          configured: true,
+          disabled: false,
+          model: 'xai/realtime'
+        },
+        chunked: { available: true, configured: true, model: 'xai/chunked' }
+      })
+    })
+
+    expect(result).toMatchObject({ kind: 'ready', blocksStart: false, transport: 'realtime' })
+  })
+
+  it('allows an explicit one-session skip without changing persisted consent', () => {
+    const result = decideGoLiveCaptionsReadiness({
+      persistedEnabled: true,
+      suppressForSession: true,
+      capabilities: null
+    })
+
+    expect(result).toMatchObject({ kind: 'skipped', blocksStart: false })
+    expect(captionsEnabledForSession({ persistedEnabled: true, suppressForSession: true })).toBe(
+      false
+    )
+    expect(captionsEnabledForSession({ persistedEnabled: true, suppressForSession: false })).toBe(
+      true
+    )
+  })
+
+  it('blocks unsupported stream burn output but preserves Continue without captions', () => {
+    const outputReadiness = captionSessionOutputReadiness({
+      burnTarget: 'both',
+      recordEnabled: true,
+      streamEnabled: true,
+      recordingVideo: { width: 1920, height: 1080, fps: 60, bitrateKbps: 9_000 },
+      streamVideos: [{ width: 1920, height: 1080, fps: 60, bitrateKbps: 9_000 }]
+    })
+    expect(outputReadiness).toMatchObject({ ready: false })
+    expect(outputReadiness.description).toContain('30 fps')
+
+    const blocked = decideGoLiveCaptionsReadiness({
+      persistedEnabled: true,
+      suppressForSession: false,
+      capabilities: null,
+      outputReadiness
+    })
+    expect(blocked).toMatchObject({ kind: 'blocked', blocksStart: true })
+
+    const skipped = decideGoLiveCaptionsReadiness({
+      persistedEnabled: true,
+      suppressForSession: true,
+      capabilities: null,
+      outputReadiness
+    })
+    expect(skipped).toMatchObject({ kind: 'skipped', blocksStart: false })
+    expect(captionRuntimeStartBlocked({ captureActive: true, outputReadiness })).toBe(true)
+    expect(captionRuntimeStartBlocked({ captureActive: false, outputReadiness })).toBe(false)
+  })
+
+  it('allows non-stream caption targets above 30fps', () => {
+    for (const burnTarget of ['off', 'recording'] as const) {
+      expect(
+        captionSessionOutputReadiness({
+          burnTarget,
+          recordEnabled: true,
+          streamEnabled: true,
+          recordingVideo: { width: 3840, height: 2160, fps: 60, bitrateKbps: 50_000 },
+          streamVideos: [{ width: 1920, height: 1080, fps: 60, bitrateKbps: 9_000 }]
+        })
+      ).toEqual({ ready: true })
+    }
+  })
+
+  it('blocks captioned record plus mixed-profile multistream', () => {
+    const readiness = captionSessionOutputReadiness({
+      burnTarget: 'stream',
+      recordEnabled: true,
+      streamEnabled: true,
+      recordingVideo: { width: 1920, height: 1080, fps: 30, bitrateKbps: 6_000 },
+      streamVideos: [
+        { width: 1920, height: 1080, fps: 30, bitrateKbps: 6_000 },
+        { width: 1280, height: 720, fps: 30, bitrateKbps: 4_000 }
+      ]
+    })
+    expect(readiness).toMatchObject({ ready: false })
+    expect(readiness.description).toContain('one shared stream output profile')
+  })
+
+  it('does not gate sessions when captions are persistently off', () => {
+    expect(
+      decideGoLiveCaptionsReadiness({
+        persistedEnabled: false,
+        suppressForSession: false,
+        capabilities: null
+      })
+    ).toMatchObject({ kind: 'disabled', blocksStart: false })
+  })
+
+  it('pre-arms eligible captions-off sessions but suppresses unsupported output shapes', () => {
+    expect(
+      captionsSuppressedForSession({
+        persistedEnabled: false,
+        explicitSuppression: false,
+        outputReadiness: { ready: true }
+      })
+    ).toBe(false)
+    expect(
+      captionsSuppressedForSession({
+        persistedEnabled: false,
+        explicitSuppression: false,
+        outputReadiness: { ready: false }
+      })
+    ).toBe(true)
+    expect(
+      captionsSuppressedForSession({
+        persistedEnabled: true,
+        explicitSuppression: true,
+        outputReadiness: { ready: true }
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/captions-preflight.ts
+++ b/apps/desktop/src/renderer/src/lib/captions-preflight.ts
@@ -1,0 +1,181 @@
+import type { AiCapabilities, CaptionTransport } from '@/lib/backend'
+import type { CaptionBurnTarget } from '@/lib/capture'
+
+export type GoLiveCaptionsReadiness = {
+  kind: 'disabled' | 'ready' | 'blocked' | 'skipped'
+  blocksStart: boolean
+  title: string
+  description: string
+  transport: CaptionTransport | null
+}
+
+export type CaptionSessionOutputReadiness = {
+  ready: boolean
+  description?: string
+}
+
+type CaptionOutputProfile = {
+  width: number
+  height: number
+  fps: number
+  bitrateKbps: number
+}
+
+/**
+ * Live caption pixels require the maintained compositor path and one
+ * captioned stream profile beside a clean recording. Fail before Go Live
+ * instead of promising captions to only some viewers.
+ */
+export function captionSessionOutputReadiness(input: {
+  burnTarget: CaptionBurnTarget
+  recordEnabled: boolean
+  streamEnabled: boolean
+  recordingVideo: CaptionOutputProfile
+  streamVideos: CaptionOutputProfile[]
+}): CaptionSessionOutputReadiness {
+  const burnsStream = input.burnTarget === 'stream' || input.burnTarget === 'both'
+  if (!burnsStream || !input.streamEnabled) return { ready: true }
+
+  const streamVideos = input.streamVideos.length > 0 ? input.streamVideos : [input.recordingVideo]
+  if (input.recordingVideo.fps > 30 || streamVideos.some((video) => video.fps > 30)) {
+    return {
+      ready: false,
+      description:
+        'Livestream caption burn-in currently supports up to 30 fps. Choose a 30 fps output, select Recording only, or continue this session without captions.'
+    }
+  }
+
+  if (input.recordEnabled && uniqueProfiles(streamVideos).length > 1) {
+    return {
+      ready: false,
+      description:
+        'Captioned record + multistream currently requires one shared stream output profile. Match the enabled destination profiles, or continue this session without captions.'
+    }
+  }
+
+  return { ready: true }
+}
+
+export function captionRuntimeStartBlocked(input: {
+  captureActive: boolean
+  outputReadiness: CaptionSessionOutputReadiness
+}): boolean {
+  return input.captureActive && !input.outputReadiness.ready
+}
+
+export function decideGoLiveCaptionsReadiness(input: {
+  persistedEnabled: boolean
+  suppressForSession: boolean
+  capabilities: AiCapabilities | null
+  outputReadiness?: CaptionSessionOutputReadiness
+}): GoLiveCaptionsReadiness {
+  if (!input.persistedEnabled) {
+    return {
+      kind: 'disabled',
+      blocksStart: false,
+      title: 'Captions off',
+      description: 'Live captions are not enabled for this session.',
+      transport: null
+    }
+  }
+  if (input.suppressForSession) {
+    return {
+      kind: 'skipped',
+      blocksStart: false,
+      title: 'Captions skipped',
+      description: 'This livestream will start without captions. Your saved setting is unchanged.',
+      transport: null
+    }
+  }
+  if (input.outputReadiness && !input.outputReadiness.ready) {
+    return blocked(
+      input.outputReadiness.description ??
+        'Live captions are not compatible with the selected output configuration.'
+    )
+  }
+
+  const captions = input.capabilities?.captions
+  if (!captions) {
+    return blocked(
+      'Videorc could not verify live-caption readiness for this deployment. Try again, or continue this session without captions.'
+    )
+  }
+  if (!captions.available || !captions.preferredTransport) {
+    return blocked(unavailableReason(captions.reasonCode))
+  }
+
+  return {
+    kind: 'ready',
+    blocksStart: false,
+    title: 'Captions ready',
+    description:
+      captions.preferredTransport === 'realtime'
+        ? 'Realtime microphone transcription is ready.'
+        : 'Caption transcription is ready with a slightly higher delay.',
+    transport: captions.preferredTransport
+  }
+}
+
+function uniqueProfiles(profiles: CaptionOutputProfile[]): CaptionOutputProfile[] {
+  return profiles.filter(
+    (profile, index) =>
+      profiles.findIndex(
+        (candidate) =>
+          candidate.width === profile.width &&
+          candidate.height === profile.height &&
+          candidate.fps === profile.fps &&
+          candidate.bitrateKbps === profile.bitrateKbps
+      ) === index
+  )
+}
+
+export function captionsEnabledForSession(input: {
+  persistedEnabled: boolean
+  suppressForSession: boolean
+}): boolean {
+  return input.persistedEnabled && !input.suppressForSession
+}
+
+/**
+ * Distinguish saved captions-off from an explicit/required session skip.
+ * Eligible captions-off sessions pre-arm their output leg for a later
+ * mid-session opt-in; unsupported output shapes cannot make that promise.
+ */
+export function captionsSuppressedForSession(input: {
+  persistedEnabled: boolean
+  explicitSuppression: boolean
+  outputReadiness: CaptionSessionOutputReadiness
+}): boolean {
+  return input.explicitSuppression || (!input.persistedEnabled && !input.outputReadiness.ready)
+}
+
+function blocked(description: string): GoLiveCaptionsReadiness {
+  return {
+    kind: 'blocked',
+    blocksStart: true,
+    title: 'Captions unavailable',
+    description,
+    transport: null
+  }
+}
+
+function unavailableReason(
+  reasonCode: NonNullable<AiCapabilities['captions']>['reasonCode']
+): string {
+  switch (reasonCode) {
+    case 'cloud-ai-premium-required':
+      return 'Live captions are not available for this account. Continue without captions or review your plan.'
+    case 'ai-user-disabled':
+      return 'Live captions are disabled for this account. Continue without captions or contact support.'
+    case 'captions-monthly-quota-exhausted':
+      return 'Your monthly live-caption allowance is exhausted. Continue this session without captions.'
+    case 'ai-disabled':
+    case 'captions-disabled':
+      return 'Live captions are temporarily disabled on this Videorc deployment.'
+    case 'captions-invalid-config':
+    case 'captions-not-configured':
+      return 'Live captions are not configured correctly on this Videorc deployment.'
+    default:
+      return 'Live captions are not ready on this Videorc deployment.'
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/captions-ui.test.ts
+++ b/apps/desktop/src/renderer/src/lib/captions-ui.test.ts
@@ -3,11 +3,42 @@ import { describe, expect, it } from 'vitest'
 import type { CaptionsUpdate } from '@/lib/backend'
 import {
   appendCaptionLine,
+  captionDwellMs,
   captionLineAboveFloor,
+  captionOverlayKey,
+  captionOverlayTargetPlan,
   captionSessionFloor,
+  CaptionCueRenderGuard,
   captionStripLines,
-  decideOverlayPush
+  captionsStatusIsActive,
+  decideCaptionsRuntimeIntent,
+  decideOverlayPush,
+  LatestWinsScheduler,
+  latestFinalCaptionText,
+  shouldCancelCaptionCueRender
 } from './captions-ui'
+
+describe('CaptionCueRenderGuard', () => {
+  it('invalidates queued cue renders on supersession and authoritative clear', () => {
+    const guard = new CaptionCueRenderGuard()
+    const first = guard.begin()
+    expect(guard.isCurrent(first)).toBe(true)
+
+    const replacement = guard.begin()
+    expect(guard.isCurrent(first)).toBe(false)
+    expect(guard.isCurrent(replacement)).toBe(true)
+
+    guard.cancel()
+    expect(guard.isCurrent(replacement)).toBe(false)
+  })
+
+  it('purges on sign-out without cancelling normal final-copy boundaries', () => {
+    expect(shouldCancelCaptionCueRender('signed-out')).toBe(true)
+    expect(shouldCancelCaptionCueRender('capture-ended')).toBe(false)
+    expect(shouldCancelCaptionCueRender('blocked')).toBe(false)
+    expect(shouldCancelCaptionCueRender(undefined)).toBe(false)
+  })
+})
 
 const update = (seq: number, overrides: Partial<CaptionsUpdate> = {}): CaptionsUpdate => ({
   sessionClientId: 'captions-session-a',
@@ -56,6 +87,103 @@ describe('captionStripLines', () => {
     const lines = [update(1), update(2), update(3), update(4)]
     expect(captionStripLines(lines, 2).map((line) => line.seq)).toEqual([3, 4])
   })
+
+  it('selects settled text for aria-live and ignores the latest partial', () => {
+    const lines = [
+      update(1, { kind: 'final', text: 'Settled.' }),
+      update(2, { kind: 'partial', text: 'Still changing' })
+    ]
+    expect(latestFinalCaptionText(lines)).toBe('Settled.')
+    expect(latestFinalCaptionText([lines[1]!])).toBeUndefined()
+  })
+})
+
+describe('caption runtime helpers', () => {
+  it('recognizes both the new state machine and the rolling Alpha live state', () => {
+    expect(captionsStatusIsActive({ state: 'starting' })).toBe(true)
+    expect(captionsStatusIsActive({ state: 'listening' })).toBe(true)
+    expect(captionsStatusIsActive({ state: 'reconnecting' })).toBe(true)
+    expect(captionsStatusIsActive({ state: 'degraded' })).toBe(true)
+    expect(captionsStatusIsActive({ state: 'live' })).toBe(true)
+    expect(captionsStatusIsActive({ state: 'ready' })).toBe(false)
+  })
+
+  it('bounds caption dwell between two and six seconds', () => {
+    expect(captionDwellMs('Hi')).toBe(2000)
+    expect(captionDwellMs('x'.repeat(500))).toBe(6000)
+  })
+
+  it('serializes persisted idle enable into backend Ready intent', () => {
+    expect(
+      decideCaptionsRuntimeIntent({
+        persistedEnabled: true,
+        suppressForSession: false,
+        captureActive: false,
+        status: { state: 'idle', desiredEnabled: false },
+        startAttempted: false,
+        stopAttempted: false
+      })
+    ).toBe('start')
+    expect(
+      decideCaptionsRuntimeIntent({
+        persistedEnabled: true,
+        suppressForSession: false,
+        captureActive: false,
+        status: { state: 'ready', desiredEnabled: true },
+        startAttempted: true,
+        stopAttempted: false
+      })
+    ).toBe('none')
+  })
+
+  it.each(['ready', 'blocked', 'error'] as const)(
+    'serializes idle disable from %s into backend Idle intent',
+    (state) => {
+      expect(
+        decideCaptionsRuntimeIntent({
+          persistedEnabled: false,
+          suppressForSession: false,
+          captureActive: false,
+          status: { state, desiredEnabled: true },
+          startAttempted: false,
+          stopAttempted: false
+        })
+      ).toBe('stop')
+    }
+  )
+
+  it('starts Ready captions at the next capture and does not spin failed attempts', () => {
+    expect(
+      decideCaptionsRuntimeIntent({
+        persistedEnabled: true,
+        suppressForSession: false,
+        captureActive: true,
+        status: { state: 'ready', desiredEnabled: true },
+        startAttempted: false,
+        stopAttempted: false
+      })
+    ).toBe('start')
+    expect(
+      decideCaptionsRuntimeIntent({
+        persistedEnabled: true,
+        suppressForSession: false,
+        captureActive: true,
+        status: { state: 'blocked', desiredEnabled: true },
+        startAttempted: true,
+        stopAttempted: false
+      })
+    ).toBe('none')
+    expect(
+      decideCaptionsRuntimeIntent({
+        persistedEnabled: false,
+        suppressForSession: false,
+        captureActive: false,
+        status: { state: 'error', desiredEnabled: true },
+        startAttempted: false,
+        stopAttempted: true
+      })
+    ).toBe('none')
+  })
 })
 
 describe('caption session floor', () => {
@@ -102,6 +230,42 @@ describe('decideOverlayPush', () => {
     ).toBe('push')
   })
 
+  it('repushes the same text when style, revision, dimensions, or placement changes', () => {
+    const firstKey = captionOverlayKey(update(8), {
+      styleId: 'glass',
+      styleRevision: 1,
+      position: 'bottom',
+      textSize: 'm',
+      canvasWidth: 1920,
+      canvasHeight: 1080,
+      outputLeg: 'stream'
+    })
+    const nextKey = captionOverlayKey(update(8), {
+      styleId: 'classic',
+      styleRevision: 2,
+      position: 'top',
+      textSize: 'l',
+      canvasWidth: 3840,
+      canvasHeight: 2160,
+      outputLeg: 'recording'
+    })
+    expect(decideOverlayPush({ ...base, candidateKey: firstKey, pushedKey: firstKey }).action).toBe(
+      'none'
+    )
+    expect(decideOverlayPush({ ...base, candidateKey: nextKey, pushedKey: firstKey }).action).toBe(
+      'push'
+    )
+  })
+
+  it('does not repush a final that has expired during silence', () => {
+    expect(
+      decideOverlayPush({
+        ...base,
+        expiredLineId: `${base.latest.sessionClientId}:${base.latest.seq}`
+      }).action
+    ).toBe('none')
+  })
+
   it('REGRESSION (carry-over bug): never re-pushes the previous video at the next session start', () => {
     // Video 1 ends: overlay cleared, pushedKey null — but the previous
     // video's last line is still the newest buffer entry. Video 2 starts with
@@ -128,5 +292,181 @@ describe('decideOverlayPush', () => {
   it('stays quiet while a rasterize round-trip is in flight or there is no line', () => {
     expect(decideOverlayPush({ ...base, busy: true }).action).toBe('none')
     expect(decideOverlayPush({ ...base, latest: undefined }).action).toBe('none')
+  })
+})
+
+describe('captionOverlayTargetPlan', () => {
+  const base = {
+    recordingVideo: { width: 3840, height: 2160 },
+    streamVideo: { width: 1920, height: 1080 }
+  }
+
+  it('keeps the 4K source recording clean and maps only the 1080p stream auxiliary', () => {
+    expect(
+      captionOverlayTargetPlan({
+        ...base,
+        burnTarget: 'both',
+        recordEnabled: true,
+        streamEnabled: true
+      })
+    ).toEqual([
+      {
+        target: 'auxiliary',
+        outputLeg: 'stream',
+        canvasWidth: 1920,
+        canvasHeight: 1080
+      }
+    ])
+  })
+
+  it('uses primary for the only enabled output and ignores mismatched routing', () => {
+    expect(
+      captionOverlayTargetPlan({
+        ...base,
+        burnTarget: 'recording',
+        recordEnabled: true,
+        streamEnabled: false
+      })
+    ).toEqual([])
+    expect(
+      captionOverlayTargetPlan({
+        ...base,
+        burnTarget: 'stream',
+        recordEnabled: true,
+        streamEnabled: false
+      })
+    ).toEqual([])
+    expect(
+      captionOverlayTargetPlan({
+        ...base,
+        burnTarget: 'stream',
+        recordEnabled: false,
+        streamEnabled: true
+      })
+    ).toEqual([
+      {
+        target: 'primary',
+        outputLeg: 'stream',
+        canvasWidth: 3840,
+        canvasHeight: 2160
+      }
+    ])
+  })
+
+  it('rasterizes a stream-only overlay at the real primary compositor canvas', () => {
+    expect(
+      captionOverlayTargetPlan({
+        burnTarget: 'stream',
+        recordEnabled: false,
+        streamEnabled: true,
+        recordingVideo: { width: 3840, height: 2160 },
+        streamVideo: { width: 1920, height: 1080 }
+      })
+    ).toEqual([
+      {
+        target: 'primary',
+        outputLeg: 'stream',
+        canvasWidth: 3840,
+        canvasHeight: 2160
+      }
+    ])
+  })
+
+  it('keeps only the live stream role when split outputs have matching dimensions', () => {
+    expect(
+      captionOverlayTargetPlan({
+        burnTarget: 'both',
+        recordEnabled: true,
+        streamEnabled: true,
+        recordingVideo: { width: 1920, height: 1080 },
+        streamVideo: { width: 1920, height: 1080 }
+      }).map((entry) => entry.target)
+    ).toEqual(['auxiliary'])
+  })
+
+  it('keys current and stale style revisions independently for every role', () => {
+    const line = update(9, { kind: 'final', text: 'Settled caption.' })
+    const targets = captionOverlayTargetPlan({
+      ...base,
+      burnTarget: 'both',
+      recordEnabled: true,
+      streamEnabled: true
+    })
+    const keys = (styleRevision: number) =>
+      targets.map((target) =>
+        captionOverlayKey(line, {
+          styleId: 'glass',
+          styleRevision,
+          position: 'bottom',
+          textSize: 'm',
+          canvasWidth: target.canvasWidth,
+          canvasHeight: target.canvasHeight,
+          outputLeg: target.target
+        })
+      )
+
+    expect(keys(4)).not.toEqual(keys(5))
+    expect(new Set(keys(5)).size).toBe(1)
+  })
+})
+
+describe('LatestWinsScheduler', () => {
+  it('runs the in-flight request and then only the newest queued request', async () => {
+    const seen: string[] = []
+    let releaseFirst: (() => void) | undefined
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const scheduler = new LatestWinsScheduler<string>(async (value) => {
+      seen.push(value)
+      if (value === 'partial-1') await firstGate
+    })
+
+    scheduler.enqueue('partial-1')
+    scheduler.enqueue('partial-2')
+    scheduler.enqueue('final')
+    releaseFirst?.()
+    await scheduler.whenIdle()
+
+    expect(seen).toEqual(['partial-1', 'final'])
+  })
+
+  it('continues with the latest request after a worker failure', async () => {
+    const seen: string[] = []
+    const scheduler = new LatestWinsScheduler<string>(async (value) => {
+      seen.push(value)
+      if (value === 'bad') throw new Error('render failed')
+    })
+    scheduler.enqueue('bad')
+    scheduler.enqueue('final')
+    await scheduler.whenIdle()
+    expect(seen.at(-1)).toBe('final')
+  })
+
+  it('keeps primary and auxiliary in one atomic latest-wins work item', async () => {
+    type Work = { label: string; outputs: Array<'primary' | 'auxiliary'> }
+    const seen: string[] = []
+    let releaseFirst: (() => void) | undefined
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const scheduler = new LatestWinsScheduler<Work>(async (work) => {
+      for (const output of work.outputs) {
+        seen.push(`${work.label}-${output}`)
+        if (work.label === 'partial' && output === 'primary') await firstGate
+      }
+    })
+
+    scheduler.enqueue({ label: 'partial', outputs: ['primary', 'auxiliary'] })
+    scheduler.enqueue({ label: 'final', outputs: ['primary', 'auxiliary'] })
+    releaseFirst?.()
+    await scheduler.whenIdle()
+
+    expect(seen).toEqual([
+      'partial-primary',
+      'partial-auxiliary',
+      'final-primary',
+      'final-auxiliary'
+    ])
   })
 })

--- a/apps/desktop/src/renderer/src/lib/captions-ui.ts
+++ b/apps/desktop/src/renderer/src/lib/captions-ui.ts
@@ -1,7 +1,35 @@
-import type { CaptionsUpdate } from '@/lib/backend'
+import type { CaptionStyleId, CaptionsStatus, CaptionsUpdate } from '@/lib/backend'
+import type { CaptionBurnTarget } from '@/lib/capture'
 
 /** Lines kept for the captions strip / detached window. */
 export const MAX_CAPTION_LINES = 50
+
+/**
+ * Generation guard for renderer-owned caption cue raster work. Privacy
+ * boundaries and client teardown invalidate older async renders before they
+ * can retain or submit more transcript pixels.
+ */
+export class CaptionCueRenderGuard {
+  private generation = 0
+
+  begin(): number {
+    this.generation += 1
+    return this.generation
+  }
+
+  cancel(): void {
+    this.generation += 1
+  }
+
+  isCurrent(generation: number): boolean {
+    return generation === this.generation
+  }
+}
+
+/** Final-copy work survives ordinary capture boundaries; sign-out purges it. */
+export function shouldCancelCaptionCueRender(reason: string | undefined): boolean {
+  return reason === 'signed-out'
+}
 
 /**
  * Append a caption update: streaming PARTIALS (and the final that settles
@@ -34,6 +62,184 @@ export function appendCaptionLine(
 /** The strip shows the tail of the transcript, most recent lines only. */
 export function captionStripLines(lines: CaptionsUpdate[], count = 3): CaptionsUpdate[] {
   return lines.slice(-count)
+}
+
+/** Screen readers announce settled cues only; evolving partials remain visual. */
+export function latestFinalCaptionText(lines: CaptionsUpdate[]): string | undefined {
+  return [...lines].reverse().find((line) => line.kind !== 'partial')?.text
+}
+
+export function captionsStatusIsActive(status: CaptionsStatus): boolean {
+  return ['starting', 'listening', 'reconnecting', 'degraded', 'live'].includes(status.state)
+}
+
+/**
+ * Reconciles persisted caption consent with backend-owned desired intent.
+ * Attempts are tracked by StudioProvider per toggle/capture/client scope so a
+ * blocked provider cannot spin, while an explicit retry edge can try once.
+ */
+export function decideCaptionsRuntimeIntent(input: {
+  persistedEnabled: boolean
+  suppressForSession: boolean
+  captureActive: boolean
+  status: CaptionsStatus
+  startAttempted: boolean
+  stopAttempted: boolean
+}): 'start' | 'stop' | 'none' {
+  const shouldEnable = input.persistedEnabled && !input.suppressForSession
+  const backendHasIntent = input.status.state !== 'idle' || input.status.desiredEnabled === true
+
+  if (!shouldEnable) {
+    return backendHasIntent && !input.stopAttempted ? 'stop' : 'none'
+  }
+  if (captionsStatusIsActive(input.status)) {
+    return 'none'
+  }
+  if (
+    input.status.state === 'ready' &&
+    input.status.desiredEnabled !== false &&
+    !input.captureActive
+  ) {
+    return 'none'
+  }
+  return input.startAttempted ? 'none' : 'start'
+}
+
+export function captionLineIdentity(line: CaptionsUpdate): string {
+  return `${line.sessionClientId}:${line.seq}`
+}
+
+export interface CaptionOverlaySignature {
+  styleId: CaptionStyleId
+  styleRevision: number
+  position: 'top' | 'bottom'
+  textSize: 's' | 'm' | 'l'
+  canvasWidth: number
+  canvasHeight: number
+  outputLeg: 'shared' | 'stream' | 'recording' | 'primary' | 'auxiliary'
+}
+
+export interface CaptionOverlayTargetPlan {
+  target: 'primary' | 'auxiliary'
+  outputLeg: 'recording' | 'stream'
+  canvasWidth: number
+  canvasHeight: number
+}
+
+/** Map user-facing outputs to the backend's session-stable compositor roles. */
+export function captionOverlayTargetPlan(input: {
+  burnTarget: CaptionBurnTarget
+  recordEnabled: boolean
+  streamEnabled: boolean
+  recordingVideo: { width: number; height: number }
+  streamVideo: { width: number; height: number }
+}): CaptionOverlayTargetPlan[] {
+  const streamRequested =
+    input.streamEnabled && (input.burnTarget === 'stream' || input.burnTarget === 'both')
+
+  if (input.recordEnabled && input.streamEnabled) {
+    // Recording captions are rendered later into a non-destructive copy. The
+    // source recording remains clean, so the only live raster is the split
+    // viewer-facing stream leg.
+    return streamRequested
+      ? [
+          {
+            target: 'auxiliary' as const,
+            outputLeg: 'stream' as const,
+            canvasWidth: input.streamVideo.width,
+            canvasHeight: input.streamVideo.height
+          }
+        ]
+      : []
+  }
+  if (streamRequested) {
+    return [
+      {
+        target: 'primary',
+        outputLeg: 'stream',
+        // Stream-only sessions do not allocate the auxiliary stream canvas:
+        // the primary compositor stays at the capture canvas and FFmpeg scales
+        // that complete frame to the destination profile. Rasterize at the
+        // actual compositor size so text scales with the video instead of
+        // becoming a small 1080p island on a 4K primary.
+        canvasWidth: input.recordingVideo.width,
+        canvasHeight: input.recordingVideo.height
+      }
+    ]
+  }
+  return []
+}
+
+/** Everything that can change pixels belongs in the key. */
+export function captionOverlayKey(
+  line: CaptionsUpdate,
+  signature: CaptionOverlaySignature
+): string {
+  return [
+    captionLineIdentity(line),
+    line.text,
+    signature.styleId,
+    signature.styleRevision,
+    signature.position,
+    signature.textSize,
+    `${signature.canvasWidth}x${signature.canvasHeight}`,
+    signature.outputLeg
+  ].join(':')
+}
+
+/** Readable dwell for a settled line: two seconds minimum, six maximum. */
+export function captionDwellMs(text: string): number {
+  return Math.min(6000, Math.max(2000, 1800 + text.trim().length * 45))
+}
+
+/**
+ * Serial, bounded latest-wins work queue. At most one request is rendering and
+ * one newest request is pending; intermediate partials are deliberately
+ * coalesced, while a final/style update can never be stranded behind a busy ref.
+ */
+export class LatestWinsScheduler<T> {
+  private running = false
+  private pending: T | null = null
+  private idleResolvers: Array<() => void> = []
+
+  constructor(private readonly worker: (value: T) => Promise<void>) {}
+
+  enqueue(value: T): void {
+    this.pending = value
+    if (!this.running) {
+      void this.drain()
+    }
+  }
+
+  clearPending(): void {
+    this.pending = null
+  }
+
+  whenIdle(): Promise<void> {
+    if (!this.running && this.pending === null) {
+      return Promise.resolve()
+    }
+    return new Promise((resolve) => this.idleResolvers.push(resolve))
+  }
+
+  private async drain(): Promise<void> {
+    this.running = true
+    try {
+      while (this.pending !== null) {
+        const next = this.pending
+        this.pending = null
+        try {
+          await this.worker(next)
+        } catch {
+          // One failed render/push must not strand the newest queued request.
+        }
+      }
+    } finally {
+      this.running = false
+      const resolvers = this.idleResolvers.splice(0)
+      resolvers.forEach((resolve) => resolve())
+    }
+  }
 }
 
 /**
@@ -81,17 +287,25 @@ export function decideOverlayPush(input: {
   latest: CaptionsUpdate | undefined
   floor: CaptionSessionFloor | null
   pushedKey: string | null
-  busy: boolean
+  candidateKey?: string
+  expiredLineId?: string | null
+  /** Legacy caller compatibility; the latest-wins scheduler replaces this gate. */
+  busy?: boolean
 }): { action: 'push' | 'clear' | 'none'; key: string | null } {
   if (!input.burnIn || !input.captionsRunning || !input.sessionActive) {
     return { action: input.pushedKey !== null ? 'clear' : 'none', key: null }
   }
-  if (!input.latest || input.busy || !captionLineAboveFloor(input.latest, input.floor)) {
+  if (
+    !input.latest ||
+    input.busy ||
+    !captionLineAboveFloor(input.latest, input.floor) ||
+    input.expiredLineId === captionLineIdentity(input.latest)
+  ) {
     return { action: 'none', key: input.pushedKey }
   }
   // Streaming partials share a seq while the text evolves — key on both so
   // the live bar refreshes with every refinement.
-  const key = `${input.latest.seq}:${input.latest.text}`
+  const key = input.candidateKey ?? `${input.latest.seq}:${input.latest.text}`
   if (input.pushedKey === key) {
     return { action: 'none', key }
   }

--- a/apps/desktop/src/renderer/src/lib/capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.test.ts
@@ -6,6 +6,7 @@ import {
   applyAudioSyncRecommendation,
   audioSyncCalibrationState,
   applyStoredManualStreamKeyResult,
+  auxiliaryStreamOutputVideoSettings,
   buildCameraSources,
   buildCaptureSources,
   buildMicrophoneSources,
@@ -1023,6 +1024,51 @@ describe('videoProfileCompatibility', () => {
     })
   })
 
+  it('uses the enabled Twitch 1080p override for a 4K-default auxiliary canvas', () => {
+    const config = captureConfigFixture()
+    config.video = videoPresets['record-4k30']
+    config.streaming = {
+      ...config.streaming,
+      enabled: true,
+      defaultOutputPreset: 'stream-youtube-4k30',
+      defaultBitrateKbps: 30000,
+      targets: config.streaming.targets.map((target) =>
+        target.platform === 'twitch'
+          ? {
+              ...target,
+              enabled: true,
+              outputPreset: 'stream-safe-1080p30',
+              outputBitrateKbps: 6000
+            }
+          : { ...target, enabled: target.platform === 'youtube' }
+      )
+    }
+
+    expect(streamOutputVideoSettings(config.video, config.streaming)).toEqual(
+      videoPresets['stream-youtube-4k30']
+    )
+    expect(auxiliaryStreamOutputVideoSettings(config.video, config.streaming)).toEqual(
+      videoPresets['stream-safe-1080p30']
+    )
+  })
+
+  it('falls back to the recording canvas when enabled targets share its profile', () => {
+    const config = captureConfigFixture()
+    config.video = videoPresets['record-4k30']
+    config.streaming = {
+      ...config.streaming,
+      enabled: true,
+      defaultOutputPreset: 'stream-youtube-4k30',
+      defaultBitrateKbps: 30000,
+      targets: config.streaming.targets.map((target) => ({
+        ...target,
+        enabled: target.platform === 'youtube'
+      }))
+    }
+
+    expect(auxiliaryStreamOutputVideoSettings(config.video, config.streaming)).toEqual(config.video)
+  })
+
   it('warns (never blocks) on 4K local recording while streaming — the reproduced freeze profile', () => {
     // docs/live-video-freeze-incident-plan.md: split-output 4K record + stream
     // drops recorded video to ~8fps. Warning only, until LVF2–LVF4 land.
@@ -1065,6 +1111,22 @@ describe('videoProfileCompatibility', () => {
     })
     expect(warned.blockingReason).toBeNull()
     expect(warned.warning).not.toBeNull()
+  })
+})
+
+describe('persistable capture settings', () => {
+  it('keeps live microphone gain and mute as next-session defaults', () => {
+    const config = captureConfigFixture()
+    config.audio = {
+      ...config.audio,
+      microphoneGainDb: 6,
+      microphoneMuted: true
+    }
+
+    expect(persistableCaptureConfig(config).audio).toMatchObject({
+      microphoneGainDb: 6,
+      microphoneMuted: true
+    })
   })
 })
 
@@ -1219,18 +1281,30 @@ describe('normalizeCaptionsCaptureSettings', () => {
   it('defaults, validates, and migrates the pre-R1 boolean', async () => {
     const { normalizeCaptionsCaptureSettings } = await import('./capture')
     expect(normalizeCaptionsCaptureSettings(undefined)).toEqual({
-      burnTarget: 'off',
+      enabled: false,
+      burnTarget: 'stream',
+      styleId: 'classic',
+      language: 'auto',
+      styleRevision: 0,
       position: 'bottom',
       textSize: 'm'
     })
     // Pre-R1 config: burnInEnabled true meant the stream leg.
     expect(normalizeCaptionsCaptureSettings({ burnInEnabled: true })).toEqual({
+      enabled: false,
       burnTarget: 'stream',
+      styleId: 'glass',
+      language: 'auto',
+      styleRevision: 0,
       position: 'bottom',
       textSize: 'm'
     })
     expect(normalizeCaptionsCaptureSettings({ burnInEnabled: false })).toEqual({
+      enabled: false,
       burnTarget: 'off',
+      styleId: 'glass',
+      language: 'auto',
+      styleRevision: 0,
       position: 'bottom',
       textSize: 'm'
     })
@@ -1242,11 +1316,46 @@ describe('normalizeCaptionsCaptureSettings', () => {
         position: 'top',
         textSize: 'l'
       })
-    ).toEqual({ burnTarget: 'recording', position: 'top', textSize: 'l' })
+    ).toEqual({
+      enabled: false,
+      burnTarget: 'recording',
+      styleId: 'glass',
+      language: 'auto',
+      styleRevision: 0,
+      position: 'top',
+      textSize: 'l'
+    })
     expect(normalizeCaptionsCaptureSettings({ burnTarget: 'sideways' as never })).toEqual({
+      enabled: false,
       burnTarget: 'off',
+      styleId: 'glass',
+      language: 'auto',
+      styleRevision: 0,
       position: 'bottom',
       textSize: 'm'
+    })
+  })
+
+  it('keeps valid consent, language, style, and monotonic revision values', async () => {
+    const { normalizeCaptionsCaptureSettings } = await import('./capture')
+    expect(
+      normalizeCaptionsCaptureSettings({
+        enabled: true,
+        burnTarget: 'both',
+        styleId: 'high-contrast',
+        language: ' es ',
+        styleRevision: 7,
+        position: 'top',
+        textSize: 's'
+      })
+    ).toEqual({
+      enabled: true,
+      burnTarget: 'both',
+      styleId: 'high-contrast',
+      language: 'es',
+      styleRevision: 7,
+      position: 'top',
+      textSize: 's'
     })
   })
 })

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -1,5 +1,6 @@
 import type {
   AudioSettings,
+  CaptionStyleId,
   AutomaticSourceFallbackEvent,
   AutomaticSourceFallbackSourceKind,
   CameraTransform,
@@ -26,8 +27,13 @@ export type SettingsState = {
 export type CaptionBurnTarget = 'off' | 'stream' | 'recording' | 'both'
 
 export type CaptionsCaptureSettings = {
+  /** Explicit, persisted consent. Audio is uploaded only during capture sessions. */
+  enabled: boolean
   /** Which output legs the LIVE caption bar burns into (R1). */
   burnTarget: CaptionBurnTarget
+  styleId: CaptionStyleId
+  language: string
+  styleRevision: number
   position: 'top' | 'bottom'
   textSize: 's' | 'm' | 'l'
 }
@@ -417,6 +423,31 @@ export function streamOutputVideosForTargets(
   }))
 }
 
+function sameVideoOutputProfile(left: VideoSettings, right: VideoSettings): boolean {
+  return (
+    left.width === right.width &&
+    left.height === right.height &&
+    left.fps === right.fps &&
+    left.bitrateKbps === right.bitrateKbps
+  )
+}
+
+/**
+ * Mirrors the backend's record+stream auxiliary compositor profile choice.
+ * The auxiliary uses the distinct enabled-target output; when every enabled
+ * target shares the recording profile, caption routing forces a same-profile
+ * auxiliary and therefore falls back to the recording canvas.
+ */
+export function auxiliaryStreamOutputVideoSettings(
+  recording: VideoSettings,
+  streaming: StreamingSettings | undefined
+): VideoSettings {
+  const companion = streamOutputVideosForTargets(recording, streaming).find(
+    ({ video }) => !sameVideoOutputProfile(video, recording)
+  )
+  return companion?.video ?? recording
+}
+
 export const defaultCaptureConfig: CaptureConfig = {
   sources: {},
   layout: {
@@ -457,10 +488,19 @@ export const defaultCaptureConfig: CaptureConfig = {
 }
 
 export function defaultCaptionsCaptureSettings(): CaptionsCaptureSettings {
-  return { burnTarget: 'off', position: 'bottom', textSize: 'm' }
+  return {
+    enabled: false,
+    burnTarget: 'stream',
+    styleId: 'classic',
+    language: 'auto',
+    styleRevision: 0,
+    position: 'bottom',
+    textSize: 'm'
+  }
 }
 
 const CAPTION_BURN_TARGETS: CaptionBurnTarget[] = ['off', 'stream', 'recording', 'both']
+const CAPTION_STYLE_IDS: CaptionStyleId[] = ['classic', 'glass', 'lower-third', 'high-contrast']
 
 export function normalizeCaptionsCaptureSettings(
   loaded: (Partial<CaptionsCaptureSettings> & { burnInEnabled?: boolean }) | undefined
@@ -468,11 +508,34 @@ export function normalizeCaptionsCaptureSettings(
   const defaults = defaultCaptionsCaptureSettings()
   // Pre-R1 configs carried a boolean; true meant the stream leg.
   const migrated: CaptionBurnTarget | undefined =
-    loaded?.burnTarget === undefined && loaded?.burnInEnabled === true ? 'stream' : undefined
+    loaded?.burnTarget === undefined && typeof loaded?.burnInEnabled === 'boolean'
+      ? loaded.burnInEnabled
+        ? 'stream'
+        : 'off'
+      : undefined
   return {
+    // Missing consent is always false. Never infer permission from legacy burn-in.
+    enabled: loaded?.enabled === true,
     burnTarget: CAPTION_BURN_TARGETS.includes(loaded?.burnTarget as CaptionBurnTarget)
       ? (loaded?.burnTarget as CaptionBurnTarget)
-      : (migrated ?? defaults.burnTarget),
+      : (migrated ?? (loaded ? 'off' : defaults.burnTarget)),
+    // A real legacy captions object had the single Glass renderer. Preserve it;
+    // brand-new profiles come from defaultCaptionsCaptureSettings (Classic).
+    styleId: CAPTION_STYLE_IDS.includes(loaded?.styleId as CaptionStyleId)
+      ? (loaded?.styleId as CaptionStyleId)
+      : loaded
+        ? 'glass'
+        : defaults.styleId,
+    language:
+      typeof loaded?.language === 'string' && loaded.language.trim()
+        ? loaded.language.trim()
+        : defaults.language,
+    styleRevision:
+      typeof loaded?.styleRevision === 'number' &&
+      Number.isSafeInteger(loaded.styleRevision) &&
+      loaded.styleRevision >= 0
+        ? loaded.styleRevision
+        : defaults.styleRevision,
     position: loaded?.position === 'top' ? 'top' : defaults.position,
     textSize:
       loaded?.textSize === 's' || loaded?.textSize === 'l' ? loaded.textSize : defaults.textSize

--- a/apps/desktop/src/renderer/src/lib/live-audio-processing.test.ts
+++ b/apps/desktop/src/renderer/src/lib/live-audio-processing.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  activeAudioProcessingUpdateParams,
+  rejectedLiveAudioProcessingUpdate
+} from './live-audio-processing'
+
+describe('activeAudioProcessingUpdateParams', () => {
+  it.each(['recording', 'streaming'] as const)(
+    'maps shared mic controls to the active %s session',
+    (state) => {
+      expect(
+        activeAudioProcessingUpdateParams(
+          { state, sessionId: 'session-1' },
+          { microphoneGainDb: 6, microphoneMuted: true }
+        )
+      ).toEqual({
+        sessionId: 'session-1',
+        microphoneGainDb: 6,
+        microphoneMuted: true
+      })
+    }
+  )
+
+  it.each(['idle', 'starting', 'stopping', 'failed'] as const)(
+    'does not target a %s session',
+    (state) => {
+      expect(
+        activeAudioProcessingUpdateParams(
+          { state, sessionId: 'session-1' },
+          { microphoneGainDb: 6, microphoneMuted: false }
+        )
+      ).toBeNull()
+    }
+  )
+
+  it('requires a backend session id so delayed updates cannot cross capture boundaries', () => {
+    expect(
+      activeAudioProcessingUpdateParams(
+        { state: 'streaming' },
+        { microphoneGainDb: -3, microphoneMuted: true }
+      )
+    ).toBeNull()
+  })
+
+  it('restores the last applied values and disables live edits when native audio is unavailable', () => {
+    expect(
+      rejectedLiveAudioProcessingUpdate({
+        recording: { state: 'recording', sessionId: 'session-1' },
+        current: { microphoneGainDb: 8, microphoneMuted: true },
+        requested: {
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true
+        },
+        result: {
+          applied: false,
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true,
+          reasonCode: 'native-audio-unavailable'
+        },
+        lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
+      })
+    ).toEqual({
+      rollback: { microphoneGainDb: -2, microphoneMuted: false },
+      disableForSession: true,
+      message:
+        'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
+    })
+  })
+
+  it('ignores a stale rejection after the user has made a newer mic edit', () => {
+    expect(
+      rejectedLiveAudioProcessingUpdate({
+        recording: { state: 'recording', sessionId: 'session-1' },
+        current: { microphoneGainDb: 3, microphoneMuted: false },
+        requested: {
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true
+        },
+        result: {
+          applied: false,
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true,
+          reasonCode: 'native-audio-unavailable'
+        },
+        lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
+      })
+    ).toBeNull()
+  })
+
+  it('does not roll back a live change the backend applied', () => {
+    expect(
+      rejectedLiveAudioProcessingUpdate({
+        recording: { state: 'recording', sessionId: 'session-1' },
+        current: { microphoneGainDb: 8, microphoneMuted: true },
+        requested: {
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true
+        },
+        result: {
+          applied: true,
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true
+        },
+        lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
+      })
+    ).toBeNull()
+  })
+
+  it.each(['recording', 'streaming'] as const)(
+    'restores and disables a current %s-session edit when the request rejects',
+    (state) => {
+      expect(
+        rejectedLiveAudioProcessingUpdate({
+          recording: { state, sessionId: 'session-1' },
+          current: { microphoneGainDb: 8, microphoneMuted: true },
+          requested: {
+            sessionId: 'session-1',
+            microphoneGainDb: 8,
+            microphoneMuted: true
+          },
+          lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
+        })
+      ).toEqual({
+        rollback: { microphoneGainDb: -2, microphoneMuted: false },
+        disableForSession: true,
+        message:
+          'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
+      })
+    }
+  )
+
+  it('ignores a rejected request after the active session changes', () => {
+    expect(
+      rejectedLiveAudioProcessingUpdate({
+        recording: { state: 'streaming', sessionId: 'session-2' },
+        current: { microphoneGainDb: 8, microphoneMuted: true },
+        requested: {
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true
+        },
+        lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
+      })
+    ).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/live-audio-processing.ts
+++ b/apps/desktop/src/renderer/src/lib/live-audio-processing.ts
@@ -1,0 +1,72 @@
+import type {
+  AudioProcessingUpdateParams,
+  AudioProcessingUpdateResult,
+  AudioSettings,
+  RecordingStatus
+} from '@/lib/backend'
+
+export type LiveAudioProcessingValues = Pick<AudioSettings, 'microphoneGainDb' | 'microphoneMuted'>
+
+export interface RejectedLiveAudioProcessingUpdate {
+  rollback: LiveAudioProcessingValues
+  disableForSession: boolean
+  message: string
+}
+
+/**
+ * Central live-sync decision for every mic control. Individual controls only
+ * update captureConfig; StudioProvider turns the latest shared settings into
+ * one session-scoped backend mutation once capture is actually active.
+ */
+export function activeAudioProcessingUpdateParams(
+  recording: Pick<RecordingStatus, 'state' | 'sessionId'>,
+  audio: Pick<AudioSettings, 'microphoneGainDb' | 'microphoneMuted'>
+): AudioProcessingUpdateParams | null {
+  if (!['recording', 'streaming'].includes(recording.state) || !recording.sessionId) {
+    return null
+  }
+  return {
+    sessionId: recording.sessionId,
+    microphoneGainDb: audio.microphoneGainDb,
+    microphoneMuted: audio.microphoneMuted
+  }
+}
+
+/**
+ * A successful websocket response is not enough: the backend can truthfully
+ * reject a live change when this capture has no native post-controls audio
+ * path. Roll back only while the UI still shows the rejected request; a late
+ * response must never overwrite a newer mic edit or a newer session.
+ */
+export function rejectedLiveAudioProcessingUpdate(input: {
+  recording: Pick<RecordingStatus, 'state' | 'sessionId'>
+  current: LiveAudioProcessingValues
+  requested: AudioProcessingUpdateParams
+  /** Missing when the `audio.processing.update` request itself rejected. */
+  result?: AudioProcessingUpdateResult
+  lastApplied: LiveAudioProcessingValues
+}): RejectedLiveAudioProcessingUpdate | null {
+  if (
+    !['recording', 'streaming'].includes(input.recording.state) ||
+    input.recording.sessionId !== input.requested.sessionId ||
+    input.result?.applied ||
+    (input.result && input.result.sessionId !== input.requested.sessionId) ||
+    input.current.microphoneGainDb !== input.requested.microphoneGainDb ||
+    input.current.microphoneMuted !== input.requested.microphoneMuted
+  ) {
+    return null
+  }
+
+  // A rejected request provides no acknowledgement that the native session
+  // changed. Treat it as unavailable for the rest of this capture: restoring
+  // the last acknowledged values is the only state the UI can claim truthfully.
+  const nativeAudioUnavailable =
+    !input.result || input.result.reasonCode === 'native-audio-unavailable'
+  return {
+    rollback: input.lastApplied,
+    disableForSession: nativeAudioUnavailable,
+    message: nativeAudioUnavailable
+      ? 'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
+      : 'The live microphone change was not applied. The previous gain and mute settings were restored.'
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/session-params.test.ts
+++ b/apps/desktop/src/renderer/src/lib/session-params.test.ts
@@ -135,6 +135,89 @@ describe('buildStartSessionParams', () => {
     expect(params.streaming).toBe(config.streaming)
   })
 
+  it('snapshots caption consent, style, language, and revision for the session', () => {
+    const config = captureConfig({
+      captions: {
+        enabled: true,
+        burnTarget: 'both',
+        styleId: 'lower-third',
+        language: 'es',
+        styleRevision: 4,
+        position: 'top',
+        textSize: 'l'
+      }
+    })
+    const params = buildStartSessionParams({
+      captureConfig: config,
+      scene,
+      settings: { outputDirectory: '', ffmpegPath: '' }
+    })
+
+    expect(params.captions).toEqual({ ...config.captions, suppressedForSession: false })
+  })
+
+  it('can suppress captions for one session without mutating persisted consent', () => {
+    const config = captureConfig({
+      captions: { ...defaultCaptureConfig.captions, enabled: true }
+    })
+    const params = buildStartSessionParams({
+      captureConfig: config,
+      scene,
+      settings: { outputDirectory: '', ffmpegPath: '' },
+      suppressCaptionsForSession: true
+    })
+
+    expect(config.captions.enabled).toBe(true)
+    expect(params.captions?.enabled).toBe(false)
+    expect(params.captions?.suppressedForSession).toBe(true)
+  })
+
+  it('pre-arms an eligible saved live-caption leg for mid-session opt-in', () => {
+    const config = captureConfig({
+      streamEnabled: true,
+      video: videoPresets['stream-safe-1080p30'],
+      captions: {
+        ...defaultCaptureConfig.captions,
+        enabled: false,
+        burnTarget: 'both'
+      }
+    })
+    const params = buildStartSessionParams({
+      captureConfig: config,
+      scene,
+      settings: { outputDirectory: '', ffmpegPath: '' }
+    })
+
+    expect(params.captions).toMatchObject({
+      enabled: false,
+      suppressedForSession: false,
+      burnTarget: 'both'
+    })
+  })
+
+  it('suppresses mid-session opt-in when the saved live leg cannot be pre-armed', () => {
+    const config = captureConfig({
+      streamEnabled: true,
+      video: videoPresets['stream-safe-1080p60'],
+      captions: {
+        ...defaultCaptureConfig.captions,
+        enabled: false,
+        burnTarget: 'stream'
+      }
+    })
+    const params = buildStartSessionParams({
+      captureConfig: config,
+      scene,
+      settings: { outputDirectory: '', ffmpegPath: '' }
+    })
+
+    expect(params.captions).toMatchObject({
+      enabled: false,
+      suppressedForSession: true,
+      burnTarget: 'stream'
+    })
+  })
+
   it('passes 4K recording video and stream-safe output defaults for split output sessions', () => {
     const config = captureConfig({
       recordEnabled: true,

--- a/apps/desktop/src/renderer/src/lib/session-params.ts
+++ b/apps/desktop/src/renderer/src/lib/session-params.ts
@@ -1,17 +1,44 @@
 import type { Scene, StartSessionParams } from './backend'
-import type { CaptureConfig, SettingsState } from './capture'
+import {
+  captionsEnabledForSession,
+  captionsSuppressedForSession,
+  captionSessionOutputReadiness
+} from './captions-preflight'
+import { streamOutputVideosForTargets, type CaptureConfig, type SettingsState } from './capture'
 
 export function buildStartSessionParams(input: {
   captureConfig: CaptureConfig
   scene: Scene | null
   sceneEditMode?: boolean
   settings: SettingsState
+  suppressCaptionsForSession?: boolean
 }): StartSessionParams {
-  const { captureConfig, scene, sceneEditMode = false, settings } = input
+  const {
+    captureConfig,
+    scene,
+    sceneEditMode = false,
+    settings,
+    suppressCaptionsForSession = false
+  } = input
 
   // Send the scene whenever edit mode is on OR it carries a background, so the
   // backend learns the selected background even outside transform editing (A5).
   const includeScene = sceneEditMode || scene?.background != null
+  const captionOutputReadiness = captionSessionOutputReadiness({
+    burnTarget: captureConfig.captions.burnTarget,
+    recordEnabled: captureConfig.recordEnabled,
+    streamEnabled: captureConfig.streamEnabled,
+    recordingVideo: captureConfig.video,
+    streamVideos: streamOutputVideosForTargets(
+      captureConfig.video,
+      captureConfig.streamEnabled ? captureConfig.streaming : undefined
+    ).map(({ video }) => video)
+  })
+  const captionsSuppressed = captionsSuppressedForSession({
+    persistedEnabled: captureConfig.captions.enabled,
+    explicitSuppression: suppressCaptionsForSession,
+    outputReadiness: captionOutputReadiness
+  })
 
   return {
     sources: captureConfig.sources,
@@ -32,7 +59,15 @@ export function buildStartSessionParams(input: {
     audio: captureConfig.audio,
     streaming: captureConfig.streaming,
     captions: {
+      enabled: captionsEnabledForSession({
+        persistedEnabled: captureConfig.captions.enabled,
+        suppressForSession: suppressCaptionsForSession
+      }),
+      suppressedForSession: captionsSuppressed,
       burnTarget: captureConfig.captions.burnTarget,
+      styleId: captureConfig.captions.styleId,
+      language: captureConfig.captions.language,
+      styleRevision: captureConfig.captions.styleRevision,
       position: captureConfig.captions.position,
       textSize: captureConfig.captions.textSize
     }

--- a/apps/desktop/src/renderer/src/lib/shortcuts.test.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcuts.test.ts
@@ -16,9 +16,11 @@ describe('SHORTCUTS registry', () => {
         ? true
         : entry.id.startsWith('nav-')
     )
-    expect(navEntries.filter((entry) => /^[1-9]$/.test(entry.keys.at(-1) ?? '')).length).toBe(
-      WORKSPACE_SHORTCUTS.length
-    )
+    expect(
+      navEntries.filter(
+        (entry) => /^[1-9]$/.test(entry.keys.at(-1) ?? '') || entry.keys.at(-1) === ','
+      ).length
+    ).toBe(WORKSPACE_SHORTCUTS.length)
   })
 
   it('has unique ids and non-empty key lists', () => {

--- a/apps/desktop/src/renderer/src/lib/shortcuts.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcuts.ts
@@ -18,10 +18,11 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
   { id: 'nav-layouts', keys: ['⌘', '3'], label: 'Scene', group: 'Navigation' },
   { id: 'nav-assets', keys: ['⌘', '4'], label: 'Assets', group: 'Navigation' },
   { id: 'nav-live', keys: ['⌘', '5'], label: 'Livestream', group: 'Navigation' },
-  { id: 'nav-recording', keys: ['⌘', '6'], label: 'Output', group: 'Navigation' },
-  { id: 'nav-library', keys: ['⌘', '7'], label: 'Library', group: 'Navigation' },
-  { id: 'nav-ai', keys: ['⌘', '8'], label: 'Publish', group: 'Navigation' },
-  { id: 'nav-settings', keys: ['⌘', '9'], label: 'Settings', group: 'Navigation' },
+  { id: 'nav-captions', keys: ['⌘', '6'], label: 'Captions', group: 'Navigation' },
+  { id: 'nav-recording', keys: ['⌘', '7'], label: 'Output', group: 'Navigation' },
+  { id: 'nav-library', keys: ['⌘', '8'], label: 'Library', group: 'Navigation' },
+  { id: 'nav-ai', keys: ['⌘', '9'], label: 'Publish', group: 'Navigation' },
+  { id: 'nav-settings', keys: ['⌘', ','], label: 'Settings', group: 'Navigation' },
   { id: 'search', keys: ['⌘', 'K'], label: 'Search & commands', group: 'Navigation' },
 
   { id: 'record-toggle', keys: ['␣'], label: 'Start / stop the session', group: 'Session' },
@@ -29,6 +30,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
   { id: 'preview-window', keys: ['⌘', 'P'], label: 'Open preview window', group: 'Windows' },
   { id: 'notes-window', keys: ['⌘', '⇧', 'N'], label: 'Open notes window', group: 'Windows' },
   { id: 'comments-window', keys: ['⌘', '⇧', 'J'], label: 'Open comments window', group: 'Windows' },
+  { id: 'captions-window', keys: ['⌘', '⇧', 'C'], label: 'Open captions reader', group: 'Windows' },
 
   { id: 'theme-toggle', keys: ['D'], label: 'Toggle light / dark theme', group: 'Appearance' }
 ] as const
@@ -43,9 +45,9 @@ export function shortcutsByGroup(): Map<ShortcutEntry['group'], ShortcutEntry[]>
   return groups
 }
 
-/** Navigation digit for a workspace tab id ("nav-<tab>" convention). */
+/** Navigation key for a workspace tab id ("nav-<tab>" convention). */
 export function navShortcutDigit(tab: string): string | undefined {
   const entry = SHORTCUTS.find((candidate) => candidate.id === `nav-${tab}`)
   const digit = entry?.keys.at(-1)
-  return digit && /^[1-9]$/.test(digit) ? digit : undefined
+  return digit && (/^[1-9]$/.test(digit) || digit === ',') ? digit : undefined
 }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1051,7 +1051,13 @@ export interface StartSessionParams {
 /** Burn-in intent for the session (shapes output legs; see burn-in plan A0/R1)
  *  plus the styling the post-recording captioned copy uses. */
 export interface CaptionsSessionParams {
+  enabled: boolean
+  /** Explicit per-session skip or an output shape that cannot be pre-armed. */
+  suppressedForSession: boolean
   burnTarget: 'off' | 'stream' | 'recording' | 'both'
+  styleId: CaptionStyleId
+  language: string
+  styleRevision: number
   position?: 'top' | 'bottom'
   textSize?: 's' | 'm' | 'l'
 }
@@ -1061,6 +1067,17 @@ export interface AudioSettings {
   microphoneMuted: boolean
   microphoneSyncOffsetMs: number
   microphoneSyncOffsetUserSet?: boolean
+}
+
+export interface AudioProcessingUpdateParams {
+  sessionId: string
+  microphoneGainDb: number
+  microphoneMuted: boolean
+}
+
+export interface AudioProcessingUpdateResult extends AudioProcessingUpdateParams {
+  applied: boolean
+  reasonCode?: 'no-active-session' | 'stale-session' | 'native-audio-unavailable'
 }
 
 export interface RemuxSessionParams {
@@ -2028,6 +2045,35 @@ export interface ExportPublishPackResult {
 }
 
 export interface AiCapabilities {
+  /** Optional during rolling web deployments. Missing must fail closed when captions are enabled. */
+  captions?: {
+    available: boolean
+    preferredTransport: CaptionTransport | null
+    reasonCode:
+      | 'ai-disabled'
+      | 'ai-user-disabled'
+      | 'captions-disabled'
+      | 'captions-invalid-config'
+      | 'captions-monthly-quota-exhausted'
+      | 'captions-not-configured'
+      | 'cloud-ai-premium-required'
+      | 'ready-chunked-realtime-disabled'
+      | 'ready-chunked-realtime-unconfigured'
+      | 'ready-realtime'
+    monthlySecondsLimit?: number | null
+    remainingSeconds?: number | null
+    realtime: {
+      available: boolean
+      configured: boolean
+      disabled: boolean
+      model: string
+    }
+    chunked: {
+      available: boolean
+      configured: boolean
+      model: string
+    }
+  }
   entitlement: {
     checkedAt: string
     cloudAi: boolean
@@ -2612,6 +2658,9 @@ export interface VideorcApi {
   getCaptionsWindowState: () => Promise<CaptionsWindowState>
   setCaptionsWindowAlwaysOnTop: (alwaysOnTop: boolean) => Promise<CaptionsWindowState>
   onCaptionsWindowState: (callback: (state: CaptionsWindowState) => void) => () => void
+  pushCaptionSnapshot: (snapshot: CaptionWindowSnapshot) => Promise<void>
+  getCaptionSnapshot: () => Promise<CaptionWindowSnapshot | null>
+  onCaptionSnapshot: (callback: (snapshot: CaptionWindowSnapshot) => void) => () => void
   pushCaptionLines: (lines: CaptionsUpdate[]) => Promise<void>
   getCaptionLines: () => Promise<CaptionsUpdate[] | null>
   onCaptionLines: (callback: (lines: CaptionsUpdate[]) => void) => () => void
@@ -2873,11 +2922,33 @@ export function createEmptyLiveChatSnapshot(updatedAt: string): LiveChatSnapshot
 }
 
 // Live captions (captions.* RPCs + events; premium cloud-AI feature).
-// 'degraded' = uploads failing + retrying with backoff; recovers on its own.
-export type CaptionsState = 'idle' | 'live' | 'degraded' | 'error'
+// `live` remains accepted during the rolling upgrade from the Alpha backend;
+// new coordinators publish the more truthful ready/listening state machine.
+export type CaptionsState =
+  | 'idle'
+  | 'ready'
+  | 'starting'
+  | 'listening'
+  | 'reconnecting'
+  | 'degraded'
+  | 'blocked'
+  | 'error'
+  | 'live'
+
+export type CaptionStyleId = 'classic' | 'glass' | 'lower-third' | 'high-contrast'
+export type CaptionTransport = 'realtime' | 'chunked'
+export type CaptionAudioSource = 'microphone'
 
 export interface CaptionsStatus {
   state: CaptionsState
+  desiredEnabled?: boolean
+  transport?: CaptionTransport
+  audioSource?: CaptionAudioSource
+  audioFramesSeen?: number
+  droppedAudioFrames?: number
+  droppedAudioSeconds?: number
+  providerReady?: boolean
+  reasonCode?: string
   message?: string
   remainingSeconds?: number
   sessionClientId?: string
@@ -2902,6 +2973,15 @@ export interface CaptionsWindowState {
   alwaysOnTop: boolean
   enabled: boolean
   message?: string
+}
+
+/** Complete detached-reader view so it follows style, status, and cue finality. */
+export interface CaptionWindowSnapshot {
+  lines: CaptionsUpdate[]
+  status: CaptionsStatus
+  styleId: CaptionStyleId
+  position: 'top' | 'bottom'
+  textSize: 's' | 'm' | 'l'
 }
 
 // --- OBS setup import (plan: vault 2026-07-07 OBS Import) ----------------

--- a/crates/videorc-backend/src/audio.rs
+++ b/crates/videorc-backend/src/audio.rs
@@ -25,6 +25,13 @@ const METER_SAMPLE_DURATION: Duration = Duration::from_millis(700);
 const FIFO_OPEN_RETRY: Duration = Duration::from_millis(20);
 pub const NATIVE_AUDIO_FFMPEG_QUEUE_SIZE: u32 = 1024;
 
+/// Reserved CoreAudio id used only by the maintained debug caption smoke.
+/// A release build does not compile the synthetic source or its RPC handle.
+#[cfg(debug_assertions)]
+pub const CAPTION_CONTRACT_TEST_DEVICE_ID: u32 = u32::MAX;
+#[cfg(debug_assertions)]
+const CAPTION_CONTRACT_TEST_PACKET_MS: u64 = 20;
+
 /// Fraction of the expected audio sample-frames that were actually captured over the
 /// elapsed window: `captured / (elapsed × sample_rate)`. 1.0 means full real-time
 /// coverage; values meaningfully below 1.0 indicate the mic stalled (a capture gap).
@@ -83,6 +90,143 @@ impl Default for AudioProcessingSettings {
             muted: false,
         }
     }
+}
+
+/// Lock-free snapshot read by the realtime CoreAudio callback on every frame.
+/// Gain and mute share one atomic word so callbacks never observe a mixed pair
+/// from two renderer updates, and the callback never takes a mutex.
+#[derive(Debug, Clone)]
+pub struct AudioProcessingSettingsHandle {
+    packed: Arc<AtomicU64>,
+}
+
+impl AudioProcessingSettingsHandle {
+    pub fn new(settings: AudioProcessingSettings) -> Self {
+        Self {
+            packed: Arc::new(AtomicU64::new(pack_audio_processing_settings(settings))),
+        }
+    }
+
+    pub fn update(&self, settings: AudioProcessingSettings) {
+        self.packed
+            .store(pack_audio_processing_settings(settings), Ordering::Release);
+    }
+
+    fn load(&self) -> AudioProcessingSettings {
+        unpack_audio_processing_settings(self.packed.load(Ordering::Acquire))
+    }
+}
+
+fn normalized_audio_processing_settings(
+    settings: AudioProcessingSettings,
+) -> AudioProcessingSettings {
+    AudioProcessingSettings {
+        gain_db: if settings.gain_db.is_finite() {
+            settings.gain_db.clamp(-24.0, 24.0)
+        } else {
+            0.0
+        },
+        muted: settings.muted,
+    }
+}
+
+fn pack_audio_processing_settings(settings: AudioProcessingSettings) -> u64 {
+    let settings = normalized_audio_processing_settings(settings);
+    u64::from(settings.gain_db.to_bits()) | (u64::from(settings.muted) << 32)
+}
+
+fn unpack_audio_processing_settings(packed: u64) -> AudioProcessingSettings {
+    AudioProcessingSettings {
+        gain_db: f32::from_bits(packed as u32),
+        muted: ((packed >> 32) & 1) == 1,
+    }
+}
+
+/// Raw-tone controller for the permissionless maintained caption smoke.
+///
+/// The producer owns the real source cadence. This handle only selects a
+/// bounded number of raw packets to fill with a tone; the producer then runs
+/// them through `processed_capture_frame_with_handle` before the shared FIFO
+/// writer fans the resulting frame out to captions and FFmpeg.
+#[cfg(debug_assertions)]
+#[derive(Debug, Clone)]
+pub struct CaptionContractTestAudioInjector {
+    raw_peak_bits: Arc<AtomicU64>,
+    packets_remaining: Arc<AtomicU64>,
+    packets_generated: Arc<AtomicU64>,
+    injection_active: Arc<AtomicBool>,
+    stop: Arc<AtomicBool>,
+}
+
+#[cfg(debug_assertions)]
+#[derive(Debug, Clone, Copy)]
+pub struct CaptionContractTestAudioInjection {
+    pub packets_generated: u64,
+    pub raw_peak: f32,
+}
+
+#[cfg(debug_assertions)]
+impl CaptionContractTestAudioInjector {
+    pub async fn inject(
+        &self,
+        duration_ms: u64,
+        raw_peak: f32,
+    ) -> Result<CaptionContractTestAudioInjection> {
+        if !caption_contract_test_audio_enabled() {
+            bail!("Caption contract test audio is disabled.");
+        }
+        if !raw_peak.is_finite() || !(0.001..=0.5).contains(&raw_peak) {
+            bail!("Caption contract test raw peak must be between 0.001 and 0.5.");
+        }
+        self.injection_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| anyhow::anyhow!("A caption contract PCM injection is already active."))?;
+
+        let duration_ms = duration_ms.clamp(CAPTION_CONTRACT_TEST_PACKET_MS, 5_000);
+        let packet_count = duration_ms.div_ceil(CAPTION_CONTRACT_TEST_PACKET_MS);
+        let before = self.packets_generated.load(Ordering::Acquire);
+        self.raw_peak_bits
+            .store(u64::from(raw_peak.to_bits()), Ordering::Release);
+        self.packets_remaining
+            .store(packet_count, Ordering::Release);
+
+        let deadline = tokio::time::Instant::now()
+            + Duration::from_millis(duration_ms)
+            + Duration::from_secs(2);
+        let outcome = loop {
+            let generated = self
+                .packets_generated
+                .load(Ordering::Acquire)
+                .saturating_sub(before);
+            if generated >= packet_count {
+                break Ok(CaptionContractTestAudioInjection {
+                    packets_generated: generated,
+                    raw_peak,
+                });
+            }
+            if self.stop.load(Ordering::Acquire) {
+                break Err(anyhow::anyhow!(
+                    "The active native audio session stopped during PCM injection."
+                ));
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break Err(anyhow::anyhow!(
+                    "Timed out waiting for the synthetic native audio source."
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        };
+
+        self.packets_remaining.store(0, Ordering::Release);
+        self.raw_peak_bits.store(0, Ordering::Release);
+        self.injection_active.store(false, Ordering::Release);
+        outcome
+    }
+}
+
+#[cfg(debug_assertions)]
+fn caption_contract_test_audio_enabled() -> bool {
+    std::env::var("VIDEORC_CAPTION_CONTRACT_TEST").as_deref() == Ok("1")
 }
 
 #[derive(Debug, Default)]
@@ -221,8 +365,13 @@ pub struct NativeAudioSource {
     pub device_name: String,
     receiver: Option<mpsc::Receiver<AudioFrame>>,
     stats: Arc<AudioCaptureStats>,
+    processing_settings: AudioProcessingSettingsHandle,
     stop: Arc<AtomicBool>,
     stop_on_drop: bool,
+    #[cfg(debug_assertions)]
+    caption_contract_test_injector: Option<CaptionContractTestAudioInjector>,
+    #[cfg(debug_assertions)]
+    caption_contract_test_producer: Option<thread::JoinHandle<()>>,
     #[cfg(target_os = "macos")]
     audio_unit: Option<coreaudio::audio_unit::AudioUnit>,
 }
@@ -254,6 +403,10 @@ impl Drop for NativeAudioSource {
             return;
         }
         self.stop.store(true, Ordering::Relaxed);
+        #[cfg(debug_assertions)]
+        if let Some(producer) = self.caption_contract_test_producer.take() {
+            let _ = producer.join();
+        }
         #[cfg(target_os = "macos")]
         if let Some(audio_unit) = self.audio_unit.as_mut() {
             let _ = audio_unit.stop();
@@ -266,8 +419,13 @@ pub struct NativeAudioCaptureSession {
     pub device_name: String,
     pub fifo_path: PathBuf,
     stats: Arc<AudioCaptureStats>,
+    processing_settings: AudioProcessingSettingsHandle,
     stop: Arc<AtomicBool>,
     writer: Option<thread::JoinHandle<()>>,
+    #[cfg(debug_assertions)]
+    caption_contract_test_injector: Option<CaptionContractTestAudioInjector>,
+    #[cfg(debug_assertions)]
+    caption_contract_test_producer: Option<thread::JoinHandle<()>>,
     #[cfg(target_os = "macos")]
     audio_unit: Option<coreaudio::audio_unit::AudioUnit>,
 }
@@ -309,11 +467,27 @@ impl NativeAudioCaptureSession {
     pub fn finish_recording_window(&self) {
         self.stats.finish_recording_window();
     }
+
+    pub fn update_processing_settings(&self, settings: AudioProcessingSettings) {
+        self.processing_settings.update(settings);
+    }
+
+    /// Clone the permissionless raw-PCM controller installed only for the
+    /// maintained debug caption smoke. Production CoreAudio sessions return
+    /// `None`, so the RPC cannot inject into an ordinary microphone session.
+    #[cfg(debug_assertions)]
+    pub fn caption_contract_test_injector(&self) -> Option<CaptionContractTestAudioInjector> {
+        self.caption_contract_test_injector.clone()
+    }
 }
 
 impl Drop for NativeAudioCaptureSession {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
+        #[cfg(debug_assertions)]
+        if let Some(producer) = self.caption_contract_test_producer.take() {
+            let _ = producer.join();
+        }
         if let Some(writer) = self.writer.take() {
             let _ = writer.join();
         }
@@ -359,6 +533,13 @@ pub fn start_native_audio_source(
     device_id: u32,
     settings: AudioProcessingSettings,
 ) -> Result<NativeAudioSource> {
+    #[cfg(debug_assertions)]
+    if device_id == CAPTION_CONTRACT_TEST_DEVICE_ID {
+        if !caption_contract_test_audio_enabled() {
+            bail!("The caption contract test microphone requires VIDEORC_CAPTION_CONTRACT_TEST=1.");
+        }
+        return start_caption_contract_test_audio_source(settings);
+    }
     start_platform_audio_source(device_id, settings)
 }
 
@@ -523,7 +704,12 @@ pub fn attach_fifo_writer(
         .take()
         .expect("native audio source receiver is available before attaching FIFO writer");
     let stats = source.stats.clone();
+    let processing_settings = source.processing_settings.clone();
     let stop = source.stop.clone();
+    #[cfg(debug_assertions)]
+    let caption_contract_test_injector = source.caption_contract_test_injector.clone();
+    #[cfg(debug_assertions)]
+    let caption_contract_test_producer = source.caption_contract_test_producer.take();
     #[cfg(target_os = "macos")]
     let audio_unit = source.audio_unit.take();
 
@@ -590,9 +776,9 @@ pub fn attach_fifo_writer(
         while !writer_stop.load(Ordering::Relaxed) {
             match receiver.recv_timeout(Duration::from_millis(50)) {
                 Ok(frame) => {
-                    // Live captions listen on the same mic frames; the offer is
-                    // a relaxed-atomic no-op unless a caption session is active
-                    // and never blocks this writer.
+                    // Live captions listen on this same post-gain/post-mute mic
+                    // bus; the offer is a relaxed-atomic no-op unless a caption
+                    // session is active and never blocks this writer.
                     crate::captions::offer_caption_frame(&frame);
                     let frame_peak = frame
                         .samples
@@ -618,8 +804,13 @@ pub fn attach_fifo_writer(
         device_name,
         fifo_path,
         stats,
+        processing_settings,
         stop,
         writer: Some(writer),
+        #[cfg(debug_assertions)]
+        caption_contract_test_injector,
+        #[cfg(debug_assertions)]
+        caption_contract_test_producer,
         #[cfg(target_os = "macos")]
         audio_unit,
     }
@@ -775,6 +966,131 @@ pub fn process_interleaved_f32(
     }
 
     output
+}
+
+#[cfg(any(test, target_os = "macos", debug_assertions))]
+fn processed_capture_frame(
+    input: &[f32],
+    source_channels: usize,
+    settings: AudioProcessingSettings,
+    timestamp_micros: u64,
+) -> AudioFrame {
+    AudioFrame {
+        timestamp_micros,
+        captured_at: Instant::now(),
+        sample_rate: NATIVE_AUDIO_SAMPLE_RATE,
+        channels: NATIVE_AUDIO_CHANNELS,
+        samples: process_interleaved_f32(input, source_channels, settings),
+    }
+}
+
+#[cfg(any(test, target_os = "macos", debug_assertions))]
+fn processed_capture_frame_with_handle(
+    input: &[f32],
+    source_channels: usize,
+    settings: &AudioProcessingSettingsHandle,
+    timestamp_micros: u64,
+) -> AudioFrame {
+    processed_capture_frame(input, source_channels, settings.load(), timestamp_micros)
+}
+
+#[cfg(debug_assertions)]
+fn start_caption_contract_test_audio_source(
+    settings: AudioProcessingSettings,
+) -> Result<NativeAudioSource> {
+    let (sender, receiver) = mpsc::sync_channel(AUDIO_RING_CAPACITY_PACKETS);
+    let stats = Arc::new(AudioCaptureStats::default());
+    let processing_settings = AudioProcessingSettingsHandle::new(settings);
+    let stop = Arc::new(AtomicBool::new(false));
+    let injector = CaptionContractTestAudioInjector {
+        raw_peak_bits: Arc::new(AtomicU64::new(0)),
+        packets_remaining: Arc::new(AtomicU64::new(0)),
+        packets_generated: Arc::new(AtomicU64::new(0)),
+        injection_active: Arc::new(AtomicBool::new(false)),
+        stop: stop.clone(),
+    };
+
+    let producer_stats = stats.clone();
+    let producer_settings = processing_settings.clone();
+    let producer_stop = stop.clone();
+    let producer_injector = injector.clone();
+    let producer = thread::spawn(move || {
+        const SOURCE_CHANNELS: usize = 2;
+        let samples_per_channel = (u64::from(NATIVE_AUDIO_SAMPLE_RATE)
+            * CAPTION_CONTRACT_TEST_PACKET_MS
+            / 1_000) as usize;
+        let packet_duration = Duration::from_millis(CAPTION_CONTRACT_TEST_PACKET_MS);
+        let mut frame_cursor = 0_u64;
+        let mut next_tick = Instant::now();
+
+        while !producer_stop.load(Ordering::Acquire) {
+            let inject_tone = producer_injector
+                .packets_remaining
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                    (remaining > 0).then(|| remaining - 1)
+                })
+                .is_ok();
+            let raw_peak = if inject_tone {
+                f32::from_bits(producer_injector.raw_peak_bits.load(Ordering::Acquire) as u32)
+            } else {
+                0.0
+            };
+            let mut input = Vec::with_capacity(samples_per_channel * SOURCE_CHANNELS);
+            for sample_index in 0..samples_per_channel {
+                let absolute = frame_cursor as usize + sample_index;
+                let phase = absolute as f32 * 440.0 * std::f32::consts::TAU
+                    / NATIVE_AUDIO_SAMPLE_RATE as f32;
+                let sample = phase.sin() * raw_peak;
+                input.extend_from_slice(&[sample, sample]);
+            }
+            let frame = processed_capture_frame_with_handle(
+                &input,
+                SOURCE_CHANNELS,
+                &producer_settings,
+                timestamp_for_frame(frame_cursor),
+            );
+            let frame_count = frame.frame_count() as u64;
+            frame_cursor = frame_cursor.saturating_add(frame_count);
+            producer_stats.record_captured_frames(frame_count);
+
+            match sender.try_send(frame) {
+                Ok(()) => {}
+                Err(mpsc::TrySendError::Full(frame)) => {
+                    producer_stats.record_dropped_frames(frame.frame_count() as u64);
+                }
+                Err(mpsc::TrySendError::Disconnected(_)) => break,
+            }
+            if inject_tone {
+                producer_injector
+                    .packets_generated
+                    .fetch_add(1, Ordering::Release);
+            }
+
+            next_tick = next_tick
+                .checked_add(packet_duration)
+                .unwrap_or_else(Instant::now);
+            let now = Instant::now();
+            if next_tick > now {
+                thread::sleep(next_tick.duration_since(now));
+            } else {
+                next_tick = now;
+            }
+        }
+    });
+
+    Ok(NativeAudioSource {
+        device_id: CAPTION_CONTRACT_TEST_DEVICE_ID,
+        device_name: "Caption contract test microphone".to_string(),
+        receiver: Some(receiver),
+        stats,
+        processing_settings,
+        stop,
+        stop_on_drop: true,
+        caption_contract_test_injector: Some(injector),
+        caption_contract_test_producer: Some(producer),
+        #[cfg(target_os = "macos")]
+        audio_unit: None,
+    })
 }
 
 fn centered_voice_sample(left: f32, right: f32) -> f32 {
@@ -939,6 +1255,8 @@ fn start_platform_audio_source(
     let (sender, receiver) = mpsc::sync_channel(AUDIO_RING_CAPACITY_PACKETS);
     let stats = Arc::new(AudioCaptureStats::default());
     let callback_stats = stats.clone();
+    let processing_settings = AudioProcessingSettingsHandle::new(settings);
+    let callback_processing_settings = processing_settings.clone();
     let stop = Arc::new(AtomicBool::new(false));
     let callback_stop = stop.clone();
     let mut frame_cursor = 0_u64;
@@ -950,15 +1268,17 @@ fn start_platform_audio_source(
                 return Ok(());
             }
 
-            let samples = process_interleaved_f32(args.data.buffer, args.data.channels, settings);
-            let frame_count = samples.len() / usize::from(NATIVE_AUDIO_CHANNELS);
-            let frame = AudioFrame {
-                timestamp_micros: timestamp_for_frame(frame_cursor),
-                captured_at: Instant::now(),
-                sample_rate: NATIVE_AUDIO_SAMPLE_RATE,
-                channels: NATIVE_AUDIO_CHANNELS,
-                samples,
-            };
+            // This processed frame is the single native microphone bus shared
+            // by FFmpeg and live captions. Gain/mute are already applied before
+            // either consumer can see it, so muted speech never reaches cloud
+            // transcription and caption levels match audible mic levels.
+            let frame = processed_capture_frame_with_handle(
+                args.data.buffer,
+                args.data.channels,
+                &callback_processing_settings,
+                timestamp_for_frame(frame_cursor),
+            );
+            let frame_count = frame.samples.len() / usize::from(NATIVE_AUDIO_CHANNELS);
             frame_cursor = frame_cursor.saturating_add(frame_count as u64);
             callback_stats.record_captured_frames(frame_count as u64);
 
@@ -985,8 +1305,13 @@ fn start_platform_audio_source(
         device_name,
         receiver: Some(receiver),
         stats,
+        processing_settings,
         stop,
         stop_on_drop: true,
+        #[cfg(debug_assertions)]
+        caption_contract_test_injector: None,
+        #[cfg(debug_assertions)]
+        caption_contract_test_producer: None,
         audio_unit: Some(audio_unit),
     })
 }
@@ -1317,8 +1642,15 @@ mod tests {
             device_name: "Built-in Microphone".to_string(),
             receiver: Some(receiver),
             stats: Arc::new(AudioCaptureStats::default()),
+            processing_settings: AudioProcessingSettingsHandle::new(
+                AudioProcessingSettings::default(),
+            ),
             stop: Arc::new(AtomicBool::new(false)),
             stop_on_drop: true,
+            #[cfg(debug_assertions)]
+            caption_contract_test_injector: None,
+            #[cfg(debug_assertions)]
+            caption_contract_test_producer: None,
             #[cfg(target_os = "macos")]
             audio_unit: None,
         };
@@ -1471,6 +1803,78 @@ mod tests {
             },
         );
         assert!(muted.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn shared_native_capture_frame_applies_controls_before_caption_fanout() {
+        let muted = processed_capture_frame(
+            &[0.8, 0.8, -0.5, -0.5],
+            2,
+            AudioProcessingSettings {
+                gain_db: 24.0,
+                muted: true,
+            },
+            42,
+        );
+        assert_eq!(muted.timestamp_micros, 42);
+        assert!(muted.samples.iter().all(|sample| *sample == 0.0));
+
+        let gained = processed_capture_frame(
+            &[0.1, 0.1],
+            2,
+            AudioProcessingSettings {
+                gain_db: 6.0,
+                muted: false,
+            },
+            43,
+        );
+        assert!(gained.samples[0] > 0.1);
+        assert_eq!(gained.samples[0], gained.samples[1]);
+    }
+
+    #[test]
+    fn caption_contract_test_source_delivers_permissionless_warmup_frames() {
+        let mut source = start_caption_contract_test_audio_source(AudioProcessingSettings {
+            gain_db: 6.0,
+            muted: true,
+        })
+        .expect("debug caption source should start without a device");
+        let stats = source.stats_handle();
+        let receiver = source
+            .receiver
+            .take()
+            .expect("debug caption source owns its receiver");
+        let frame = receiver
+            .recv_timeout(Duration::from_millis(500))
+            .expect("debug caption source should deliver a warmup frame");
+
+        assert_eq!(frame.frame_count(), 960);
+        assert!(frame.samples.iter().all(|sample| *sample == 0.0));
+        assert!(stats.captured_frames() >= 960);
+    }
+
+    #[test]
+    fn live_audio_processing_updates_reach_fifo_and_caption_bus_without_restarting_capture() {
+        let settings = AudioProcessingSettingsHandle::new(AudioProcessingSettings::default());
+        let input = [0.1, 0.1, -0.2, -0.2];
+
+        settings.update(AudioProcessingSettings {
+            gain_db: 6.0,
+            muted: false,
+        });
+        let gained = processed_capture_frame_with_handle(&input, 2, &settings, 100);
+        let caption_gained = crate::captions::round_trip_caption_audio_test_frame(&gained);
+        assert_eq!(caption_gained.samples, gained.samples);
+        assert!(gained.samples[0] > input[0]);
+
+        settings.update(AudioProcessingSettings {
+            gain_db: 24.0,
+            muted: true,
+        });
+        let muted = processed_capture_frame_with_handle(&input, 2, &settings, 101);
+        let caption_muted = crate::captions::round_trip_caption_audio_test_frame(&muted);
+        assert!(muted.samples.iter().all(|sample| *sample == 0.0));
+        assert!(caption_muted.samples.iter().all(|sample| *sample == 0.0));
     }
 
     #[test]

--- a/crates/videorc-backend/src/captions.rs
+++ b/crates/videorc-backend/src/captions.rs
@@ -7,23 +7,83 @@
 //! clients and accumulate as chunk records for the SRT + burned copy.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use anyhow::{Result, bail};
 use serde::Serialize;
-use tokio::sync::Mutex;
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc, watch};
 
 use crate::audio::AudioFrame;
 use crate::process_job::spawn_owned_tokio;
 use crate::state::AppState;
-use crate::videorc_api::{CaptionChunkFailure, VideorcApiClient};
+use crate::videorc_api::{
+    CAPTION_CHUNK_UPLOAD_TIMEOUT, CaptionChunkFailure, CaptionChunkResponse, VideorcApiClient,
+};
 
 pub const CAPTION_SAMPLE_RATE: u32 = 16_000;
 pub const CAPTION_CHUNK_SECONDS: f64 = 3.0;
 /// Bounded frame queue between the realtime audio thread and the session task.
 /// At ~93 CoreAudio callbacks/s, 256 frames ≈ 2.7s of cushion.
 const TAP_CHANNEL_CAPACITY: usize = 256;
+/// A provider must acknowledge the requested transcription configuration before
+/// the coordinator can claim that captions are listening.
+const REALTIME_CONFIG_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+/// A connected transport without frames is not a working caption path. Native
+/// mute still produces digital-silence frames, so this detects unsupported or
+/// disconnected capture paths without treating intentional mute as failure.
+const CAPTION_AUDIO_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+/// Once the caption bus has produced frames, native mute/silence must keep
+/// producing them. A gap this long means the producer/path itself stalled.
+const CAPTION_AUDIO_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+/// Speech energy or provider VAD without any transcript is a silent-socket
+/// failure. Chunked transcription is slower but preferable to false readiness.
+const TRANSCRIPT_WATCHDOG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const CAPTION_FINAL_TRANSCRIPT_GRACE: std::time::Duration = std::time::Duration::from_millis(1_500);
+/// Configuration acknowledgement alone is not transport health. A socket earns
+/// a fresh retry budget only after a transcript or this sustained ready+audio
+/// interval, which prevents accepting-then-closing gateways from spinning.
+const REALTIME_RECONNECT_HEALTHY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+/// One in-flight upload plus eight queued chunks buffers roughly 27 seconds of
+/// chunked caption audio without ever stalling the realtime producer.
+const MAX_BUFFERED_CAPTION_CHUNKS: usize = 8;
+/// Once the renderer has started returning cue frames, only inactivity is a
+/// failure. A fixed whole-request deadline breaks long 4K recordings where
+/// hundreds of healthy sequential renders can legitimately take minutes.
+const CAPTION_CUE_RENDER_INACTIVITY_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(30);
+/// Scheduling/filesystem headroom after the bounded sequence of chunk upload
+/// request timeouts during capture finalization.
+const CAPTION_FINAL_UPLOAD_OVERHEAD: std::time::Duration = std::time::Duration::from_secs(2);
+/// Capture stop preserves only the upload already in flight and the final
+/// sub-chunk remainder. Older queued backlog is explicitly dropped with health
+/// truth so normal recording finalization stays near twenty seconds.
+const CAPTION_FINAL_UPLOAD_COUNT: usize = 2;
+const MAX_REALTIME_RECONNECTS: u8 = 2;
+
+fn caption_final_upload_grace(upload_count: usize) -> std::time::Duration {
+    let upload_count = u32::try_from(upload_count.max(1)).unwrap_or(u32::MAX);
+    CAPTION_CHUNK_UPLOAD_TIMEOUT
+        .saturating_mul(upload_count)
+        .saturating_add(CAPTION_FINAL_UPLOAD_OVERHEAD)
+}
+
+fn caption_contract_test_enabled() -> bool {
+    cfg!(debug_assertions)
+        && std::env::var("VIDEORC_CAPTION_CONTRACT_TEST")
+            .ok()
+            .is_some_and(|value| value == "1")
+}
+
+/// The transport-only smoke has no recording pipeline, so it opts into an
+/// idle provider session separately from the debug audio-injection gate. The
+/// renderer/compositor smoke keeps this unset and must prove a real active
+/// capture before captions start.
+fn caption_contract_idle_session_enabled() -> bool {
+    caption_contract_test_enabled()
+        && std::env::var("VIDEORC_CAPTION_CONTRACT_ALLOW_IDLE")
+            .ok()
+            .is_some_and(|value| value == "1")
+}
 
 // ---------------------------------------------------------------------------
 // Tap: the audio FIFO writer thread offers every mic frame here. Fast path is
@@ -32,22 +92,139 @@ const TAP_CHANNEL_CAPACITY: usize = 256;
 // ---------------------------------------------------------------------------
 
 static TAP_ACTIVE: AtomicBool = AtomicBool::new(false);
+static TAP_FRAMES_SEEN: AtomicU64 = AtomicU64::new(0);
+static TAP_FRAMES_DROPPED: AtomicU64 = AtomicU64::new(0);
+/// Audio intentionally evicted from the bounded chunk queue, in milliseconds.
+/// Zero in normal operation; non-zero is exposed in status and health events.
+static CAPTION_AUDIO_MILLIS_DROPPED: AtomicU64 = AtomicU64::new(0);
+static TAP_CLOCK_EPOCH: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+/// 1-based monotonic microseconds since `TAP_CLOCK_EPOCH`; zero means no frame
+/// has entered the current caption bus. Updated on the producer fast path.
+static TAP_LAST_FRAME_MICROS: AtomicU64 = AtomicU64::new(0);
 static TAP: std::sync::Mutex<Option<mpsc::Sender<AudioFrame>>> = std::sync::Mutex::new(None);
+/// Serializes caption control transitions across every backend WebSocket.
+/// Without this guard a start racing sign-out could clone the bearer between
+/// teardown and credential removal, then install a fresh provider task.
+static CAPTION_CONTROL: Mutex<()> = Mutex::const_new(());
 
 pub fn offer_caption_frame(frame: &AudioFrame) {
-    if !TAP_ACTIVE.load(Ordering::Relaxed) {
+    offer_caption_frame_to_tap(
+        frame,
+        &TAP_ACTIVE,
+        &TAP_FRAMES_SEEN,
+        &TAP_FRAMES_DROPPED,
+        &TAP_LAST_FRAME_MICROS,
+        &TAP,
+    );
+}
+
+fn offer_caption_frame_to_tap(
+    frame: &AudioFrame,
+    active: &AtomicBool,
+    frames_seen: &AtomicU64,
+    frames_dropped: &AtomicU64,
+    last_frame_micros: &AtomicU64,
+    tap: &std::sync::Mutex<Option<mpsc::Sender<AudioFrame>>>,
+) {
+    if !active.load(Ordering::Relaxed) {
         return;
     }
-    let Ok(guard) = TAP.try_lock() else {
+    let Ok(guard) = tap.try_lock() else {
+        frames_dropped.fetch_add(1, Ordering::Relaxed);
         return;
     };
     if let Some(sender) = guard.as_ref() {
-        let _ = sender.try_send(frame.clone());
+        match sender.try_send(frame.clone()) {
+            Ok(()) => {
+                frames_seen.fetch_add(1, Ordering::Relaxed);
+                last_frame_micros.store(caption_bus_clock_micros(), Ordering::Release);
+            }
+            Err(_) => {
+                frames_dropped.fetch_add(1, Ordering::Relaxed);
+            }
+        }
     }
+}
+
+#[cfg(test)]
+pub(crate) fn round_trip_caption_audio_test_frame(frame: &AudioFrame) -> AudioFrame {
+    let active = AtomicBool::new(true);
+    let frames_seen = AtomicU64::new(0);
+    let frames_dropped = AtomicU64::new(0);
+    let last_frame_micros = AtomicU64::new(0);
+    let (sender, mut receiver) = mpsc::channel(1);
+    let tap = std::sync::Mutex::new(Some(sender));
+    offer_caption_frame_to_tap(
+        frame,
+        &active,
+        &frames_seen,
+        &frames_dropped,
+        &last_frame_micros,
+        &tap,
+    );
+    assert_eq!(frames_seen.load(Ordering::Relaxed), 1);
+    assert_eq!(frames_dropped.load(Ordering::Relaxed), 0);
+    assert!(last_frame_micros.load(Ordering::Acquire) > 0);
+    receiver
+        .try_recv()
+        .expect("caption test bus should receive the offered frame")
+}
+
+fn caption_bus_clock_micros() -> u64 {
+    let epoch = TAP_CLOCK_EPOCH.get_or_init(std::time::Instant::now);
+    let elapsed = epoch.elapsed().as_micros().min(u128::from(u64::MAX - 1)) as u64;
+    elapsed + 1
+}
+
+fn caption_audio_seconds_dropped() -> f64 {
+    CAPTION_AUDIO_MILLIS_DROPPED.load(Ordering::Relaxed) as f64 / 1_000.0
+}
+
+/// Debug-only contract seam used by the maintained fake-Gateway smoke. It
+/// enters through the same bounded post-controls audio bus as a native mic.
+/// Release builds have no RPC exposing this function, and the env gate is
+/// checked again here to prevent accidental use in an ordinary dev session.
+#[cfg(debug_assertions)]
+pub async fn inject_caption_contract_test_audio(duration_ms: u64) -> Result<u64> {
+    if !caption_contract_test_enabled() {
+        bail!("Caption contract test audio is disabled.");
+    }
+    if !TAP_ACTIVE.load(Ordering::Relaxed) {
+        bail!("Start the caption contract session before injecting audio.");
+    }
+    let duration_ms = duration_ms.clamp(20, 5_000);
+    let frames = duration_ms.div_ceil(20);
+    let samples_per_channel = (48_000_u64 * 20 / 1_000) as usize;
+    let before = TAP_FRAMES_SEEN.load(Ordering::Relaxed);
+    for frame_index in 0..frames {
+        let mut samples = Vec::with_capacity(samples_per_channel * 2);
+        for sample_index in 0..samples_per_channel {
+            let absolute = frame_index as usize * samples_per_channel + sample_index;
+            let phase = absolute as f32 * 440.0 * std::f32::consts::TAU / 48_000.0;
+            let sample = phase.sin() * 0.12;
+            samples.extend_from_slice(&[sample, sample]);
+        }
+        offer_caption_frame(&AudioFrame {
+            timestamp_micros: frame_index * 20_000,
+            captured_at: std::time::Instant::now(),
+            sample_rate: 48_000,
+            channels: 2,
+            samples,
+        });
+        tokio::task::yield_now().await;
+    }
+    Ok(TAP_FRAMES_SEEN
+        .load(Ordering::Relaxed)
+        .saturating_sub(before))
 }
 
 fn install_tap() -> mpsc::Receiver<AudioFrame> {
     let (sender, receiver) = mpsc::channel(TAP_CHANNEL_CAPACITY);
+    TAP_FRAMES_SEEN.store(0, Ordering::Relaxed);
+    TAP_FRAMES_DROPPED.store(0, Ordering::Relaxed);
+    CAPTION_AUDIO_MILLIS_DROPPED.store(0, Ordering::Relaxed);
+    TAP_LAST_FRAME_MICROS.store(0, Ordering::Release);
+    TAP_CLOCK_EPOCH.get_or_init(std::time::Instant::now);
     *TAP.lock().expect("caption tap lock") = Some(sender);
     TAP_ACTIVE.store(true, Ordering::Relaxed);
     receiver
@@ -140,6 +317,30 @@ pub struct CaptionChunkRecord {
     /// at t≈0 of the next). Stamped by the session, filtered at finalize.
     #[serde(skip_serializing)]
     pub capture_epoch: u64,
+    /// Stable realtime provider utterance identity. Batch chunks do not have
+    /// one. Repeated completion events for the same item upsert this record so
+    /// SRT and captioned-copy output contain one canonical cue.
+    #[serde(skip_serializing)]
+    pub provider_item_id: Option<String>,
+}
+
+fn upsert_caption_record(chunks: &mut Vec<CaptionChunkRecord>, record: CaptionChunkRecord) -> bool {
+    let existing = record
+        .provider_item_id
+        .as_ref()
+        .and_then(|provider_item_id| {
+            chunks.iter_mut().find(|candidate| {
+                candidate.capture_epoch == record.capture_epoch
+                    && candidate.provider_item_id.as_ref() == Some(provider_item_id)
+            })
+        });
+    if let Some(existing) = existing {
+        *existing = record;
+        false
+    } else {
+        chunks.push(record);
+        true
+    }
 }
 
 /// A frame timestamp lower than the last one means the capture pipeline
@@ -211,8 +412,69 @@ pub enum CaptionTextSize {
     L,
 }
 
-/// Which output legs carry the LIVE caption bar (R1). The lag caveat applies
-/// wherever it burns; the recording additionally gets the aligned copy.
+/// Visual preset captured with each session. The renderer owns the actual
+/// recipe, while Rust persists the stable identity for artifact/session parity.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CaptionStyleId {
+    #[default]
+    Classic,
+    Glass,
+    LowerThird,
+    HighContrast,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptionStyleSnapshot {
+    pub position: CaptionOverlayPosition,
+    pub text_size: CaptionTextSize,
+    pub style_id: CaptionStyleId,
+    pub style_revision: u64,
+    pub output_width: u32,
+    pub output_height: u32,
+}
+
+impl Default for CaptionStyleSnapshot {
+    fn default() -> Self {
+        Self {
+            position: CaptionOverlayPosition::Bottom,
+            text_size: CaptionTextSize::M,
+            style_id: CaptionStyleId::Classic,
+            style_revision: 0,
+            output_width: 0,
+            output_height: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetCaptionStyleParams {
+    pub position: CaptionOverlayPosition,
+    pub text_size: CaptionTextSize,
+    pub style_id: CaptionStyleId,
+    pub style_revision: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Caption style revision {received} is stale; current revision is {current}.")]
+struct StaleCaptionStyleRevision {
+    received: u64,
+    current: u64,
+}
+
+pub fn caption_style_error_code(error: &anyhow::Error) -> &'static str {
+    if error.downcast_ref::<StaleCaptionStyleRevision>().is_some() {
+        "captions-style-stale"
+    } else {
+        "captions-style-invalid"
+    }
+}
+
+/// Which caption products the user selected for this session. `Recording`
+/// means a non-destructive aligned `(captioned)` copy; the source recording is
+/// never a live burn target.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum CaptionBurnTarget {
@@ -227,20 +489,23 @@ impl CaptionBurnTarget {
     pub fn burns_stream(self) -> bool {
         matches!(self, CaptionBurnTarget::Stream | CaptionBurnTarget::Both)
     }
-    pub fn burns_recording(self) -> bool {
+
+    pub fn requests_captioned_copy(self) -> bool {
         matches!(self, CaptionBurnTarget::Recording | CaptionBurnTarget::Both)
     }
 }
 
 /// Per-leg overlay plan for a session shape (pure; unit-tested matrix).
-/// `force_same_profile_split`: record+stream sessions whose legs must DIFFER
-/// (one burned, one clean) need a separate stream render even at the same
-/// profile; when both legs agree they share frames.
+/// The primary leg is the source recording whenever recording is enabled and
+/// therefore always stays clean. A captioned stream in a combined session uses
+/// the auxiliary leg, forcing a same-profile split when profiles otherwise
+/// match. `captioned_copy` is fulfilled after finalization from the clean source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CaptionOverlayLegPlan {
     pub primary: bool,
     pub aux: bool,
     pub force_same_profile_split: bool,
+    pub captioned_copy: bool,
 }
 
 pub fn caption_overlay_leg_plan(
@@ -252,29 +517,34 @@ pub fn caption_overlay_leg_plan(
         primary: false,
         aux: false,
         force_same_profile_split: false,
+        captioned_copy: false,
     };
     if target == CaptionBurnTarget::Off {
         return none;
     }
     match (record_enabled, stream_enabled) {
         (false, false) => none,
-        // Record only: the primary leg IS the recording.
+        // Record only: preserve the clean source and fulfill Recording with a
+        // post-recording copy.
         (true, false) => CaptionOverlayLegPlan {
-            primary: target.burns_recording(),
+            primary: false,
             aux: false,
             force_same_profile_split: false,
+            captioned_copy: target.requests_captioned_copy(),
         },
         // Stream only: the primary leg IS the stream.
         (false, true) => CaptionOverlayLegPlan {
             primary: target.burns_stream(),
             aux: false,
             force_same_profile_split: false,
+            captioned_copy: false,
         },
-        // Record + stream: primary = recording, aux = stream (when split).
+        // Record + stream: primary = clean source recording, aux = stream.
         (true, true) => CaptionOverlayLegPlan {
-            primary: target.burns_recording(),
+            primary: false,
             aux: target.burns_stream(),
-            force_same_profile_split: target.burns_recording() != target.burns_stream(),
+            force_same_profile_split: target.burns_stream(),
+            captioned_copy: target.requests_captioned_copy(),
         },
     }
 }
@@ -339,12 +609,65 @@ fn format_srt_timestamp(seconds: f64) -> String {
     format!("{hours:02}:{minutes:02}:{secs:02},{millis:03}")
 }
 
-pub async fn drain_caption_chunks(state: &AppState) -> Vec<CaptionChunkRecord> {
+/// Every capture owns a fresh transcript epoch. Purging at the boundary is
+/// authoritative even if a previous FFmpeg session failed before artifact
+/// generation, so its canonical cues can never be drained into the next file.
+fn advance_caption_capture_epoch_and_purge(coordinator: &mut CaptionsCoordinator) -> usize {
+    let discarded = coordinator.chunks.len();
+    coordinator.chunks.clear();
+    coordinator.capture_epoch = coordinator.capture_epoch.saturating_add(1);
+    coordinator.sequence.reset();
+    coordinator.finalized_style = None;
+    discarded
+}
+
+/// Failed captures have no valid artifact owner. The caption provider task is
+/// joined before this hook runs, then all canonical cues are discarded and the
+/// epoch advances so no failed-session text can be attributed to a later run.
+pub async fn discard_failed_caption_capture(state: &AppState) -> usize {
     let mut coordinator = state.captions.lock().await;
+    advance_caption_capture_epoch_and_purge(&mut coordinator)
+}
+
+#[derive(Debug, Clone)]
+pub struct FinalizedCaptionArtifact {
+    pub chunks: Vec<CaptionChunkRecord>,
+    style: CaptionStyleSnapshot,
+    artifact_generation: u64,
+}
+
+fn take_finalized_caption_artifact(
+    coordinator: &mut CaptionsCoordinator,
+) -> FinalizedCaptionArtifact {
     let epoch = coordinator.capture_epoch;
-    let drained = std::mem::take(&mut coordinator.chunks);
-    drop(coordinator);
-    filter_caption_records_for_epoch(drained, epoch)
+    let chunks =
+        caption_records_for_session_end(std::mem::take(&mut coordinator.chunks), epoch, true);
+    FinalizedCaptionArtifact {
+        chunks,
+        style: caption_style_for_final_artifact(
+            coordinator.finalized_style.take(),
+            coordinator.style,
+        ),
+        artifact_generation: coordinator.artifact_generation,
+    }
+}
+
+pub async fn take_finalized_caption_artifact_for_capture(
+    state: &AppState,
+) -> FinalizedCaptionArtifact {
+    let mut coordinator = state.captions.lock().await;
+    take_finalized_caption_artifact(&mut coordinator)
+}
+
+pub fn caption_records_for_session_end(
+    records: Vec<CaptionChunkRecord>,
+    epoch: u64,
+    retain_for_artifact: bool,
+) -> Vec<CaptionChunkRecord> {
+    if !retain_for_artifact {
+        return Vec::new();
+    }
+    filter_caption_records_for_epoch(records, epoch)
 }
 
 /// Keep only records from the capture epoch being finalized; stragglers from
@@ -370,23 +693,34 @@ pub fn filter_caption_records_for_epoch(
 
 /// Session-stop hook (recording finalize path): drain the chunks recorded
 /// during this session and write the `.srt` sidecar next to the recording.
-/// Returns the drained chunks so the burned-copy job can reuse them. Never
-/// fails the session — problems downgrade to health warnings.
+/// Returns an owned artifact bundle so a later capture cannot replace its
+/// chunks, frozen style, or privacy generation before the burned-copy request
+/// is registered. Never fails the session — problems downgrade to warnings.
 pub async fn write_caption_artifacts(
     state: &AppState,
     session_id: &str,
     recording_path: &std::path::Path,
-) -> Vec<CaptionChunkRecord> {
-    let chunks = drain_caption_chunks(state).await;
-    if chunks.is_empty() {
-        return chunks;
+    artifact: FinalizedCaptionArtifact,
+) -> FinalizedCaptionArtifact {
+    if artifact.chunks.is_empty() {
+        return artifact;
     }
-    let srt = render_srt(&chunks);
+    let srt = render_srt(&artifact.chunks);
     if srt.is_empty() {
-        return chunks;
+        return artifact;
     }
     let srt_path = recording_path.with_extension("srt");
-    match tokio::fs::write(&srt_path, &srt).await {
+    // Serialize publication with the sign-out generation boundary. If
+    // sign-out wins, this artifact is stale and writes nothing. If this write
+    // wins, sign-out cannot return until the transcript file is fully present.
+    let write_result = {
+        let coordinator = state.captions.lock().await;
+        if coordinator.artifact_generation != artifact.artifact_generation {
+            return artifact;
+        }
+        tokio::fs::write(&srt_path, &srt).await
+    };
+    match write_result {
         Ok(()) => {
             let _ = crate::recording::emit_health_event(
                 state,
@@ -406,7 +740,7 @@ pub async fn write_caption_artifacts(
             );
         }
     }
-    chunks
+    artifact
 }
 
 /// Build the ffconcat playlist for the caption track: transparent gap frames
@@ -449,9 +783,9 @@ pub async fn begin_caption_cue_render(
     session_id: &str,
     ffmpeg_path: &str,
     recording_path: &std::path::Path,
-    chunks: &[CaptionChunkRecord],
+    artifact: &FinalizedCaptionArtifact,
 ) {
-    let cues = caption_cues(chunks);
+    let cues = caption_cues(&artifact.chunks);
     if cues.is_empty() {
         return;
     }
@@ -468,68 +802,155 @@ pub async fn begin_caption_cue_render(
     }
 
     let request_id = format!("cues-{}", uuid::Uuid::new_v4().simple());
-    let (position, text_size, canvas) = {
+    {
         let mut coordinator = state.captions.lock().await;
-        let style = coordinator.style;
-        let canvas = coordinator.output_size;
+        if coordinator.artifact_generation != artifact.artifact_generation {
+            drop(coordinator);
+            let _ = tokio::fs::remove_dir_all(&frames_dir).await;
+            return;
+        }
         let mut expected: std::collections::BTreeSet<u64> =
             cues.iter().map(|cue| cue.seq).collect();
         expected.insert(CAPTION_BLANK_FRAME_SEQ);
-        coordinator.pending_cue_render = Some(PendingCueRender {
-            request_id: request_id.clone(),
-            session_id: session_id.to_string(),
-            ffmpeg_path: ffmpeg_path.to_string(),
-            recording_path: recording_path.to_path_buf(),
-            frames_dir: frames_dir.clone(),
-            cues: cues.clone(),
-            expected,
-            received: std::collections::BTreeSet::new(),
-        });
-        (style.0, style.1, canvas)
-    };
+        coordinator.pending_cue_renders.insert(
+            request_id.clone(),
+            PendingCueRender {
+                session_id: session_id.to_string(),
+                ffmpeg_path: ffmpeg_path.to_string(),
+                recording_path: recording_path.to_path_buf(),
+                frames_dir: frames_dir.clone(),
+                cues: cues.clone(),
+                expected,
+                received: std::collections::BTreeSet::new(),
+                artifact_generation: artifact.artifact_generation,
+                last_progress_at: tokio::time::Instant::now(),
+                watchdog_active: false,
+            },
+        );
+        coordinator
+            .pending_cue_render_order
+            .push_back(request_id.clone());
+        // Transcript-bearing emission is part of the same privacy-generation
+        // critical section as registration. Sign-out either observes and
+        // purges this request, or wins first and suppresses the event.
+        state.emit_event(
+            "captions.cues.render-request",
+            serde_json::json!({
+                "requestId": request_id,
+                "canvasWidth": artifact.style.output_width.max(2),
+                "canvasHeight": artifact.style.output_height.max(2),
+                "position": artifact.style.position,
+                "textSize": artifact.style.text_size,
+                "styleId": artifact.style.style_id,
+                "styleRevision": artifact.style.style_revision,
+                "blankSeq": CAPTION_BLANK_FRAME_SEQ,
+                "cues": cues
+                    .iter()
+                    .map(|cue| serde_json::json!({ "seq": cue.seq, "text": cue.text }))
+                    .collect::<Vec<_>>(),
+            }),
+        );
+    }
 
-    state.emit_event(
-        "captions.cues.render-request",
-        serde_json::json!({
-            "requestId": request_id,
-            "canvasWidth": canvas.0.max(2),
-            "canvasHeight": canvas.1.max(2),
-            "position": position,
-            "textSize": text_size,
-            "blankSeq": CAPTION_BLANK_FRAME_SEQ,
-            "cues": cues
-                .iter()
-                .map(|cue| serde_json::json!({ "seq": cue.seq, "text": cue.text }))
-                .collect::<Vec<_>>(),
-        }),
-    );
-
-    // Watchdog: if the renderer never completes this request, clean up and
-    // report — the .srt sidecar already exists either way.
+    // Progress watchdog: a many-cue 4K render may legitimately exceed thirty
+    // seconds in total. It only degrades when no new requested frame arrives
+    // for the full inactivity interval.
     let watchdog_state = state.clone();
     let watchdog_request = request_id.clone();
     tokio::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-        let pending = {
-            let mut coordinator = watchdog_state.captions.lock().await;
-            match &coordinator.pending_cue_render {
-                Some(pending) if pending.request_id == watchdog_request => {
-                    coordinator.pending_cue_render.take()
+        loop {
+            let watchdog = {
+                let mut coordinator = watchdog_state.captions.lock().await;
+                pending_cue_render_watchdog_state(
+                    &mut coordinator,
+                    &watchdog_request,
+                    tokio::time::Instant::now(),
+                )
+            };
+            let deadline = match watchdog {
+                CueRenderWatchdogState::Missing => return,
+                CueRenderWatchdogState::Queued => {
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    continue;
                 }
-                _ => None,
-            }
-        };
-        if let Some(pending) = pending {
-            let _ = tokio::fs::remove_dir_all(&pending.frames_dir).await;
+                CueRenderWatchdogState::ActiveUntil(deadline) => deadline,
+            };
+            tokio::time::sleep_until(deadline).await;
+            let pending = {
+                let mut coordinator = watchdog_state.captions.lock().await;
+                if coordinator.pending_cue_render_order.front() != Some(&watchdog_request) {
+                    continue;
+                }
+                let Some(pending) = coordinator.pending_cue_renders.get(&watchdog_request) else {
+                    return;
+                };
+                if cue_render_is_inactive(pending.last_progress_at, tokio::time::Instant::now()) {
+                    let pending = remove_pending_cue_render(&mut coordinator, &watchdog_request);
+                    if let Some(pending) = pending.as_ref() {
+                        // Keep the generation coordinator locked until private
+                        // frame cleanup finishes, so sign-out cannot miss an
+                        // already-removed request and return ahead of deletion.
+                        let _ = tokio::fs::remove_dir_all(&pending.frames_dir).await;
+                    }
+                    pending
+                } else {
+                    None
+                }
+            };
+            let Some(pending) = pending else {
+                continue;
+            };
             let _ = crate::recording::emit_health_event(
                 &watchdog_state,
                 Some(&pending.session_id),
                 crate::protocol::HealthLevel::Warn,
                 "captions-burn-failed",
-                "The caption frames were not rendered in time; the .srt sidecar is still available.",
+                "Caption frame rendering stopped making progress; the .srt sidecar is still available.",
             );
+            return;
         }
     });
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CueRenderWatchdogState {
+    Missing,
+    Queued,
+    ActiveUntil(tokio::time::Instant),
+}
+
+fn pending_cue_render_watchdog_state(
+    coordinator: &mut CaptionsCoordinator,
+    request_id: &str,
+    now: tokio::time::Instant,
+) -> CueRenderWatchdogState {
+    let Some(pending) = coordinator.pending_cue_renders.get_mut(request_id) else {
+        return CueRenderWatchdogState::Missing;
+    };
+    if coordinator
+        .pending_cue_render_order
+        .front()
+        .map(String::as_str)
+        != Some(request_id)
+    {
+        return CueRenderWatchdogState::Queued;
+    }
+    if !pending.watchdog_active {
+        pending.watchdog_active = true;
+        pending.last_progress_at = now;
+    }
+    CueRenderWatchdogState::ActiveUntil(cue_render_inactivity_deadline(pending.last_progress_at))
+}
+
+fn cue_render_inactivity_deadline(last_progress_at: tokio::time::Instant) -> tokio::time::Instant {
+    last_progress_at + CAPTION_CUE_RENDER_INACTIVITY_TIMEOUT
+}
+
+fn cue_render_is_inactive(
+    last_progress_at: tokio::time::Instant,
+    now: tokio::time::Instant,
+) -> bool {
+    now.saturating_duration_since(last_progress_at) >= CAPTION_CUE_RENDER_INACTIVITY_TIMEOUT
 }
 
 /// One rendered cue frame from the renderer. Returns whether the request is
@@ -548,33 +969,41 @@ pub async fn submit_caption_cue_frame(
         bail!("Caption frame payload size is out of range.");
     }
 
-    let completed = {
+    let (completed, finished_burn_tasks) = {
         let mut coordinator = state.captions.lock().await;
-        let Some(pending) = coordinator.pending_cue_render.as_mut() else {
-            bail!("No caption frame request is in flight.");
-        };
-        if pending.request_id != request_id {
+        let watchdog_active = coordinator
+            .pending_cue_render_order
+            .front()
+            .map(String::as_str)
+            == Some(request_id);
+        let Some(pending) = coordinator.pending_cue_renders.get_mut(request_id) else {
             bail!("Caption frame request is stale.");
-        }
+        };
         if !pending.expected.contains(&seq) {
             bail!("Caption frame seq {seq} was not requested.");
         }
         let path = pending.frames_dir.join(format!("{seq}.png"));
         std::fs::write(&path, &bytes)
             .map_err(|error| anyhow::anyhow!("Could not store caption frame: {error}"))?;
-        pending.received.insert(seq);
+        if pending.received.insert(seq) {
+            pending.last_progress_at = tokio::time::Instant::now();
+            pending.watchdog_active = watchdog_active;
+        }
         if pending.received == pending.expected {
-            coordinator.pending_cue_render.take()
+            let pending = remove_pending_cue_render(&mut coordinator, request_id)
+                .expect("completed caption render remains installed");
+            let finished = take_finished_caption_burn_tasks(&mut coordinator);
+            register_caption_overlay_burn(state.clone(), pending, &mut coordinator);
+            (true, finished)
         } else {
-            None
+            (false, Vec::new())
         }
     };
 
-    if let Some(pending) = completed {
-        enqueue_caption_overlay_burn(state.clone(), pending);
-        return Ok(true);
+    for task in finished_burn_tasks {
+        let _ = task.join.await;
     }
-    Ok(false)
+    Ok(completed)
 }
 
 /// Burn the aligned captions into a `(captioned)` copy of the recording:
@@ -583,82 +1012,225 @@ pub async fn submit_caption_cue_frame(
 /// ffmpeg (no libass). Runs through the idle-aware ffmpeg coordinator; the
 /// original file is never touched; failures degrade to SRT-only with a
 /// health warning. Not restart-resumable (v1).
-fn enqueue_caption_overlay_burn(state: AppState, pending: PendingCueRender) {
-    tokio::spawn(async move {
-        let list = build_caption_track_concat(&pending.cues, CAPTION_BLANK_FRAME_SEQ);
-        let list_path = pending.frames_dir.join("track.ffconcat");
-        if let Err(error) = tokio::fs::write(&list_path, &list).await {
-            let _ = crate::recording::emit_health_event(
-                &state,
-                Some(&pending.session_id),
-                crate::protocol::HealthLevel::Warn,
-                "captions-burn-failed",
-                &format!("Could not write the caption track list: {error}"),
-            );
-            let _ = tokio::fs::remove_dir_all(&pending.frames_dir).await;
+fn register_caption_overlay_burn(
+    state: AppState,
+    pending: PendingCueRender,
+    coordinator: &mut CaptionsCoordinator,
+) {
+    debug_assert_eq!(
+        pending.artifact_generation, coordinator.artifact_generation,
+        "sign-out must take a pending render before it can register a burn task"
+    );
+    let output_path = captioned_copy_path(&pending.recording_path);
+    let frames_dir = pending.frames_dir.clone();
+    let (cancel, cancel_receiver) = watch::channel(false);
+    let task_state = state.clone();
+    let join = tokio::spawn(async move {
+        run_caption_overlay_burn(task_state, pending, cancel_receiver).await;
+    });
+    coordinator.caption_burn_tasks.push(CaptionBurnTask {
+        cancel,
+        join,
+        output_path,
+        frames_dir,
+    });
+}
+
+fn take_finished_caption_burn_tasks(coordinator: &mut CaptionsCoordinator) -> Vec<CaptionBurnTask> {
+    let mut active = Vec::with_capacity(coordinator.caption_burn_tasks.len());
+    let mut finished = Vec::new();
+    for task in std::mem::take(&mut coordinator.caption_burn_tasks) {
+        if task.join.is_finished() {
+            finished.push(task);
+        } else {
+            active.push(task);
+        }
+    }
+    coordinator.caption_burn_tasks = active;
+    finished
+}
+
+fn remove_pending_cue_render(
+    coordinator: &mut CaptionsCoordinator,
+    request_id: &str,
+) -> Option<PendingCueRender> {
+    let pending = coordinator.pending_cue_renders.remove(request_id)?;
+    coordinator
+        .pending_cue_render_order
+        .retain(|queued| queued != request_id);
+    Some(pending)
+}
+
+fn take_pending_caption_frame_dirs(
+    coordinator: &mut CaptionsCoordinator,
+) -> Vec<std::path::PathBuf> {
+    coordinator.pending_cue_render_order.clear();
+    std::mem::take(&mut coordinator.pending_cue_renders)
+        .into_values()
+        .map(|pending| pending.frames_dir)
+        .collect()
+}
+
+async fn wait_for_caption_burn_cancel(cancel: &mut watch::Receiver<bool>) {
+    if *cancel.borrow() {
+        return;
+    }
+    while cancel.changed().await.is_ok() {
+        if *cancel.borrow() {
             return;
         }
+    }
+}
+
+fn caption_burn_cancelled(cancel: &watch::Receiver<bool>) -> bool {
+    *cancel.borrow()
+}
+
+fn caption_burn_can_publish_ready(
+    cancelled: bool,
+    artifact_generation: u64,
+    current_generation: u64,
+) -> bool {
+    !cancelled && artifact_generation == current_generation
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaptionBurnInterruption {
+    RetryAfterCapture,
+    CancelForSignOut,
+}
+
+fn caption_burn_interruption(
+    sign_out_cancelled: bool,
+    capture_cancelled: bool,
+) -> Option<CaptionBurnInterruption> {
+    if sign_out_cancelled {
+        Some(CaptionBurnInterruption::CancelForSignOut)
+    } else if capture_cancelled {
+        Some(CaptionBurnInterruption::RetryAfterCapture)
+    } else {
+        None
+    }
+}
+
+async fn run_caption_overlay_burn(
+    state: AppState,
+    pending: PendingCueRender,
+    mut sign_out_cancel: watch::Receiver<bool>,
+) {
+    let output_path = captioned_copy_path(&pending.recording_path);
+    let outcome = async {
+        if caption_burn_cancelled(&sign_out_cancel) {
+            return Err("signed out; captioned copy cancelled".to_string());
+        }
+        let list = build_caption_track_concat(&pending.cues, CAPTION_BLANK_FRAME_SEQ);
+        let list_path = pending.frames_dir.join("track.ffconcat");
+        tokio::fs::write(&list_path, &list)
+            .await
+            .map_err(|error| format!("could not write the caption track list: {error}"))?;
 
         // Wait out the same idle window as the quality gates, then hold the
-        // maintenance permit so the encode never competes with a capture.
-        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-        let maintenance = state.ffmpeg_work.begin_maintenance_when_idle().await;
-        let cancel = maintenance.cancel_token();
-        let output_path = captioned_copy_path(&pending.recording_path);
-        state.emit_log(
-            "info",
-            format!("Burning captions into {}.", output_path.display()),
-        );
-
-        let mut command = tokio::process::Command::new(&pending.ffmpeg_path);
-        command
-            .arg("-y")
-            .arg("-i")
-            .arg(&pending.recording_path)
-            .arg("-f")
-            .arg("concat")
-            .arg("-i")
-            .arg(&list_path)
-            .arg("-filter_complex")
-            .arg("[0:v][1:v]overlay=eof_action=pass")
-            .arg("-c:a")
-            .arg("copy")
-            .arg(&output_path)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
-        let spawned = spawn_owned_tokio(&mut command);
-        let mut child = match spawned {
-            Ok(child) => child,
-            Err(error) => {
-                let _ = crate::recording::emit_health_event(
-                    &state,
-                    Some(&pending.session_id),
-                    crate::protocol::HealthLevel::Warn,
-                    "captions-burn-failed",
-                    &format!("Could not start ffmpeg for the captioned copy: {error}"),
-                );
-                let _ = tokio::fs::remove_dir_all(&pending.frames_dir).await;
-                return;
+        // maintenance permit so the encode never competes with a capture. Both
+        // waits are interruptible at the sign-out privacy boundary.
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+            _ = wait_for_caption_burn_cancel(&mut sign_out_cancel) => {
+                return Err("signed out; captioned copy cancelled".to_string());
             }
-        };
-
-        let outcome = loop {
-            if cancel.is_cancelled() {
-                let _ = child.kill().await;
-                break Err("capture started; captioned copy cancelled".to_string());
+        }
+        // A new capture preempts maintenance, but does not invalidate a
+        // finalized artifact. Drop the partial output and reacquire the next
+        // idle permit until the burn completes. Sign-out remains terminal.
+        'retry_after_capture: loop {
+            let maintenance = tokio::select! {
+                maintenance = state.ffmpeg_work.begin_maintenance_when_idle() => maintenance,
+                _ = wait_for_caption_burn_cancel(&mut sign_out_cancel) => {
+                    return Err("signed out; captioned copy cancelled".to_string());
+                }
+            };
+            let capture_cancel = maintenance.cancel_token();
+            if caption_burn_cancelled(&sign_out_cancel) {
+                return Err("signed out; captioned copy cancelled".to_string());
             }
-            match child.try_wait() {
-                Ok(Some(status)) if status.success() => break Ok(()),
-                Ok(Some(status)) => break Err(format!("ffmpeg exited with {status}")),
-                Ok(None) => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
-                Err(error) => break Err(format!("could not wait for ffmpeg: {error}")),
-            }
-        };
+            state.emit_log(
+                "info",
+                format!("Burning captions into {}.", output_path.display()),
+            );
 
-        match outcome {
-            Ok(()) => {
-                let _ = tokio::fs::remove_dir_all(&pending.frames_dir).await;
+            let mut command = tokio::process::Command::new(&pending.ffmpeg_path);
+            command
+                .arg("-y")
+                .arg("-i")
+                .arg(&pending.recording_path)
+                .arg("-f")
+                .arg("concat")
+                .arg("-i")
+                .arg(&list_path)
+                .arg("-filter_complex")
+                .arg("[0:v][1:v]overlay=eof_action=pass")
+                .arg("-c:a")
+                .arg("copy")
+                .arg(&output_path)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            command.kill_on_drop(true);
+            let mut child = spawn_owned_tokio(&mut command).map_err(|error| {
+                format!("could not start ffmpeg for the captioned copy: {error}")
+            })?;
+
+            loop {
+                match caption_burn_interruption(
+                    caption_burn_cancelled(&sign_out_cancel),
+                    capture_cancel.is_cancelled(),
+                ) {
+                    Some(CaptionBurnInterruption::CancelForSignOut) => {
+                        let _ = child.kill().await;
+                        return Err("signed out; captioned copy cancelled".to_string());
+                    }
+                    Some(CaptionBurnInterruption::RetryAfterCapture) => {
+                        let _ = child.kill().await;
+                        let _ = tokio::fs::remove_file(&output_path).await;
+                        state.emit_log(
+                            "info",
+                            "Captioned copy paused for a new capture; it will resume when capture is idle.",
+                        );
+                        continue 'retry_after_capture;
+                    }
+                    None => {}
+                }
+                match child.try_wait() {
+                    Ok(Some(status)) if status.success() => return Ok(()),
+                    Ok(Some(status)) => return Err(format!("ffmpeg exited with {status}")),
+                    Ok(None) => {
+                        tokio::select! {
+                            _ = tokio::time::sleep(std::time::Duration::from_millis(250)) => {}
+                            _ = wait_for_caption_burn_cancel(&mut sign_out_cancel) => {
+                                let _ = child.kill().await;
+                                return Err("signed out; captioned copy cancelled".to_string());
+                            }
+                        }
+                    }
+                    Err(error) => return Err(format!("could not wait for ffmpeg: {error}")),
+                }
+            }
+        }
+    }
+    .await;
+
+    let _ = tokio::fs::remove_dir_all(&pending.frames_dir).await;
+    match outcome {
+        Ok(()) => {
+            // Hold the generation lock through publication. Either this event
+            // wins before sign-out advances the generation, or sign-out wins
+            // and this task removes the output without publishing readiness.
+            let coordinator = state.captions.lock().await;
+            let publish_ready = caption_burn_can_publish_ready(
+                caption_burn_cancelled(&sign_out_cancel),
+                pending.artifact_generation,
+                coordinator.artifact_generation,
+            );
+            if publish_ready {
                 let _ = crate::recording::emit_health_event(
                     &state,
                     Some(&pending.session_id),
@@ -667,9 +1239,14 @@ fn enqueue_caption_overlay_burn(state: AppState, pending: PendingCueRender) {
                     &format!("Captioned copy saved to {}.", output_path.display()),
                 );
             }
-            Err(reason) => {
+            drop(coordinator);
+            if !publish_ready {
                 let _ = tokio::fs::remove_file(&output_path).await;
-                let _ = tokio::fs::remove_dir_all(&pending.frames_dir).await;
+            }
+        }
+        Err(reason) => {
+            let _ = tokio::fs::remove_file(&output_path).await;
+            if !reason.starts_with("signed out") {
                 let _ = crate::recording::emit_health_event(
                     &state,
                     Some(&pending.session_id),
@@ -681,7 +1258,41 @@ fn enqueue_caption_overlay_burn(state: AppState, pending: PendingCueRender) {
                 );
             }
         }
-    });
+    }
+}
+
+async fn cancel_and_join_caption_burn_tasks(tasks: Vec<CaptionBurnTask>) {
+    let tasks = tasks
+        .into_iter()
+        .map(|task| {
+            let cancelled = !task.join.is_finished();
+            if cancelled {
+                let _ = task.cancel.send(true);
+            }
+            (task, cancelled)
+        })
+        .collect::<Vec<_>>();
+
+    for (task, cancelled) in tasks {
+        let _ = task.join.await;
+        let _ = tokio::fs::remove_dir_all(&task.frames_dir).await;
+        if cancelled {
+            let _ = tokio::fs::remove_file(&task.output_path).await;
+        }
+    }
+}
+
+async fn remove_pending_caption_frame_dirs(frames_dirs: Vec<std::path::PathBuf>) {
+    for frames_dir in frames_dirs {
+        if let Err(error) = tokio::fs::remove_dir_all(&frames_dir).await
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                "Could not remove caption frame cache {}: {error}",
+                frames_dir.display()
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -707,7 +1318,7 @@ pub enum CaptionOverlayPosition {
     Bottom,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CaptionOverlay {
     pub rgba: Arc<Vec<u8>>,
     pub bgra: Arc<Vec<u8>>,
@@ -723,6 +1334,41 @@ pub fn new_caption_overlay_slot() -> CaptionOverlaySlot {
     Arc::new(std::sync::Mutex::new(None))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CaptionOverlayTarget {
+    Primary,
+    Auxiliary,
+}
+
+#[derive(Clone, Default)]
+pub struct CaptionOverlaySlots {
+    inner: Arc<std::sync::Mutex<CaptionOverlaySlotsState>>,
+}
+
+#[derive(Default)]
+struct CaptionOverlaySlotsState {
+    primary: CaptionOverlayTargetState,
+    auxiliary: CaptionOverlayTargetState,
+}
+
+#[derive(Default)]
+struct CaptionOverlayTargetState {
+    overlay: Option<CaptionOverlay>,
+    revision: u64,
+    style_revision: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CaptionOverlaySlotsSnapshot {
+    pub primary: Option<CaptionOverlay>,
+    pub auxiliary: Option<CaptionOverlay>,
+}
+
+pub fn new_caption_overlay_slots() -> CaptionOverlaySlots {
+    CaptionOverlaySlots::default()
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CaptionOverlayInfo {
@@ -730,6 +1376,67 @@ pub struct CaptionOverlayInfo {
     pub width: u32,
     pub height: u32,
     pub revision: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptionOverlayTargetInfo {
+    pub active: bool,
+    pub width: u32,
+    pub height: u32,
+    pub revision: u64,
+    pub style_revision: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptionOverlayTargetsInfo {
+    /// Compatibility field used by existing renderer/smoke callers.
+    pub active: bool,
+    pub primary: CaptionOverlayTargetInfo,
+    pub auxiliary: CaptionOverlayTargetInfo,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetCaptionOverlayParams {
+    pub png_base64: String,
+    #[serde(default)]
+    pub position: CaptionOverlayPosition,
+    #[serde(default)]
+    pub target: Option<CaptionOverlayTarget>,
+    #[serde(default)]
+    pub style_revision: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearCaptionOverlayParams {
+    #[serde(default)]
+    pub target: Option<CaptionOverlayTarget>,
+    #[serde(default)]
+    pub style_revision: Option<u64>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "Caption overlay style revision {received} is stale for {target:?}; current revision is {current}."
+)]
+struct StaleCaptionOverlayRevision {
+    target: CaptionOverlayTarget,
+    received: u64,
+    current: u64,
+}
+
+pub fn caption_overlay_error_code(error: &anyhow::Error) -> &'static str {
+    if error
+        .downcast_ref::<StaleCaptionOverlayRevision>()
+        .is_some()
+    {
+        "captions-overlay-stale"
+    } else {
+        "captions-overlay-invalid"
+    }
 }
 
 /// Decode + validate a caption bar and install it in the overlay slot.
@@ -740,6 +1447,33 @@ pub fn install_caption_overlay(
     png_base64: &str,
     position: CaptionOverlayPosition,
 ) -> Result<CaptionOverlayInfo> {
+    let decoded = decode_caption_overlay(png_base64)?;
+    let mut guard = slot.lock().expect("caption overlay lock");
+    let revision = guard.as_ref().map_or(1, |overlay| overlay.revision + 1);
+    *guard = Some(CaptionOverlay {
+        rgba: decoded.rgba,
+        bgra: decoded.bgra,
+        width: decoded.width,
+        height: decoded.height,
+        position,
+        revision,
+    });
+    Ok(CaptionOverlayInfo {
+        active: true,
+        width: decoded.width,
+        height: decoded.height,
+        revision,
+    })
+}
+
+struct DecodedCaptionOverlay {
+    rgba: Arc<Vec<u8>>,
+    bgra: Arc<Vec<u8>>,
+    width: u32,
+    height: u32,
+}
+
+fn decode_caption_overlay(png_base64: &str) -> Result<DecodedCaptionOverlay> {
     use base64::Engine as _;
 
     let encoded_len = png_base64.len();
@@ -760,27 +1494,17 @@ pub fn install_caption_overlay(
         bail!("Caption overlay dimensions are out of range ({width}x{height}).");
     }
 
-    let mut guard = slot.lock().expect("caption overlay lock");
-    let revision = guard.as_ref().map_or(1, |overlay| overlay.revision + 1);
     let rgba = Arc::new(image.into_raw());
     let bgra = Arc::new(
         rgba.chunks_exact(4)
             .flat_map(|pixel| [pixel[2], pixel[1], pixel[0], pixel[3]])
             .collect(),
     );
-    *guard = Some(CaptionOverlay {
+    Ok(DecodedCaptionOverlay {
         rgba,
         bgra,
         width,
         height,
-        position,
-        revision,
-    });
-    Ok(CaptionOverlayInfo {
-        active: true,
-        width,
-        height,
-        revision,
     })
 }
 
@@ -800,6 +1524,152 @@ pub fn current_caption_overlay(slot: &CaptionOverlaySlot) -> Option<CaptionOverl
     slot.lock().expect("caption overlay lock").clone()
 }
 
+pub fn install_caption_overlays(
+    slots: &CaptionOverlaySlots,
+    params: SetCaptionOverlayParams,
+) -> Result<CaptionOverlayTargetsInfo> {
+    let decoded = decode_caption_overlay(&params.png_base64)?;
+    let mut guard = slots.inner.lock().expect("caption overlay slots lock");
+    validate_overlay_style_revision(&guard, params.target, params.style_revision)?;
+
+    if params
+        .target
+        .is_none_or(|target| target == CaptionOverlayTarget::Primary)
+    {
+        install_decoded_caption_overlay(
+            &mut guard.primary,
+            &decoded,
+            params.position,
+            params.style_revision,
+        );
+    }
+    if params
+        .target
+        .is_none_or(|target| target == CaptionOverlayTarget::Auxiliary)
+    {
+        install_decoded_caption_overlay(
+            &mut guard.auxiliary,
+            &decoded,
+            params.position,
+            params.style_revision,
+        );
+    }
+    Ok(caption_overlay_targets_info(&guard))
+}
+
+pub fn clear_caption_overlays(
+    slots: &CaptionOverlaySlots,
+    params: ClearCaptionOverlayParams,
+) -> Result<CaptionOverlayTargetsInfo> {
+    let mut guard = slots.inner.lock().expect("caption overlay slots lock");
+    validate_overlay_style_revision(&guard, params.target, params.style_revision)?;
+    if params
+        .target
+        .is_none_or(|target| target == CaptionOverlayTarget::Primary)
+    {
+        clear_caption_overlay_target(&mut guard.primary, params.style_revision);
+    }
+    if params
+        .target
+        .is_none_or(|target| target == CaptionOverlayTarget::Auxiliary)
+    {
+        clear_caption_overlay_target(&mut guard.auxiliary, params.style_revision);
+    }
+    Ok(caption_overlay_targets_info(&guard))
+}
+
+pub fn current_caption_overlays(slots: &CaptionOverlaySlots) -> CaptionOverlaySlotsSnapshot {
+    let guard = slots.inner.lock().expect("caption overlay slots lock");
+    CaptionOverlaySlotsSnapshot {
+        primary: guard.primary.overlay.clone(),
+        auxiliary: guard.auxiliary.overlay.clone(),
+    }
+}
+
+pub fn caption_overlay_targets_metadata(slots: &CaptionOverlaySlots) -> CaptionOverlayTargetsInfo {
+    let guard = slots.inner.lock().expect("caption overlay slots lock");
+    caption_overlay_targets_info(&guard)
+}
+
+fn validate_overlay_style_revision(
+    state: &CaptionOverlaySlotsState,
+    target: Option<CaptionOverlayTarget>,
+    requested: Option<u64>,
+) -> Result<()> {
+    let Some(received) = requested else {
+        return Ok(());
+    };
+    for (candidate_target, candidate) in [
+        (CaptionOverlayTarget::Primary, &state.primary),
+        (CaptionOverlayTarget::Auxiliary, &state.auxiliary),
+    ] {
+        if target.is_some_and(|target| target != candidate_target) {
+            continue;
+        }
+        if let Some(current) = candidate.style_revision
+            && received < current
+        {
+            return Err(StaleCaptionOverlayRevision {
+                target: candidate_target,
+                received,
+                current,
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn install_decoded_caption_overlay(
+    target: &mut CaptionOverlayTargetState,
+    decoded: &DecodedCaptionOverlay,
+    position: CaptionOverlayPosition,
+    style_revision: Option<u64>,
+) {
+    target.revision = target.revision.saturating_add(1);
+    if let Some(style_revision) = style_revision {
+        target.style_revision = Some(style_revision);
+    }
+    target.overlay = Some(CaptionOverlay {
+        rgba: decoded.rgba.clone(),
+        bgra: decoded.bgra.clone(),
+        width: decoded.width,
+        height: decoded.height,
+        position,
+        revision: target.revision,
+    });
+}
+
+fn clear_caption_overlay_target(
+    target: &mut CaptionOverlayTargetState,
+    style_revision: Option<u64>,
+) {
+    if let Some(style_revision) = style_revision {
+        target.style_revision = Some(style_revision);
+    }
+    target.overlay = None;
+}
+
+fn caption_overlay_targets_info(state: &CaptionOverlaySlotsState) -> CaptionOverlayTargetsInfo {
+    let primary = caption_overlay_target_info(&state.primary);
+    let auxiliary = caption_overlay_target_info(&state.auxiliary);
+    CaptionOverlayTargetsInfo {
+        active: primary.active || auxiliary.active,
+        primary,
+        auxiliary,
+    }
+}
+
+fn caption_overlay_target_info(state: &CaptionOverlayTargetState) -> CaptionOverlayTargetInfo {
+    CaptionOverlayTargetInfo {
+        active: state.overlay.is_some(),
+        width: state.overlay.as_ref().map_or(0, |overlay| overlay.width),
+        height: state.overlay.as_ref().map_or(0, |overlay| overlay.height),
+        revision: state.revision,
+        style_revision: state.style_revision.unwrap_or(0),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Session state machine.
 // ---------------------------------------------------------------------------
@@ -808,17 +1678,52 @@ pub fn current_caption_overlay(slot: &CaptionOverlaySlot) -> Option<CaptionOverl
 #[serde(rename_all = "kebab-case")]
 pub enum CaptionsState {
     Idle,
-    Live,
-    /// Uploads are failing and retrying with backoff; the session survives
-    /// and recovers on the next successful chunk (R0).
+    /// Persisted opt-in is on, but no capture session owns the audio bus.
+    Ready,
+    /// Preflight/transport setup is in progress; never present this as live.
+    Starting,
+    /// Provider configuration is acknowledged and caption audio frames flow.
+    Listening,
+    /// Realtime transport is reconnecting within its bounded retry budget.
+    Reconnecting,
+    /// Chunked fallback is working at higher latency.
     Degraded,
+    /// Captions cannot start without a user/deployment/platform change.
+    Blocked,
+    /// Reserved for unexpected coordinator failures rather than actionable
+    /// auth/config/audio-path blockers.
+    #[allow(dead_code)]
     Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CaptionsTransport {
+    Realtime,
+    Chunked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CaptionAudioSource {
+    Microphone,
 }
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CaptionsStatus {
     pub state: CaptionsState,
+    pub desired_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<CaptionsTransport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_source: Option<CaptionAudioSource>,
+    pub audio_frames_seen: u64,
+    pub dropped_audio_frames: u64,
+    pub dropped_audio_seconds: f64,
+    pub provider_ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -831,9 +1736,51 @@ impl CaptionsStatus {
     pub fn idle() -> Self {
         Self {
             state: CaptionsState::Idle,
+            desired_enabled: false,
+            transport: None,
+            audio_source: None,
+            audio_frames_seen: 0,
+            dropped_audio_frames: 0,
+            dropped_audio_seconds: 0.0,
+            provider_ready: false,
+            reason_code: None,
             message: None,
             remaining_seconds: None,
             session_client_id: None,
+        }
+    }
+
+    fn ready() -> Self {
+        Self {
+            state: CaptionsState::Ready,
+            desired_enabled: true,
+            transport: None,
+            audio_source: Some(CaptionAudioSource::Microphone),
+            audio_frames_seen: 0,
+            dropped_audio_frames: 0,
+            dropped_audio_seconds: 0.0,
+            provider_ready: false,
+            reason_code: None,
+            message: Some("Captions will start with the next capture session.".to_string()),
+            remaining_seconds: None,
+            session_client_id: None,
+        }
+    }
+
+    fn active(state: CaptionsState, transport: CaptionsTransport, session_client_id: &str) -> Self {
+        Self {
+            state,
+            desired_enabled: true,
+            transport: Some(transport),
+            audio_source: Some(CaptionAudioSource::Microphone),
+            audio_frames_seen: TAP_FRAMES_SEEN.load(Ordering::Relaxed),
+            dropped_audio_frames: TAP_FRAMES_DROPPED.load(Ordering::Relaxed),
+            dropped_audio_seconds: caption_audio_seconds_dropped(),
+            provider_ready: false,
+            reason_code: None,
+            message: None,
+            remaining_seconds: None,
+            session_client_id: Some(session_client_id.to_string()),
         }
     }
 }
@@ -860,11 +1807,33 @@ pub struct CaptionsUpdate {
     pub remaining_seconds: Option<u64>,
 }
 
+#[cfg(debug_assertions)]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptionContractTestSnapshot {
+    pub status: CaptionsStatus,
+    pub chunk_count: usize,
+    pub canonical_cues: Vec<CaptionContractTestCue>,
+    pub dropped_audio_frames: u64,
+    pub overlays: CaptionOverlayTargetsInfo,
+}
+
+#[cfg(debug_assertions)]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptionContractTestCue {
+    pub seq: u64,
+    pub text: String,
+    pub capture_epoch: u64,
+}
+
 #[derive(Default)]
 pub struct CaptionsCoordinator {
     task: Option<tokio::task::JoinHandle<()>>,
     stop: Option<Arc<AtomicBool>>,
     status: Option<CaptionsStatus>,
+    desired_enabled: bool,
+    language: Option<String>,
     /// Transcribed chunks awaiting the post-recording pass (drained +
     /// epoch-filtered at session stop).
     chunks: Vec<CaptionChunkRecord>,
@@ -872,16 +1841,32 @@ pub struct CaptionsCoordinator {
     /// (frame-timestamp regression); finalize keeps only current-epoch
     /// records.
     capture_epoch: u64,
-    /// Styling knobs + output size captured at session start for the burned copy.
-    style: (CaptionOverlayPosition, CaptionTextSize),
-    output_size: (u32, u32),
-    /// In-flight cue-frame render request (R2): the renderer supplies one
-    /// full-frame PNG per cue; complete → the overlay burn runs.
-    pending_cue_render: Option<PendingCueRender>,
+    /// One allocator per capture, shared by every off/on provider runtime.
+    /// Artifact cue-frame filenames use `seq`, so toggling captions must not
+    /// restart this namespace until a genuinely new capture begins.
+    sequence: CaptionSequence,
+    /// Live style plus the end-of-capture snapshot used for the one-style
+    /// captioned copy. The frozen copy cannot drift during MP4 export.
+    style: CaptionStyleSnapshot,
+    finalized_style: Option<CaptionStyleSnapshot>,
+    /// In-flight cue-frame render requests (R2), retained independently across
+    /// back-to-back captures. The renderer serializes them, but submissions are
+    /// keyed so a newer request can never replace or stale an older artifact.
+    pending_cue_renders: std::collections::BTreeMap<String, PendingCueRender>,
+    /// Renderer requests are emitted eagerly but processed as a mutable FIFO.
+    /// Only the head spends inactivity budget; queued requests start a fresh
+    /// watchdog window when promoted.
+    pending_cue_render_order: std::collections::VecDeque<String>,
+    /// Burn jobs remain owned until joined. Sign-out cancels every in-flight
+    /// job before credentials are removed, preventing a transcript-bearing
+    /// output from appearing after the privacy boundary.
+    caption_burn_tasks: Vec<CaptionBurnTask>,
+    /// Invalidates a frame-complete request racing sign-out before it can
+    /// install its burn task in `caption_burn_tasks`.
+    artifact_generation: u64,
 }
 
 pub struct PendingCueRender {
-    pub request_id: String,
     pub session_id: String,
     pub ffmpeg_path: String,
     pub recording_path: std::path::PathBuf,
@@ -889,6 +1874,16 @@ pub struct PendingCueRender {
     pub cues: Vec<CaptionCue>,
     pub expected: std::collections::BTreeSet<u64>,
     pub received: std::collections::BTreeSet<u64>,
+    artifact_generation: u64,
+    last_progress_at: tokio::time::Instant,
+    watchdog_active: bool,
+}
+
+struct CaptionBurnTask {
+    cancel: watch::Sender<bool>,
+    join: tokio::task::JoinHandle<()>,
+    output_path: std::path::PathBuf,
+    frames_dir: std::path::PathBuf,
 }
 
 /// The blank (fully transparent) gap frame's pseudo-seq in a render request.
@@ -900,12 +1895,60 @@ pub async fn set_caption_session_style(
     state: &AppState,
     position: CaptionOverlayPosition,
     text_size: CaptionTextSize,
+    style_id: CaptionStyleId,
+    style_revision: u64,
     output_width: u32,
     output_height: u32,
 ) {
     let mut coordinator = state.captions.lock().await;
-    coordinator.style = (position, text_size);
-    coordinator.output_size = (output_width, output_height);
+    let discarded = advance_caption_capture_epoch_and_purge(&mut coordinator);
+    if discarded > 0 {
+        tracing::info!("Discarded {discarded} stale caption cue(s) at the new capture boundary.");
+    }
+    coordinator.style = CaptionStyleSnapshot {
+        position,
+        text_size,
+        style_id,
+        style_revision,
+        output_width,
+        output_height,
+    };
+}
+
+pub async fn update_caption_style(
+    state: &AppState,
+    params: SetCaptionStyleParams,
+) -> Result<CaptionStyleSnapshot> {
+    let mut coordinator = state.captions.lock().await;
+    coordinator.style = apply_caption_style_update(coordinator.style, params)?;
+    Ok(coordinator.style)
+}
+
+fn apply_caption_style_update(
+    current: CaptionStyleSnapshot,
+    params: SetCaptionStyleParams,
+) -> Result<CaptionStyleSnapshot> {
+    if params.style_revision < current.style_revision {
+        return Err(StaleCaptionStyleRevision {
+            received: params.style_revision,
+            current: current.style_revision,
+        }
+        .into());
+    }
+    Ok(CaptionStyleSnapshot {
+        position: params.position,
+        text_size: params.text_size,
+        style_id: params.style_id,
+        style_revision: params.style_revision,
+        ..current
+    })
+}
+
+fn caption_style_for_final_artifact(
+    finalized: Option<CaptionStyleSnapshot>,
+    current: CaptionStyleSnapshot,
+) -> CaptionStyleSnapshot {
+    finalized.unwrap_or(current)
 }
 
 pub type CaptionsSlot = Arc<Mutex<CaptionsCoordinator>>;
@@ -914,14 +1957,270 @@ pub fn new_captions_slot() -> CaptionsSlot {
     Arc::new(Mutex::new(CaptionsCoordinator::default()))
 }
 
+#[cfg(test)]
+pub struct CaptionSignOutTestProbe {
+    frames_received: Arc<AtomicU64>,
+    task_finished: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+struct CaptionTestTaskFinished(Arc<AtomicBool>);
+
+#[cfg(test)]
+impl Drop for CaptionTestTaskFinished {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+impl CaptionSignOutTestProbe {
+    pub fn frames_received(&self) -> u64 {
+        self.frames_received.load(Ordering::Acquire)
+    }
+
+    pub fn task_finished(&self) -> bool {
+        self.task_finished.load(Ordering::Acquire)
+    }
+}
+
+/// Deterministic opt-out probe: audio can be queued while the consumer is
+/// paused, then the test releases it only after the stop boundary has taken
+/// ownership of the task. A privacy stop must exit without consuming any of
+/// those queued frames; capture finalization is the only draining boundary.
+#[cfg(test)]
+pub struct CaptionQueuedAudioTestProbe {
+    frames_received: Arc<AtomicU64>,
+    task_started: Arc<AtomicBool>,
+    release_consumer: Arc<tokio::sync::Semaphore>,
+}
+
+#[cfg(test)]
+impl CaptionQueuedAudioTestProbe {
+    pub fn frames_received(&self) -> u64 {
+        self.frames_received.load(Ordering::Acquire)
+    }
+
+    pub fn task_started(&self) -> bool {
+        self.task_started.load(Ordering::Acquire)
+    }
+
+    pub fn release(&self) {
+        self.release_consumer.add_permits(1);
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+pub struct CaptionSignOutTestSnapshot {
+    pub task_present: bool,
+    pub stop_present: bool,
+    pub desired_enabled: bool,
+    pub language_present: bool,
+    pub chunk_count: usize,
+    pub finalized_style_present: bool,
+    pub tap_active: bool,
+    pub primary_overlay_active: bool,
+    pub auxiliary_overlay_active: bool,
+}
+
+/// Installs a deterministic active caption task without touching account
+/// secrets or the network. The command-dispatch regression uses this seam to
+/// prove that sign-out joins the task and disconnects the real global tap.
+#[cfg(test)]
+pub async fn install_caption_sign_out_test_session(state: &AppState) -> CaptionSignOutTestProbe {
+    let mut receiver = install_tap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let task_stop = stop.clone();
+    let frames_received = Arc::new(AtomicU64::new(0));
+    let task_frames_received = frames_received.clone();
+    let task_finished = Arc::new(AtomicBool::new(false));
+    let task_finished_signal = task_finished.clone();
+    let task = tokio::spawn(async move {
+        // Cancellation is also completion. The guard makes the probe observe
+        // abort+join as finished before credential removal.
+        let _finished = CaptionTestTaskFinished(task_finished_signal);
+        loop {
+            if task_stop.load(Ordering::Acquire) {
+                break;
+            }
+            match tokio::time::timeout(std::time::Duration::from_millis(10), receiver.recv()).await
+            {
+                Ok(Some(_)) => {
+                    task_frames_received.fetch_add(1, Ordering::AcqRel);
+                }
+                Ok(None) => break,
+                Err(_) => {}
+            }
+        }
+    });
+
+    {
+        let mut coordinator = state.captions.lock().await;
+        coordinator.task = Some(task);
+        coordinator.stop = Some(stop);
+        coordinator.desired_enabled = true;
+        coordinator.language = Some("en".to_string());
+        let capture_epoch = coordinator.capture_epoch;
+        coordinator.chunks.push(CaptionChunkRecord {
+            seq: 1,
+            offset_seconds: 0.0,
+            duration_seconds: 1.0,
+            text: "private caption".to_string(),
+            segments: Vec::new(),
+            capture_epoch,
+            provider_item_id: Some("private-item".to_string()),
+        });
+        coordinator.finalized_style = Some(coordinator.style);
+        coordinator.status = Some(CaptionsStatus::active(
+            CaptionsState::Listening,
+            CaptionsTransport::Realtime,
+            "captions-sign-out-test",
+        ));
+    }
+
+    {
+        let mut overlays = state
+            .caption_overlay
+            .inner
+            .lock()
+            .expect("caption overlay slots lock");
+        let overlay = CaptionOverlay {
+            rgba: Arc::new(vec![255, 255, 255, 255]),
+            bgra: Arc::new(vec![255, 255, 255, 255]),
+            width: 1,
+            height: 1,
+            position: CaptionOverlayPosition::Bottom,
+            revision: 1,
+        };
+        overlays.primary.overlay = Some(overlay.clone());
+        overlays.primary.revision = 1;
+        overlays.auxiliary.overlay = Some(overlay);
+        overlays.auxiliary.revision = 1;
+    }
+
+    CaptionSignOutTestProbe {
+        frames_received,
+        task_finished,
+    }
+}
+
+#[cfg(test)]
+pub async fn install_caption_queued_audio_test_session(
+    state: &AppState,
+) -> CaptionQueuedAudioTestProbe {
+    let mut receiver = install_tap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let task_stop = stop.clone();
+    let frames_received = Arc::new(AtomicU64::new(0));
+    let task_frames_received = frames_received.clone();
+    let task_started = Arc::new(AtomicBool::new(false));
+    let task_started_signal = task_started.clone();
+    let release_consumer = Arc::new(tokio::sync::Semaphore::new(0));
+    let task_release_consumer = release_consumer.clone();
+    let task = tokio::spawn(async move {
+        task_started_signal.store(true, Ordering::Release);
+        let Ok(_permit) = task_release_consumer.acquire().await else {
+            return;
+        };
+        while !task_stop.load(Ordering::Acquire) {
+            let Some(_frame) = receiver.recv().await else {
+                break;
+            };
+            task_frames_received.fetch_add(1, Ordering::AcqRel);
+        }
+    });
+
+    {
+        let mut coordinator = state.captions.lock().await;
+        coordinator.task = Some(task);
+        coordinator.stop = Some(stop);
+        coordinator.desired_enabled = true;
+        coordinator.status = Some(CaptionsStatus::active(
+            CaptionsState::Listening,
+            CaptionsTransport::Realtime,
+            "captions-queued-audio-test",
+        ));
+    }
+
+    CaptionQueuedAudioTestProbe {
+        frames_received,
+        task_started,
+        release_consumer,
+    }
+}
+
+#[cfg(test)]
+pub async fn caption_task_detached_for_test(state: &AppState) -> bool {
+    state.captions.lock().await.task.is_none()
+}
+
+#[cfg(test)]
+pub async fn caption_sign_out_test_snapshot(state: &AppState) -> CaptionSignOutTestSnapshot {
+    let coordinator = state.captions.lock().await;
+    let overlays = current_caption_overlays(&state.caption_overlay);
+    CaptionSignOutTestSnapshot {
+        task_present: coordinator.task.is_some(),
+        stop_present: coordinator.stop.is_some(),
+        desired_enabled: coordinator.desired_enabled,
+        language_present: coordinator.language.is_some(),
+        chunk_count: coordinator.chunks.len(),
+        finalized_style_present: coordinator.finalized_style.is_some(),
+        tap_active: TAP_ACTIVE.load(Ordering::Acquire),
+        primary_overlay_active: overlays.primary.is_some(),
+        auxiliary_overlay_active: overlays.auxiliary.is_some(),
+    }
+}
+
 pub async fn captions_status(state: &AppState) -> CaptionsStatus {
-    state
+    let mut status = state
         .captions
         .lock()
         .await
         .status
         .clone()
-        .unwrap_or_else(CaptionsStatus::idle)
+        .unwrap_or_else(CaptionsStatus::idle);
+    if matches!(
+        status.state,
+        CaptionsState::Starting
+            | CaptionsState::Listening
+            | CaptionsState::Reconnecting
+            | CaptionsState::Degraded
+    ) {
+        status.audio_frames_seen = TAP_FRAMES_SEEN.load(Ordering::Relaxed);
+        status.dropped_audio_frames = TAP_FRAMES_DROPPED.load(Ordering::Relaxed);
+        status.dropped_audio_seconds = caption_audio_seconds_dropped();
+    }
+    status
+}
+
+#[cfg(debug_assertions)]
+pub async fn caption_contract_test_snapshot(
+    state: &AppState,
+) -> Result<CaptionContractTestSnapshot> {
+    if !caption_contract_test_enabled() {
+        bail!("Caption contract test snapshot is disabled.");
+    }
+    let status = captions_status(state).await;
+    let coordinator = state.captions.lock().await;
+    let chunk_count = coordinator.chunks.len();
+    let canonical_cues = coordinator
+        .chunks
+        .iter()
+        .map(|chunk| CaptionContractTestCue {
+            seq: chunk.seq,
+            text: chunk.text.clone(),
+            capture_epoch: chunk.capture_epoch,
+        })
+        .collect();
+    drop(coordinator);
+    Ok(CaptionContractTestSnapshot {
+        status,
+        chunk_count,
+        canonical_cues,
+        dropped_audio_frames: TAP_FRAMES_DROPPED.load(Ordering::Relaxed),
+        overlays: caption_overlay_targets_metadata(&state.caption_overlay),
+    })
 }
 
 fn set_status(state: &AppState, coordinator: &mut CaptionsCoordinator, status: CaptionsStatus) {
@@ -939,15 +2238,38 @@ async fn publish_status(state: &AppState, status: CaptionsStatus) {
 }
 
 pub async fn start_captions(state: &AppState, language: Option<String>) -> Result<CaptionsStatus> {
+    let _control = CAPTION_CONTROL.lock().await;
     let Some(bearer) = crate::account::stored_session_token() else {
         bail!("Sign in to use live captions.");
     };
     let client = VideorcApiClient::new()?;
+    let language = normalize_caption_language(language);
+    let capture_elapsed_seconds = crate::recording::active_capture_elapsed_seconds(state).await;
+    let capture_active =
+        capture_elapsed_seconds.is_some() || caption_contract_idle_session_enabled();
 
     let mut coordinator = state.captions.lock().await;
+    coordinator.desired_enabled = true;
+    coordinator.language = language.clone();
+    if !capture_active {
+        if let Some(task) = coordinator.task.take() {
+            task.abort();
+        }
+        coordinator.stop = None;
+        remove_tap();
+        let status = CaptionsStatus::ready();
+        set_status(state, &mut coordinator, status.clone());
+        return Ok(status);
+    }
     if let (Some(task), Some(status)) = (coordinator.task.as_ref(), coordinator.status.as_ref())
         && !task.is_finished()
-        && matches!(status.state, CaptionsState::Live | CaptionsState::Degraded)
+        && matches!(
+            status.state,
+            CaptionsState::Starting
+                | CaptionsState::Listening
+                | CaptionsState::Reconnecting
+                | CaptionsState::Degraded
+        )
     {
         return Ok(status.clone());
     }
@@ -957,14 +2279,15 @@ pub async fn start_captions(state: &AppState, language: Option<String>) -> Resul
     remove_tap();
 
     let session_client_id = format!("captions-{}", uuid::Uuid::new_v4().simple());
+    let sequence = coordinator.sequence.clone();
     let stop = Arc::new(AtomicBool::new(false));
     let receiver = install_tap();
-    let status = CaptionsStatus {
-        state: CaptionsState::Live,
-        message: None,
-        remaining_seconds: None,
-        session_client_id: Some(session_client_id.clone()),
-    };
+    let mut status = CaptionsStatus::active(
+        CaptionsState::Starting,
+        CaptionsTransport::Realtime,
+        &session_client_id,
+    );
+    status.message = Some("Connecting live captions…".to_string());
     set_status(state, &mut coordinator, status.clone());
 
     let task_state = state.clone();
@@ -974,7 +2297,9 @@ pub async fn start_captions(state: &AppState, language: Option<String>) -> Resul
         client,
         language,
         receiver,
+        capture_elapsed_seconds: capture_elapsed_seconds.unwrap_or(0.0),
         session_client_id,
+        sequence,
         state: task_state,
         stop: task_stop,
     })));
@@ -984,17 +2309,210 @@ pub async fn start_captions(state: &AppState, language: Option<String>) -> Resul
 }
 
 pub async fn stop_captions(state: &AppState) -> CaptionsStatus {
-    let mut coordinator = state.captions.lock().await;
-    if let Some(stop) = coordinator.stop.take() {
-        stop.store(true, Ordering::Relaxed);
+    let _control = CAPTION_CONTROL.lock().await;
+    // Explicit opt-out is a privacy boundary: do not transcribe audio already
+    // queued behind the user's click. Graceful draining is reserved for the
+    // capture-finalization path below so its last settled cue can reach SRT.
+    finish_caption_task(state, false, false).await;
+    let status = {
+        let mut coordinator = state.captions.lock().await;
+        coordinator.desired_enabled = false;
+        coordinator.language = None;
+        remove_tap();
+        let status = CaptionsStatus::idle();
+        coordinator.status = Some(status.clone());
+        status
+    };
+    publish_caption_boundary(state, &status, "stopped");
+    status
+}
+
+/// Sign-out is a privacy boundary, not a graceful recording boundary. Stop
+/// and join the provider task before the caller removes its credentials, then
+/// purge every in-memory transcript/session artifact and both compositor bars.
+pub async fn stop_captions_for_sign_out(
+    state: &AppState,
+    clear_credentials: impl FnOnce(),
+) -> CaptionsStatus {
+    let _control = CAPTION_CONTROL.lock().await;
+    finish_caption_task(state, false, false).await;
+    let pending_frames_dirs;
+    let caption_burn_tasks;
+    let status = {
+        let mut coordinator = state.captions.lock().await;
+        coordinator.desired_enabled = false;
+        coordinator.language = None;
+        coordinator.chunks.clear();
+        coordinator.capture_epoch = coordinator.capture_epoch.saturating_add(1);
+        coordinator.finalized_style = None;
+        coordinator.artifact_generation = coordinator.artifact_generation.saturating_add(1);
+        pending_frames_dirs = take_pending_caption_frame_dirs(&mut coordinator);
+        caption_burn_tasks = std::mem::take(&mut coordinator.caption_burn_tasks);
+        remove_tap();
+        TAP_FRAMES_SEEN.store(0, Ordering::Release);
+        TAP_FRAMES_DROPPED.store(0, Ordering::Release);
+        let status = CaptionsStatus::idle();
+        coordinator.status = Some(status.clone());
+        status
+    };
+    remove_pending_caption_frame_dirs(pending_frames_dirs).await;
+    cancel_and_join_caption_burn_tasks(caption_burn_tasks).await;
+    publish_caption_boundary(state, &status, "signed-out");
+    clear_credentials();
+    status
+}
+
+/// Stop and join the provider task before backend shutdown takes ownership of
+/// the active recording. Taking `state.recording` makes its monitor return
+/// before ordinary capture finalization, so shutdown cannot rely on that path
+/// to remove the microphone tap. Preferences and artifact cues remain intact
+/// for the separate artifact teardown below.
+pub async fn shutdown_caption_runtime(state: &AppState) {
+    let _control = CAPTION_CONTROL.lock().await;
+    finish_caption_task(state, true, false).await;
+    TAP_FRAMES_SEEN.store(0, Ordering::Release);
+    TAP_FRAMES_DROPPED.store(0, Ordering::Release);
+    let status = {
+        let mut coordinator = state.captions.lock().await;
+        let status = if coordinator.desired_enabled {
+            CaptionsStatus::ready()
+        } else {
+            CaptionsStatus::idle()
+        };
+        coordinator.status = Some(status.clone());
+        status
+    };
+    publish_caption_boundary(state, &status, "backend-shutdown");
+}
+
+/// Graceful backend shutdown owns the same artifact teardown as sign-out, but
+/// leaves account credentials and user caption preferences untouched. Runtime
+/// exit cannot abandon private frame caches or a partial `(captioned)` copy.
+pub async fn shutdown_caption_artifacts(state: &AppState) {
+    let (pending_frames_dirs, caption_burn_tasks) = {
+        let mut coordinator = state.captions.lock().await;
+        coordinator.chunks.clear();
+        coordinator.finalized_style = None;
+        coordinator.artifact_generation = coordinator.artifact_generation.saturating_add(1);
+        (
+            take_pending_caption_frame_dirs(&mut coordinator),
+            std::mem::take(&mut coordinator.caption_burn_tasks),
+        )
+    };
+    remove_pending_caption_frame_dirs(pending_frames_dirs).await;
+    cancel_and_join_caption_burn_tasks(caption_burn_tasks).await;
+}
+
+/// Capture sessions own caption audio. Closing the tap lets queued frames drain
+/// and gives realtime VAD a bounded window to settle the last utterance before
+/// artifact generation drains canonical cues.
+pub async fn finish_captions_for_capture(state: &AppState) -> CaptionsStatus {
+    let _control = CAPTION_CONTROL.lock().await;
+    {
+        let mut coordinator = state.captions.lock().await;
+        let style = coordinator.style;
+        coordinator.finalized_style = Some(style);
     }
-    if let Some(task) = coordinator.task.take() {
-        task.abort();
+    finish_caption_task(state, true, true).await;
+    let status = {
+        let mut coordinator = state.captions.lock().await;
+        let status = if coordinator.desired_enabled {
+            CaptionsStatus::ready()
+        } else {
+            CaptionsStatus::idle()
+        };
+        set_status(state, &mut coordinator, status.clone());
+        status
+    };
+    // Canonical chunks remain in the coordinator until artifact generation
+    // drains them, but live compositor/readers must not retain the last cue.
+    clear_caption_presentation(state, "capture-ended");
+    status
+}
+
+async fn finish_caption_task(
+    state: &AppState,
+    preserve_desired: bool,
+    drain_final_transcript: bool,
+) {
+    let (task, stop) = {
+        let mut coordinator = state.captions.lock().await;
+        if !preserve_desired {
+            coordinator.desired_enabled = false;
+        }
+        (coordinator.task.take(), coordinator.stop.take())
+    };
+    if !drain_final_transcript && let Some(stop) = stop.as_ref() {
+        stop.store(true, Ordering::Release);
     }
     remove_tap();
-    let status = CaptionsStatus::idle();
-    set_status(state, &mut coordinator, status.clone());
-    status
+    let Some(mut task) = task else {
+        return;
+    };
+    if !drain_final_transcript {
+        // Cancellation drops the receiver and any in-flight upload future at
+        // once. Waiting for a cooperative loop turn could otherwise let a
+        // queued chunk reach the provider after the user opted out.
+        task.abort();
+        let _ = task.await;
+        return;
+    }
+    // At close the chunked path keeps the current request plus only the final
+    // sub-chunk remainder, discarding older backlog with explicit health truth.
+    // Budget one full HTTP timeout for each of those two permitted attempts.
+    let final_upload_grace = caption_final_upload_grace(CAPTION_FINAL_UPLOAD_COUNT);
+    if tokio::time::timeout(final_upload_grace, &mut task)
+        .await
+        .is_err()
+    {
+        if let Some(stop) = stop.as_ref() {
+            stop.store(true, Ordering::Release);
+        }
+        task.abort();
+        let _ = task.await;
+    }
+}
+
+pub async fn block_captions_for_audio_path(state: &AppState, message: impl Into<String>) {
+    block_captions(state, "audio-path-unsupported", message).await;
+}
+
+pub async fn block_captions(state: &AppState, reason_code: &str, message: impl Into<String>) {
+    let _control = CAPTION_CONTROL.lock().await;
+    // A block is terminal for this runtime. Discard pending PCM just like an
+    // explicit opt-out; only a normal capture end may drain final audio.
+    finish_caption_task(state, true, false).await;
+    let status = {
+        let mut coordinator = state.captions.lock().await;
+        coordinator.desired_enabled = true;
+        let mut status = CaptionsStatus::ready();
+        status.state = CaptionsState::Blocked;
+        status.reason_code = Some(reason_code.to_string());
+        status.message = Some(message.into());
+        coordinator.status = Some(status.clone());
+        status
+    };
+    publish_caption_boundary(state, &status, "blocked");
+}
+
+fn publish_caption_boundary(state: &AppState, status: &CaptionsStatus, reason: &str) {
+    state.emit_event("captions.status", status);
+    clear_caption_presentation(state, reason);
+}
+
+fn clear_caption_presentation(state: &AppState, reason: &str) {
+    if let Err(error) =
+        clear_caption_overlays(&state.caption_overlay, ClearCaptionOverlayParams::default())
+    {
+        tracing::warn!("Could not clear caption overlays at the {reason} boundary: {error:#}");
+    }
+    state.emit_event("captions.cleared", serde_json::json!({ "reason": reason }));
+}
+
+fn normalize_caption_language(language: Option<String>) -> Option<String> {
+    language
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("auto"))
 }
 
 struct CaptionSession {
@@ -1002,28 +2520,461 @@ struct CaptionSession {
     client: VideorcApiClient,
     language: Option<String>,
     receiver: mpsc::Receiver<AudioFrame>,
+    capture_elapsed_seconds: f64,
     session_client_id: String,
+    sequence: CaptionSequence,
     state: AppState,
     stop: Arc<AtomicBool>,
+}
+
+/// Session-wide caption sequence shared by every provider transport.
+///
+/// `session_client_id` intentionally survives a realtime-to-chunked fallback,
+/// so its sequence must survive too: renderers use that pair as both their
+/// ordering watermark and cue identity.
+#[derive(Clone, Default)]
+struct CaptionSequence {
+    last: Arc<AtomicU64>,
+}
+
+impl CaptionSequence {
+    fn next(&self) -> u64 {
+        self.last.fetch_add(1, Ordering::Relaxed).saturating_add(1)
+    }
+
+    fn reset(&self) {
+        self.last.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Capture-relative audio timeline shared across realtime and chunked
+/// transports. Its initial base supports captions enabled mid-session; audio
+/// consumed before a fallback advances the same cursor used by chunked cues.
+struct CaptionTimeline {
+    capture_base_seconds: f64,
+    processed_seconds: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaptionAudioPathFailure {
+    Unavailable,
+    Stalled,
+    Disconnected,
+}
+
+impl CaptionAudioPathFailure {
+    fn reason_code(self) -> &'static str {
+        match self {
+            Self::Unavailable => "audio-path-unavailable",
+            Self::Stalled => "audio-path-stalled",
+            Self::Disconnected => "audio-path-disconnected",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::Unavailable => {
+                "Captions received no microphone frames. Select a supported microphone capture path and try again."
+            }
+            Self::Stalled => {
+                "The live-caption microphone path stopped delivering frames. Reconnect or reselect the microphone, then restart captions."
+            }
+            Self::Disconnected => {
+                "The live-caption microphone path disconnected while capture was active. Reconnect or reselect the microphone, then restart captions."
+            }
+        }
+    }
+}
+
+struct CaptionAudioHeartbeat {
+    started_at: std::time::Instant,
+    last_frame_at: Option<std::time::Instant>,
+}
+
+impl CaptionAudioHeartbeat {
+    fn new(started_at: std::time::Instant) -> Self {
+        Self {
+            started_at,
+            last_frame_at: None,
+        }
+    }
+
+    fn record_frame(&mut self, received_at: std::time::Instant) {
+        self.last_frame_at = Some(received_at);
+    }
+
+    fn refresh_from_caption_bus(&mut self) {
+        let tick = TAP_LAST_FRAME_MICROS.load(Ordering::Acquire);
+        let Some(epoch) = TAP_CLOCK_EPOCH.get().copied().filter(|_| tick > 0) else {
+            return;
+        };
+        let observed_at = epoch + std::time::Duration::from_micros(tick - 1);
+        if self
+            .last_frame_at
+            .is_none_or(|last_frame_at| observed_at > last_frame_at)
+        {
+            self.last_frame_at = Some(observed_at);
+        }
+    }
+
+    fn has_seen_frame(&self) -> bool {
+        self.last_frame_at.is_some()
+    }
+
+    fn failure_at(&self, now: std::time::Instant) -> Option<CaptionAudioPathFailure> {
+        let (anchor, timeout, failure) = match self.last_frame_at {
+            Some(last_frame_at) => (
+                last_frame_at,
+                CAPTION_AUDIO_STALL_TIMEOUT,
+                CaptionAudioPathFailure::Stalled,
+            ),
+            None => (
+                self.started_at,
+                CAPTION_AUDIO_READY_TIMEOUT,
+                CaptionAudioPathFailure::Unavailable,
+            ),
+        };
+        (now.saturating_duration_since(anchor) >= timeout).then_some(failure)
+    }
+}
+
+impl CaptionTimeline {
+    fn new(capture_base_seconds: f64) -> Self {
+        Self {
+            capture_base_seconds: if capture_base_seconds.is_finite() {
+                capture_base_seconds.max(0.0)
+            } else {
+                0.0
+            },
+            processed_seconds: 0.0,
+        }
+    }
+
+    fn current_seconds(&self) -> f64 {
+        self.capture_base_seconds + self.processed_seconds
+    }
+
+    fn advance_seconds(&mut self, seconds: f64) {
+        self.processed_seconds += seconds.max(0.0);
+    }
+
+    fn reset_capture(&mut self) {
+        self.capture_base_seconds = 0.0;
+        self.processed_seconds = 0.0;
+    }
+}
+
+/// Provider-specific wire details live behind this adapter. The coordinator
+/// consumes stable caption-domain events and does not construct or inspect raw
+/// Gateway JSON anywhere else.
+struct GatewayRealtimeCaptionTransport;
+
+#[derive(Debug, Clone, PartialEq)]
+enum RealtimeCaptionEvent {
+    ConfigurationAcknowledged,
+    SpeechStarted {
+        item_id: String,
+        audio_start_ms: Option<f64>,
+    },
+    Partial {
+        item_id: String,
+        transcript: String,
+    },
+    Completed {
+        item_id: String,
+        transcript: String,
+    },
+    Error(RealtimeTransportFailure),
+    AssistantResponse,
+    Ignored,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RealtimeFailureKind {
+    Terminal,
+    Retryable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RealtimeTransportFailure {
+    kind: RealtimeFailureKind,
+    code: String,
+    message: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RealtimeCaptionTimeline {
+    capture_base_seconds: f64,
+    ms_at_anchor: f64,
+    socket_audio_base_ms: f64,
+    ms_sent: f64,
+    capture_epoch: u64,
+}
+
+impl RealtimeCaptionTimeline {
+    fn cue_offset_seconds(&self, audio_start_ms: Option<f64>) -> f64 {
+        let absolute_start_ms = audio_start_ms
+            .map(|relative| self.socket_audio_base_ms + relative)
+            .unwrap_or(self.ms_sent);
+        self.capture_base_seconds + ((absolute_start_ms - self.ms_at_anchor) / 1000.0).max(0.0)
+    }
+
+    fn cue_end_seconds(&self, offset_seconds: f64) -> f64 {
+        (self.capture_base_seconds + (self.ms_sent - self.ms_at_anchor) / 1000.0)
+            .max(offset_seconds + 0.5)
+    }
+}
+
+impl GatewayRealtimeCaptionTransport {
+    fn configure(language: Option<&str>) -> serde_json::Value {
+        let mut transcription = serde_json::json!({ "enabled": true });
+        if let Some(language) = language {
+            transcription["language"] = serde_json::Value::String(language.to_string());
+        }
+        serde_json::json!({
+            "type": "session.update",
+            "session": {
+                // `create_response: false` is the important guard: server VAD
+                // must transcribe input without
+                // starting an assistant turn whose audio Videorc would discard.
+                "input_audio_format": "pcm16",
+                "input_audio_transcription": transcription,
+                "turn_detection": {
+                    "type": "server_vad",
+                    "create_response": false,
+                    "interrupt_response": false
+                }
+            }
+        })
+    }
+
+    fn append_audio(pcm_s16le: &[u8]) -> serde_json::Value {
+        use base64::Engine as _;
+        serde_json::json!({
+            "type": "input_audio_buffer.append",
+            "audio": base64::engine::general_purpose::STANDARD.encode(pcm_s16le),
+        })
+    }
+
+    fn parse(event: &serde_json::Value) -> RealtimeCaptionEvent {
+        let event_type = event
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let raw_type = event
+            .get("rawType")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+
+        if matches!(event_type, "session-updated" | "session.updated")
+            || (event_type == "custom" && raw_type == "session.updated")
+        {
+            return RealtimeCaptionEvent::ConfigurationAcknowledged;
+        }
+        if event_type == "error" || raw_type == "error" {
+            return RealtimeCaptionEvent::Error(parse_realtime_error(event));
+        }
+        if event_type.starts_with("response-") || raw_type.starts_with("response.") {
+            return RealtimeCaptionEvent::AssistantResponse;
+        }
+        if event_type == "speech-started" {
+            let item_id = realtime_item_id(event);
+            if item_id.is_empty() {
+                return RealtimeCaptionEvent::Ignored;
+            }
+            return RealtimeCaptionEvent::SpeechStarted {
+                item_id,
+                audio_start_ms: event
+                    .get("audioStartMs")
+                    .or_else(|| event.pointer("/raw/audio_start_ms"))
+                    .and_then(serde_json::Value::as_f64),
+            };
+        }
+        if event_type == "input-transcription-delta"
+            || (event_type == "custom"
+                && matches!(
+                    raw_type,
+                    "conversation.item.input_audio_transcription.updated"
+                        | "conversation.item.input_audio_transcription.delta"
+                ))
+        {
+            let item_id = realtime_item_id(event);
+            let transcript = realtime_transcript(event, true);
+            if item_id.is_empty() || transcript.is_empty() {
+                return RealtimeCaptionEvent::Ignored;
+            }
+            return RealtimeCaptionEvent::Partial {
+                item_id,
+                transcript,
+            };
+        }
+        if event_type == "input-transcription-completed"
+            || (event_type == "custom"
+                && raw_type == "conversation.item.input_audio_transcription.completed")
+        {
+            let item_id = realtime_item_id(event);
+            let transcript = realtime_transcript(event, false);
+            if item_id.is_empty() || transcript.is_empty() {
+                return RealtimeCaptionEvent::Ignored;
+            }
+            return RealtimeCaptionEvent::Completed {
+                item_id,
+                transcript,
+            };
+        }
+        RealtimeCaptionEvent::Ignored
+    }
+}
+
+fn realtime_item_id(event: &serde_json::Value) -> String {
+    event
+        .get("itemId")
+        .or_else(|| event.get("item_id"))
+        .or_else(|| event.pointer("/raw/item_id"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn realtime_transcript(event: &serde_json::Value, allow_delta: bool) -> String {
+    event
+        .get("transcript")
+        .or_else(|| allow_delta.then(|| event.get("delta")).flatten())
+        .or_else(|| event.pointer("/raw/transcript"))
+        .or_else(|| allow_delta.then(|| event.pointer("/raw/delta")).flatten())
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn parse_realtime_error(event: &serde_json::Value) -> RealtimeTransportFailure {
+    let code = event
+        .pointer("/error/code")
+        .or_else(|| event.pointer("/raw/error/code"))
+        .or_else(|| event.get("code"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("realtime-provider-error")
+        .to_string();
+    let message = event
+        .pointer("/error/message")
+        .or_else(|| event.pointer("/raw/error/message"))
+        .or_else(|| event.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|message| !message.trim().is_empty())
+        .unwrap_or("The realtime caption provider reported an error.")
+        .to_string();
+    let haystack = format!("{code} {message}").to_ascii_lowercase();
+    let terminal = [
+        "auth",
+        "unauthor",
+        "forbidden",
+        "permission",
+        "api_key",
+        "quota",
+        "rate_limit",
+        "billing",
+        "model_not_found",
+        "invalid_model",
+        "invalid_session",
+        "configuration",
+        "not_configured",
+    ]
+    .iter()
+    .any(|needle| haystack.contains(needle));
+    RealtimeTransportFailure {
+        kind: if terminal {
+            RealtimeFailureKind::Terminal
+        } else {
+            RealtimeFailureKind::Retryable
+        },
+        code,
+        message,
+    }
+}
+
+fn classify_realtime_close(code: u16, reason: &str) -> RealtimeTransportFailure {
+    let terminal = matches!(code, 1008 | 4001 | 4003 | 4401 | 4403 | 4429);
+    RealtimeTransportFailure {
+        kind: if terminal {
+            RealtimeFailureKind::Terminal
+        } else {
+            RealtimeFailureKind::Retryable
+        },
+        code: format!("realtime-close-{code}"),
+        message: if reason.trim().is_empty() {
+            format!("Realtime caption socket closed with code {code}.")
+        } else {
+            format!("Realtime caption socket closed with code {code}: {reason}")
+        },
+    }
+}
+
+fn pcm_has_speech_energy(samples: &[i16]) -> bool {
+    if samples.is_empty() {
+        return false;
+    }
+    let mean_square = samples
+        .iter()
+        .map(|sample| {
+            let normalized = f64::from(*sample) / f64::from(i16::MAX);
+            normalized * normalized
+        })
+        .sum::<f64>()
+        / samples.len() as f64;
+    mean_square.sqrt() >= 0.015
 }
 
 /// Streaming-first: try the gateway realtime transport (S2) and fall back to
 /// chunked transcription whenever streaming is unavailable — the caption
 /// session always works, streaming just makes it ~1s instead of ~4s.
 async fn run_caption_session(mut session: CaptionSession) {
-    let ended_normally = match run_realtime_caption_session(&mut session).await {
+    let sequence = session.sequence.clone();
+    let mut timeline = CaptionTimeline::new(session.capture_elapsed_seconds);
+    let mut audio_heartbeat = CaptionAudioHeartbeat::new(std::time::Instant::now());
+    let ended_normally = match run_realtime_caption_session(
+        &mut session,
+        &sequence,
+        &mut timeline,
+        &mut audio_heartbeat,
+    )
+    .await
+    {
         RealtimeOutcome::Ended => true,
         RealtimeOutcome::Fallback(reason) => {
             tracing::info!(
                 "Streaming captions unavailable ({reason}); using chunked transcription."
             );
-            run_chunked_caption_session(&mut session).await
+            let mut status = CaptionsStatus::active(
+                CaptionsState::Degraded,
+                CaptionsTransport::Chunked,
+                &session.session_client_id,
+            );
+            status.reason_code = Some("realtime-fallback".to_string());
+            status.message = Some(format!("Captions on with higher delay — {reason}"));
+            publish_status(&session.state, status).await;
+            run_chunked_caption_session(
+                &mut session,
+                &sequence,
+                &mut timeline,
+                &mut audio_heartbeat,
+            )
+            .await
         }
         RealtimeOutcome::Terminal => false,
     };
     if ended_normally {
         remove_tap();
-        publish_status(&session.state, CaptionsStatus::idle()).await;
+        let desired_enabled = session.state.captions.lock().await.desired_enabled;
+        publish_status(
+            &session.state,
+            if desired_enabled {
+                CaptionsStatus::ready()
+            } else {
+                CaptionsStatus::idle()
+            },
+        )
+        .await;
     }
 }
 
@@ -1044,16 +2995,20 @@ enum RealtimeOutcome {
 /// captions + chunk records for the SRT/burned copy. Tokens are short-lived
 /// (≤300s): the loop reminting + reconnects transparently, reports streamed
 /// seconds to the usage route, and degrades per R0 on socket loss.
-async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeOutcome {
+async fn run_realtime_caption_session(
+    session: &mut CaptionSession,
+    sequence: &CaptionSequence,
+    timeline: &mut CaptionTimeline,
+    audio_heartbeat: &mut CaptionAudioHeartbeat,
+) -> RealtimeOutcome {
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::client::IntoClientRequest;
     use tokio_tungstenite::tungstenite::protocol::Message;
 
-    let mut first_attempt = true;
-    let mut backoff: Option<std::time::Duration> = None;
+    let mut ever_connected = false;
+    let mut retry_budget = RealtimeRetryBudget::default();
     // Utterance bookkeeping: item id → (caption seq, audio offset seconds).
     let mut items: std::collections::HashMap<String, (u64, f64)> = std::collections::HashMap::new();
-    let mut seq = 0_u64;
     // Recording-epoch anchoring (same idea as chunked): mono ms sent since the
     // capture pipeline (re)started. speech_started's audio_start_ms is
     // relative to the WS stream, so remember the stream ms at each anchor.
@@ -1061,7 +3016,7 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
     let mut ms_at_anchor: f64 = 0.0;
     let mut last_frame_timestamp: Option<u64> = None;
     let mut unreported_ms: f64 = 0.0;
-    let mut degraded = false;
+    let mut reconnecting = false;
     let mut capture_epoch = session.state.captions.lock().await.capture_epoch;
 
     'reconnect: loop {
@@ -1078,26 +3033,20 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
             Err(CaptionChunkFailure::Terminal { code, message }) => {
                 tracing::warn!("Live captions stopped ({code}): {message}");
                 remove_tap();
-                publish_status(
-                    &session.state,
-                    CaptionsStatus {
-                        state: CaptionsState::Error,
-                        message: Some(message),
-                        remaining_seconds: None,
-                        session_client_id: Some(session.session_client_id.clone()),
-                    },
-                )
-                .await;
+                publish_blocked_status(session, &code, &message, CaptionsTransport::Realtime).await;
                 return RealtimeOutcome::Terminal;
             }
-            Err(CaptionChunkFailure::Transient { message }) => {
-                if first_attempt {
+            Err(CaptionChunkFailure::Transient { code, message }) => {
+                if let Some(code) = code.as_deref() {
+                    tracing::warn!(reason_code = code, "Realtime caption token request failed.");
+                }
+                if !ever_connected {
                     return RealtimeOutcome::Fallback(message);
                 }
-                // Streaming worked before — treat as an outage and retry.
-                let wait = next_caption_backoff(backoff);
-                backoff = Some(wait);
-                signal_degraded(session, &mut degraded, &message).await;
+                let Some(wait) = retry_budget.retry_delay() else {
+                    return RealtimeOutcome::Fallback(message);
+                };
+                signal_reconnecting(session, &mut reconnecting, &message).await;
                 tokio::time::sleep(wait).await;
                 continue 'reconnect;
             }
@@ -1121,38 +3070,37 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
             Ok(connected) => connected,
             Err(error) => {
                 let message = format!("realtime connect failed: {error}");
-                if first_attempt {
+                if !ever_connected {
                     return RealtimeOutcome::Fallback(message);
                 }
-                let wait = next_caption_backoff(backoff);
-                backoff = Some(wait);
-                signal_degraded(session, &mut degraded, &message).await;
+                let Some(wait) = retry_budget.retry_delay() else {
+                    return RealtimeOutcome::Fallback(message);
+                };
+                signal_reconnecting(session, &mut reconnecting, &message).await;
                 tokio::time::sleep(wait).await;
                 continue 'reconnect;
             }
         };
-        first_attempt = false;
-        backoff = None;
+        ever_connected = true;
         tracing::info!("Streaming captions connected ({}).", token.model);
 
-        let configure = serde_json::json!({
-            "type": "session.update",
-            "session": {
-                "input_audio_format": "pcm16",
-                "input_audio_transcription": { "enabled": true },
-                "turn_detection": { "type": "server_vad" }
-            }
-        });
+        let configure = GatewayRealtimeCaptionTransport::configure(session.language.as_deref());
         if ws
             .send(Message::Text(configure.to_string().into()))
             .await
             .is_err()
         {
+            let message = "realtime socket closed while configuring captions";
+            let Some(wait) = retry_budget.retry_delay() else {
+                return RealtimeOutcome::Fallback(message.to_string());
+            };
+            signal_reconnecting(session, &mut reconnecting, message).await;
+            tokio::time::sleep(wait).await;
             continue 'reconnect;
         }
 
-        if degraded {
-            degraded = false;
+        if reconnecting {
+            reconnecting = false;
             let _ = crate::recording::emit_health_event(
                 &session.state,
                 None,
@@ -1161,16 +3109,11 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
                 "Streaming captions reconnected.",
             );
         }
-        publish_status(
-            &session.state,
-            CaptionsStatus {
-                state: CaptionsState::Live,
-                message: None,
-                remaining_seconds: Some(token.remaining_seconds),
-                session_client_id: Some(session.session_client_id.clone()),
-            },
-        )
-        .await;
+        let connected_at = tokio::time::Instant::now();
+        let socket_audio_base_ms = ms_sent;
+        let mut provider_ready = false;
+        let mut listening_published = false;
+        let mut speech_watchdog_since: Option<tokio::time::Instant> = None;
 
         // Refresh well before the token expires (60s of headroom against the
         // server-reported expiry, else 240s for the ≤300s default TTL).
@@ -1191,6 +3134,9 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
         let mut report_tick = tokio::time::interval(std::time::Duration::from_secs(60));
         report_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         report_tick.reset();
+        let mut watchdog_tick = tokio::time::interval(std::time::Duration::from_millis(250));
+        watchdog_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        watchdog_tick.reset();
 
         loop {
             if session.stop.load(Ordering::Relaxed) {
@@ -1201,15 +3147,64 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
             tokio::select! {
                 maybe_frame = session.receiver.recv() => {
                     let Some(frame) = maybe_frame else {
+                        if let Some(failure) = caption_disconnect_failure(
+                            caption_session_expects_audio(session).await,
+                        ) {
+                            publish_caption_audio_failure(
+                                session,
+                                CaptionsTransport::Realtime,
+                                failure,
+                            )
+                            .await;
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Terminal;
+                        }
+                        // Server VAD owns commit. The provider documents manual
+                        // input_audio_buffer.commit as invalid while VAD is on,
+                        // so simply keep reading for a bounded final-transcript
+                        // grace after the post-controls audio bus closes.
+                        let drain_until = tokio::time::Instant::now() + CAPTION_FINAL_TRANSCRIPT_GRACE;
+                        while let Ok(Some(Ok(Message::Text(text)))) =
+                            tokio::time::timeout_at(drain_until, ws.next()).await
+                        {
+                            let Ok(event) = serde_json::from_str::<serde_json::Value>(&text) else {
+                                continue;
+                            };
+                            let parsed = GatewayRealtimeCaptionTransport::parse(&event);
+                            if matches!(
+                                &parsed,
+                                RealtimeCaptionEvent::SpeechStarted { .. }
+                                    | RealtimeCaptionEvent::Partial { .. }
+                                    | RealtimeCaptionEvent::Completed { .. }
+                            ) {
+                                handle_realtime_event(
+                                    session,
+                                    parsed,
+                                    &mut items,
+                                    sequence,
+                                    RealtimeCaptionTimeline {
+                                        capture_base_seconds: timeline.capture_base_seconds,
+                                        ms_at_anchor,
+                                        socket_audio_base_ms,
+                                        ms_sent,
+                                        capture_epoch,
+                                    },
+                                )
+                                .await;
+                            }
+                        }
                         let _ = ws.send(Message::Close(None)).await;
                         report_usage(session, &mut unreported_ms).await;
                         return RealtimeOutcome::Ended;
                     };
+                    audio_heartbeat.record_frame(std::time::Instant::now());
                     if caption_anchor_should_reset(last_frame_timestamp, frame.timestamp_micros) {
                         // New recording: re-anchor, forget in-flight
                         // utterances (their transcripts belong to the
                         // previous video), and advance the capture epoch.
                         ms_at_anchor = ms_sent;
+                        timeline.reset_capture();
+                        sequence.reset();
                         items.clear();
                         let mut coordinator = session.state.captions.lock().await;
                         coordinator.capture_epoch += 1;
@@ -1224,39 +3219,155 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
                     if mono.is_empty() {
                         continue;
                     }
-                    ms_sent += mono.len() as f64 * 1000.0 / f64::from(CAPTION_SAMPLE_RATE);
-                    unreported_ms += mono.len() as f64 * 1000.0 / f64::from(CAPTION_SAMPLE_RATE);
+                    if provider_ready
+                        && speech_watchdog_since.is_none()
+                        && pcm_has_speech_energy(&mono)
+                    {
+                        speech_watchdog_since = Some(tokio::time::Instant::now());
+                    }
+                    let frame_seconds = mono.len() as f64 / f64::from(CAPTION_SAMPLE_RATE);
+                    ms_sent += frame_seconds * 1000.0;
+                    unreported_ms += frame_seconds * 1000.0;
+                    timeline.advance_seconds(frame_seconds);
                     let mut bytes = Vec::with_capacity(mono.len() * 2);
                     for sample in &mono {
                         bytes.extend_from_slice(&sample.to_le_bytes());
                     }
-                    use base64::Engine as _;
-                    let event = serde_json::json!({
-                        "type": "input_audio_buffer.append",
-                        "audio": base64::engine::general_purpose::STANDARD.encode(&bytes),
-                    });
+                    let event = GatewayRealtimeCaptionTransport::append_audio(&bytes);
                     if ws.send(Message::Text(event.to_string().into())).await.is_err() {
-                        signal_degraded(session, &mut degraded, "realtime socket dropped").await;
+                        if retry_budget.retry_delay().is_none() {
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Fallback("realtime socket repeatedly dropped".to_string());
+                        }
+                        signal_reconnecting(session, &mut reconnecting, "realtime socket dropped").await;
                         continue 'reconnect;
                     }
+                    publish_listening_if_ready(
+                        session,
+                        provider_ready,
+                        audio_heartbeat.has_seen_frame(),
+                        &mut listening_published,
+                        token.remaining_seconds,
+                    )
+                    .await;
                 }
                 maybe_message = ws.next() => {
-                    let Some(Ok(message)) = maybe_message else {
-                        signal_degraded(session, &mut degraded, "realtime socket closed").await;
+                    let Some(message) = maybe_message else {
+                        if retry_budget.retry_delay().is_none() {
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Fallback("realtime socket repeatedly closed".to_string());
+                        }
+                        signal_reconnecting(session, &mut reconnecting, "realtime socket closed").await;
                         continue 'reconnect;
                     };
+                    let message = match message {
+                        Ok(message) => message,
+                        Err(error) => {
+                            let reason = format!("realtime socket error: {error}");
+                            if retry_budget.retry_delay().is_none() {
+                                report_usage(session, &mut unreported_ms).await;
+                                return RealtimeOutcome::Fallback(reason);
+                            }
+                            signal_reconnecting(session, &mut reconnecting, &reason).await;
+                            continue 'reconnect;
+                        }
+                    };
+                    if let Message::Close(frame) = message {
+                        let failure = frame
+                            .map(|frame| classify_realtime_close(u16::from(frame.code), &frame.reason))
+                            .unwrap_or_else(|| classify_realtime_close(1006, "socket ended without a close frame"));
+                        if failure.kind == RealtimeFailureKind::Terminal {
+                            publish_blocked_status(
+                                session,
+                                &failure.code,
+                                &failure.message,
+                                CaptionsTransport::Realtime,
+                            )
+                            .await;
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Terminal;
+                        }
+                        if retry_budget.retry_delay().is_none() {
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Fallback(failure.message);
+                        }
+                        signal_reconnecting(session, &mut reconnecting, &failure.message).await;
+                        continue 'reconnect;
+                    }
                     let Message::Text(text) = message else { continue };
                     let Ok(event) = serde_json::from_str::<serde_json::Value>(&text) else {
                         continue;
                     };
+                    let parsed = GatewayRealtimeCaptionTransport::parse(&event);
+                    match &parsed {
+                        RealtimeCaptionEvent::ConfigurationAcknowledged => {
+                            provider_ready = true;
+                            retry_budget.observe(
+                                RealtimeHealthEvidence::ConfigurationAcknowledged,
+                            );
+                        }
+                        RealtimeCaptionEvent::SpeechStarted { .. } => {
+                            // Receiving VAD proves the configured input pipeline
+                            // is active even if an older provider omits the ack.
+                            provider_ready = true;
+                            retry_budget.observe(RealtimeHealthEvidence::SpeechStarted);
+                            speech_watchdog_since.get_or_insert_with(tokio::time::Instant::now);
+                        }
+                        RealtimeCaptionEvent::Partial { .. }
+                        | RealtimeCaptionEvent::Completed { .. } => {
+                            provider_ready = true;
+                            speech_watchdog_since = None;
+                            retry_budget.observe(RealtimeHealthEvidence::Transcript);
+                        }
+                        RealtimeCaptionEvent::Error(failure) => {
+                            if failure.kind == RealtimeFailureKind::Terminal {
+                                publish_blocked_status(
+                                    session,
+                                    &failure.code,
+                                    &failure.message,
+                                    CaptionsTransport::Realtime,
+                                )
+                                .await;
+                                report_usage(session, &mut unreported_ms).await;
+                                return RealtimeOutcome::Terminal;
+                            }
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Fallback(failure.message.clone());
+                        }
+                        RealtimeCaptionEvent::AssistantResponse => {
+                            let message = "Realtime caption model generated an assistant response; switching to transcription-only fallback.";
+                            let _ = crate::recording::emit_health_event(
+                                &session.state,
+                                None,
+                                crate::protocol::HealthLevel::Warn,
+                                "captions-assistant-response-generated",
+                                message,
+                            );
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Fallback(message.to_string());
+                        }
+                        RealtimeCaptionEvent::Ignored => {}
+                    }
                     handle_realtime_event(
                         session,
-                        &event,
+                        parsed,
                         &mut items,
-                        &mut seq,
-                        ms_at_anchor,
-                        ms_sent,
-                        capture_epoch,
+                        sequence,
+                        RealtimeCaptionTimeline {
+                            capture_base_seconds: timeline.capture_base_seconds,
+                            ms_at_anchor,
+                            socket_audio_base_ms,
+                            ms_sent,
+                            capture_epoch,
+                        },
+                    )
+                    .await;
+                    publish_listening_if_ready(
+                        session,
+                        provider_ready,
+                        audio_heartbeat.has_seen_frame(),
+                        &mut listening_published,
+                        token.remaining_seconds,
                     )
                     .await;
                 }
@@ -1269,17 +3380,66 @@ async fn run_realtime_caption_session(session: &mut CaptionSession) -> RealtimeO
                 _ = report_tick.tick() => {
                     report_usage(session, &mut unreported_ms).await;
                 }
+                _ = watchdog_tick.tick() => {
+                    let elapsed = connected_at.elapsed();
+                    audio_heartbeat.refresh_from_caption_bus();
+                    if !provider_ready && elapsed >= REALTIME_CONFIG_ACK_TIMEOUT {
+                        let _ = ws.send(Message::Close(None)).await;
+                        report_usage(session, &mut unreported_ms).await;
+                        return RealtimeOutcome::Fallback(
+                            "realtime provider did not acknowledge the caption configuration".to_string(),
+                        );
+                    }
+                    if provider_ready
+                        && audio_heartbeat.has_seen_frame()
+                        && elapsed >= REALTIME_RECONNECT_HEALTHY_INTERVAL
+                    {
+                        retry_budget.observe(RealtimeHealthEvidence::StableInterval);
+                    }
+                    if provider_ready
+                        && let Some(failure) =
+                            audio_heartbeat.failure_at(std::time::Instant::now())
+                    {
+                        if caption_session_expects_audio(session).await {
+                            publish_caption_audio_failure(
+                                session,
+                                CaptionsTransport::Realtime,
+                                failure,
+                            )
+                            .await;
+                            report_usage(session, &mut unreported_ms).await;
+                            return RealtimeOutcome::Terminal;
+                        }
+                        let _ = ws.send(Message::Close(None)).await;
+                        report_usage(session, &mut unreported_ms).await;
+                        return RealtimeOutcome::Ended;
+                    }
+                    if speech_watchdog_since
+                        .is_some_and(|started| started.elapsed() >= TRANSCRIPT_WATCHDOG_TIMEOUT)
+                    {
+                        let message = "speech reached the realtime socket but no transcript arrived";
+                        let _ = crate::recording::emit_health_event(
+                            &session.state,
+                            None,
+                            crate::protocol::HealthLevel::Warn,
+                            "captions-transcript-watchdog",
+                            "Realtime captions detected speech without a transcript; switching to chunked fallback.",
+                        );
+                        report_usage(session, &mut unreported_ms).await;
+                        return RealtimeOutcome::Fallback(message.to_string());
+                    }
+                }
             }
         }
     }
 }
 
-async fn signal_degraded(session: &CaptionSession, degraded: &mut bool, message: &str) {
-    if *degraded {
+async fn signal_reconnecting(session: &CaptionSession, reconnecting: &mut bool, message: &str) {
+    if *reconnecting {
         return;
     }
-    *degraded = true;
-    tracing::warn!("Streaming captions degraded: {message}");
+    *reconnecting = true;
+    tracing::warn!("Streaming captions reconnecting: {message}");
     let _ = crate::recording::emit_health_event(
         &session.state,
         None,
@@ -1287,16 +3447,97 @@ async fn signal_degraded(session: &CaptionSession, degraded: &mut bool, message:
         "captions-upload-failed",
         &format!("Streaming captions interrupted; reconnecting. {message}"),
     );
-    publish_status(
-        &session.state,
-        CaptionsStatus {
-            state: CaptionsState::Degraded,
-            message: Some(format!("Captions reconnecting — {message}")),
-            remaining_seconds: None,
-            session_client_id: Some(session.session_client_id.clone()),
-        },
-    )
-    .await;
+    let mut status = CaptionsStatus::active(
+        CaptionsState::Reconnecting,
+        CaptionsTransport::Realtime,
+        &session.session_client_id,
+    );
+    status.reason_code = Some("realtime-reconnecting".to_string());
+    status.message = Some(format!("Captions reconnecting — {message}"));
+    publish_status(&session.state, status).await;
+}
+
+async fn caption_session_expects_audio(session: &CaptionSession) -> bool {
+    if session.stop.load(Ordering::Acquire) {
+        return false;
+    }
+    let desired_enabled = session.state.captions.lock().await.desired_enabled;
+    if !desired_enabled {
+        return false;
+    }
+    if caption_contract_idle_session_enabled() {
+        return true;
+    }
+    session.state.recording.lock().await.is_some()
+}
+
+fn caption_disconnect_failure(audio_expected: bool) -> Option<CaptionAudioPathFailure> {
+    audio_expected.then_some(CaptionAudioPathFailure::Disconnected)
+}
+
+async fn publish_caption_audio_failure(
+    session: &CaptionSession,
+    transport: CaptionsTransport,
+    failure: CaptionAudioPathFailure,
+) {
+    publish_blocked_status(session, failure.reason_code(), failure.message(), transport).await;
+}
+
+async fn publish_listening_if_ready(
+    session: &CaptionSession,
+    provider_ready: bool,
+    audio_seen: bool,
+    listening_published: &mut bool,
+    remaining_seconds: Option<u64>,
+) {
+    if !provider_ready || !audio_seen || *listening_published {
+        return;
+    }
+    *listening_published = true;
+    let mut status = CaptionsStatus::active(
+        CaptionsState::Listening,
+        CaptionsTransport::Realtime,
+        &session.session_client_id,
+    );
+    status.provider_ready = true;
+    status.remaining_seconds = remaining_seconds;
+    publish_status(&session.state, status).await;
+}
+
+async fn publish_blocked_status(
+    session: &CaptionSession,
+    reason_code: &str,
+    message: &str,
+    transport: CaptionsTransport,
+) {
+    remove_tap();
+    let mut status = CaptionsStatus::active(
+        CaptionsState::Blocked,
+        transport,
+        &session.session_client_id,
+    );
+    status.reason_code = Some(reason_code.to_string());
+    status.message = Some(message.to_string());
+    publish_blocked_presentation(&session.state, status).await;
+}
+
+async fn publish_blocked_presentation(state: &AppState, status: CaptionsStatus) {
+    let mut coordinator = state.captions.lock().await;
+    coordinator.status = Some(status.clone());
+    drop(coordinator);
+    publish_caption_boundary(state, &status, "blocked");
+}
+
+#[cfg(test)]
+pub async fn publish_terminal_caption_failure_for_test(state: &AppState) {
+    let mut status = CaptionsStatus::active(
+        CaptionsState::Blocked,
+        CaptionsTransport::Realtime,
+        "captions-terminal-failure-test",
+    );
+    status.reason_code = Some("audio-path-stalled".to_string());
+    status.message = Some("Caption audio stopped arriving.".to_string());
+    publish_blocked_presentation(state, status).await;
 }
 
 async fn report_usage(session: &CaptionSession, unreported_ms: &mut f64) {
@@ -1321,64 +3562,26 @@ async fn report_usage(session: &CaptionSession, unreported_ms: &mut f64) {
 /// Route one gateway realtime event into caption updates + chunk records.
 async fn handle_realtime_event(
     session: &CaptionSession,
-    event: &serde_json::Value,
+    event: RealtimeCaptionEvent,
     items: &mut std::collections::HashMap<String, (u64, f64)>,
-    seq: &mut u64,
-    ms_at_anchor: f64,
-    ms_sent: f64,
-    capture_epoch: u64,
+    sequence: &CaptionSequence,
+    timeline: RealtimeCaptionTimeline,
 ) {
-    let event_type = event
-        .get("type")
-        .and_then(|value| value.as_str())
-        .unwrap_or("");
-    let raw_type = event
-        .get("rawType")
-        .and_then(|value| value.as_str())
-        .unwrap_or("");
-
-    let item_entry = |items: &mut std::collections::HashMap<String, (u64, f64)>,
-                      seq: &mut u64,
-                      item_id: &str,
-                      offset: f64| {
-        *items.entry(item_id.to_string()).or_insert_with(|| {
-            *seq += 1;
-            (*seq, offset)
-        })
-    };
-
-    match (event_type, raw_type) {
-        ("speech-started", _) => {
-            let item_id = event
-                .get("itemId")
-                .or_else(|| event.pointer("/raw/item_id"))
-                .and_then(|value| value.as_str())
-                .unwrap_or_default();
-            let start_ms = event
-                .pointer("/raw/audio_start_ms")
-                .and_then(|value| value.as_f64())
-                .unwrap_or(ms_sent);
-            if !item_id.is_empty() {
-                let offset = ((start_ms - ms_at_anchor) / 1000.0).max(0.0);
-                item_entry(items, seq, item_id, offset);
-            }
+    match event {
+        RealtimeCaptionEvent::SpeechStarted {
+            item_id,
+            audio_start_ms,
+        } => {
+            let offset = timeline.cue_offset_seconds(audio_start_ms);
+            realtime_item_entry(items, sequence, &item_id, offset);
         }
-        ("custom", "conversation.item.input_audio_transcription.updated") => {
-            let item_id = event
-                .pointer("/raw/item_id")
-                .and_then(|value| value.as_str())
-                .unwrap_or_default();
-            let transcript = event
-                .pointer("/raw/transcript")
-                .and_then(|value| value.as_str())
-                .unwrap_or_default()
-                .trim();
-            if item_id.is_empty() || transcript.is_empty() {
-                return;
-            }
+        RealtimeCaptionEvent::Partial {
+            item_id,
+            transcript,
+        } => {
             // Unknown item = its speech started before a recording boundary
             // (we cleared it) — the transcript belongs to the previous video.
-            let Some(&(item_seq, _)) = items.get(item_id) else {
+            let Some(&(item_seq, _)) = items.get(&item_id) else {
                 return;
             };
             session.state.emit_event(
@@ -1387,238 +3590,651 @@ async fn handle_realtime_event(
                     session_client_id: session.session_client_id.clone(),
                     seq: item_seq,
                     kind: CaptionUpdateKind::Partial,
-                    text: transcript.to_string(),
+                    text: transcript,
                     chunk_seconds: 0,
                     remaining_seconds: None,
                 },
             );
         }
-        ("input-transcription-completed", _) => {
-            let item_id = event
-                .get("itemId")
-                .or_else(|| event.pointer("/raw/item_id"))
-                .and_then(|value| value.as_str())
-                .unwrap_or_default();
-            let transcript = event
-                .get("transcript")
-                .or_else(|| event.pointer("/raw/transcript"))
-                .and_then(|value| value.as_str())
-                .unwrap_or_default()
-                .trim();
-            if item_id.is_empty() || transcript.is_empty() {
-                return;
-            }
+        RealtimeCaptionEvent::Completed {
+            item_id,
+            transcript,
+        } => {
             // Same boundary rule as partials: cleared items never resurrect.
-            let Some(&(item_seq, offset)) = items.get(item_id) else {
+            let Some(&(item_seq, offset)) = items.get(&item_id) else {
                 return;
             };
-            let end = ((ms_sent - ms_at_anchor) / 1000.0).max(offset + 0.5);
-            session
-                .state
-                .captions
-                .lock()
-                .await
-                .chunks
-                .push(CaptionChunkRecord {
-                    seq: item_seq,
-                    offset_seconds: offset,
-                    duration_seconds: (end - offset).clamp(0.5, 30.0),
-                    text: transcript.to_string(),
-                    segments: Vec::new(),
-                    capture_epoch,
-                });
+            let end = timeline.cue_end_seconds(offset);
+            let inserted = {
+                let mut coordinator = session.state.captions.lock().await;
+                upsert_caption_record(
+                    &mut coordinator.chunks,
+                    CaptionChunkRecord {
+                        seq: item_seq,
+                        offset_seconds: offset,
+                        duration_seconds: (end - offset).clamp(0.5, 30.0),
+                        text: transcript.clone(),
+                        segments: Vec::new(),
+                        capture_epoch: timeline.capture_epoch,
+                        provider_item_id: Some(item_id.clone()),
+                    },
+                )
+            };
+            if !inserted {
+                tracing::debug!(
+                    provider_item_id = %item_id,
+                    "Coalesced a repeated realtime caption completion."
+                );
+            }
             session.state.emit_event(
                 "captions.update",
                 CaptionsUpdate {
                     session_client_id: session.session_client_id.clone(),
                     seq: item_seq,
                     kind: CaptionUpdateKind::Final,
-                    text: transcript.to_string(),
+                    text: transcript,
                     chunk_seconds: (end - offset).ceil() as u64,
                     remaining_seconds: None,
                 },
             );
         }
-        _ => {}
+        RealtimeCaptionEvent::ConfigurationAcknowledged
+        | RealtimeCaptionEvent::Error(_)
+        | RealtimeCaptionEvent::AssistantResponse
+        | RealtimeCaptionEvent::Ignored => {}
     }
 }
 
-async fn run_chunked_caption_session(session: &mut CaptionSession) -> bool {
+fn realtime_item_entry(
+    items: &mut std::collections::HashMap<String, (u64, f64)>,
+    sequence: &CaptionSequence,
+    item_id: &str,
+    offset: f64,
+) -> (u64, f64) {
+    *items
+        .entry(item_id.to_string())
+        .or_insert_with(|| (sequence.next(), offset))
+}
+
+#[derive(Debug)]
+struct BufferedCaptionChunk {
+    samples: Vec<i16>,
+    seq: u64,
+    offset_seconds: f64,
+    duration_seconds: f64,
+    capture_epoch: u64,
+}
+
+struct CaptionChunkBuffer {
+    chunk_samples: usize,
+    max_pending: usize,
+    pcm: Vec<i16>,
+    pending: std::collections::VecDeque<BufferedCaptionChunk>,
+}
+
+impl CaptionChunkBuffer {
+    fn new(chunk_samples: usize, max_pending: usize) -> Self {
+        Self {
+            chunk_samples: chunk_samples.max(1),
+            max_pending: max_pending.max(1),
+            pcm: Vec::with_capacity(chunk_samples.saturating_mul(2)),
+            pending: std::collections::VecDeque::new(),
+        }
+    }
+
+    /// Returns seconds evicted from the bounded queue. In ordinary operation
+    /// this is zero: the receiver keeps draining while one HTTP upload waits.
+    fn push_samples(
+        &mut self,
+        samples: Vec<i16>,
+        capture_epoch: u64,
+        sequence: &CaptionSequence,
+        timeline: &mut CaptionTimeline,
+    ) -> f64 {
+        self.pcm.extend(samples);
+        let mut dropped_seconds = 0.0;
+        while self.pcm.len() >= self.chunk_samples {
+            let chunk = self.pcm.drain(..self.chunk_samples).collect();
+            dropped_seconds +=
+                self.enqueue_back(Self::stamp_chunk(chunk, capture_epoch, sequence, timeline));
+        }
+        dropped_seconds
+    }
+
+    #[cfg(test)]
+    fn flush_remainder(
+        &mut self,
+        capture_epoch: u64,
+        sequence: &CaptionSequence,
+        timeline: &mut CaptionTimeline,
+    ) -> f64 {
+        if self.pcm.is_empty() {
+            return 0.0;
+        }
+        let remainder = std::mem::take(&mut self.pcm);
+        let stamped = Self::stamp_chunk(remainder, capture_epoch, sequence, timeline);
+        self.enqueue_back(stamped)
+    }
+
+    /// At capture stop, stale queued backlog must not hold recording
+    /// finalization through the full queue. Preserve exactly one tail nearest
+    /// the stop boundary: prefer the sub-chunk PCM remainder, otherwise retain
+    /// the newest queued full chunk when speech ended on an exact boundary.
+    /// The caller reports every older discarded second.
+    fn prepare_final_remainder(
+        &mut self,
+        capture_epoch: u64,
+        sequence: &CaptionSequence,
+        timeline: &mut CaptionTimeline,
+    ) -> f64 {
+        let tail = if !self.pcm.is_empty() {
+            let remainder = std::mem::take(&mut self.pcm);
+            Some(Self::stamp_chunk(
+                remainder,
+                capture_epoch,
+                sequence,
+                timeline,
+            ))
+        } else {
+            self.pending.pop_back()
+        };
+        let dropped_seconds = self
+            .pending
+            .drain(..)
+            .map(|chunk| chunk.duration_seconds)
+            .sum();
+        if let Some(tail) = tail {
+            self.pending.push_back(tail);
+        }
+        dropped_seconds
+    }
+
+    fn stamp_chunk(
+        samples: Vec<i16>,
+        capture_epoch: u64,
+        sequence: &CaptionSequence,
+        timeline: &mut CaptionTimeline,
+    ) -> BufferedCaptionChunk {
+        let duration_seconds = samples.len() as f64 / f64::from(CAPTION_SAMPLE_RATE);
+        let offset_seconds = timeline.current_seconds();
+        timeline.advance_seconds(duration_seconds);
+        BufferedCaptionChunk {
+            samples,
+            seq: sequence.next(),
+            offset_seconds,
+            duration_seconds,
+            capture_epoch,
+        }
+    }
+
+    fn enqueue_back(&mut self, chunk: BufferedCaptionChunk) -> f64 {
+        let dropped_seconds = if self.pending.len() >= self.max_pending {
+            self.pending
+                .pop_front()
+                .map_or(0.0, |dropped| dropped.duration_seconds)
+        } else {
+            0.0
+        };
+        self.pending.push_back(chunk);
+        dropped_seconds
+    }
+
+    fn requeue_front(&mut self, chunk: BufferedCaptionChunk) -> f64 {
+        let dropped_seconds = if self.pending.len() >= self.max_pending {
+            self.pending
+                .pop_back()
+                .map_or(0.0, |dropped| dropped.duration_seconds)
+        } else {
+            0.0
+        };
+        self.pending.push_front(chunk);
+        dropped_seconds
+    }
+
+    fn pop_front(&mut self) -> Option<BufferedCaptionChunk> {
+        self.pending.pop_front()
+    }
+
+    fn clear(&mut self) {
+        self.pcm.clear();
+        self.pending.clear();
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pcm.is_empty() && self.pending.is_empty()
+    }
+
+    #[cfg(test)]
+    fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    #[cfg(test)]
+    fn drain_pending(&mut self) -> Vec<BufferedCaptionChunk> {
+        self.pending.drain(..).collect()
+    }
+}
+
+type CaptionChunkUploadResult = (
+    BufferedCaptionChunk,
+    std::result::Result<CaptionChunkResponse, CaptionChunkFailure>,
+);
+type CaptionChunkUploadFuture =
+    std::pin::Pin<Box<dyn std::future::Future<Output = CaptionChunkUploadResult> + Send>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaptionChunkTransientAction {
+    RetryWithBackoff { wait: std::time::Duration },
+    DropAndContinueFinalDrain,
+}
+
+#[derive(Debug)]
+struct CaptionChunkTransientTransition {
+    action: CaptionChunkTransientAction,
+    dropped_seconds: f64,
+}
+
+fn apply_caption_chunk_transient_failure(
+    receiver_open: bool,
+    chunk: BufferedCaptionChunk,
+    buffer: &mut CaptionChunkBuffer,
+    backoff: &mut Option<std::time::Duration>,
+    next_upload_allowed_at: &mut tokio::time::Instant,
+    now: tokio::time::Instant,
+) -> CaptionChunkTransientTransition {
+    if receiver_open {
+        let wait = next_caption_backoff(*backoff);
+        *backoff = Some(wait);
+        *next_upload_allowed_at = now + wait;
+        CaptionChunkTransientTransition {
+            action: CaptionChunkTransientAction::RetryWithBackoff { wait },
+            dropped_seconds: buffer.requeue_front(chunk),
+        }
+    } else {
+        *backoff = None;
+        *next_upload_allowed_at = now;
+        CaptionChunkTransientTransition {
+            action: CaptionChunkTransientAction::DropAndContinueFinalDrain,
+            dropped_seconds: chunk.duration_seconds,
+        }
+    }
+}
+
+fn prepare_caption_final_drain(
+    buffer: &mut CaptionChunkBuffer,
+    capture_epoch: u64,
+    sequence: &CaptionSequence,
+    timeline: &mut CaptionTimeline,
+    backoff: &mut Option<std::time::Duration>,
+    next_upload_allowed_at: &mut tokio::time::Instant,
+    now: tokio::time::Instant,
+) -> f64 {
+    *backoff = None;
+    *next_upload_allowed_at = now;
+    buffer.prepare_final_remainder(capture_epoch, sequence, timeline)
+}
+
+fn begin_caption_chunk_upload(
+    session: &CaptionSession,
+    chunk: BufferedCaptionChunk,
+) -> CaptionChunkUploadFuture {
+    let client = session.client.clone();
+    let bearer = session.bearer.clone();
+    let session_client_id = session.session_client_id.clone();
+    let language = session.language.clone();
+    let wav = encode_wav_16k_mono(&chunk.samples);
+    Box::pin(async move {
+        let result = client
+            .transcribe_caption_chunk(&bearer, &session_client_id, wav, language.as_deref())
+            .await;
+        (chunk, result)
+    })
+}
+
+async fn await_caption_chunk_upload(
+    upload: &mut Option<CaptionChunkUploadFuture>,
+) -> CaptionChunkUploadResult {
+    match upload {
+        Some(upload) => upload.await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn run_chunked_caption_session(
+    session: &mut CaptionSession,
+    sequence: &CaptionSequence,
+    timeline: &mut CaptionTimeline,
+    audio_heartbeat: &mut CaptionAudioHeartbeat,
+) -> bool {
     let chunk_samples = (f64::from(CAPTION_SAMPLE_RATE) * CAPTION_CHUNK_SECONDS) as usize;
-    let mut pcm: Vec<i16> = Vec::with_capacity(chunk_samples * 2);
-    let mut seq = 0_u64;
+    let mut buffer = CaptionChunkBuffer::new(chunk_samples, MAX_BUFFERED_CAPTION_CHUNKS);
+    let mut in_flight: Option<CaptionChunkUploadFuture> = None;
+    let mut receiver_open = true;
     let mut capture_epoch = session.state.captions.lock().await.capture_epoch;
-    // Recording-epoch anchoring for the post pass: mono samples consumed since
-    // the current capture pipeline started (frames are already epoch-trimmed).
-    let mut consumed_samples: u64 = 0;
     let mut last_frame_timestamp: Option<u64> = None;
-    // Transient-failure backoff (R0): failed chunks are DROPPED — captions
-    // skip a beat instead of dying — and uploads resume automatically once a
-    // chunk succeeds after the backoff window. Never terminal.
+    // Transient failures requeue the same stamped chunk. Audio continues into
+    // the bounded queue while the request or backoff waits, so ordinary slow
+    // uploads never starve the tap receiver.
     let mut backoff: Option<std::time::Duration> = None;
-    let mut next_upload_allowed_at = std::time::Instant::now();
+    let mut next_upload_allowed_at = tokio::time::Instant::now();
     let mut degraded_reason: Option<String> = None;
+    let mut provider_confirmed = false;
+    let mut last_reported_tap_drops = TAP_FRAMES_DROPPED.load(Ordering::Relaxed);
+    let mut heartbeat_tick = tokio::time::interval(std::time::Duration::from_millis(250));
+    heartbeat_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    heartbeat_tick.reset();
 
     loop {
         if session.stop.load(Ordering::Relaxed) {
+            // Sign-out/privacy teardown cancels the owned upload future by
+            // dropping this session task. Graceful capture stop leaves the stop
+            // flag clear and closes the receiver so queued audio can flush.
+            return false;
+        }
+
+        if in_flight.is_none()
+            && tokio::time::Instant::now() >= next_upload_allowed_at
+            && let Some(chunk) = buffer.pop_front()
+        {
+            in_flight = Some(begin_caption_chunk_upload(session, chunk));
+        }
+        if !receiver_open && in_flight.is_none() && buffer.is_empty() {
             break;
         }
-        let Some(frame) = session.receiver.recv().await else {
-            break; // tap removed
-        };
-        if caption_anchor_should_reset(last_frame_timestamp, frame.timestamp_micros) {
-            // New capture pipeline (new recording): drop cross-session audio,
-            // restart the offset anchor, and advance the capture epoch so any
-            // still-in-flight transcripts from the previous recording can
-            // never be attributed to this one.
-            pcm.clear();
-            consumed_samples = 0;
-            let mut coordinator = session.state.captions.lock().await;
-            coordinator.capture_epoch += 1;
-            capture_epoch = coordinator.capture_epoch;
-        }
-        last_frame_timestamp = Some(frame.timestamp_micros);
-        pcm.extend(downmix_resample_to_16k_mono(
-            &frame.samples,
-            frame.channels,
-            frame.sample_rate,
-        ));
-        if pcm.len() < chunk_samples {
-            continue;
-        }
 
-        let chunk: Vec<i16> = pcm.drain(..chunk_samples).collect();
-        seq += 1;
-        let offset_seconds = consumed_samples as f64 / f64::from(CAPTION_SAMPLE_RATE);
-        consumed_samples += chunk_samples as u64;
-        // In backoff: drop this chunk without an upload attempt (the loop keeps
-        // draining frames so the tap channel never backs up).
-        if std::time::Instant::now() < next_upload_allowed_at {
-            continue;
-        }
-        let wav = encode_wav_16k_mono(&chunk);
-
-        match session
-            .client
-            .transcribe_caption_chunk(
-                &session.bearer,
-                &session.session_client_id,
-                wav,
-                session.language.as_deref(),
-            )
-            .await
-        {
-            Ok(response) => {
-                if degraded_reason.take().is_some() {
-                    // Outage over: say so once and go back to Live.
-                    let _ = crate::recording::emit_health_event(
-                        &session.state,
-                        None,
-                        crate::protocol::HealthLevel::Info,
-                        "captions-upload-recovered",
-                        "Caption uploads recovered; live captions resumed.",
+        tokio::select! {
+            maybe_frame = session.receiver.recv(), if receiver_open => {
+                let Some(frame) = maybe_frame else {
+                    if let Some(failure) = caption_disconnect_failure(
+                        caption_session_expects_audio(session).await,
+                    ) {
+                        publish_caption_audio_failure(
+                            session,
+                            CaptionsTransport::Chunked,
+                            failure,
+                        )
+                        .await;
+                        return false;
+                    }
+                    receiver_open = false;
+                    let dropped_seconds = prepare_caption_final_drain(
+                        &mut buffer,
+                        capture_epoch,
+                        sequence,
+                        timeline,
+                        &mut backoff,
+                        &mut next_upload_allowed_at,
+                        tokio::time::Instant::now(),
                     );
-                    publish_status(
-                        &session.state,
-                        CaptionsStatus {
-                            state: CaptionsState::Live,
-                            message: None,
-                            remaining_seconds: Some(response.remaining_seconds),
-                            session_client_id: Some(session.session_client_id.clone()),
-                        },
+                    if dropped_seconds > 0.0 {
+                        surface_chunked_audio_drop(
+                            session,
+                            dropped_seconds,
+                            0,
+                            provider_confirmed,
+                        )
+                        .await;
+                    }
+                    continue;
+                };
+                audio_heartbeat.record_frame(std::time::Instant::now());
+                if caption_anchor_should_reset(last_frame_timestamp, frame.timestamp_micros) {
+                    // A new capture owns a new artifact namespace. Any old
+                    // pending chunks are cross-session work and cannot be
+                    // attributed to this recording.
+                    buffer.clear();
+                    timeline.reset_capture();
+                    sequence.reset();
+                    let mut coordinator = session.state.captions.lock().await;
+                    coordinator.capture_epoch += 1;
+                    capture_epoch = coordinator.capture_epoch;
+                }
+                last_frame_timestamp = Some(frame.timestamp_micros);
+                let dropped_seconds = buffer.push_samples(
+                    downmix_resample_to_16k_mono(
+                        &frame.samples,
+                        frame.channels,
+                        frame.sample_rate,
+                    ),
+                    capture_epoch,
+                    sequence,
+                    timeline,
+                );
+                if dropped_seconds > 0.0 {
+                    surface_chunked_audio_drop(
+                        session,
+                        dropped_seconds,
+                        0,
+                        provider_confirmed,
                     )
                     .await;
                 }
-                backoff = None;
-                if !response.text.trim().is_empty() {
-                    let current_epoch = {
-                        let mut coordinator = session.state.captions.lock().await;
-                        coordinator.chunks.push(CaptionChunkRecord {
-                            seq,
-                            offset_seconds,
-                            duration_seconds: CAPTION_CHUNK_SECONDS,
-                            text: response.text.trim().to_string(),
-                            segments: response.segments.clone(),
-                            capture_epoch,
-                        });
-                        coordinator.capture_epoch
-                    };
-                    // An upload that outlived its recording (slow round trip
-                    // across a session boundary) still lands in `chunks` —
-                    // the drain filter attributes it correctly — but it must
-                    // not be ANNOUNCED: the live strip and burn bar belong to
-                    // the current video (carry-over fix, 2026-07-04).
-                    if capture_epoch == current_epoch {
-                        session.state.emit_event(
-                            "captions.update",
-                            CaptionsUpdate {
-                                session_client_id: session.session_client_id.clone(),
-                                seq,
-                                kind: CaptionUpdateKind::Final,
-                                text: response.text.trim().to_string(),
-                                chunk_seconds: response.chunk_seconds,
-                                remaining_seconds: Some(response.remaining_seconds),
-                            },
+            }
+            (chunk, result) = await_caption_chunk_upload(&mut in_flight) => {
+                in_flight = None;
+                match result {
+                    Ok(response) => {
+                        let recovered = degraded_reason.take().is_some();
+                        if recovered {
+                            let _ = crate::recording::emit_health_event(
+                                &session.state,
+                                None,
+                                crate::protocol::HealthLevel::Info,
+                                "captions-upload-recovered",
+                                "Caption uploads recovered; live captions resumed.",
+                            );
+                        }
+                        if recovered || !provider_confirmed {
+                            provider_confirmed = true;
+                            let mut status = CaptionsStatus::active(
+                                CaptionsState::Degraded,
+                                CaptionsTransport::Chunked,
+                                &session.session_client_id,
+                            );
+                            status.provider_ready = true;
+                            status.reason_code = Some("realtime-fallback".to_string());
+                            status.message = Some("Captions on with higher delay.".to_string());
+                            status.remaining_seconds = Some(response.remaining_seconds);
+                            publish_status(&session.state, status).await;
+                        }
+                        backoff = None;
+                        next_upload_allowed_at = tokio::time::Instant::now();
+                        if !response.text.trim().is_empty() {
+                            let current_epoch = {
+                                let mut coordinator = session.state.captions.lock().await;
+                                coordinator.chunks.push(CaptionChunkRecord {
+                                    seq: chunk.seq,
+                                    offset_seconds: chunk.offset_seconds,
+                                    duration_seconds: chunk.duration_seconds,
+                                    text: response.text.trim().to_string(),
+                                    segments: response.segments.clone(),
+                                    capture_epoch: chunk.capture_epoch,
+                                    provider_item_id: None,
+                                });
+                                coordinator.capture_epoch
+                            };
+                            if chunk.capture_epoch == current_epoch {
+                                session.state.emit_event(
+                                    "captions.update",
+                                    CaptionsUpdate {
+                                        session_client_id: session.session_client_id.clone(),
+                                        seq: chunk.seq,
+                                        kind: CaptionUpdateKind::Final,
+                                        text: response.text.trim().to_string(),
+                                        chunk_seconds: response.chunk_seconds,
+                                        remaining_seconds: Some(response.remaining_seconds),
+                                    },
+                                );
+                            } else {
+                                tracing::info!(
+                                    "Suppressed a caption update from a previous recording (epoch {} < {}).",
+                                    chunk.capture_epoch,
+                                    current_epoch,
+                                );
+                            }
+                        }
+                    }
+                    Err(CaptionChunkFailure::Terminal { code, message }) => {
+                        tracing::warn!("Live captions stopped ({code}): {message}");
+                        publish_blocked_status(
+                            session,
+                            &code,
+                            &message,
+                            CaptionsTransport::Chunked,
+                        )
+                        .await;
+                        return false;
+                    }
+                    Err(CaptionChunkFailure::Transient { message, .. }) => {
+                        let transition = apply_caption_chunk_transient_failure(
+                            receiver_open,
+                            chunk,
+                            &mut buffer,
+                            &mut backoff,
+                            &mut next_upload_allowed_at,
+                            tokio::time::Instant::now(),
                         );
-                    } else {
-                        tracing::info!(
-                            "Suppressed a caption update from a previous recording (epoch {capture_epoch} < {current_epoch})."
+                        if transition.dropped_seconds > 0.0 {
+                            surface_chunked_audio_drop(
+                                session,
+                                transition.dropped_seconds,
+                                0,
+                                provider_confirmed,
+                            )
+                            .await;
+                        }
+                        let CaptionChunkTransientAction::RetryWithBackoff {
+                            wait: next_backoff,
+                        } = transition.action
+                        else {
+                            tracing::warn!(
+                                "Final caption chunk upload failed; continuing with the remaining capture-end queue: {message}"
+                            );
+                            continue;
+                        };
+                        tracing::warn!(
+                            "Live caption chunk failed (retrying in {}s): {message}",
+                            next_backoff.as_secs()
                         );
+                        if degraded_reason.as_deref() != Some(message.as_str()) {
+                            let _ = crate::recording::emit_health_event(
+                                &session.state,
+                                None,
+                                crate::protocol::HealthLevel::Warn,
+                                "captions-upload-failed",
+                                &format!("Caption upload failed; retrying with backoff. {message}"),
+                            );
+                            let mut status = CaptionsStatus::active(
+                                CaptionsState::Degraded,
+                                CaptionsTransport::Chunked,
+                                &session.session_client_id,
+                            );
+                            status.provider_ready = provider_confirmed;
+                            status.reason_code = Some("chunk-upload-retrying".to_string());
+                            status.message = Some(format!("Captions retrying — {message}"));
+                            publish_status(&session.state, status).await;
+                            degraded_reason = Some(message);
+                        }
                     }
                 }
             }
-            Err(CaptionChunkFailure::Terminal { code, message }) => {
-                // Only auth/premium/quota/disabled end the session.
-                tracing::warn!("Live captions stopped ({code}): {message}");
-                remove_tap();
-                publish_status(
-                    &session.state,
-                    CaptionsStatus {
-                        state: CaptionsState::Error,
-                        message: Some(message),
-                        remaining_seconds: None,
-                        session_client_id: Some(session.session_client_id.clone()),
-                    },
-                )
-                .await;
-                return false;
-            }
-            Err(CaptionChunkFailure::Transient { message }) => {
-                let next_backoff = next_caption_backoff(backoff);
-                backoff = Some(next_backoff);
-                next_upload_allowed_at = std::time::Instant::now() + next_backoff;
-                tracing::warn!(
-                    "Live caption chunk failed (retrying in {}s): {message}",
-                    next_backoff.as_secs()
-                );
-                if degraded_reason.as_deref() != Some(message.as_str()) {
-                    // First failure of this outage (or the reason changed):
-                    // one health event + a degraded status carrying the REAL
-                    // reason — never a silent generic stop.
-                    let _ = crate::recording::emit_health_event(
-                        &session.state,
-                        None,
-                        crate::protocol::HealthLevel::Warn,
-                        "captions-upload-failed",
-                        &format!("Caption upload failed; retrying with backoff. {message}"),
+            _ = tokio::time::sleep_until(next_upload_allowed_at),
+                if in_flight.is_none()
+                    && tokio::time::Instant::now() < next_upload_allowed_at
+                    && !buffer.is_empty() => {}
+            _ = heartbeat_tick.tick(), if receiver_open => {
+                audio_heartbeat.refresh_from_caption_bus();
+                if let Some(failure) = audio_heartbeat.failure_at(std::time::Instant::now()) {
+                    if caption_session_expects_audio(session).await {
+                        publish_caption_audio_failure(
+                            session,
+                            CaptionsTransport::Chunked,
+                            failure,
+                        )
+                        .await;
+                        return false;
+                    }
+                    receiver_open = false;
+                    let dropped_seconds = prepare_caption_final_drain(
+                        &mut buffer,
+                        capture_epoch,
+                        sequence,
+                        timeline,
+                        &mut backoff,
+                        &mut next_upload_allowed_at,
+                        tokio::time::Instant::now(),
                     );
-                    publish_status(
-                        &session.state,
-                        CaptionsStatus {
-                            state: CaptionsState::Degraded,
-                            message: Some(format!("Captions reconnecting — {message}")),
-                            remaining_seconds: None,
-                            session_client_id: Some(session.session_client_id.clone()),
-                        },
+                    if dropped_seconds > 0.0 {
+                        surface_chunked_audio_drop(
+                            session,
+                            dropped_seconds,
+                            0,
+                            provider_confirmed,
+                        )
+                        .await;
+                    }
+                }
+                let tap_drops = TAP_FRAMES_DROPPED.load(Ordering::Relaxed);
+                let new_tap_drops = tap_drops.saturating_sub(last_reported_tap_drops);
+                if new_tap_drops > 0 {
+                    last_reported_tap_drops = tap_drops;
+                    surface_chunked_audio_drop(
+                        session,
+                        0.0,
+                        new_tap_drops,
+                        provider_confirmed,
                     )
                     .await;
-                    degraded_reason = Some(message);
                 }
             }
         }
     }
 
     true
+}
+
+async fn surface_chunked_audio_drop(
+    session: &CaptionSession,
+    dropped_seconds: f64,
+    dropped_frames: u64,
+    provider_confirmed: bool,
+) {
+    if dropped_seconds > 0.0 {
+        let dropped_ms = (dropped_seconds * 1_000.0).ceil() as u64;
+        CAPTION_AUDIO_MILLIS_DROPPED.fetch_add(dropped_ms, Ordering::Relaxed);
+    }
+    let detail = match (dropped_seconds > 0.0, dropped_frames > 0) {
+        (true, true) => format!(
+            "Live captions skipped {dropped_seconds:.1}s of buffered audio and {dropped_frames} microphone frame(s)."
+        ),
+        (true, false) => {
+            format!(
+                "Live captions skipped {dropped_seconds:.1}s because the upload buffer was full."
+            )
+        }
+        (false, true) => {
+            format!(
+                "Live captions dropped {dropped_frames} microphone frame(s) before transcription."
+            )
+        }
+        (false, false) => return,
+    };
+    let _ = crate::recording::emit_health_event(
+        &session.state,
+        None,
+        crate::protocol::HealthLevel::Warn,
+        "captions-audio-dropped",
+        &detail,
+    );
+    let mut status = CaptionsStatus::active(
+        CaptionsState::Degraded,
+        CaptionsTransport::Chunked,
+        &session.session_client_id,
+    );
+    status.provider_ready = provider_confirmed;
+    status.reason_code = Some("captions-audio-dropped".to_string());
+    status.message = Some(detail);
+    publish_status(&session.state, status).await;
 }
 
 /// Exponential backoff for transient upload failures: 2s doubling to a 30s
@@ -1632,9 +4248,62 @@ pub fn next_caption_backoff(current: Option<std::time::Duration>) -> std::time::
     }
 }
 
+fn next_realtime_retry_delay(
+    attempts: &mut u8,
+    backoff: &mut Option<std::time::Duration>,
+) -> Option<std::time::Duration> {
+    *attempts = attempts.saturating_add(1);
+    if *attempts > MAX_REALTIME_RECONNECTS {
+        return None;
+    }
+    let wait = next_caption_backoff(*backoff);
+    *backoff = Some(wait);
+    Some(wait)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RealtimeHealthEvidence {
+    ConfigurationAcknowledged,
+    SpeechStarted,
+    Transcript,
+    StableInterval,
+}
+
+#[derive(Default)]
+struct RealtimeRetryBudget {
+    attempts: u8,
+    backoff: Option<std::time::Duration>,
+}
+
+impl RealtimeRetryBudget {
+    fn retry_delay(&mut self) -> Option<std::time::Duration> {
+        next_realtime_retry_delay(&mut self.attempts, &mut self.backoff)
+    }
+
+    fn observe(&mut self, evidence: RealtimeHealthEvidence) {
+        if matches!(
+            evidence,
+            RealtimeHealthEvidence::Transcript | RealtimeHealthEvidence::StableInterval
+        ) {
+            self.attempts = 0;
+            self.backoff = None;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_caption_app_state() -> AppState {
+        let (events, _) = tokio::sync::broadcast::channel(16);
+        AppState::new(
+            "test-token".to_string(),
+            0,
+            events,
+            crate::storage::Database::open_in_memory_for_tests(),
+        )
+    }
 
     #[test]
     fn resample_decimates_48k_stereo_to_16k_mono() {
@@ -1666,6 +4335,291 @@ mod tests {
     }
 
     #[test]
+    fn realtime_adapter_serializes_transcription_only_session_and_audio() {
+        let configure = GatewayRealtimeCaptionTransport::configure(Some("es"));
+        assert_eq!(configure["type"], "session.update");
+        assert_eq!(
+            configure["session"]["turn_detection"]["create_response"],
+            false
+        );
+        assert_eq!(
+            configure["session"]["turn_detection"]["interrupt_response"],
+            false
+        );
+        assert_eq!(
+            configure["session"]["input_audio_transcription"]["language"],
+            "es"
+        );
+
+        let append = GatewayRealtimeCaptionTransport::append_audio(&[0, 1, 2, 3]);
+        assert_eq!(append["type"], "input_audio_buffer.append");
+        assert_eq!(append["audio"], "AAECAw==");
+    }
+
+    #[test]
+    fn realtime_adapter_parses_normalized_and_provider_events() {
+        assert_eq!(
+            GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+                "type": "session-updated"
+            })),
+            RealtimeCaptionEvent::ConfigurationAcknowledged
+        );
+        assert_eq!(
+            GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+                "type": "custom",
+                "rawType": "session.updated",
+                "raw": {}
+            })),
+            RealtimeCaptionEvent::ConfigurationAcknowledged
+        );
+        assert_eq!(
+            GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+                "type": "speech-started",
+                "itemId": "item-1",
+                "raw": { "audio_start_ms": 125 }
+            })),
+            RealtimeCaptionEvent::SpeechStarted {
+                item_id: "item-1".to_string(),
+                audio_start_ms: Some(125.0),
+            }
+        );
+        assert_eq!(
+            GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+                "type": "custom",
+                "rawType": "conversation.item.input_audio_transcription.updated",
+                "raw": { "item_id": "item-1", "transcript": "hola" }
+            })),
+            RealtimeCaptionEvent::Partial {
+                item_id: "item-1".to_string(),
+                transcript: "hola".to_string(),
+            }
+        );
+        assert_eq!(
+            GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+                "type": "input-transcription-completed",
+                "itemId": "item-1",
+                "transcript": "hola mundo"
+            })),
+            RealtimeCaptionEvent::Completed {
+                item_id: "item-1".to_string(),
+                transcript: "hola mundo".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn realtime_adapter_classifies_errors_and_assistant_responses() {
+        let auth = GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+            "type": "error",
+            "error": { "code": "invalid_api_key", "message": "bad client secret" }
+        }));
+        assert!(matches!(
+            auth,
+            RealtimeCaptionEvent::Error(RealtimeTransportFailure {
+                kind: RealtimeFailureKind::Terminal,
+                ..
+            })
+        ));
+        let outage = GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+            "type": "error",
+            "error": { "code": "provider_unavailable", "message": "try again" }
+        }));
+        assert!(matches!(
+            outage,
+            RealtimeCaptionEvent::Error(RealtimeTransportFailure {
+                kind: RealtimeFailureKind::Retryable,
+                ..
+            })
+        ));
+        assert_eq!(
+            GatewayRealtimeCaptionTransport::parse(&serde_json::json!({
+                "type": "response-audio-delta"
+            })),
+            RealtimeCaptionEvent::AssistantResponse
+        );
+        assert_eq!(
+            classify_realtime_close(1008, "policy").kind,
+            RealtimeFailureKind::Terminal
+        );
+        assert_eq!(
+            classify_realtime_close(1013, "retry later").kind,
+            RealtimeFailureKind::Retryable
+        );
+    }
+
+    #[test]
+    fn realtime_repeated_completions_upsert_one_canonical_cue() {
+        let mut chunks = Vec::new();
+        let first = CaptionChunkRecord {
+            seq: 7,
+            offset_seconds: 1.0,
+            duration_seconds: 1.0,
+            text: "hello".to_string(),
+            segments: Vec::new(),
+            capture_epoch: 3,
+            provider_item_id: Some("item-7".to_string()),
+        };
+        assert!(upsert_caption_record(&mut chunks, first.clone()));
+        let mut revised = first;
+        revised.duration_seconds = 1.8;
+        revised.text = "hello everyone".to_string();
+        assert!(!upsert_caption_record(&mut chunks, revised));
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].text, "hello everyone");
+        assert_eq!(chunks[0].duration_seconds, 1.8);
+
+        let next_epoch = CaptionChunkRecord {
+            capture_epoch: 4,
+            text: "new capture".to_string(),
+            ..chunks[0].clone()
+        };
+        assert!(upsert_caption_record(&mut chunks, next_epoch));
+        assert_eq!(chunks.len(), 2);
+    }
+
+    #[test]
+    fn realtime_final_then_chunk_fallback_keeps_monotonic_unique_sequences() {
+        let mut sequence = CaptionSequence::default();
+        let mut realtime_items = std::collections::HashMap::new();
+
+        let (realtime_seq, offset) =
+            realtime_item_entry(&mut realtime_items, &mut sequence, "item-1", 0.25);
+        assert_eq!(realtime_seq, 1);
+        assert_eq!(
+            realtime_item_entry(&mut realtime_items, &mut sequence, "item-1", 0.5),
+            (realtime_seq, offset),
+            "provider revisions keep the canonical realtime cue identity"
+        );
+
+        let mut chunks = Vec::new();
+        assert!(upsert_caption_record(
+            &mut chunks,
+            CaptionChunkRecord {
+                seq: realtime_seq,
+                offset_seconds: offset,
+                duration_seconds: 1.0,
+                text: "realtime final".to_string(),
+                segments: Vec::new(),
+                capture_epoch: 0,
+                provider_item_id: Some("item-1".to_string()),
+            },
+        ));
+        assert!(!upsert_caption_record(
+            &mut chunks,
+            CaptionChunkRecord {
+                seq: realtime_seq,
+                offset_seconds: offset,
+                duration_seconds: 1.2,
+                text: "realtime final revised".to_string(),
+                segments: Vec::new(),
+                capture_epoch: 0,
+                provider_item_id: Some("item-1".to_string()),
+            },
+        ));
+
+        // This is the allocator used by `run_chunked_caption_session` after
+        // `run_realtime_caption_session` falls back under the same client id.
+        let fallback_chunk_seq = sequence.next();
+        chunks.push(CaptionChunkRecord {
+            seq: fallback_chunk_seq,
+            offset_seconds: 3.0,
+            duration_seconds: CAPTION_CHUNK_SECONDS,
+            text: "fallback chunk".to_string(),
+            segments: Vec::new(),
+            capture_epoch: 0,
+            provider_item_id: None,
+        });
+
+        assert_eq!(fallback_chunk_seq, 2);
+        assert!(fallback_chunk_seq > realtime_seq);
+        assert_eq!(
+            caption_cues(&chunks)
+                .into_iter()
+                .map(|cue| cue.seq)
+                .collect::<Vec<_>>(),
+            vec![1, 2],
+            "the canonical artifact and renderer keys stay unique across fallback"
+        );
+    }
+
+    #[test]
+    fn mid_session_timeline_stays_capture_relative_across_chunk_fallback() {
+        let mut timeline = CaptionTimeline::new(42.0);
+        let realtime = RealtimeCaptionTimeline {
+            capture_base_seconds: timeline.capture_base_seconds,
+            ms_at_anchor: 0.0,
+            socket_audio_base_ms: 0.0,
+            ms_sent: 1_500.0,
+            capture_epoch: 0,
+        };
+
+        assert_eq!(realtime.cue_offset_seconds(Some(500.0)), 42.5);
+        assert_eq!(realtime.cue_end_seconds(42.5), 43.5);
+
+        // Realtime consumed 1.5 seconds before degrading. Chunked starts from
+        // that same cursor, not from zero or from the original enable instant.
+        timeline.advance_seconds(1.5);
+        assert_eq!(timeline.current_seconds(), 43.5);
+        timeline.advance_seconds(CAPTION_CHUNK_SECONDS);
+        assert_eq!(timeline.current_seconds(), 46.5);
+
+        // A genuine new capture timestamp regression remains the only reset.
+        timeline.reset_capture();
+        assert_eq!(timeline.current_seconds(), 0.0);
+    }
+
+    #[test]
+    fn local_speech_watchdog_ignores_silence_and_detects_voice_energy() {
+        assert!(!pcm_has_speech_energy(&vec![0; 1_600]));
+        assert!(pcm_has_speech_energy(&vec![2_000; 1_600]));
+    }
+
+    #[test]
+    fn first_frame_then_stall_is_not_masked_by_lifetime_frame_count() {
+        let started_at = std::time::Instant::now();
+        let mut heartbeat = CaptionAudioHeartbeat::new(started_at);
+        heartbeat.record_frame(started_at + std::time::Duration::from_secs(1));
+
+        assert_eq!(
+            heartbeat.failure_at(started_at + std::time::Duration::from_secs(8)),
+            None
+        );
+        assert_eq!(
+            heartbeat.failure_at(started_at + std::time::Duration::from_secs(9)),
+            Some(CaptionAudioPathFailure::Stalled),
+            "one historical frame must not keep an active path healthy forever"
+        );
+    }
+
+    #[test]
+    fn silent_frames_keep_caption_audio_heartbeat_healthy() {
+        let started_at = std::time::Instant::now();
+        let mut heartbeat = CaptionAudioHeartbeat::new(started_at);
+        for second in [1, 7, 13, 19] {
+            // Heartbeat is intentionally independent of sample energy: native
+            // mute and ordinary quiet still deliver healthy digital-silence frames.
+            heartbeat.record_frame(started_at + std::time::Duration::from_secs(second));
+        }
+        assert_eq!(
+            heartbeat.failure_at(started_at + std::time::Duration::from_secs(26)),
+            None
+        );
+    }
+
+    #[test]
+    fn receiver_disconnect_blocks_only_while_caption_audio_is_expected() {
+        assert_eq!(
+            caption_disconnect_failure(true),
+            Some(CaptionAudioPathFailure::Disconnected)
+        );
+        assert_eq!(
+            caption_disconnect_failure(false),
+            None,
+            "capture teardown and explicit caption stop close the bus intentionally"
+        );
+    }
+
+    #[test]
     fn wav_header_describes_16k_mono_s16le() {
         let wav = encode_wav_16k_mono(&[0, 1, -1]);
         assert_eq!(&wav[0..4], b"RIFF");
@@ -1694,35 +4648,53 @@ mod tests {
     fn caption_leg_plan_matrix() {
         use CaptionBurnTarget::*;
         let plan = caption_overlay_leg_plan;
-        // Off burns nothing anywhere.
-        for (record, stream) in [(true, false), (false, true), (true, true)] {
-            assert_eq!(
-                plan(record, stream, Off),
-                CaptionOverlayLegPlan {
-                    primary: false,
-                    aux: false,
-                    force_same_profile_split: false
-                }
-            );
-        }
-        // Record only: primary is the recording; stream targets are inert.
-        assert!(plan(true, false, Recording).primary);
-        assert!(plan(true, false, Both).primary);
-        assert!(!plan(true, false, Stream).primary);
-        // Stream only: primary IS the stream; recording targets are inert.
-        assert!(plan(false, true, Stream).primary);
-        assert!(plan(false, true, Both).primary);
-        assert!(!plan(false, true, Recording).primary);
-        // Record+stream: split forced ONLY when the legs must differ.
-        let stream_only = plan(true, true, Stream);
-        assert_eq!((stream_only.primary, stream_only.aux), (false, true));
-        assert!(stream_only.force_same_profile_split);
-        let recording_only = plan(true, true, Recording);
-        assert_eq!((recording_only.primary, recording_only.aux), (true, false));
-        assert!(recording_only.force_same_profile_split);
-        let both = plan(true, true, Both);
-        assert_eq!((both.primary, both.aux), (true, true));
-        assert!(!both.force_same_profile_split);
+        let expected =
+            |primary, aux, force_same_profile_split, captioned_copy| CaptionOverlayLegPlan {
+                primary,
+                aux,
+                force_same_profile_split,
+                captioned_copy,
+            };
+
+        // Record-only: no live overlay ever touches the source recording.
+        assert_eq!(plan(true, false, Off), expected(false, false, false, false));
+        assert_eq!(
+            plan(true, false, Stream),
+            expected(false, false, false, false)
+        );
+        assert_eq!(
+            plan(true, false, Recording),
+            expected(false, false, false, true)
+        );
+        assert_eq!(plan(true, false, Both), expected(false, false, false, true));
+
+        // Stream-only: the primary leg is the stream; recording selection is
+        // inert because there is no source recording from which to make a copy.
+        assert_eq!(plan(false, true, Off), expected(false, false, false, false));
+        assert_eq!(
+            plan(false, true, Stream),
+            expected(true, false, false, false)
+        );
+        assert_eq!(
+            plan(false, true, Recording),
+            expected(false, false, false, false)
+        );
+        assert_eq!(plan(false, true, Both), expected(true, false, false, false));
+
+        // Combined: the source recording remains clean. Any captioned stream
+        // uses one auxiliary leg (never primary + aux), even at the same profile.
+        assert_eq!(plan(true, true, Off), expected(false, false, false, false));
+        assert_eq!(plan(true, true, Stream), expected(false, true, true, false));
+        assert_eq!(
+            plan(true, true, Recording),
+            expected(false, false, false, true)
+        );
+        assert_eq!(plan(true, true, Both), expected(false, true, true, true));
+
+        assert_eq!(
+            plan(false, false, Both),
+            expected(false, false, false, false)
+        );
     }
 
     #[test]
@@ -1761,6 +4733,186 @@ mod tests {
     }
 
     #[test]
+    fn failed_capture_cues_are_purged_before_the_next_capture_epoch() {
+        let mut coordinator = CaptionsCoordinator::default();
+        advance_caption_capture_epoch_and_purge(&mut coordinator);
+        let failed_epoch = coordinator.capture_epoch;
+        let mut failed = chunk(1, 0.0, "private words from failed capture A", &[]);
+        failed.capture_epoch = failed_epoch;
+        coordinator.chunks.push(failed);
+
+        assert_eq!(advance_caption_capture_epoch_and_purge(&mut coordinator), 1);
+        assert!(coordinator.chunks.is_empty());
+        assert!(coordinator.capture_epoch > failed_epoch);
+
+        // Capture B gets another authoritative boundary and only its own epoch
+        // can survive artifact filtering.
+        advance_caption_capture_epoch_and_purge(&mut coordinator);
+        let successful_epoch = coordinator.capture_epoch;
+        let mut successful = chunk(1, 0.0, "capture B", &[]);
+        successful.capture_epoch = successful_epoch;
+        coordinator.chunks.push(successful.clone());
+        let drained = filter_caption_records_for_epoch(
+            std::mem::take(&mut coordinator.chunks),
+            successful_epoch,
+        );
+        assert_eq!(drained, vec![successful]);
+        assert_ne!(failed_epoch, successful_epoch);
+    }
+
+    #[test]
+    fn drained_artifact_keeps_its_epoch_style_and_generation_across_capture_start() {
+        let mut coordinator = CaptionsCoordinator::default();
+        coordinator.capture_epoch = 12;
+        coordinator.artifact_generation = 7;
+        let frozen_style = CaptionStyleSnapshot {
+            position: CaptionOverlayPosition::Top,
+            text_size: CaptionTextSize::L,
+            style_id: CaptionStyleId::HighContrast,
+            style_revision: 42,
+            output_width: 3_840,
+            output_height: 2_160,
+        };
+        coordinator.finalized_style = Some(frozen_style);
+        let mut finalized = chunk(3, 1.25, "owned by capture twelve", &[]);
+        finalized.capture_epoch = 12;
+        coordinator.chunks.push(finalized.clone());
+
+        let artifact = take_finalized_caption_artifact(&mut coordinator);
+        advance_caption_capture_epoch_and_purge(&mut coordinator);
+        coordinator.style = CaptionStyleSnapshot {
+            style_revision: 43,
+            output_width: 1_920,
+            output_height: 1_080,
+            ..CaptionStyleSnapshot::default()
+        };
+
+        assert_eq!(artifact.chunks, vec![finalized]);
+        assert_eq!(artifact.style, frozen_style);
+        assert_eq!(artifact.artifact_generation, 7);
+        assert_eq!(coordinator.capture_epoch, 13);
+        assert_ne!(artifact.style, coordinator.style);
+    }
+
+    #[tokio::test]
+    async fn stale_privacy_generation_cannot_publish_srt_or_renderer_cues() {
+        let root = std::env::temp_dir().join(format!(
+            "videorc-caption-generation-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let recording_path = root.join("recording.mp4");
+        let srt_path = recording_path.with_extension("srt");
+        let frames_dir = recording_path.with_extension("captions-frames");
+        let state = test_caption_app_state();
+        state.captions.lock().await.artifact_generation = 2;
+        let mut events = state.events.subscribe();
+        let stale = FinalizedCaptionArtifact {
+            chunks: vec![chunk(1, 0.0, "private stale cue", &[])],
+            style: CaptionStyleSnapshot {
+                output_width: 1_920,
+                output_height: 1_080,
+                ..CaptionStyleSnapshot::default()
+            },
+            artifact_generation: 1,
+        };
+
+        let stale = write_caption_artifacts(&state, "stale", &recording_path, stale).await;
+        begin_caption_cue_render(&state, "stale", "ffmpeg", &recording_path, &stale).await;
+        assert!(!srt_path.exists());
+        assert!(!frames_dir.exists());
+        assert!(
+            std::iter::from_fn(|| events.try_recv().ok())
+                .all(|event| event.event != "captions.cues.render-request"),
+            "a request invalidated by sign-out generation must emit no cue text"
+        );
+
+        let current = FinalizedCaptionArtifact {
+            chunks: vec![chunk(2, 0.0, "current cue", &[])],
+            style: stale.style,
+            artifact_generation: 2,
+        };
+        let current = write_caption_artifacts(&state, "current", &recording_path, current).await;
+        assert!(
+            srt_path.exists(),
+            "a current-generation SRT is fully published before write returns"
+        );
+        begin_caption_cue_render(&state, "current", "ffmpeg", &recording_path, &current).await;
+        let emitted = std::iter::from_fn(|| events.try_recv().ok()).collect::<Vec<_>>();
+        assert!(emitted.iter().any(|event| {
+            event.event == "captions.cues.render-request"
+                && event.payload["cues"][0]["text"] == "current cue"
+        }));
+
+        shutdown_caption_artifacts(&state).await;
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[test]
+    fn stream_only_caption_text_is_dropped_while_recorded_sessions_retain_current_epoch() {
+        let mut previous = chunk(1, 0.0, "previous", &[]);
+        previous.capture_epoch = 2;
+        let mut current = chunk(2, 0.0, "current", &[]);
+        current.capture_epoch = 3;
+
+        let retained =
+            caption_records_for_session_end(vec![previous.clone(), current.clone()], 3, true);
+        assert_eq!(retained, vec![current]);
+        assert!(caption_records_for_session_end(vec![previous], 2, false).is_empty());
+    }
+
+    #[test]
+    fn live_style_update_preserves_canvas_and_rejects_stale_revisions() {
+        let current = CaptionStyleSnapshot {
+            position: CaptionOverlayPosition::Bottom,
+            text_size: CaptionTextSize::M,
+            style_id: CaptionStyleId::Glass,
+            style_revision: 4,
+            output_width: 3_840,
+            output_height: 2_160,
+        };
+        let updated = apply_caption_style_update(
+            current,
+            SetCaptionStyleParams {
+                position: CaptionOverlayPosition::Top,
+                text_size: CaptionTextSize::L,
+                style_id: CaptionStyleId::HighContrast,
+                style_revision: 5,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            (updated.output_width, updated.output_height),
+            (3_840, 2_160)
+        );
+        assert_eq!(updated.style_id, CaptionStyleId::HighContrast);
+        assert_eq!(updated.style_revision, 5);
+
+        let later_ui_edit = CaptionStyleSnapshot {
+            style_id: CaptionStyleId::Classic,
+            style_revision: 6,
+            ..updated
+        };
+        assert_eq!(
+            caption_style_for_final_artifact(Some(updated), later_ui_edit),
+            updated,
+            "the style frozen at capture stop owns the whole captioned copy"
+        );
+
+        let stale = apply_caption_style_update(
+            updated,
+            SetCaptionStyleParams {
+                position: CaptionOverlayPosition::Bottom,
+                text_size: CaptionTextSize::S,
+                style_id: CaptionStyleId::Classic,
+                style_revision: 4,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(caption_style_error_code(&stale), "captions-style-stale");
+    }
+
+    #[test]
     fn caption_backoff_doubles_to_a_thirty_second_cap() {
         use std::time::Duration;
         let first = next_caption_backoff(None);
@@ -1772,6 +4924,262 @@ mod tests {
             current = next_caption_backoff(Some(current));
         }
         assert_eq!(current, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn configuration_send_failures_exhaust_realtime_retry_budget() {
+        use std::time::Duration;
+
+        let mut attempts = 0;
+        let mut backoff = None;
+        assert_eq!(
+            next_realtime_retry_delay(&mut attempts, &mut backoff),
+            Some(Duration::from_secs(2))
+        );
+        assert_eq!(
+            next_realtime_retry_delay(&mut attempts, &mut backoff),
+            Some(Duration::from_secs(4))
+        );
+        assert_eq!(
+            next_realtime_retry_delay(&mut attempts, &mut backoff),
+            None,
+            "an accepting-then-closing gateway must fall back instead of spinning"
+        );
+    }
+
+    #[test]
+    fn configuration_ack_then_close_still_exhausts_realtime_retry_budget() {
+        use std::time::Duration;
+
+        let mut budget = RealtimeRetryBudget::default();
+        assert_eq!(budget.retry_delay(), Some(Duration::from_secs(2)));
+
+        // A socket accepting configuration is not proof that transcription is
+        // healthy. Repeated ack-then-close cycles must remain bounded.
+        budget.observe(RealtimeHealthEvidence::ConfigurationAcknowledged);
+        assert_eq!(budget.retry_delay(), Some(Duration::from_secs(4)));
+        budget.observe(RealtimeHealthEvidence::ConfigurationAcknowledged);
+        assert_eq!(budget.retry_delay(), None);
+
+        // A real transcript or a sustained healthy interval earns a fresh
+        // reconnect budget.
+        budget.observe(RealtimeHealthEvidence::Transcript);
+        assert_eq!(budget.retry_delay(), Some(Duration::from_secs(2)));
+        budget.observe(RealtimeHealthEvidence::StableInterval);
+        assert_eq!(budget.retry_delay(), Some(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn chunk_buffer_drains_while_upload_is_pending_and_flushes_final_remainder() {
+        let sequence = CaptionSequence::default();
+        let mut timeline = CaptionTimeline::new(0.0);
+        let mut buffer = CaptionChunkBuffer::new(4, 4);
+
+        assert_eq!(
+            buffer.push_samples(vec![1, 2, 3, 4], 7, &sequence, &mut timeline),
+            0.0
+        );
+        let in_flight = buffer.pop_front().expect("first chunk starts uploading");
+        assert_eq!(in_flight.seq, 1);
+
+        // The first upload is still pending. New conversation must continue
+        // entering the bounded queue instead of backing up the tap receiver.
+        assert_eq!(
+            buffer.push_samples(
+                vec![5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+                7,
+                &sequence,
+                &mut timeline,
+            ),
+            0.0
+        );
+        assert_eq!(buffer.pending_len(), 2);
+        assert_eq!(buffer.flush_remainder(7, &sequence, &mut timeline), 0.0);
+
+        let queued = buffer.drain_pending();
+        assert_eq!(
+            queued.iter().map(|chunk| chunk.seq).collect::<Vec<_>>(),
+            vec![2, 3, 4]
+        );
+        assert_eq!(queued.last().map(|chunk| chunk.samples.len()), Some(2));
+        assert!(
+            queued
+                .last()
+                .is_some_and(|chunk| chunk.duration_seconds < 3.0)
+        );
+    }
+
+    #[test]
+    fn final_drain_budget_covers_two_near_timeout_uploads_and_remains_bounded() {
+        let two_uploads = caption_final_upload_grace(2);
+        assert_eq!(
+            two_uploads,
+            CAPTION_CHUNK_UPLOAD_TIMEOUT
+                .saturating_mul(2)
+                .saturating_add(CAPTION_FINAL_UPLOAD_OVERHEAD)
+        );
+        assert!(two_uploads > std::time::Duration::from_secs(20));
+        assert_eq!(
+            caption_final_upload_grace(CAPTION_FINAL_UPLOAD_COUNT),
+            std::time::Duration::from_secs(22),
+            "capture stop is bounded to the in-flight upload plus final remainder"
+        );
+    }
+
+    #[test]
+    fn capture_close_drops_failed_uploads_without_starving_the_final_remainder() {
+        let sequence = CaptionSequence::default();
+        let mut timeline = CaptionTimeline::new(0.0);
+        let mut policy_buffer = CaptionChunkBuffer::new(4, 4);
+        policy_buffer.push_samples(vec![1; 8], 3, &sequence, &mut timeline);
+        let failed = policy_buffer
+            .pop_front()
+            .expect("first upload fails transiently");
+        let failed_duration = failed.duration_seconds;
+        let now = tokio::time::Instant::now();
+        let mut backoff = None;
+        let mut next_upload_allowed_at = now;
+        let open_transition = apply_caption_chunk_transient_failure(
+            true,
+            failed,
+            &mut policy_buffer,
+            &mut backoff,
+            &mut next_upload_allowed_at,
+            now,
+        );
+        assert_eq!(
+            open_transition.action,
+            CaptionChunkTransientAction::RetryWithBackoff {
+                wait: std::time::Duration::from_secs(2)
+            }
+        );
+        assert_eq!(backoff, Some(std::time::Duration::from_secs(2)));
+        assert_eq!(
+            next_upload_allowed_at,
+            now + std::time::Duration::from_secs(2)
+        );
+
+        let failed_at_close = policy_buffer
+            .pop_front()
+            .expect("retry is at the front of the queue");
+        backoff = Some(std::time::Duration::from_secs(30));
+        next_upload_allowed_at = now + std::time::Duration::from_secs(30);
+        let closed_at = now + std::time::Duration::from_secs(1);
+        let closed_transition = apply_caption_chunk_transient_failure(
+            false,
+            failed_at_close,
+            &mut policy_buffer,
+            &mut backoff,
+            &mut next_upload_allowed_at,
+            closed_at,
+        );
+        assert_eq!(
+            closed_transition.action,
+            CaptionChunkTransientAction::DropAndContinueFinalDrain
+        );
+        assert_eq!(closed_transition.dropped_seconds, failed_duration);
+        assert_eq!(backoff, None, "capture close clears retry backoff");
+        assert_eq!(
+            next_upload_allowed_at, closed_at,
+            "the next unique queued chunk is eligible immediately"
+        );
+        assert_eq!(
+            policy_buffer.pop_front().map(|chunk| chunk.seq),
+            Some(2),
+            "the failed close-time chunk is not requeued ahead of the remainder"
+        );
+
+        let final_sequence = CaptionSequence::default();
+        let mut timeline = CaptionTimeline::new(0.0);
+        let mut buffer = CaptionChunkBuffer::new(4, MAX_BUFFERED_CAPTION_CHUNKS);
+        buffer.push_samples(vec![1; 4], 3, &final_sequence, &mut timeline);
+        let in_flight = buffer.pop_front().expect("one upload is in flight");
+        assert_eq!(in_flight.seq, 1);
+
+        // Fill all eight queue slots while the first upload is near timeout,
+        // then close with a short final remainder. Stop drops the old backlog,
+        // preserves the tail, clears backoff, and leaves only two attempts.
+        buffer.push_samples(
+            vec![2; MAX_BUFFERED_CAPTION_CHUNKS * 4 + 2],
+            3,
+            &final_sequence,
+            &mut timeline,
+        );
+        let mut final_backoff = Some(std::time::Duration::from_secs(30));
+        let mut final_next_upload = now + std::time::Duration::from_secs(30);
+        let closed_at = now + std::time::Duration::from_secs(5);
+        let dropped = prepare_caption_final_drain(
+            &mut buffer,
+            3,
+            &final_sequence,
+            &mut timeline,
+            &mut final_backoff,
+            &mut final_next_upload,
+            closed_at,
+        );
+        assert!(dropped > 0.0, "older queued backlog is surfaced as dropped");
+        assert_eq!(final_backoff, None);
+        assert_eq!(final_next_upload, closed_at);
+        assert_eq!(1 + buffer.pending_len(), CAPTION_FINAL_UPLOAD_COUNT);
+        let queued = buffer.drain_pending();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued.last().map(|chunk| chunk.samples.len()), Some(2));
+    }
+
+    #[test]
+    fn capture_close_exact_boundary_preserves_the_newest_full_chunk() {
+        let sequence = CaptionSequence::default();
+        let mut timeline = CaptionTimeline::new(0.0);
+        let mut buffer = CaptionChunkBuffer::new(4, MAX_BUFFERED_CAPTION_CHUNKS);
+        buffer.push_samples(vec![1; 4], 9, &sequence, &mut timeline);
+        let in_flight = buffer.pop_front().expect("one upload is in flight");
+        assert_eq!(in_flight.seq, 1);
+
+        // Three exact full chunks arrive while that upload is pending. There is
+        // no PCM remainder, so the newest full chunk (seq 4) owns the last words.
+        buffer.push_samples(vec![2; 12], 9, &sequence, &mut timeline);
+        assert!(buffer.pcm.is_empty());
+        let now = tokio::time::Instant::now();
+        let mut backoff = Some(std::time::Duration::from_secs(30));
+        let mut next_upload_allowed_at = now + std::time::Duration::from_secs(30);
+        let dropped = prepare_caption_final_drain(
+            &mut buffer,
+            9,
+            &sequence,
+            &mut timeline,
+            &mut backoff,
+            &mut next_upload_allowed_at,
+            now,
+        );
+
+        assert_eq!(
+            dropped,
+            8.0 / f64::from(CAPTION_SAMPLE_RATE),
+            "only the two older queued full chunks are discarded"
+        );
+        let retained = buffer.drain_pending();
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].seq, 4);
+        assert_eq!(retained[0].samples.len(), 4);
+        assert_eq!(1 + retained.len(), CAPTION_FINAL_UPLOAD_COUNT);
+        assert_eq!(backoff, None);
+        assert_eq!(next_upload_allowed_at, now);
+    }
+
+    #[test]
+    fn caption_sequence_survives_off_on_runtime_restarts_until_capture_reset() {
+        let capture_sequence = CaptionSequence::default();
+        let first_runtime = capture_sequence.clone();
+        assert_eq!(first_runtime.next(), 1);
+        assert_eq!(first_runtime.next(), 2);
+
+        // Turning captions off and back on creates another provider runtime,
+        // but the recording still owns one monotonic artifact namespace.
+        let second_runtime = capture_sequence.clone();
+        assert_eq!(second_runtime.next(), 3);
+
+        capture_sequence.reset();
+        assert_eq!(capture_sequence.next(), 1);
     }
 
     #[test]
@@ -1802,6 +5210,7 @@ mod tests {
                 })
                 .collect(),
             capture_epoch: 0,
+            provider_item_id: None,
         }
     }
 
@@ -1825,6 +5234,32 @@ mod tests {
             srt,
             "1\n00:00:00,100 --> 00:00:01,200\nHello viewers\n\n\
              2\n00:00:03,050 --> 00:00:03,900\nwelcome back\n\n"
+        );
+    }
+
+    #[test]
+    fn chunk_buffer_is_bounded_and_reports_evicted_audio() {
+        let sequence = CaptionSequence::default();
+        let mut timeline = CaptionTimeline::new(0.0);
+        let mut buffer = CaptionChunkBuffer::new(4, 2);
+
+        let dropped = buffer.push_samples(
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            1,
+            &sequence,
+            &mut timeline,
+        );
+
+        assert!(dropped > 0.0, "bounded overflow must be observable");
+        assert_eq!(buffer.pending_len(), 2);
+        assert_eq!(
+            buffer
+                .drain_pending()
+                .into_iter()
+                .map(|chunk| chunk.seq)
+                .collect::<Vec<_>>(),
+            vec![2, 3],
+            "the queue evicts the oldest audio so live captions can catch up"
         );
     }
 
@@ -1899,6 +5334,291 @@ mod tests {
              file '0.png'\nduration 0.100\n\
              file '0.png'\n"
         );
+    }
+
+    #[test]
+    fn cue_render_watchdog_allows_hundreds_of_frames_while_progress_continues() {
+        let started_at = tokio::time::Instant::now();
+        let mut last_progress_at = started_at;
+        let mut received = std::collections::BTreeSet::new();
+
+        for seq in 1..=400_u64 {
+            let now = started_at + std::time::Duration::from_secs(seq * 20);
+            if received.insert(seq) {
+                assert!(
+                    !cue_render_is_inactive(last_progress_at, now),
+                    "unique cue {seq} arrived before the inactivity deadline"
+                );
+                last_progress_at = now;
+            }
+        }
+
+        assert!(last_progress_at.duration_since(started_at) > std::time::Duration::from_secs(30));
+        assert!(!cue_render_is_inactive(
+            last_progress_at,
+            cue_render_inactivity_deadline(last_progress_at) - std::time::Duration::from_millis(1),
+        ));
+        let duplicate_at = last_progress_at + std::time::Duration::from_secs(29);
+        assert!(!received.insert(400), "duplicate frames are not progress");
+        assert!(!cue_render_is_inactive(last_progress_at, duplicate_at));
+        assert!(cue_render_is_inactive(
+            last_progress_at,
+            duplicate_at + std::time::Duration::from_secs(1),
+        ));
+    }
+
+    fn pending_render_for_test(request_id: &str, artifact_generation: u64) -> PendingCueRender {
+        PendingCueRender {
+            session_id: format!("session-{request_id}"),
+            ffmpeg_path: "ffmpeg".to_string(),
+            recording_path: std::path::PathBuf::from(format!("/{request_id}.mp4")),
+            frames_dir: std::path::PathBuf::from(format!("/{request_id}.captions-frames")),
+            cues: vec![CaptionCue {
+                seq: 1,
+                start_seconds: 0.0,
+                end_seconds: 1.0,
+                text: request_id.to_string(),
+            }],
+            expected: [1, CAPTION_BLANK_FRAME_SEQ].into_iter().collect(),
+            received: std::collections::BTreeSet::new(),
+            artifact_generation,
+            last_progress_at: tokio::time::Instant::now(),
+            watchdog_active: false,
+        }
+    }
+
+    #[test]
+    fn back_to_back_finalized_render_requests_are_retained_independently() {
+        let mut coordinator = CaptionsCoordinator::default();
+        coordinator
+            .pending_cue_renders
+            .insert("first".to_string(), pending_render_for_test("first", 4));
+        coordinator
+            .pending_cue_render_order
+            .push_back("first".to_string());
+
+        // A new capture advances transcript ownership but must not replace a
+        // finalized recording's renderer request.
+        advance_caption_capture_epoch_and_purge(&mut coordinator);
+        coordinator
+            .pending_cue_renders
+            .insert("second".to_string(), pending_render_for_test("second", 4));
+        coordinator
+            .pending_cue_render_order
+            .push_back("second".to_string());
+
+        assert_eq!(coordinator.pending_cue_renders.len(), 2);
+        coordinator
+            .pending_cue_renders
+            .get_mut("first")
+            .unwrap()
+            .received
+            .insert(1);
+        assert!(
+            coordinator
+                .pending_cue_renders
+                .get("second")
+                .unwrap()
+                .received
+                .is_empty(),
+            "each request keeps independent frame progress"
+        );
+        assert_eq!(
+            remove_pending_cue_render(&mut coordinator, "first")
+                .unwrap()
+                .artifact_generation,
+            4
+        );
+        assert!(coordinator.pending_cue_renders.contains_key("second"));
+        assert_eq!(
+            coordinator
+                .pending_cue_render_order
+                .front()
+                .map(String::as_str),
+            Some("second")
+        );
+    }
+
+    #[test]
+    fn queued_render_starts_a_fresh_watchdog_window_when_promoted() {
+        let mut coordinator = CaptionsCoordinator::default();
+        for request_id in ["first", "second"] {
+            coordinator.pending_cue_renders.insert(
+                request_id.to_string(),
+                pending_render_for_test(request_id, 5),
+            );
+            coordinator
+                .pending_cue_render_order
+                .push_back(request_id.to_string());
+        }
+        let started_at = tokio::time::Instant::now();
+        assert_eq!(
+            pending_cue_render_watchdog_state(&mut coordinator, "second", started_at),
+            CueRenderWatchdogState::Queued
+        );
+        assert_eq!(
+            pending_cue_render_watchdog_state(&mut coordinator, "first", started_at),
+            CueRenderWatchdogState::ActiveUntil(cue_render_inactivity_deadline(started_at))
+        );
+
+        remove_pending_cue_render(&mut coordinator, "first").unwrap();
+        let promoted_at = started_at + std::time::Duration::from_secs(90);
+        assert_eq!(
+            pending_cue_render_watchdog_state(&mut coordinator, "second", promoted_at),
+            CueRenderWatchdogState::ActiveUntil(cue_render_inactivity_deadline(promoted_at)),
+            "time spent waiting in the renderer FIFO is not inactivity"
+        );
+    }
+
+    #[test]
+    fn privacy_teardown_takes_every_pending_render_cache() {
+        let mut coordinator = CaptionsCoordinator::default();
+        for request_id in ["first", "second"] {
+            coordinator.pending_cue_renders.insert(
+                request_id.to_string(),
+                pending_render_for_test(request_id, 8),
+            );
+            coordinator
+                .pending_cue_render_order
+                .push_back(request_id.to_string());
+        }
+
+        let mut frames_dirs = take_pending_caption_frame_dirs(&mut coordinator);
+        frames_dirs.sort();
+        assert_eq!(
+            frames_dirs,
+            vec![
+                std::path::PathBuf::from("/first.captions-frames"),
+                std::path::PathBuf::from("/second.captions-frames"),
+            ]
+        );
+        assert!(coordinator.pending_cue_renders.is_empty());
+        assert!(coordinator.pending_cue_render_order.is_empty());
+    }
+
+    #[test]
+    fn capture_preemption_retries_caption_burn_but_sign_out_is_terminal() {
+        assert_eq!(
+            caption_burn_interruption(false, true),
+            Some(CaptionBurnInterruption::RetryAfterCapture)
+        );
+        assert_eq!(
+            caption_burn_interruption(true, true),
+            Some(CaptionBurnInterruption::CancelForSignOut),
+            "privacy cancellation wins when capture and sign-out race"
+        );
+        assert_eq!(caption_burn_interruption(false, false), None);
+    }
+
+    #[tokio::test]
+    async fn backend_shutdown_joins_burns_and_removes_every_private_artifact() {
+        let root = std::env::temp_dir().join(format!(
+            "videorc-caption-shutdown-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let pending_frames = root.join("pending.captions-frames");
+        let burn_frames = root.join("burn.captions-frames");
+        let partial_output = root.join("recording (captioned).mp4");
+        tokio::fs::create_dir_all(&pending_frames).await.unwrap();
+        tokio::fs::create_dir_all(&burn_frames).await.unwrap();
+        tokio::fs::write(pending_frames.join("1.png"), b"pending private frame")
+            .await
+            .unwrap();
+        tokio::fs::write(burn_frames.join("1.png"), b"burn private frame")
+            .await
+            .unwrap();
+        tokio::fs::write(&partial_output, b"partial captioned copy")
+            .await
+            .unwrap();
+
+        let state = test_caption_app_state();
+        let (cancel, mut cancel_receiver) = watch::channel(false);
+        let joined = Arc::new(AtomicBool::new(false));
+        let task_joined = joined.clone();
+        let join = tokio::spawn(async move {
+            wait_for_caption_burn_cancel(&mut cancel_receiver).await;
+            task_joined.store(true, Ordering::Release);
+        });
+        {
+            let mut coordinator = state.captions.lock().await;
+            coordinator.artifact_generation = 11;
+            let mut pending = pending_render_for_test("pending", 11);
+            pending.frames_dir = pending_frames.clone();
+            coordinator
+                .pending_cue_renders
+                .insert("pending".to_string(), pending);
+            coordinator
+                .pending_cue_render_order
+                .push_back("pending".to_string());
+            coordinator.caption_burn_tasks.push(CaptionBurnTask {
+                cancel,
+                join,
+                output_path: partial_output.clone(),
+                frames_dir: burn_frames.clone(),
+            });
+        }
+
+        shutdown_caption_artifacts(&state).await;
+
+        let coordinator = state.captions.lock().await;
+        assert_eq!(coordinator.artifact_generation, 12);
+        assert!(coordinator.pending_cue_renders.is_empty());
+        assert!(coordinator.pending_cue_render_order.is_empty());
+        assert!(coordinator.caption_burn_tasks.is_empty());
+        drop(coordinator);
+        assert!(joined.load(Ordering::Acquire));
+        assert!(!pending_frames.exists());
+        assert!(!burn_frames.exists());
+        assert!(!partial_output.exists());
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn caption_burn_cancellation_joins_and_removes_partial_private_artifacts() {
+        let root = std::env::temp_dir().join(format!(
+            "videorc-caption-burn-cancel-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let frames_dir = root.join("recording.captions-frames");
+        let output_path = root.join("recording (captioned).mp4");
+        tokio::fs::create_dir_all(&frames_dir).await.unwrap();
+        tokio::fs::write(frames_dir.join("1.png"), b"private frame")
+            .await
+            .unwrap();
+        tokio::fs::write(&output_path, b"partial private output")
+            .await
+            .unwrap();
+
+        let (cancel, mut cancel_receiver) = watch::channel(false);
+        let finished = Arc::new(AtomicBool::new(false));
+        let task_finished = finished.clone();
+        let join = tokio::spawn(async move {
+            wait_for_caption_burn_cancel(&mut cancel_receiver).await;
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            task_finished.store(true, Ordering::Release);
+        });
+        cancel_and_join_caption_burn_tasks(vec![CaptionBurnTask {
+            cancel,
+            join,
+            output_path: output_path.clone(),
+            frames_dir: frames_dir.clone(),
+        }])
+        .await;
+
+        assert!(
+            finished.load(Ordering::Acquire),
+            "privacy teardown returns only after the burn task has joined"
+        );
+        assert!(!output_path.exists());
+        assert!(!frames_dir.exists());
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[test]
+    fn caption_burn_ready_requires_the_current_privacy_generation() {
+        assert!(caption_burn_can_publish_ready(false, 7, 7));
+        assert!(!caption_burn_can_publish_ready(true, 7, 7));
+        assert!(!caption_burn_can_publish_ready(false, 7, 8));
     }
 
     #[test]
@@ -2005,6 +5725,166 @@ mod tests {
         let cleared = clear_caption_overlay(&slot);
         assert!(!cleared.active);
         assert!(current_caption_overlay(&slot).is_none());
+    }
+
+    #[test]
+    fn per_output_overlays_keep_distinct_4k_and_1080p_rasters() {
+        let slots = new_caption_overlay_slots();
+        install_caption_overlays(
+            &slots,
+            SetCaptionOverlayParams {
+                png_base64: encode_test_png(3_840, 320),
+                position: CaptionOverlayPosition::Bottom,
+                target: Some(CaptionOverlayTarget::Primary),
+                style_revision: Some(5),
+            },
+        )
+        .unwrap();
+        let info = install_caption_overlays(
+            &slots,
+            SetCaptionOverlayParams {
+                png_base64: encode_test_png(1_920, 180),
+                position: CaptionOverlayPosition::Top,
+                target: Some(CaptionOverlayTarget::Auxiliary),
+                style_revision: Some(5),
+            },
+        )
+        .unwrap();
+        assert!(info.active);
+        assert_eq!((info.primary.width, info.primary.height), (3_840, 320));
+        assert_eq!((info.auxiliary.width, info.auxiliary.height), (1_920, 180));
+
+        let snapshot = current_caption_overlays(&slots);
+        assert_eq!(snapshot.primary.unwrap().width, 3_840);
+        assert_eq!(snapshot.auxiliary.unwrap().width, 1_920);
+    }
+
+    #[test]
+    fn overlay_style_revision_rejects_stale_but_allows_same_revision_text_updates() {
+        let slots = new_caption_overlay_slots();
+        let first = install_caption_overlays(
+            &slots,
+            SetCaptionOverlayParams {
+                png_base64: encode_test_png(640, 100),
+                position: CaptionOverlayPosition::Bottom,
+                target: Some(CaptionOverlayTarget::Primary),
+                style_revision: Some(9),
+            },
+        )
+        .unwrap();
+        let same_style_new_text = install_caption_overlays(
+            &slots,
+            SetCaptionOverlayParams {
+                png_base64: encode_test_png(700, 110),
+                position: CaptionOverlayPosition::Bottom,
+                target: Some(CaptionOverlayTarget::Primary),
+                style_revision: Some(9),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            first.primary.revision + 1,
+            same_style_new_text.primary.revision
+        );
+        assert_eq!(same_style_new_text.primary.width, 700);
+
+        let stale = install_caption_overlays(
+            &slots,
+            SetCaptionOverlayParams {
+                png_base64: encode_test_png(800, 120),
+                position: CaptionOverlayPosition::Top,
+                target: Some(CaptionOverlayTarget::Primary),
+                style_revision: Some(8),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(caption_overlay_error_code(&stale), "captions-overlay-stale");
+        let survivor = current_caption_overlays(&slots).primary.unwrap();
+        assert_eq!(
+            (survivor.width, survivor.position),
+            (700, CaptionOverlayPosition::Bottom)
+        );
+
+        let stale_clear = clear_caption_overlays(
+            &slots,
+            ClearCaptionOverlayParams {
+                target: Some(CaptionOverlayTarget::Primary),
+                style_revision: Some(7),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            caption_overlay_error_code(&stale_clear),
+            "captions-overlay-stale"
+        );
+        assert!(current_caption_overlays(&slots).primary.is_some());
+    }
+
+    #[test]
+    fn missing_overlay_target_sets_and_clears_both_for_legacy_callers() {
+        let slots = new_caption_overlay_slots();
+        let set = install_caption_overlays(
+            &slots,
+            SetCaptionOverlayParams {
+                png_base64: encode_test_png(800, 140),
+                position: CaptionOverlayPosition::Bottom,
+                target: None,
+                style_revision: None,
+            },
+        )
+        .unwrap();
+        assert!(set.active);
+        assert!(set.primary.active && set.auxiliary.active);
+
+        let primary_clear = clear_caption_overlays(
+            &slots,
+            ClearCaptionOverlayParams {
+                target: Some(CaptionOverlayTarget::Primary),
+                style_revision: None,
+            },
+        )
+        .unwrap();
+        assert!(primary_clear.active, "auxiliary is still active");
+        assert!(!primary_clear.primary.active && primary_clear.auxiliary.active);
+
+        let cleared = clear_caption_overlays(&slots, ClearCaptionOverlayParams::default()).unwrap();
+        assert!(!cleared.active);
+        assert!(!cleared.primary.active && !cleared.auxiliary.active);
+    }
+
+    #[test]
+    fn overlay_and_style_rpc_params_use_the_documented_wire_contract() {
+        let set: SetCaptionOverlayParams = serde_json::from_value(serde_json::json!({
+            "pngBase64": "payload",
+            "position": "top",
+            "styleRevision": 3
+        }))
+        .unwrap();
+        assert_eq!(
+            set.target, None,
+            "missing target is the legacy all-targets form"
+        );
+        assert_eq!(set.position, CaptionOverlayPosition::Top);
+        assert_eq!(set.style_revision, Some(3));
+
+        let clear: ClearCaptionOverlayParams = serde_json::from_value(serde_json::json!({
+            "target": "auxiliary",
+            "styleRevision": 4
+        }))
+        .unwrap();
+        assert_eq!(clear.target, Some(CaptionOverlayTarget::Auxiliary));
+        assert_eq!(clear.style_revision, Some(4));
+
+        let style: SetCaptionStyleParams = serde_json::from_value(serde_json::json!({
+            "position": "bottom",
+            "textSize": "l",
+            "styleId": "lower-third",
+            "styleRevision": 5
+        }))
+        .unwrap();
+        assert_eq!(style.text_size, CaptionTextSize::L);
+        assert_eq!(style.style_id, CaptionStyleId::LowerThird);
+        assert_eq!(style.style_revision, 5);
     }
 
     #[test]

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -2194,18 +2194,20 @@ fn push_caption_overlay_gpu_source<'a>(
     canvas_width: u32,
     canvas_height: u32,
     content_namespace: u64,
+    safe_inset: usize,
 ) {
     let overlay_width = overlay.width as usize;
     let overlay_height = overlay.height as usize;
     if overlay.rgba.len() < overlay_width * overlay_height * 4 {
         return;
     }
-    let (source_left, dest_left, dest_top, draw_width) = caption_overlay_layout(
+    let (source_left, dest_left, dest_top, draw_width) = caption_overlay_layout_with_inset(
         overlay_width,
         overlay_height,
         canvas_width.max(1) as usize,
         canvas_height.max(1) as usize,
         overlay.position,
+        safe_inset,
     );
     let draw_height = overlay_height.min(canvas_height.max(1) as usize);
     // Channel conversion happens once when the overlay revision is installed. Crop only
@@ -2382,12 +2384,18 @@ fn try_gpu_compose(
             mask: SourceMask::None,
         });
         if let Some(overlay) = inputs.caption_overlay {
+            let safe_inset = caption_overlay_safe_inset(
+                inputs.caption_overlay,
+                inputs.highlight_overlay,
+                inputs.height,
+            );
             push_caption_overlay_gpu_source(
                 &mut prepared_sources,
                 overlay,
                 inputs.width,
                 inputs.height,
                 2,
+                safe_inset,
             );
         }
         if let Some(overlay) = inputs.highlight_overlay {
@@ -2397,6 +2405,7 @@ fn try_gpu_compose(
                 inputs.width,
                 inputs.height,
                 3,
+                0,
             );
         }
         let sources = prepared_sources
@@ -2444,12 +2453,18 @@ fn try_gpu_compose(
             mask: SourceMask::None,
         });
         if let Some(overlay) = inputs.caption_overlay {
+            let safe_inset = caption_overlay_safe_inset(
+                inputs.caption_overlay,
+                inputs.highlight_overlay,
+                inputs.height,
+            );
             push_caption_overlay_gpu_source(
                 &mut prepared_sources,
                 overlay,
                 inputs.width,
                 inputs.height,
                 2,
+                safe_inset,
             );
         }
         if let Some(overlay) = inputs.highlight_overlay {
@@ -2459,6 +2474,7 @@ fn try_gpu_compose(
                 inputs.width,
                 inputs.height,
                 3,
+                0,
             );
         }
         let sources = prepared_sources
@@ -2646,12 +2662,18 @@ fn try_gpu_compose(
         return Err("no visible compositor sources".to_string());
     }
     if let Some(overlay) = inputs.caption_overlay {
+        let safe_inset = caption_overlay_safe_inset(
+            inputs.caption_overlay,
+            inputs.highlight_overlay,
+            inputs.height,
+        );
         push_caption_overlay_gpu_source(
             &mut prepared_sources,
             overlay,
             inputs.width,
             inputs.height,
             2,
+            safe_inset,
         );
     }
     if let Some(overlay) = inputs.highlight_overlay {
@@ -2661,6 +2683,7 @@ fn try_gpu_compose(
             inputs.width,
             inputs.height,
             3,
+            0,
         );
     }
     let sources = prepared_sources
@@ -2972,6 +2995,20 @@ fn try_gpu_compose(
     Err("Metal compositor unavailable on this OS".to_string())
 }
 
+fn caption_overlay_for_output(
+    overlays: &crate::captions::CaptionOverlaySlotsSnapshot,
+    target: crate::captions::CaptionOverlayTarget,
+    enabled: bool,
+) -> Option<&crate::captions::CaptionOverlay> {
+    if !enabled {
+        return None;
+    }
+    match target {
+        crate::captions::CaptionOverlayTarget::Primary => overlays.primary.as_ref(),
+        crate::captions::CaptionOverlayTarget::Auxiliary => overlays.auxiliary.as_ref(),
+    }
+}
+
 // Internal render-loop plumbing; the parameters are the loop's working set, not an API.
 #[allow(clippy::too_many_arguments)]
 async fn publish_compositor_frame(
@@ -3057,9 +3094,10 @@ async fn publish_compositor_frame(
     let mut pixel_format = CompositorPixelFormat::yuv420p_cpu_buffer();
     let mut export_handle = CompositorFrameExportHandle::default();
     let metal_target_handoff;
-    // One overlay snapshot per frame (Arc clone); the stream leg always
-    // carries it, the primary leg only for stream-only sessions (A0 verdict).
-    let caption_overlay = crate::captions::current_caption_overlay(&state.caption_overlay);
+    // One atomic per-target overlay snapshot per frame (Arc clones). Split
+    // outputs can carry independently rasterized 4K primary and 1080p
+    // auxiliary bars without scaling one leg's pixels onto the other.
+    let caption_overlays = crate::captions::current_caption_overlays(&state.caption_overlay);
     let highlight_overlay = crate::captions::current_caption_overlay(&state.highlight_overlay);
     let mut bytes;
     {
@@ -3072,11 +3110,11 @@ async fn publish_compositor_frame(
             background_image_source: background_image_source.as_ref(),
             camera_frame: camera_frame.as_ref().map(|(frame, _layout)| frame),
             screen_frame: screen_frame.as_ref(),
-            caption_overlay: if caption_overlay_on_primary {
-                caption_overlay.as_ref()
-            } else {
-                None
-            },
+            caption_overlay: caption_overlay_for_output(
+                &caption_overlays,
+                crate::captions::CaptionOverlayTarget::Primary,
+                caption_overlay_on_primary,
+            ),
             highlight_overlay: if highlight_overlay_on_primary {
                 highlight_overlay.as_ref()
             } else {
@@ -3144,11 +3182,11 @@ async fn publish_compositor_frame(
             camera_frame: camera_frame.as_ref().map(|(frame, _layout)| frame),
             screen_frame: screen_frame.as_ref(),
             // The auxiliary (stream) leg carries the bar per the leg plan.
-            caption_overlay: if caption_overlay_on_aux {
-                caption_overlay.as_ref()
-            } else {
-                None
-            },
+            caption_overlay: caption_overlay_for_output(
+                &caption_overlays,
+                crate::captions::CaptionOverlayTarget::Auxiliary,
+                caption_overlay_on_aux,
+            ),
             highlight_overlay: if highlight_overlay_on_aux {
                 highlight_overlay.as_ref()
             } else {
@@ -3284,10 +3322,20 @@ struct CompositorRenderInputs<'a> {
 fn render_compositor_yuv420p_frame(inputs: CompositorRenderInputs<'_>, bytes: &mut [u8]) {
     render_compositor_yuv420p_scene(inputs, bytes);
     if let Some(overlay) = inputs.caption_overlay {
-        composite_caption_overlay(overlay, inputs.width, inputs.height, bytes);
+        composite_caption_overlay(
+            overlay,
+            inputs.width,
+            inputs.height,
+            bytes,
+            caption_overlay_safe_inset(
+                inputs.caption_overlay,
+                inputs.highlight_overlay,
+                inputs.height,
+            ),
+        );
     }
     if let Some(overlay) = inputs.highlight_overlay {
-        composite_caption_overlay(overlay, inputs.width, inputs.height, bytes);
+        composite_caption_overlay(overlay, inputs.width, inputs.height, bytes, 0);
     }
 }
 
@@ -3962,6 +4010,28 @@ fn render_synthetic_source_rect(
 
 /// Vertical safe margin for the caption bar, as a fraction of canvas height.
 const CAPTION_OVERLAY_MARGIN: f64 = 0.04;
+const OVERLAY_COLLISION_GAP: f64 = 0.02;
+
+/// Highlights currently occupy the selected edge (top by default). When a
+/// creator also chooses captions on that edge, reserve the complete highlight
+/// bitmap plus a small title-safe gap. Both CPU and Metal paths consume this
+/// value, so the live stream cannot diverge from preview/recording output.
+fn caption_overlay_safe_inset(
+    caption: Option<&crate::captions::CaptionOverlay>,
+    highlight: Option<&crate::captions::CaptionOverlay>,
+    canvas_height: u32,
+) -> usize {
+    let (Some(caption), Some(highlight)) = (caption, highlight) else {
+        return 0;
+    };
+    if caption.position != highlight.position {
+        return 0;
+    }
+    let gap = ((canvas_height.max(1) as f64) * OVERLAY_COLLISION_GAP)
+        .round()
+        .max(1.0) as usize;
+    (highlight.height as usize).saturating_add(gap)
+}
 
 /// Alpha-composite the caption bar over a YUV420p frame — the one true
 /// alpha-blending blit (scene blits are binary: alpha<16 skip, else write).
@@ -3970,6 +4040,7 @@ const CAPTION_OVERLAY_MARGIN: f64 = 0.04;
 /// Where the caption bar lands on a canvas (shared by the CPU blit and the
 /// Metal source placement): centered, 4% vertical safe margin, wider bars
 /// center-cropped.
+#[cfg(test)]
 pub(crate) fn caption_overlay_layout(
     overlay_width: usize,
     overlay_height: usize,
@@ -3977,17 +4048,36 @@ pub(crate) fn caption_overlay_layout(
     canvas_height: usize,
     position: crate::captions::CaptionOverlayPosition,
 ) -> (usize, usize, usize, usize) {
+    caption_overlay_layout_with_inset(
+        overlay_width,
+        overlay_height,
+        canvas_width,
+        canvas_height,
+        position,
+        0,
+    )
+}
+
+fn caption_overlay_layout_with_inset(
+    overlay_width: usize,
+    overlay_height: usize,
+    canvas_width: usize,
+    canvas_height: usize,
+    position: crate::captions::CaptionOverlayPosition,
+    safe_inset: usize,
+) -> (usize, usize, usize, usize) {
     let draw_width = overlay_width.min(canvas_width);
     let draw_height = overlay_height.min(canvas_height);
     let source_left = (overlay_width - draw_width) / 2;
     let dest_left = (canvas_width - draw_width) / 2;
     let margin = ((canvas_height as f64) * CAPTION_OVERLAY_MARGIN).round() as usize;
+    let inset_margin = margin.saturating_add(safe_inset);
     let dest_top = match position {
         crate::captions::CaptionOverlayPosition::Top => {
-            margin.min(canvas_height.saturating_sub(draw_height))
+            inset_margin.min(canvas_height.saturating_sub(draw_height))
         }
         crate::captions::CaptionOverlayPosition::Bottom => {
-            canvas_height.saturating_sub(draw_height + margin)
+            canvas_height.saturating_sub(draw_height.saturating_add(inset_margin))
         }
     };
     (source_left, dest_left, dest_top, draw_width.max(1))
@@ -3998,6 +4088,7 @@ fn composite_caption_overlay(
     canvas_width: u32,
     canvas_height: u32,
     dest: &mut [u8],
+    safe_inset: usize,
 ) {
     let canvas_width = canvas_width.max(1) as usize;
     let canvas_height = canvas_height.max(1) as usize;
@@ -4011,12 +4102,13 @@ fn composite_caption_overlay(
     }
 
     let draw_height = overlay_height.min(canvas_height);
-    let (source_left, dest_left, dest_top, draw_width) = caption_overlay_layout(
+    let (source_left, dest_left, dest_top, draw_width) = caption_overlay_layout_with_inset(
         overlay_width,
         overlay_height,
         canvas_width,
         canvas_height,
         overlay.position,
+        safe_inset,
     );
 
     let y_len = canvas_width * canvas_height;
@@ -7255,6 +7347,46 @@ mod tests {
     }
 
     #[test]
+    fn split_outputs_select_distinct_primary_4k_and_auxiliary_1080p_caption_rasters() {
+        let overlays = crate::captions::CaptionOverlaySlotsSnapshot {
+            primary: Some(test_caption_overlay(
+                3_840,
+                320,
+                [255, 255, 255, 255],
+                crate::captions::CaptionOverlayPosition::Bottom,
+            )),
+            auxiliary: Some(test_caption_overlay(
+                1_920,
+                180,
+                [255, 255, 255, 255],
+                crate::captions::CaptionOverlayPosition::Bottom,
+            )),
+        };
+        let primary = caption_overlay_for_output(
+            &overlays,
+            crate::captions::CaptionOverlayTarget::Primary,
+            true,
+        )
+        .unwrap();
+        let auxiliary = caption_overlay_for_output(
+            &overlays,
+            crate::captions::CaptionOverlayTarget::Auxiliary,
+            true,
+        )
+        .unwrap();
+        assert_eq!((primary.width, primary.height), (3_840, 320));
+        assert_eq!((auxiliary.width, auxiliary.height), (1_920, 180));
+        assert!(
+            caption_overlay_for_output(
+                &overlays,
+                crate::captions::CaptionOverlayTarget::Auxiliary,
+                false,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
     fn caption_and_highlight_overlays_coexist_top_and_bottom() {
         // Comments upgrade S2: the highlight card (top) and the captions bar
         // (bottom) render in the SAME frame from their independent slots.
@@ -7303,6 +7435,53 @@ mod tests {
         let bottom_index = 13 * canvas_w as usize + (canvas_w as usize / 2);
         assert_eq!(with_both[bottom_index], white_y);
         assert_ne!(with_both[bottom_index], baseline[bottom_index]);
+    }
+
+    #[test]
+    fn caption_and_highlight_same_edge_resolve_safe_areas_in_landscape_and_vertical() {
+        for (canvas_width, canvas_height) in [(1920_usize, 1080_usize), (1080, 1920)] {
+            for position in [
+                crate::captions::CaptionOverlayPosition::Top,
+                crate::captions::CaptionOverlayPosition::Bottom,
+            ] {
+                let caption = test_caption_overlay(960, 120, [255, 255, 255, 255], position);
+                let highlight = test_caption_overlay(720, 180, [255, 255, 255, 255], position);
+                let safe_inset = caption_overlay_safe_inset(
+                    Some(&caption),
+                    Some(&highlight),
+                    canvas_height as u32,
+                );
+                let (_, _, caption_top, _) = caption_overlay_layout_with_inset(
+                    caption.width as usize,
+                    caption.height as usize,
+                    canvas_width,
+                    canvas_height,
+                    position,
+                    safe_inset,
+                );
+                let (_, _, highlight_top, _) = caption_overlay_layout(
+                    highlight.width as usize,
+                    highlight.height as usize,
+                    canvas_width,
+                    canvas_height,
+                    position,
+                );
+                let gap = ((canvas_height as f64) * OVERLAY_COLLISION_GAP)
+                    .round()
+                    .max(1.0) as usize;
+
+                match position {
+                    crate::captions::CaptionOverlayPosition::Top => assert!(
+                        caption_top >= highlight_top + highlight.height as usize + gap,
+                        "top safe areas overlap at {canvas_width}x{canvas_height}"
+                    ),
+                    crate::captions::CaptionOverlayPosition::Bottom => assert!(
+                        caption_top + caption.height as usize + gap <= highlight_top,
+                        "bottom safe areas overlap at {canvas_width}x{canvas_height}"
+                    ),
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -96,7 +96,8 @@ use protocol::{
 use recording::{
     create_preview_snapshot, idle_status, live_preview_status, preview_file_path, remux_session,
     resume_pending_repair_jobs, shutdown_capture_processes, start_live_preview, start_session,
-    stop_live_preview, stop_recording, subscribe_live_preview_frames, update_preview_frame_age,
+    stop_live_preview, stop_recording, subscribe_live_preview_frames,
+    update_active_audio_processing, update_preview_frame_age,
 };
 use scene::{
     nudge_source, reorder_sources, reset_source_transform, scene_from_capture_config,
@@ -306,9 +307,11 @@ async fn shutdown_signal(state: AppState) {
 
     state.emit_log(
         "info",
-        "Backend shutdown requested; stopping capture processes.",
+        "Backend shutdown requested; stopping caption, capture, and artifact processes.",
     );
-    shutdown_capture_processes(state).await;
+    captions::shutdown_caption_runtime(&state).await;
+    shutdown_capture_processes(state.clone()).await;
+    captions::shutdown_caption_artifacts(&state).await;
 }
 
 /// A dedicated OS thread that kills this process when its parent dies. This MUST be
@@ -3206,7 +3209,10 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
             ServerResponse::ok(command.id, account::current_account(session.as_ref()))
         }
         "account.sign_out" => {
-            account::clear_persisted_account();
+            clear_account_credentials_after_caption_shutdown(state, || {
+                account::clear_persisted_account();
+            })
+            .await;
             // The account no longer vouches for premium — drop hydrated
             // entitlements with it (multistream gate closes immediately).
             if entitlements::clear_account_entitlements() {
@@ -3254,23 +3260,63 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
         "captions.status.get" => {
             ServerResponse::ok(command.id, captions::captions_status(state).await)
         }
-        "captions.overlay.set" => {
-            let png_base64 = command
-                .params
-                .get("pngBase64")
-                .and_then(|value| value.as_str())
-                .unwrap_or_default();
-            let position = command
-                .params
-                .get("position")
-                .and_then(|value| {
-                    serde_json::from_value::<captions::CaptionOverlayPosition>(value.clone()).ok()
-                })
-                .unwrap_or(captions::CaptionOverlayPosition::Bottom);
-            match captions::install_caption_overlay(&state.caption_overlay, png_base64, position) {
-                Ok(info) => ServerResponse::ok(command.id, info),
+        "captions.style.set" => {
+            match serde_json::from_value::<captions::SetCaptionStyleParams>(command.params) {
+                Ok(params) => match captions::update_caption_style(state, params).await {
+                    Ok(style) => ServerResponse::ok(command.id, style),
+                    Err(error) => ServerResponse::error(
+                        command.id,
+                        captions::caption_style_error_code(&error),
+                        error.to_string(),
+                    ),
+                },
                 Err(error) => {
-                    ServerResponse::error(command.id, "captions-overlay-invalid", error.to_string())
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
+        #[cfg(debug_assertions)]
+        "captions.test.inject-audio" => {
+            let duration_ms = command
+                .params
+                .get("durationMs")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(600);
+            match captions::inject_caption_contract_test_audio(duration_ms).await {
+                Ok(frames_accepted) => ServerResponse::ok(
+                    command.id,
+                    serde_json::json!({ "framesAccepted": frames_accepted }),
+                ),
+                Err(error) => ServerResponse::error(
+                    command.id,
+                    "caption-contract-test-disabled",
+                    error.to_string(),
+                ),
+            }
+        }
+        #[cfg(debug_assertions)]
+        "captions.test.snapshot" => match captions::caption_contract_test_snapshot(state).await {
+            Ok(snapshot) => ServerResponse::ok(command.id, snapshot),
+            Err(error) => ServerResponse::error(
+                command.id,
+                "caption-contract-test-disabled",
+                error.to_string(),
+            ),
+        },
+        "captions.overlay.set" => {
+            match serde_json::from_value::<captions::SetCaptionOverlayParams>(command.params) {
+                Ok(params) => {
+                    match captions::install_caption_overlays(&state.caption_overlay, params) {
+                        Ok(info) => ServerResponse::ok(command.id, info),
+                        Err(error) => ServerResponse::error(
+                            command.id,
+                            captions::caption_overlay_error_code(&error),
+                            error.to_string(),
+                        ),
+                    }
+                }
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
                 }
             }
         }
@@ -3297,10 +3343,23 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
             command.id,
             comment_highlight::clear_comment_highlight(state).await,
         ),
-        "captions.overlay.clear" => ServerResponse::ok(
-            command.id,
-            captions::clear_caption_overlay(&state.caption_overlay),
-        ),
+        "captions.overlay.clear" => {
+            match serde_json::from_value::<captions::ClearCaptionOverlayParams>(command.params) {
+                Ok(params) => {
+                    match captions::clear_caption_overlays(&state.caption_overlay, params) {
+                        Ok(info) => ServerResponse::ok(command.id, info),
+                        Err(error) => ServerResponse::error(
+                            command.id,
+                            captions::caption_overlay_error_code(&error),
+                            error.to_string(),
+                        ),
+                    }
+                }
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
         "captions.cues.submit" => {
             let request_id = command
                 .params
@@ -3544,6 +3603,65 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
                 Err(error) => {
                     ServerResponse::error(command.id, "invalid-params", error.to_string())
                 }
+            }
+        }
+        "audio.processing.update" => {
+            match serde_json::from_value::<protocol::AudioProcessingUpdateParams>(command.params) {
+                Ok(params) => ServerResponse::ok(
+                    command.id,
+                    update_active_audio_processing(state, params).await,
+                ),
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
+        #[cfg(debug_assertions)]
+        "audio.test.inject-pcm" => {
+            let session_id = command
+                .params
+                .get("sessionId")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let duration_ms = command
+                .params
+                .get("durationMs")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(600);
+            let raw_peak = command
+                .params
+                .get("rawPeak")
+                .and_then(|value| value.as_f64())
+                .unwrap_or(0.12) as f32;
+            let injector = {
+                let recording = state.recording.lock().await;
+                recording
+                    .as_ref()
+                    .filter(|active| active.session_id == session_id)
+                    .and_then(|active| active.native_audio.as_ref())
+                    .and_then(|native_audio| native_audio.caption_contract_test_injector())
+            };
+            match injector {
+                Some(injector) => match injector.inject(duration_ms, raw_peak).await {
+                    Ok(injection) => ServerResponse::ok(
+                        command.id,
+                        serde_json::json!({
+                            "packetsGenerated": injection.packets_generated,
+                            "rawPeak": injection.raw_peak,
+                        }),
+                    ),
+                    Err(error) => ServerResponse::error(
+                        command.id,
+                        "caption-contract-test-disabled",
+                        error.to_string(),
+                    ),
+                },
+                None => ServerResponse::error(
+                    command.id,
+                    "caption-contract-test-disabled",
+                    "The matching caption contract test microphone session is not active.",
+                ),
             }
         }
         "scene.get" => {
@@ -4791,6 +4909,13 @@ async fn handle_text_message(state: &AppState, text: &str) -> ServerResponse {
     }
 }
 
+async fn clear_account_credentials_after_caption_shutdown(
+    state: &AppState,
+    clear_credentials: impl FnOnce(),
+) {
+    captions::stop_captions_for_sign_out(state, clear_credentials).await;
+}
+
 fn stored_ai_session_token() -> Result<String> {
     account::stored_session_token().context("Sign in to use cloud AI.")
 }
@@ -4980,6 +5105,8 @@ mod tests {
     use serde_json::json;
     use std::time::Instant;
     use tokio::sync::broadcast;
+
+    static CAPTION_LIFECYCLE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
     async fn receive_tracked_json(
         receiver: &mut mpsc::Receiver<Message>,
@@ -5641,6 +5768,298 @@ mod tests {
             events,
             Database::open_in_memory_for_tests(),
         )
+    }
+
+    #[tokio::test]
+    async fn live_audio_processing_update_requires_an_active_matching_session() {
+        let state = test_state();
+        let response = handle_text_message(
+            &state,
+            r#"{"id":"audio-live","method":"audio.processing.update","params":{"sessionId":"ended-session","microphoneGainDb":6,"microphoneMuted":true}}"#,
+        )
+        .await;
+
+        assert!(response.ok);
+        let payload = response.payload.expect("audio processing payload");
+        assert_eq!(payload["applied"], false);
+        assert_eq!(payload["sessionId"], "ended-session");
+        assert_eq!(payload["microphoneGainDb"], 6.0);
+        assert_eq!(payload["microphoneMuted"], true);
+        assert_eq!(payload["reasonCode"], "no-active-session");
+    }
+
+    #[tokio::test]
+    async fn account_sign_out_stops_active_captions_before_credentials_are_cleared() {
+        let _caption_test_guard = CAPTION_LIFECYCLE_TEST_LOCK.lock().await;
+        let state = test_state();
+        let probe = captions::install_caption_sign_out_test_session(&state).await;
+        let mut events = state.events.subscribe();
+        let frame = audio::AudioFrame {
+            timestamp_micros: 0,
+            captured_at: std::time::Instant::now(),
+            sample_rate: 48_000,
+            channels: 1,
+            samples: vec![0.1; 960],
+        };
+
+        captions::offer_caption_frame(&frame);
+        timeout(Duration::from_secs(1), async {
+            while probe.frames_received() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("active caption task should consume the microphone tap");
+        let received_before_sign_out = probe.frames_received();
+
+        let credentials_cleared = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let clear_signal = credentials_cleared.clone();
+        clear_account_credentials_after_caption_shutdown(&state, || {
+            assert!(
+                probe.task_finished(),
+                "caption task must be joined before credential removal"
+            );
+            clear_signal.store(true, std::sync::atomic::Ordering::Release);
+        })
+        .await;
+        assert!(credentials_cleared.load(std::sync::atomic::Ordering::Acquire));
+
+        captions::offer_caption_frame(&audio::AudioFrame {
+            timestamp_micros: 20_000,
+            ..frame
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(
+            probe.frames_received(),
+            received_before_sign_out,
+            "signed-out captions must not continue consuming microphone audio"
+        );
+
+        assert_eq!(
+            captions::caption_sign_out_test_snapshot(&state).await,
+            captions::CaptionSignOutTestSnapshot {
+                task_present: false,
+                stop_present: false,
+                desired_enabled: false,
+                language_present: false,
+                chunk_count: 0,
+                finalized_style_present: false,
+                tap_active: false,
+                primary_overlay_active: false,
+                auxiliary_overlay_active: false,
+            }
+        );
+        assert_eq!(
+            captions::captions_status(&state).await.state,
+            captions::CaptionsState::Idle
+        );
+
+        let mut saw_idle = false;
+        let mut saw_cleared = false;
+        while let Ok(event) = events.try_recv() {
+            saw_idle |= event.event == "captions.status" && event.payload["state"] == "idle";
+            saw_cleared |= event.event == "captions.cleared";
+        }
+        assert!(saw_idle, "renderer must receive the signed-out idle state");
+        assert!(
+            saw_cleared,
+            "renderer must receive a transcript reset event"
+        );
+    }
+
+    #[tokio::test]
+    async fn backend_shutdown_joins_active_captions_and_removes_the_audio_tap() {
+        let _caption_test_guard = CAPTION_LIFECYCLE_TEST_LOCK.lock().await;
+        let state = test_state();
+        let probe = captions::install_caption_sign_out_test_session(&state).await;
+        let frame = audio::AudioFrame {
+            timestamp_micros: 0,
+            captured_at: std::time::Instant::now(),
+            sample_rate: 48_000,
+            channels: 1,
+            samples: vec![0.1; 960],
+        };
+
+        captions::offer_caption_frame(&frame);
+        timeout(Duration::from_secs(1), async {
+            while probe.frames_received() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("active caption task should consume the microphone tap");
+        let received_before_shutdown = probe.frames_received();
+
+        captions::shutdown_caption_runtime(&state).await;
+        assert!(
+            probe.task_finished(),
+            "backend shutdown must join the provider task before capture teardown"
+        );
+        captions::offer_caption_frame(&audio::AudioFrame {
+            timestamp_micros: 20_000,
+            ..frame
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(
+            probe.frames_received(),
+            received_before_shutdown,
+            "backend shutdown must disconnect the microphone tap"
+        );
+
+        assert_eq!(
+            captions::caption_sign_out_test_snapshot(&state).await,
+            captions::CaptionSignOutTestSnapshot {
+                task_present: false,
+                stop_present: false,
+                desired_enabled: true,
+                language_present: true,
+                chunk_count: 1,
+                finalized_style_present: true,
+                tap_active: false,
+                primary_overlay_active: false,
+                auxiliary_overlay_active: false,
+            },
+            "runtime shutdown preserves preferences and artifact cues until the artifact teardown"
+        );
+
+        captions::shutdown_caption_artifacts(&state).await;
+        let cleaned = captions::caption_sign_out_test_snapshot(&state).await;
+        assert_eq!(cleaned.chunk_count, 0);
+        assert!(!cleaned.finalized_style_present);
+    }
+
+    #[tokio::test]
+    async fn caption_stop_and_block_clear_backend_overlays_and_reset_renderer() {
+        let _caption_test_guard = CAPTION_LIFECYCLE_TEST_LOCK.lock().await;
+        let state = test_state();
+
+        let _stop_probe = captions::install_caption_sign_out_test_session(&state).await;
+        let mut stop_events = state.events.subscribe();
+        let stopped = captions::stop_captions(&state).await;
+        assert_eq!(stopped.state, captions::CaptionsState::Idle);
+        let stopped_snapshot = captions::caption_sign_out_test_snapshot(&state).await;
+        assert!(!stopped_snapshot.primary_overlay_active);
+        assert!(!stopped_snapshot.auxiliary_overlay_active);
+        assert_eq!(
+            stopped_snapshot.chunk_count, 1,
+            "ordinary stop preserves already-spoken cues for the recording artifact"
+        );
+        assert!(event_stream_contains_caption_reset(
+            &mut stop_events,
+            "stopped"
+        ));
+
+        let _block_probe = captions::install_caption_sign_out_test_session(&state).await;
+        let mut block_events = state.events.subscribe();
+        captions::block_captions(&state, "audio-path-unsupported", "No supported mic path").await;
+        let blocked = captions::captions_status(&state).await;
+        assert_eq!(blocked.state, captions::CaptionsState::Blocked);
+        assert_eq!(
+            blocked.reason_code.as_deref(),
+            Some("audio-path-unsupported")
+        );
+        let blocked_snapshot = captions::caption_sign_out_test_snapshot(&state).await;
+        assert!(!blocked_snapshot.primary_overlay_active);
+        assert!(!blocked_snapshot.auxiliary_overlay_active);
+        assert!(event_stream_contains_caption_reset(
+            &mut block_events,
+            "blocked"
+        ));
+    }
+
+    #[tokio::test]
+    async fn explicit_caption_opt_out_discards_audio_already_queued_for_transcription() {
+        let _caption_test_guard = CAPTION_LIFECYCLE_TEST_LOCK.lock().await;
+        let state = test_state();
+        let probe = captions::install_caption_queued_audio_test_session(&state).await;
+        timeout(Duration::from_secs(1), async {
+            while !probe.task_started() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("caption test consumer should start");
+
+        for timestamp_micros in [0, 20_000, 40_000] {
+            captions::offer_caption_frame(&audio::AudioFrame {
+                timestamp_micros,
+                captured_at: std::time::Instant::now(),
+                sample_rate: 48_000,
+                channels: 1,
+                samples: vec![0.1; 960],
+            });
+        }
+
+        let stop_state = state.clone();
+        let stopped = tokio::spawn(async move { captions::stop_captions(&stop_state).await });
+        timeout(Duration::from_secs(1), async {
+            while !captions::caption_task_detached_for_test(&state).await {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("stop should take ownership of the caption task");
+        probe.release();
+
+        assert_eq!(
+            stopped.await.expect("stop task joins").state,
+            captions::CaptionsState::Idle
+        );
+        assert_eq!(
+            probe.frames_received(),
+            0,
+            "privacy opt-out must discard queued PCM instead of transcribing it"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_caption_failure_clears_backend_overlays_and_resets_renderer() {
+        let _caption_test_guard = CAPTION_LIFECYCLE_TEST_LOCK.lock().await;
+        let state = test_state();
+        let _probe = captions::install_caption_sign_out_test_session(&state).await;
+        let mut events = state.events.subscribe();
+
+        captions::publish_terminal_caption_failure_for_test(&state).await;
+
+        let snapshot = captions::caption_sign_out_test_snapshot(&state).await;
+        assert!(!snapshot.primary_overlay_active);
+        assert!(!snapshot.auxiliary_overlay_active);
+        assert!(event_stream_contains_caption_reset(&mut events, "blocked"));
+    }
+
+    #[tokio::test]
+    async fn capture_end_resets_live_caption_presentation_but_retains_artifact_cues() {
+        let _caption_test_guard = CAPTION_LIFECYCLE_TEST_LOCK.lock().await;
+        let state = test_state();
+        let _probe = captions::install_caption_sign_out_test_session(&state).await;
+        let mut events = state.events.subscribe();
+
+        let status = captions::finish_captions_for_capture(&state).await;
+
+        assert_eq!(status.state, captions::CaptionsState::Ready);
+        let snapshot = captions::caption_sign_out_test_snapshot(&state).await;
+        assert_eq!(
+            snapshot.chunk_count, 1,
+            "capture finalization must retain canonical cues for SRT/captioned-copy generation"
+        );
+        assert!(!snapshot.primary_overlay_active);
+        assert!(!snapshot.auxiliary_overlay_active);
+        assert!(event_stream_contains_caption_reset(
+            &mut events,
+            "capture-ended"
+        ));
+    }
+
+    fn event_stream_contains_caption_reset(
+        events: &mut broadcast::Receiver<protocol::ServerEvent>,
+        reason: &str,
+    ) -> bool {
+        while let Ok(event) = events.try_recv() {
+            if event.event == "captions.cleared" && event.payload["reason"] == reason {
+                return true;
+            }
+        }
+        false
     }
 
     #[derive(Clone)]

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -793,13 +793,23 @@ pub struct StartSessionParams {
     pub captions: Option<CaptionsSessionParams>,
 }
 
-/// Live-caption burn-in intent for this session (the bar itself arrives via
-/// captions.overlay.set; this shapes output legs — see burn-in plan A0 — and
-/// styles the post-recording captioned copy).
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+/// Live-caption output intent for this session. Stream selection shapes the
+/// live compositor legs; Recording selection gates a non-destructive aligned
+/// `(captioned)` copy after finalization. The source recording remains clean.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CaptionsSessionParams {
-    /// Which legs the LIVE bar burns into (R1). Replaces `burnInEnabled`.
+    /// Persisted explicit consent. Audio is only attached while this capture
+    /// session is active; enabling while idle leaves captions Ready.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Explicit one-capture suppression selected by "Continue without
+    /// captions". Unlike `enabled: false`, this prevents pre-arming a saved
+    /// Stream/Both compositor leg for mid-session activation.
+    #[serde(default)]
+    pub suppressed_for_session: bool,
+    /// Which outputs receive captions: live Stream burn-in, an aligned
+    /// Recording copy, or both. Replaces `burnInEnabled`.
     #[serde(default)]
     pub burn_target: crate::captions::CaptionBurnTarget,
     /// Legacy pre-R1 flag; `true` maps to Stream when burn_target is absent.
@@ -809,6 +819,36 @@ pub struct CaptionsSessionParams {
     pub position: crate::captions::CaptionOverlayPosition,
     #[serde(default)]
     pub text_size: crate::captions::CaptionTextSize,
+    #[serde(default = "legacy_caption_style_id")]
+    pub style_id: crate::captions::CaptionStyleId,
+    #[serde(default = "default_caption_language")]
+    pub language: String,
+    #[serde(default)]
+    pub style_revision: u64,
+}
+
+impl Default for CaptionsSessionParams {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            suppressed_for_session: false,
+            burn_target: crate::captions::CaptionBurnTarget::Off,
+            burn_in_enabled: false,
+            position: crate::captions::CaptionOverlayPosition::Bottom,
+            text_size: crate::captions::CaptionTextSize::M,
+            style_id: crate::captions::CaptionStyleId::Classic,
+            language: default_caption_language(),
+            style_revision: 0,
+        }
+    }
+}
+
+fn default_caption_language() -> String {
+    "auto".to_string()
+}
+
+fn legacy_caption_style_id() -> crate::captions::CaptionStyleId {
+    crate::captions::CaptionStyleId::Glass
 }
 
 impl CaptionsSessionParams {
@@ -839,6 +879,25 @@ impl Default for AudioSettings {
             microphone_sync_offset_ms: default_microphone_sync_offset_ms(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioProcessingUpdateParams {
+    pub session_id: String,
+    pub microphone_gain_db: f32,
+    pub microphone_muted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioProcessingUpdateResult {
+    pub applied: bool,
+    pub session_id: String,
+    pub microphone_gain_db: f32,
+    pub microphone_muted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
 }
 
 fn default_microphone_sync_offset_ms() -> i32 {
@@ -2415,6 +2474,11 @@ pub struct AiJobGetParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AiCapabilities {
+    /// Live-caption transport readiness from videorc-web. Optional so desktop
+    /// remains compatible while older web deployments roll forward; callers
+    /// that opted into captions intentionally fail closed when it is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captions: Option<AiCapabilitiesCaptions>,
     pub entitlement: AiCapabilitiesEntitlement,
     /// Ed25519-signed entitlement proof (`v1.<payload>.<sig>`) minted by
     /// videorc.com. Optional: older web deploys (or an unconfigured signing
@@ -2429,6 +2493,59 @@ pub struct AiCapabilities {
     pub readiness: AiCapabilitiesReadiness,
     pub transcription: AiCapabilitiesTranscription,
     pub workflow: AiCapabilitiesWorkflow,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiCapabilitiesCaptions {
+    pub available: bool,
+    pub chunked: AiCapabilitiesCaptionsChunked,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub monthly_seconds_limit: Option<u64>,
+    pub preferred_transport: Option<AiCapabilitiesCaptionsTransport>,
+    pub realtime: AiCapabilitiesCaptionsRealtime,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remaining_seconds: Option<u64>,
+    pub reason_code: AiCapabilitiesCaptionsReasonCode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiCapabilitiesCaptionsChunked {
+    pub available: bool,
+    pub configured: bool,
+    pub model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiCapabilitiesCaptionsRealtime {
+    pub available: bool,
+    pub configured: bool,
+    pub disabled: bool,
+    pub model: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AiCapabilitiesCaptionsTransport {
+    Chunked,
+    Realtime,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AiCapabilitiesCaptionsReasonCode {
+    AiDisabled,
+    AiUserDisabled,
+    CaptionsDisabled,
+    CaptionsInvalidConfig,
+    CaptionsMonthlyQuotaExhausted,
+    CaptionsNotConfigured,
+    CloudAiPremiumRequired,
+    ReadyChunkedRealtimeDisabled,
+    ReadyChunkedRealtimeUnconfigured,
+    ReadyRealtime,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3025,5 +3142,38 @@ mod tests {
             serde_json::to_value(SideBySideCameraSide::Right).unwrap(),
             serde_json::json!("right")
         );
+    }
+
+    #[test]
+    fn legacy_caption_session_settings_migrate_privacy_safe_defaults() {
+        let settings: CaptionsSessionParams = serde_json::from_value(serde_json::json!({
+            "burnTarget": "stream",
+            "position": "bottom",
+            "textSize": "m"
+        }))
+        .unwrap();
+        assert!(!settings.enabled);
+        assert!(!settings.suppressed_for_session);
+        assert_eq!(settings.style_id, crate::captions::CaptionStyleId::Glass);
+        assert_eq!(settings.language, "auto");
+        assert_eq!(settings.style_revision, 0);
+    }
+
+    #[test]
+    fn caption_session_style_fields_use_stable_wire_names() {
+        let settings = CaptionsSessionParams {
+            enabled: true,
+            suppressed_for_session: true,
+            style_id: crate::captions::CaptionStyleId::HighContrast,
+            language: "es".to_string(),
+            style_revision: 12,
+            ..Default::default()
+        };
+        let value = serde_json::to_value(settings).unwrap();
+        assert_eq!(value["enabled"], true);
+        assert_eq!(value["suppressedForSession"], true);
+        assert_eq!(value["styleId"], "high-contrast");
+        assert_eq!(value["language"], "es");
+        assert_eq!(value["styleRevision"], 12);
     }
 }

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -12558,8 +12558,21 @@ mod tests {
             crate::captions::CaptionBurnTarget::Off,
             "an ineligible mixed captions-off session does not reserve an impossible live leg"
         );
+        // Platform truth: record+stream split output is VideoToolbox-only, so
+        // the captions-off session validates on macOS and is correctly
+        // rejected (for the split-output reason, not a captions reason) on
+        // Windows.
+        #[cfg(target_os = "macos")]
         validate_outputs(&captions_off)
             .expect("captions-off preserves the existing mixed-profile capture behavior");
+        #[cfg(not(target_os = "macos"))]
+        {
+            let error = validate_outputs(&captions_off).unwrap_err().to_string();
+            assert!(
+                error.contains("VideoToolbox"),
+                "captions-off must fail for the split-output platform reason, not captions: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -61,11 +61,12 @@ use crate::preview_camera::{
 use crate::preview_screen::preview_screen_latest_frame_info;
 use crate::process_job::{spawn_owned_tokio, status_owned_tokio};
 use crate::protocol::{
-    AudioSettings, AudioTrack, AudioTrackSource, BackgroundFit, CameraAspect, CameraCorner,
-    CameraFit, CameraShape, CameraSize, CameraTransformMode, CompositorBackend,
-    CompositorSceneUpdateParams, CompositorState, DiagnosticStats, EffectiveSceneBackground,
-    EncodeBackend, EntitlementsSnapshot, FeatureId, HealthLevel, LayoutPreset, LayoutSettings,
-    PreviewCameraState, PreviewLiveParams, PreviewLiveSource, PreviewLiveState, PreviewLiveStatus,
+    AudioProcessingUpdateParams, AudioProcessingUpdateResult, AudioSettings, AudioTrack,
+    AudioTrackSource, BackgroundFit, CameraAspect, CameraCorner, CameraFit, CameraShape,
+    CameraSize, CameraTransformMode, CompositorBackend, CompositorSceneUpdateParams,
+    CompositorState, DiagnosticStats, EffectiveSceneBackground, EncodeBackend,
+    EntitlementsSnapshot, FeatureId, HealthLevel, LayoutPreset, LayoutSettings, PreviewCameraState,
+    PreviewLiveParams, PreviewLiveSource, PreviewLiveState, PreviewLiveStatus,
     PreviewScreenSourceKind, PreviewScreenState, PreviewSnapshot, PreviewSnapshotParams,
     PreviewSurfaceBacking, PreviewTransport, RecordingPipelineStage, RecordingState,
     RecordingStatus, RemuxSessionParams, RtmpPreset, RtmpSettings, Scene, SceneConfigParams,
@@ -100,6 +101,17 @@ const NATIVE_AUDIO_SAMPLE_INTERVAL: Duration = Duration::from_millis(1000);
 /// silent zeros from CoreAudio — frames advance, the track holds nothing).
 const MIC_SILENT_CHECK_AFTER: Duration = Duration::from_secs(10);
 const MIC_SILENT_PEAK_EPSILON: f32 = 0.001;
+const CAPTIONS_NATIVE_AUDIO_REQUIRED_MESSAGE: &str = "Live captions require the supported native microphone audio path after gain and mute controls. This session was not started because the selected microphone path cannot supply caption audio. Continue without captions for this session or select a supported microphone.";
+/// Once split-input probing completes, the recording demux thread may absorb a
+/// bounded scheduling cushion without applying pipe backpressure; the live
+/// auxiliary input keeps the small latency-first queue.
+const SPLIT_RECORDING_INPUT_THREAD_QUEUE_PACKETS: usize = 64;
+const SPLIT_STREAM_INPUT_THREAD_QUEUE_PACKETS: usize = 8;
+/// FFmpeg starts per-input demux threads only after `avformat_find_stream_info`.
+/// A 65,536-byte probe on a low-complexity H.264 test pattern can therefore
+/// leave the sibling FIFO unread for seconds, before either thread queue can
+/// help. MPEG-TS PAT/PMT plus the first SPS/IDR fit in this split-only bound.
+const SPLIT_ENCODED_INPUT_PROBE_BYTES: usize = 4_096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SilentMicKind {
@@ -118,6 +130,61 @@ fn silent_mic_verdict(captured_frames: u64, session_peak: f32) -> Option<SilentM
         return Some(SilentMicKind::AllSilence);
     }
     None
+}
+
+/// Capability token for the publication edge of a capture session.
+///
+/// Both the user-visible Starting event and the FFmpeg/RTMP process require
+/// this token, so a captions-enabled session cannot publish before its
+/// post-controls native microphone bus has actually opened and warmed up.
+#[derive(Debug)]
+struct SessionStartPublicationPermit;
+
+fn live_captions_requested(params: &StartSessionParams) -> bool {
+    params
+        .captions
+        .as_ref()
+        .is_some_and(|captions| captions.enabled && !captions.suppressed_for_session)
+}
+
+async fn authorize_session_start_publication(
+    state: &AppState,
+    session_id: &str,
+    params: &StartSessionParams,
+    has_native_audio: bool,
+) -> Result<SessionStartPublicationPermit> {
+    if live_captions_requested(params) && !has_native_audio {
+        crate::captions::block_captions_for_audio_path(
+            state,
+            CAPTIONS_NATIVE_AUDIO_REQUIRED_MESSAGE,
+        )
+        .await;
+        let _ = emit_health_event(
+            state,
+            Some(session_id),
+            HealthLevel::Error,
+            "captions-audio-path-unsupported",
+            CAPTIONS_NATIVE_AUDIO_REQUIRED_MESSAGE,
+        );
+        bail!(CAPTIONS_NATIVE_AUDIO_REQUIRED_MESSAGE);
+    }
+
+    Ok(SessionStartPublicationPermit)
+}
+
+fn publish_authorized_session_start(
+    state: &AppState,
+    status: RecordingStatus,
+    _permit: &SessionStartPublicationPermit,
+) {
+    state.emit_event("recording.status", status);
+}
+
+fn spawn_authorized_capture_process(
+    command: &mut Command,
+    _permit: SessionStartPublicationPermit,
+) -> io::Result<tokio::process::Child> {
+    spawn_owned_tokio(command)
 }
 const RECORDING_PREVIEW_WIDTH: u32 = 640;
 const RECORDING_PREVIEW_HEIGHT: u32 = 360;
@@ -170,6 +237,11 @@ pub struct ActiveRecording {
     pub stream_url: Option<String>,
     pub ffmpeg_path: String,
     pub started_at: String,
+    /// First authoritative video-content instant for encoder-bridge sessions.
+    /// Captions use it to align cues when the user opts in after capture began.
+    capture_epoch: Arc<std::sync::OnceLock<Instant>>,
+    /// Monotonic fallback for legacy paths that do not publish a video epoch.
+    capture_started_fallback: Instant,
     pub mode: String,
     pub audio_tracks: Vec<AudioTrack>,
     pub pipeline: RecordingPipeline,
@@ -177,6 +249,10 @@ pub struct ActiveRecording {
     pub screen_overlay: Option<ScreenOverlaySession>,
     pub encoder_bridge: Option<EncoderBridgeRecordingSession>,
     pub encoder_bridge_stream: Option<EncoderBridgeRecordingSession>,
+    /// Frozen at session start from the Recording/Both caption selection.
+    /// Finalization may render a non-destructive `(captioned)` copy only when
+    /// this is true; the source recording itself always stays clean.
+    captioned_copy_requested: bool,
     /// True only when this session has a viewer-facing stream leg rendered by
     /// the compositor bridge. Legacy FFmpeg and record-only paths must reject
     /// comment highlights before touching the overlay slot.
@@ -287,6 +363,65 @@ impl ActiveRecording {
         }
         Ok(())
     }
+}
+
+/// Capture-relative media time used to seed a caption session that starts
+/// after recording/streaming is already underway.
+pub async fn active_capture_elapsed_seconds(state: &AppState) -> Option<f64> {
+    let recording = state.recording.lock().await;
+    let active = recording.as_ref()?;
+    let origin = active
+        .capture_epoch
+        .get()
+        .copied()
+        .unwrap_or(active.capture_started_fallback);
+    Some(
+        Instant::now()
+            .saturating_duration_since(origin)
+            .as_secs_f64(),
+    )
+}
+
+/// Applies renderer mic controls to the currently active native capture
+/// session. The session id makes delayed websocket commands harmless across a
+/// stop/start boundary; the CoreAudio callback consumes the update atomically.
+pub async fn update_active_audio_processing(
+    state: &AppState,
+    params: AudioProcessingUpdateParams,
+) -> AudioProcessingUpdateResult {
+    let settings = AudioProcessingSettings {
+        gain_db: if params.microphone_gain_db.is_finite() {
+            params.microphone_gain_db.clamp(-24.0, 24.0)
+        } else {
+            0.0
+        },
+        muted: params.microphone_muted,
+    };
+    let mut result = AudioProcessingUpdateResult {
+        applied: false,
+        session_id: params.session_id.clone(),
+        microphone_gain_db: settings.gain_db,
+        microphone_muted: settings.muted,
+        reason_code: None,
+    };
+
+    let recording = state.recording.lock().await;
+    let Some(active) = recording.as_ref() else {
+        result.reason_code = Some("no-active-session".to_string());
+        return result;
+    };
+    if active.session_id != params.session_id {
+        result.reason_code = Some("stale-session".to_string());
+        return result;
+    }
+    let Some(native_audio) = active.native_audio.as_ref() else {
+        result.reason_code = Some("native-audio-unavailable".to_string());
+        return result;
+    };
+
+    native_audio.update_processing_settings(settings);
+    result.applied = true;
+    result
 }
 
 pub fn initial_live_preview_state() -> LivePreviewState {
@@ -579,7 +714,20 @@ pub async fn start_session(
         && let Some(prepared) = native_audio_source.take()
     {
         let device_name = prepared.source.device_name.clone();
-        if let Some(index) =
+        if live_captions_requested(&params) {
+            let message = format!(
+                "Native microphone {device_name} did not deliver warmup frames. Live captions require this post-controls native microphone bus, so the session will not be published."
+            );
+            state.emit_log("error", &message);
+            let _ = emit_health_event(
+                &state,
+                Some(&session_id),
+                HealthLevel::Error,
+                "microphone-native-warmup-timeout",
+                &message,
+            );
+            capture.microphone = None;
+        } else if let Some(index) =
             find_avfoundation_microphone_index_for_native_name(&ffmpeg_path, &device_name).await
         {
             let message = format!(
@@ -610,6 +758,9 @@ pub async fn start_session(
         }
         let _ = crate::fifo::cleanup(&prepared.fifo_path);
     }
+    let has_native_audio = native_audio_source.is_some();
+    let session_start_publication_permit =
+        authorize_session_start_publication(&state, &session_id, &params, has_native_audio).await?;
     let audio_tracks = capture_audio_tracks(&capture);
     if matches!(capture.video, VideoInput::TestPattern) {
         let (code, message) = if matches!(params.layout.layout_preset, LayoutPreset::CameraOnly) {
@@ -681,24 +832,15 @@ pub async fn start_session(
     } else {
         None
     };
-    // Remember this session's caption styling for the post-recording burned
-    // copy (defaults when captions params are absent).
-    {
-        let captions_params = params.captions.clone().unwrap_or_default();
-        crate::captions::set_caption_session_style(
-            &state,
-            captions_params.position,
-            captions_params.text_size,
-            params.output.video.width,
-            params.output.video.height,
-        )
-        .await;
-    }
+    let session_caption_plan = caption_leg_plan(&params);
     // A new session must never inherit a composited caption bar. The overlay
     // slot is app-global and the renderer's stop-time clear is best-effort
     // (fire-and-forget, and a closed renderer never sends it) — clearing here
     // is the authoritative boundary (caption carry-over fix, 2026-07-04).
-    let _ = crate::captions::clear_caption_overlay(&state.caption_overlay);
+    let _ = crate::captions::clear_caption_overlays(
+        &state.caption_overlay,
+        crate::captions::ClearCaptionOverlayParams::default(),
+    );
     // Same boundary rule for comment highlights, including backend state and
     // any old expiry task — a new session never inherits the prior card.
     let _ = crate::comment_highlight::clear_comment_highlight_for_session_start(&state).await;
@@ -706,9 +848,8 @@ pub async fn start_session(
     // split-leg plan, an auxiliary render. Outside those shapes the captions
     // stay UI-only — say so instead of silently skipping pixels.
     {
-        let leg_plan = caption_leg_plan(&params);
-        let burn_requested = leg_plan.primary || leg_plan.aux;
-        let split_needed_but_missing = leg_plan.force_same_profile_split
+        let burn_requested = session_caption_plan.primary || session_caption_plan.aux;
+        let split_needed_but_missing = session_caption_plan.force_same_profile_split
             && params.output.record_enabled
             && params.output.stream_enabled
             && encoder_bridge_stream_output.is_none();
@@ -806,10 +947,11 @@ pub async fn start_session(
                     CompositorFrameConsumer::VideoToolboxEncoder
                 },
                 stream_output: encoder_bridge_stream_output,
-                // Per-leg overlay plan (R1): primary = recording (or the
-                // stream when stream-only), aux = the split stream leg.
-                caption_overlay_on_primary: caption_leg_plan(&params).primary,
-                caption_overlay_on_aux: caption_leg_plan(&params).aux,
+                // Per-leg overlay plan (R1): primary is the clean source
+                // recording (or the stream when stream-only); aux is the
+                // captioned stream leg for combined sessions.
+                caption_overlay_on_primary: session_caption_plan.primary,
+                caption_overlay_on_aux: session_caption_plan.aux,
                 highlight_overlay_on_primary: crate::captions::highlight_overlay_leg_plan(
                     params.output.record_enabled,
                     params.output.stream_enabled,
@@ -963,8 +1105,8 @@ pub async fn start_session(
         )?
     };
 
-    state.emit_event(
-        "recording.status",
+    publish_authorized_session_start(
+        &state,
         RecordingStatus {
             state: RecordingState::Starting,
             session_id: Some(session_id.clone()),
@@ -976,6 +1118,7 @@ pub async fn start_session(
             duration_ms: None,
             message: Some(format!("Starting {mode} session.")),
         },
+        &session_start_publication_permit,
     );
 
     let mut command = ffmpeg_command(&ffmpeg_path);
@@ -988,8 +1131,9 @@ pub async fn start_session(
         })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut child = spawn_owned_tokio(&mut command)
-        .with_context(|| format!("Could not start {ffmpeg_path}"))?;
+    let mut child =
+        spawn_authorized_capture_process(&mut command, session_start_publication_permit)
+            .with_context(|| format!("Could not start {ffmpeg_path}"))?;
 
     let stderr = child.stderr.take();
     let stdout = child.stdout.take();
@@ -1070,7 +1214,6 @@ pub async fn start_session(
         .await;
     }
     pipeline.mark_running();
-    let has_native_audio = native_audio_source.is_some();
     // Post-recording quality gate inputs (slice 8): what this session is expected to
     // contain, captured before `audio_tracks` is moved into the active recording.
     let gate_expect_audio = !audio_tracks.is_empty();
@@ -1083,6 +1226,8 @@ pub async fn start_session(
         stream_url,
         ffmpeg_path: ffmpeg_path.clone(),
         started_at: started_at.to_rfc3339(),
+        capture_epoch: video_epoch.clone(),
+        capture_started_fallback: Instant::now(),
         mode: mode.to_string(),
         audio_tracks,
         pipeline,
@@ -1104,10 +1249,28 @@ pub async fn start_session(
         },
         encoder_bridge,
         encoder_bridge_stream,
+        captioned_copy_requested: session_caption_plan.captioned_copy,
         comment_highlight_available: comment_highlight_available(&params, use_encoder_bridge),
         _capture_permit: Some(capture_permit),
         stop_requested: false,
     };
+    // The fully-constructed pipeline is now committed to becoming an active
+    // capture. Advance the caption epoch only here, after every fallible startup
+    // step, so an early start failure cannot create an orphan caption session.
+    // This boundary also purges any cues left by a previously failed capture.
+    {
+        let captions_params = params.captions.clone().unwrap_or_default();
+        crate::captions::set_caption_session_style(
+            &state,
+            captions_params.position,
+            captions_params.text_size,
+            captions_params.style_id,
+            captions_params.style_revision,
+            params.output.video.width,
+            params.output.video.height,
+        )
+        .await;
+    }
     let running_state = if params.output.stream_enabled && !params.output.record_enabled {
         RecordingState::Streaming
     } else {
@@ -1122,6 +1285,30 @@ pub async fn start_session(
     drop(recording_startup_scene.take());
     state.emit_event("recording.status", running_status.clone());
     publish_recording_live_preview_status(&state, use_encoder_bridge, None).await;
+    if let Some(captions) = params
+        .captions
+        .as_ref()
+        .filter(|captions| captions.enabled && !captions.suppressed_for_session)
+    {
+        debug_assert!(
+            has_native_audio,
+            "captions-enabled sessions must hold native audio before publication"
+        );
+        let language = (!captions.language.trim().is_empty()
+            && !captions.language.eq_ignore_ascii_case("auto"))
+        .then(|| captions.language.clone());
+        if let Err(error) = crate::captions::start_captions(&state, language).await {
+            let message = format!("Live captions could not start: {error}");
+            crate::captions::block_captions(&state, "captions-start-failed", message.clone()).await;
+            let _ = emit_health_event(
+                &state,
+                Some(&session_id),
+                HealthLevel::Warn,
+                "captions-start-failed",
+                &message,
+            );
+        }
+    }
     if has_native_audio {
         tokio::spawn(sample_native_audio_during_recording(
             state.clone(),
@@ -2644,6 +2831,7 @@ async fn monitor_session(
                 ffmpeg_path: active.ffmpeg_path.clone(),
                 started_at: active.started_at.clone(),
                 pipeline: active.pipeline.clone(),
+                captioned_copy_requested: active.captioned_copy_requested,
                 native_audio_stats,
             }
         });
@@ -2655,6 +2843,17 @@ async fn monitor_session(
     let Some(mut monitored_recording) = monitored_recording else {
         return;
     };
+
+    // Dropping ActiveRecording stops the native post-controls audio producer.
+    // Close the caption bus now, drain the provider's final utterance within a
+    // bounded grace period, and only then generate SRT/captioned artifacts.
+    crate::captions::finish_captions_for_capture(&state).await;
+    let finalized_caption_artifact =
+        crate::captions::take_finalized_caption_artifact_for_capture(&state).await;
+    let _ = crate::captions::clear_caption_overlays(
+        &state.caption_overlay,
+        crate::captions::ClearCaptionOverlayParams::default(),
+    );
 
     // Also cover provider/process exits that bypass an explicit stop RPC. The
     // session guard prevents this late monitor task from clearing a newer
@@ -2783,6 +2982,44 @@ async fn monitor_session(
             } else {
                 None
             };
+            let final_path = mp4_path.clone().or(output_path.clone());
+
+            // Establish ownership of every finalized caption artifact before
+            // publishing Idle. The renderer may start another capture as soon
+            // as it sees Idle; by then this request must already survive as an
+            // independent queued render rather than borrowing the next epoch.
+            if let Some(final_path) = final_path.as_ref() {
+                let caption_artifact = crate::captions::write_caption_artifacts(
+                    &state,
+                    &gate_session_id,
+                    final_path,
+                    finalized_caption_artifact,
+                )
+                .await;
+                if should_begin_captioned_copy_render(
+                    monitored_recording.captioned_copy_requested,
+                    caption_artifact.chunks.len(),
+                ) {
+                    crate::captions::begin_caption_cue_render(
+                        &state,
+                        &gate_session_id,
+                        &monitored_recording.ffmpeg_path,
+                        final_path,
+                        &caption_artifact,
+                    )
+                    .await;
+                }
+            } else {
+                let dropped = finalized_caption_artifact.chunks.len();
+                if dropped > 0 {
+                    state.emit_log(
+                        "info",
+                        format!(
+                            "Discarded {dropped} ephemeral live-caption cue(s) after the stream-only session ended."
+                        ),
+                    );
+                }
+            }
             let _ = state.database.finish_session(
                 &session_id,
                 "completed",
@@ -2820,23 +3057,7 @@ async fn monitor_session(
             // Slice 8: check (and, if needed, repair in place) the finalized file off
             // the hot path. The recording is already marked complete; the gate only ever
             // replaces the visible file with a validated better version, keeping a backup.
-            if let Some(final_path) = mp4_path.clone().or(output_path.clone()) {
-                // Aligned captions (burn-in plan B2/B3): drain this session's
-                // live caption chunks into an .srt sidecar, then queue the
-                // idle-time captioned copy from the same chunks.
-                let caption_chunks =
-                    crate::captions::write_caption_artifacts(&state, &gate_session_id, &final_path)
-                        .await;
-                if !caption_chunks.is_empty() {
-                    crate::captions::begin_caption_cue_render(
-                        &state,
-                        &gate_session_id,
-                        &monitored_recording.ffmpeg_path,
-                        &final_path,
-                        &caption_chunks,
-                    )
-                    .await;
-                }
+            if let Some(final_path) = final_path {
                 // Library poster (L2): one thumbnail frame per recording,
                 // extracted off the hot path under the idle ffmpeg permit.
                 {
@@ -2901,6 +3122,13 @@ async fn monitor_session(
                     message: Some(message),
                 },
             );
+            let discarded = crate::captions::discard_failed_caption_capture(&state).await;
+            if discarded > 0 {
+                state.emit_log(
+                    "info",
+                    format!("Discarded {discarded} caption cue(s) owned by the failed capture."),
+                );
+            }
         }
         Err(error) => {
             let message = format!("Could not wait for FFmpeg: {error}");
@@ -2939,6 +3167,13 @@ async fn monitor_session(
                     message: Some(message),
                 },
             );
+            let discarded = crate::captions::discard_failed_caption_capture(&state).await;
+            if discarded > 0 {
+                state.emit_log(
+                    "info",
+                    format!("Discarded {discarded} caption cue(s) owned by the failed capture."),
+                );
+            }
         }
     }
     drop(finalizing_permit);
@@ -3530,7 +3765,12 @@ struct MonitoredRecording {
     ffmpeg_path: String,
     started_at: String,
     pipeline: RecordingPipeline,
+    captioned_copy_requested: bool,
     native_audio_stats: Option<NativeAudioStats>,
+}
+
+fn should_begin_captioned_copy_render(requested: bool, caption_chunk_count: usize) -> bool {
+    requested && caption_chunk_count > 0
 }
 
 fn recording_duration_ms(started_at: &str, ended_at: &str) -> Option<i64> {
@@ -4343,8 +4583,13 @@ async fn prepare_native_audio_source(
 
     let path = native_audio_fifo_path(session_id);
     if let Err(error) = create_native_audio_fifo(&path) {
+        let consequence = if live_captions_requested(params) {
+            "the captions-enabled session cannot start"
+        } else {
+            "continuing video-only"
+        };
         let message = format!(
-            "Native CoreAudio microphone is unavailable; continuing video-only. Could not create audio FIFO: {error}"
+            "Native CoreAudio microphone is unavailable; {consequence}. Could not create audio FIFO: {error}"
         );
         state.emit_log("warn", &message);
         let _ = emit_health_event(
@@ -4377,9 +4622,13 @@ async fn prepare_native_audio_source(
         }
         Err(error) => {
             let _ = crate::fifo::cleanup(&path);
-            let message = format!(
-                "Native CoreAudio microphone is unavailable; continuing video-only. {error}"
-            );
+            let consequence = if live_captions_requested(params) {
+                "the captions-enabled session cannot start"
+            } else {
+                "continuing video-only"
+            };
+            let message =
+                format!("Native CoreAudio microphone is unavailable; {consequence}. {error}");
             state.emit_log("warn", &message);
             let _ = emit_health_event(
                 state,
@@ -4854,6 +5103,7 @@ fn bridge_compositor_split_output_ffmpeg_args(
         recording_fifo_path,
         recording_video_output,
         params.output.video.fps,
+        SPLIT_RECORDING_INPUT_THREAD_QUEUE_PACKETS,
     )?;
     let stream_video_input_index = append_bridge_encoded_video_input_args(
         &mut args,
@@ -4861,6 +5111,7 @@ fn bridge_compositor_split_output_ffmpeg_args(
         stream_fifo_path,
         recording_video_output,
         stream_video.fps,
+        SPLIT_STREAM_INPUT_THREAD_QUEUE_PACKETS,
     )?;
     let input_layout = InputLayout {
         video_input_index: recording_video_input_index,
@@ -4897,12 +5148,15 @@ fn bridge_compositor_split_output_ffmpeg_args(
     let mut uses_companion_stream_input = false;
     for target in stream_targets {
         let target_video = target.output_video.as_ref().unwrap_or(&stream_video);
-        let video_input_index = if same_video_profile(target_video, &params.output.video) {
-            uses_recording_stream_input = true;
-            recording_video_input_index
-        } else if same_video_profile(target_video, &stream_video) {
+        // Prefer the auxiliary stream input on a profile tie. A tie only exists
+        // for the forced same-profile caption split; routing primary first would
+        // silently send the clean recording pixels to RTMP.
+        let video_input_index = if same_video_profile(target_video, &stream_video) {
             uses_companion_stream_input = true;
             stream_video_input_index
+        } else if same_video_profile(target_video, &params.output.video) {
+            uses_recording_stream_input = true;
+            recording_video_input_index
         } else {
             bail!(
                 "Target {} resolves to unsupported mixed stream profile {}x{}@{} {}kbps",
@@ -5071,12 +5325,15 @@ fn append_bridge_encoded_video_input_args(
     fifo_path: &Path,
     video_output: EncoderBridgeVideoOutput,
     fps: u32,
+    thread_queue_packets: usize,
 ) -> Result<usize> {
     ensure_encoded_bridge_video_output(video_output)?;
     let input_index = *next_input_index;
     match video_output {
         EncoderBridgeVideoOutput::VideoToolboxH264AnnexB => {
             args.extend([
+                "-thread_queue_size".to_string(),
+                thread_queue_packets.max(1).to_string(),
                 "-use_wallclock_as_timestamps".to_string(),
                 "1".to_string(),
                 "-f".to_string(),
@@ -5089,13 +5346,15 @@ fn append_bridge_encoded_video_input_args(
         }
         EncoderBridgeVideoOutput::VideoToolboxH264MpegTs => {
             args.extend([
+                "-thread_queue_size".to_string(),
+                thread_queue_packets.max(1).to_string(),
                 // Same probe discipline as append_bridge_recording_input_args:
                 // the writer is our own bridge; default mpegts probing starves
                 // a multi-FIFO graph (LVF2 "no bytes", plan 023 L1). `nobuffer`
                 // is deliberately absent because it discards the first GOP on
                 // these non-seekable FIFOs and creates a deterministic A/V gap.
                 "-probesize".to_string(),
-                "65536".to_string(),
+                SPLIT_ENCODED_INPUT_PROBE_BYTES.to_string(),
                 "-analyzeduration".to_string(),
                 "0".to_string(),
                 "-f".to_string(),
@@ -6471,7 +6730,52 @@ fn validate_outputs(params: &StartSessionParams) -> Result<()> {
     }
 
     validate_video_settings(&params.output.video)?;
+    validate_caption_output_policy(params)?;
     validate_video_profile_policy(params)?;
+
+    Ok(())
+}
+
+fn validate_caption_output_policy(params: &StartSessionParams) -> Result<()> {
+    let Some(captions) = params
+        .captions
+        .as_ref()
+        .filter(|captions| captions.enabled && !captions.suppressed_for_session)
+    else {
+        // Captions-off sessions may still pre-arm an eligible saved target,
+        // but preflight must not block capture. The renderer's output-readiness
+        // guard prevents enabling an ineligible 60fps/mixed session mid-run.
+        return Ok(());
+    };
+    if !captions.effective_burn_target().burns_stream() || !params.output.stream_enabled {
+        return Ok(());
+    }
+    let plan = caption_leg_plan(params);
+    let live_caption_profiles = resolved_enabled_stream_output_videos(params)?;
+
+    if plan.aux {
+        let mut distinct_profiles = Vec::<VideoSettings>::new();
+        for profile in live_caption_profiles.iter().cloned() {
+            if !distinct_profiles
+                .iter()
+                .any(|existing| same_video_profile(existing, &profile))
+            {
+                distinct_profiles.push(profile);
+            }
+        }
+        if distinct_profiles.len() > 1 {
+            bail!(
+                "A clean recording plus live captions supports one captioned stream profile per session. Make every enabled streaming target use the same output profile."
+            );
+        }
+    }
+
+    if params.output.video.fps > 30 || live_caption_profiles.iter().any(|profile| profile.fps > 30)
+    {
+        bail!(
+            "Live caption burn-in supports stream profiles up to 30fps. Select Off or Recording captions for higher-frame-rate streaming."
+        );
+    }
 
     Ok(())
 }
@@ -6585,11 +6889,46 @@ fn resolve_split_output_profiles(params: &StartSessionParams) -> Result<SplitOut
 }
 
 fn caption_burn_target(params: &StartSessionParams) -> crate::captions::CaptionBurnTarget {
-    params
+    let Some(captions) = params
         .captions
         .as_ref()
-        .map(|captions| captions.effective_burn_target())
-        .unwrap_or_default()
+        .filter(|captions| !captions.suppressed_for_session)
+    else {
+        return crate::captions::CaptionBurnTarget::Off;
+    };
+    let target = captions.effective_burn_target();
+    let needs_live_stream_leg = target.burns_stream() && params.output.stream_enabled;
+    if !captions.enabled && needs_live_stream_leg && !caption_live_burn_output_eligible(params) {
+        return crate::captions::CaptionBurnTarget::Off;
+    }
+    target
+}
+
+fn caption_live_burn_output_eligible(params: &StartSessionParams) -> bool {
+    if params.output.video.fps > 30 {
+        return false;
+    }
+    let Ok(profiles) = resolved_enabled_stream_output_videos(params) else {
+        return false;
+    };
+    if profiles.iter().any(|profile| profile.fps > 30) {
+        return false;
+    }
+    if params.output.record_enabled && params.output.stream_enabled {
+        let mut distinct_profiles = Vec::<VideoSettings>::new();
+        for profile in profiles {
+            if !distinct_profiles
+                .iter()
+                .any(|existing| same_video_profile(existing, &profile))
+            {
+                distinct_profiles.push(profile);
+            }
+        }
+        if distinct_profiles.len() > 1 {
+            return false;
+        }
+    }
+    true
 }
 
 fn caption_leg_plan(params: &StartSessionParams) -> crate::captions::CaptionOverlayLegPlan {
@@ -7634,6 +7973,101 @@ mod tests {
         // Real audio, however quiet, is not a silent track.
         assert_eq!(silent_mic_verdict(48_000, 0.002), None);
         assert_eq!(silent_mic_verdict(48_000, 0.9), None);
+    }
+
+    fn starting_test_status() -> RecordingStatus {
+        RecordingStatus {
+            state: RecordingState::Starting,
+            session_id: Some("caption-preflight-test".to_string()),
+            output_path: None,
+            stream_url: Some("rtmp://example.invalid/live/redacted".to_string()),
+            started_at: Some("2026-07-11T00:00:00Z".to_string()),
+            audio_tracks: Vec::new(),
+            pipeline: None,
+            duration_ms: None,
+            message: Some("Starting stream session.".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn captions_enabled_without_native_audio_cannot_receive_start_publication_permit() {
+        let state = test_state();
+        let mut events = state.events.subscribe();
+        let mut params = base_params(false, true);
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            ..Default::default()
+        });
+
+        let result = authorize_session_start_publication(&state, "session", &params, false).await;
+
+        assert!(result.is_err(), "the publication permit must be withheld");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("session was not started")
+        );
+        assert!(state.recording.lock().await.is_none());
+        let emitted = std::iter::from_fn(|| events.try_recv().ok()).collect::<Vec<_>>();
+        assert!(
+            emitted
+                .iter()
+                .all(|event| event.event != "recording.status"),
+            "no Starting/Recording/Streaming status may be published without the permit"
+        );
+        let caption_status = crate::captions::captions_status(&state).await;
+        assert_eq!(
+            caption_status.state,
+            crate::captions::CaptionsState::Blocked
+        );
+        assert_eq!(
+            caption_status.reason_code.as_deref(),
+            Some("audio-path-unsupported")
+        );
+    }
+
+    #[tokio::test]
+    async fn one_session_caption_suppression_allows_normal_start_publication() {
+        let state = test_state();
+        let mut events = state.events.subscribe();
+        let mut params = base_params(false, true);
+        // The renderer preserves persisted consent and sends enabled=false only
+        // in this session snapshot after "Continue without captions".
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: false,
+            suppressed_for_session: true,
+            ..Default::default()
+        });
+
+        let permit = authorize_session_start_publication(&state, "session", &params, false)
+            .await
+            .expect("suppressed captions do not require the native caption bus");
+        publish_authorized_session_start(&state, starting_test_status(), &permit);
+
+        let event = events.try_recv().expect("Starting status is published");
+        assert_eq!(event.event, "recording.status");
+        assert_eq!(event.payload["state"], "starting");
+    }
+
+    #[tokio::test]
+    async fn captions_enabled_with_native_audio_allows_start_publication() {
+        let state = test_state();
+        let mut events = state.events.subscribe();
+        let mut params = base_params(false, true);
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            ..Default::default()
+        });
+
+        let permit = authorize_session_start_publication(&state, "session", &params, true)
+            .await
+            .expect("opened native caption bus authorizes publication");
+        publish_authorized_session_start(&state, starting_test_status(), &permit);
+
+        let event = events.try_recv().expect("Starting status is published");
+        assert_eq!(event.event, "recording.status");
+        assert_eq!(event.payload["state"], "starting");
     }
 
     #[test]
@@ -9610,6 +10044,24 @@ mod tests {
             input_arg_value(&args, &stream_fifo_path.display().to_string(), "-f"),
             Some("mpegts")
         );
+        assert_eq!(
+            input_arg_value(
+                &args,
+                &recording_fifo_path.display().to_string(),
+                "-thread_queue_size"
+            ),
+            Some("64"),
+            "the first split FIFO needs enough demux-thread cushion while FFmpeg opens the auxiliary input"
+        );
+        assert_eq!(
+            input_arg_value(
+                &args,
+                &stream_fifo_path.display().to_string(),
+                "-thread_queue_size"
+            ),
+            Some("8"),
+            "the live input stays latency-bounded"
+        );
         // MpegTs carries real encoder PTS — no -framerate synthesis and no
         // wallclock stamping on either FIFO (plan 023: the wallclock path
         // wrote duplicate-PTS slideshow recordings).
@@ -9622,8 +10074,17 @@ mod tests {
             None
         );
         assert_eq!(
+            input_arg_value(
+                &args,
+                &recording_fifo_path.display().to_string(),
+                "-probesize"
+            ),
+            Some("4096")
+        );
+        assert_eq!(
             input_arg_value(&args, &stream_fifo_path.display().to_string(), "-probesize"),
-            Some("65536")
+            Some("4096"),
+            "split FIFO probing must complete before the sibling encoder reaches its 250ms integrity ceiling"
         );
         assert!(args.windows(2).any(|pair| pair == ["-map", "1:v"]));
         assert!(args.windows(2).any(|pair| pair == ["-map", "2:v"]));
@@ -9645,14 +10106,6 @@ mod tests {
         assert_eq!(
             input_arg_value(&args, &recording_fifo_path.display().to_string(), "-f"),
             Some("mpegts")
-        );
-        assert_eq!(
-            input_arg_value(
-                &args,
-                &recording_fifo_path.display().to_string(),
-                "-probesize"
-            ),
-            Some("65536")
         );
         assert_eq!(
             input_arg_value(&args, &recording_fifo_path.display().to_string(), "-fflags"),
@@ -11796,9 +12249,9 @@ mod tests {
     }
 
     #[test]
-    fn caption_burn_in_forces_a_same_profile_stream_leg() {
+    fn captioned_stream_forces_a_same_profile_stream_leg_without_touching_recording() {
         // Same-profile record+stream normally shares frames (no aux leg);
-        // burn-in must force a separate stream leg so the recording stays clean.
+        // stream burn-in must force a separate stream leg so the recording stays clean.
         // No StreamingSettings → the stream output IS the recording profile.
         let mut params = base_params(true, true);
         params.streaming = None;
@@ -11811,22 +12264,310 @@ mod tests {
         assert_eq!(without_burn_in, None);
 
         params.captions = Some(crate::protocol::CaptionsSessionParams {
-            burn_in_enabled: true,
+            enabled: true,
+            burn_target: crate::captions::CaptionBurnTarget::Stream,
             ..Default::default()
         });
-        let with_burn_in = recording_compositor_stream_output(
+        let stream_only = recording_compositor_stream_output(
             &params,
             EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
         )
         .unwrap();
         assert_eq!(
-            with_burn_in,
+            stream_only,
             Some(CompositorAuxiliaryOutput {
                 width: params.output.video.width,
                 height: params.output.video.height,
                 frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
             })
         );
+        let stream_plan = caption_leg_plan(&params);
+        assert_eq!((stream_plan.primary, stream_plan.aux), (false, true));
+        assert!(!stream_plan.captioned_copy);
+
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            burn_target: crate::captions::CaptionBurnTarget::Recording,
+            ..Default::default()
+        });
+        assert_eq!(
+            recording_compositor_stream_output(
+                &params,
+                EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
+            )
+            .unwrap(),
+            None,
+            "Recording selection creates a later copy and needs no live split"
+        );
+        let recording_plan = caption_leg_plan(&params);
+        assert_eq!((recording_plan.primary, recording_plan.aux), (false, false));
+        assert!(recording_plan.captioned_copy);
+
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            burn_target: crate::captions::CaptionBurnTarget::Both,
+            ..Default::default()
+        });
+        assert!(
+            recording_compositor_stream_output(
+                &params,
+                EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
+            )
+            .unwrap()
+            .is_some(),
+            "Both still splits because the live stream is captioned"
+        );
+        let both_plan = caption_leg_plan(&params);
+        assert_eq!(
+            (both_plan.primary, both_plan.aux),
+            (false, true),
+            "one auxiliary overlay avoids both a dirty source and double overlay"
+        );
+        assert!(both_plan.captioned_copy);
+    }
+
+    #[test]
+    fn session_suppression_keeps_the_saved_target_but_plans_as_off() {
+        let mut params = base_params(true, true);
+        params.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p60);
+        params.streaming = None;
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: false,
+            suppressed_for_session: true,
+            burn_target: crate::captions::CaptionBurnTarget::Both,
+            ..Default::default()
+        });
+
+        assert_eq!(
+            params.captions.as_ref().unwrap().burn_target,
+            crate::captions::CaptionBurnTarget::Both,
+            "Continue without captions must not erase the user's saved selection"
+        );
+        assert_eq!(
+            caption_burn_target(&params),
+            crate::captions::CaptionBurnTarget::Off
+        );
+        assert_eq!(
+            recording_compositor_stream_output(
+                &params,
+                EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
+            )
+            .unwrap(),
+            None,
+            "session suppression must not force a same-profile auxiliary leg"
+        );
+        validate_outputs(&params)
+            .expect("session suppression must not trigger the live-burn 30fps preflight");
+    }
+
+    #[test]
+    fn captions_off_prearms_only_an_eligible_saved_live_target() {
+        let mut eligible = base_params(true, true);
+        eligible.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p30);
+        eligible.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: false,
+            suppressed_for_session: false,
+            burn_target: crate::captions::CaptionBurnTarget::Stream,
+            ..Default::default()
+        });
+        let eligible_plan = caption_leg_plan(&eligible);
+        assert_eq!((eligible_plan.primary, eligible_plan.aux), (false, true));
+        assert!(eligible_plan.force_same_profile_split);
+        validate_outputs(&eligible).expect("captions-off prearming does not block capture");
+
+        let mut ineligible = eligible.clone();
+        ineligible.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p60);
+        assert_eq!(
+            caption_burn_target(&ineligible),
+            crate::captions::CaptionBurnTarget::Off
+        );
+        assert_eq!(
+            recording_compositor_stream_output(
+                &ineligible,
+                EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
+            )
+            .unwrap(),
+            None
+        );
+        validate_outputs(&ineligible)
+            .expect("ineligible captions-off output may start with mid-session enable blocked");
+    }
+
+    #[test]
+    fn forced_same_profile_caption_split_routes_rtmp_from_the_auxiliary_input() {
+        let mut params = base_params(true, true);
+        params.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p30);
+        params.streaming = None;
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            burn_target: crate::captions::CaptionBurnTarget::Both,
+            ..Default::default()
+        });
+        let stream_output = recording_compositor_stream_output(
+            &params,
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+        )
+        .unwrap()
+        .expect("captioned stream forces an auxiliary leg");
+        let target = StreamTarget {
+            url: "rtmp://example.test/live/key".to_string(),
+            redacted_url: "rtmp://example.test/live/••••".to_string(),
+            target_id: "target:test".to_string(),
+            platform: StreamPlatform::Custom,
+            label: "Test".to_string(),
+            output_video: None,
+        };
+        let args = bridge_compositor_split_output_ffmpeg_args(
+            &CaptureInputs {
+                video: VideoInput::TestPattern,
+                camera_index: None,
+                microphone: None,
+            },
+            &params,
+            Some(Path::new("/tmp/videorc-caption-route.mkv")),
+            &[target],
+            Path::new("/tmp/videorc-caption-route-recording.ts"),
+            Path::new("/tmp/videorc-caption-route-stream.ts"),
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+            stream_output,
+        )
+        .unwrap();
+
+        assert_eq!(
+            args.windows(2)
+                .filter(|pair| pair == &["-map", "1:v"])
+                .count(),
+            1,
+            "clean primary is mapped only to the local recording"
+        );
+        assert_eq!(
+            args.windows(2)
+                .filter(|pair| pair == &["-map", "2:v"])
+                .count(),
+            1,
+            "RTMP must map the captioned auxiliary leg when both profiles tie"
+        );
+    }
+
+    #[test]
+    fn live_caption_burn_preflight_rejects_over_30fps_but_copy_only_is_allowed() {
+        for burn_target in [
+            crate::captions::CaptionBurnTarget::Stream,
+            crate::captions::CaptionBurnTarget::Both,
+        ] {
+            let mut params = base_params(true, true);
+            params.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p60);
+            params.captions = Some(crate::protocol::CaptionsSessionParams {
+                enabled: true,
+                burn_target,
+                ..Default::default()
+            });
+            let error = validate_outputs(&params).unwrap_err().to_string();
+            assert!(error.contains("30fps"), "{error}");
+            assert!(error.contains("caption"), "{error}");
+        }
+
+        for burn_target in [
+            crate::captions::CaptionBurnTarget::Off,
+            crate::captions::CaptionBurnTarget::Recording,
+        ] {
+            let mut params = base_params(true, true);
+            params.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p60);
+            params.captions = Some(crate::protocol::CaptionsSessionParams {
+                enabled: true,
+                burn_target,
+                ..Default::default()
+            });
+            validate_outputs(&params).expect("non-live caption modes remain valid above 30fps");
+        }
+
+        let mut split = base_params(true, true);
+        split.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p60);
+        split.streaming = Some(streaming_for(&[(
+            StreamPlatform::Youtube,
+            "rtmp://a.rtmp.youtube.com/live2",
+            "yt",
+        )]));
+        split.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            burn_target: crate::captions::CaptionBurnTarget::Stream,
+            ..Default::default()
+        });
+        let error = validate_outputs(&split).unwrap_err().to_string();
+        assert!(error.contains("30fps"), "{error}");
+        assert!(
+            error.contains("caption"),
+            "primary 60fps remains ineligible even when the separate stream profile is 30fps: {error}"
+        );
+    }
+
+    #[test]
+    fn captioned_record_and_stream_rejects_multiple_target_profiles() {
+        let mut params = base_params(true, true);
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            burn_target: crate::captions::CaptionBurnTarget::Stream,
+            ..Default::default()
+        });
+        let mut streaming = streaming_for(&[
+            (
+                StreamPlatform::Youtube,
+                "rtmp://a.rtmp.youtube.com/live2",
+                "yt",
+            ),
+            (StreamPlatform::Twitch, "rtmp://live.twitch.tv/app", "tw"),
+        ]);
+        let twitch = streaming
+            .targets
+            .iter_mut()
+            .find(|target| target.platform == StreamPlatform::Twitch)
+            .unwrap();
+        twitch.output_preset = Some(VideoPreset::StreamSafe1080p60);
+        twitch.output_bitrate_kbps = Some(6000);
+        params.streaming = Some(streaming);
+
+        let error = validate_outputs(&params).unwrap_err().to_string();
+        assert!(error.contains("one captioned stream profile"), "{error}");
+
+        let mut captions_off = base_params(true, true);
+        captions_off.output.video = VideoSettings {
+            preset: VideoPreset::Record4k30,
+            width: 3840,
+            height: 2160,
+            fps: 30,
+            bitrate_kbps: 30_000,
+        };
+        let mut mixed = streaming_for(&[
+            (
+                StreamPlatform::Youtube,
+                "rtmp://a.rtmp.youtube.com/live2",
+                "yt",
+            ),
+            (StreamPlatform::Twitch, "rtmp://live.twitch.tv/app", "tw"),
+        ]);
+        mixed.default_output_preset = VideoPreset::StreamYoutube4k30;
+        mixed.default_bitrate_kbps = 30_000;
+        captions_off.streaming = Some(mixed);
+        captions_off.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: false,
+            burn_target: crate::captions::CaptionBurnTarget::Stream,
+            ..Default::default()
+        });
+        assert_eq!(
+            caption_burn_target(&captions_off),
+            crate::captions::CaptionBurnTarget::Off,
+            "an ineligible mixed captions-off session does not reserve an impossible live leg"
+        );
+        validate_outputs(&captions_off)
+            .expect("captions-off preserves the existing mixed-profile capture behavior");
+    }
+
+    #[test]
+    fn captioned_copy_finalization_requires_explicit_selection_and_cues() {
+        assert!(!should_begin_captioned_copy_render(false, 0));
+        assert!(!should_begin_captioned_copy_render(false, 3));
+        assert!(!should_begin_captioned_copy_render(true, 0));
+        assert!(should_begin_captioned_copy_render(true, 3));
     }
 
     #[test]

--- a/crates/videorc-backend/src/state.rs
+++ b/crates/videorc-backend/src/state.rs
@@ -390,9 +390,10 @@ pub struct AppState {
     /// None falls back to the dev env mock; persistent token storage replaces it.
     pub account_session: Arc<tokio::sync::Mutex<Option<VideorcAccountSnapshot>>>,
     pub captions: crate::captions::CaptionsSlot,
-    /// Burn-in caption bar for the stream leg (std mutex: read from the
-    /// synchronous compositor render thread).
-    pub caption_overlay: crate::captions::CaptionOverlaySlot,
+    /// Per-output burn-in caption bars (std mutex: read from the synchronous
+    /// compositor render thread). Primary and auxiliary may use different
+    /// raster dimensions for split 4K-record/1080p-stream sessions.
+    pub caption_overlay: crate::captions::CaptionOverlaySlots,
     /// Comment-highlight overlay (Comments upgrade S2): independent from the
     /// captions bar — highlight top, captions bottom, coexisting.
     pub highlight_overlay: crate::captions::CaptionOverlaySlot,
@@ -441,7 +442,7 @@ impl AppState {
                 crate::account::restore_persisted_account(),
             )),
             captions: crate::captions::new_captions_slot(),
-            caption_overlay: crate::captions::new_caption_overlay_slot(),
+            caption_overlay: crate::captions::new_caption_overlay_slots(),
             highlight_overlay: crate::captions::new_caption_overlay_slot(),
             comment_highlight: crate::comment_highlight::new_comment_highlight_slot(),
         }

--- a/crates/videorc-backend/src/videorc_api.rs
+++ b/crates/videorc-backend/src/videorc_api.rs
@@ -15,6 +15,9 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+pub(crate) const CAPTION_CHUNK_UPLOAD_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(10);
+
 use crate::protocol::{
     AiCapabilities, AiJobCreateResponse, AiJobEnvelope, AiJobSnapshot, AiObjectUploadResponse,
     AiObjectUploadTicket, AiQuotaStatus,
@@ -341,6 +344,7 @@ impl VideorcApiClient {
             .file_name("videorc-caption-chunk.wav")
             .mime_str("audio/wav")
             .map_err(|error| CaptionChunkFailure::Transient {
+                code: None,
                 message: format!("Could not build the caption upload: {error}"),
             })?;
         let mut form = multipart::Form::new()
@@ -357,10 +361,11 @@ impl VideorcApiClient {
             .multipart(form)
             // A hung upload must become a retryable failure, not a stalled
             // caption loop (R0) — chunks are ~3s of audio, 10s is generous.
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(CAPTION_CHUNK_UPLOAD_TIMEOUT)
             .send()
             .await
             .map_err(|error| CaptionChunkFailure::Transient {
+                code: None,
                 message: format!("Could not reach the caption service: {error}"),
             })?;
 
@@ -370,6 +375,7 @@ impl VideorcApiClient {
                 .json()
                 .await
                 .map_err(|error| CaptionChunkFailure::Transient {
+                    code: None,
                     message: format!("Could not read the caption response: {error}"),
                 });
         }
@@ -396,6 +402,7 @@ impl VideorcApiClient {
             .send()
             .await
             .map_err(|error| CaptionChunkFailure::Transient {
+                code: None,
                 message: format!("Could not reach the caption service: {error}"),
             })?;
 
@@ -405,6 +412,7 @@ impl VideorcApiClient {
                 .json()
                 .await
                 .map_err(|error| CaptionChunkFailure::Transient {
+                    code: None,
                     message: format!("Could not read the streaming token: {error}"),
                 });
         }
@@ -512,7 +520,7 @@ pub struct CaptionRealtimeToken {
     pub expires_at: Option<u64>,
     pub model: String,
     #[serde(default)]
-    pub remaining_seconds: u64,
+    pub remaining_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -521,7 +529,10 @@ pub enum CaptionChunkFailure {
     /// quota exhausted, signed out, captions disabled).
     Terminal { code: String, message: String },
     /// Skip this chunk; the session keeps going (network blip, 5xx).
-    Transient { message: String },
+    Transient {
+        code: Option<String>,
+        message: String,
+    },
 }
 
 fn classify_caption_failure(status: u16, code: String, message: String) -> CaptionChunkFailure {
@@ -531,6 +542,8 @@ fn classify_caption_failure(status: u16, code: String, message: String) -> Capti
             | "captions-monthly-quota-exhausted"
             | "ai-user-disabled"
             | "ai-disabled"
+            | "ai-transcription-not-configured"
+            | "captions-config-missing"
             | "unauthorized"
     ) || status == 401
         || status == 403
@@ -539,6 +552,7 @@ fn classify_caption_failure(status: u16, code: String, message: String) -> Capti
         CaptionChunkFailure::Terminal { code, message }
     } else {
         CaptionChunkFailure::Transient {
+            code: Some(code),
             message: format!("caption chunk failed ({status}): {message}"),
         }
     }
@@ -682,6 +696,107 @@ mod tests {
         assert!(parsed.features.cloud_ai_enabled);
         assert_eq!(parsed.workflow.input_modes[1].kind, "multipart-audio");
         assert_eq!(parsed.limits.max_audio_megabytes, Some(12.5));
+        assert!(
+            parsed.captions.is_none(),
+            "older web deployments remain compatible during rollout"
+        );
+    }
+
+    #[test]
+    fn ai_capabilities_captions_readiness_survives_proxy_round_trip() {
+        let input = serde_json::json!({
+            "captions": {
+                "available": true,
+                "chunked": {
+                    "available": true,
+                    "configured": true,
+                    "model": "xai/grok-stt"
+                },
+                "monthlySecondsLimit": 180000,
+                "preferredTransport": "realtime",
+                "realtime": {
+                    "available": true,
+                    "configured": true,
+                    "disabled": false,
+                    "model": "xai/grok-voice-think-fast-1.0"
+                },
+                "remainingSeconds": 179940,
+                "reasonCode": "ready-realtime"
+            },
+            "entitlement": {
+                "checkedAt": "2026-07-11T12:00:00.000Z",
+                "cloudAi": true,
+                "expiresAt": "2026-07-11T12:05:00.000Z",
+                "isPremium": true,
+                "subscriptionStatus": "active",
+                "tier": "premium"
+            },
+            "features": {
+                "cloudAiEnabled": true,
+                "gatewayConfigured": true,
+                "modelTestingEnabled": true,
+                "multipartAudioJobsEnabled": true,
+                "objectBackedJobsEnabled": false,
+                "transcriptJobsEnabled": true,
+                "uploadTicketsEnabled": false
+            },
+            "generatedAt": "2026-07-11T12:00:00.000Z",
+            "limits": {
+                "dailyJobs": 25,
+                "maxAudioBytes": 13107200,
+                "maxAudioMegabytes": 12.5,
+                "maxOutputTokens": 1900,
+                "maxTranscriptCharacters": 90000,
+                "monthlyJobs": 600
+            },
+            "models": {
+                "allowedTextModelCount": 2,
+                "allowedTextModelsConfigured": true,
+                "defaultTextModel": "openai/gpt-5.5",
+                "fallbackTextModels": ["google/gemini"]
+            },
+            "objectStorage": {
+                "deleteConfigured": false,
+                "downloadConfigured": false,
+                "provider": null,
+                "providerError": null,
+                "proofConfigured": false,
+                "proofTtlMs": null,
+                "uploadConfigured": false
+            },
+            "readiness": {
+                "access": { "cloudAiEntitled": true, "globallyDisabled": false },
+                "gateway": { "configError": null, "configured": true },
+                "objectStorage": {
+                    "deleteConfigError": null,
+                    "downloadConfigError": null,
+                    "proofConfigError": null,
+                    "providerError": null,
+                    "uploadConfigError": null
+                },
+                "transcription": { "configError": null, "configured": true }
+            },
+            "transcription": {
+                "configured": true,
+                "configError": null,
+                "maxAudioBytes": 13107200,
+                "maxAudioMegabytes": 12.5,
+                "requestTimeoutMs": 65000
+            },
+            "workflow": {
+                "inputModes": [{ "enabled": true, "kind": "multipart-audio" }],
+                "kind": "post-recording-publish-pack",
+                "outputs": ["summary"]
+            }
+        });
+
+        let parsed: AiCapabilities = serde_json::from_value(input.clone()).unwrap();
+        let proxied = serde_json::to_value(parsed).unwrap();
+
+        assert_eq!(
+            proxied["captions"], input["captions"],
+            "the Rust proxy must preserve the complete readiness contract"
+        );
     }
 
     #[test]
@@ -700,5 +815,48 @@ mod tests {
             Some("ai-daily-quota-exhausted")
         );
         assert_eq!(parsed.today.remaining, 0);
+    }
+
+    #[test]
+    fn missing_chunk_transcription_config_is_terminal_not_an_infinite_retry() {
+        let failure = classify_caption_failure(
+            503,
+            "ai-transcription-not-configured".to_string(),
+            "Live captions are not configured.".to_string(),
+        );
+        assert!(matches!(
+            failure,
+            CaptionChunkFailure::Terminal { code, .. }
+                if code == "ai-transcription-not-configured"
+        ));
+    }
+
+    #[test]
+    fn realtime_unavailable_remains_eligible_for_chunk_fallback() {
+        let failure = classify_caption_failure(
+            503,
+            "captions-realtime-unavailable".to_string(),
+            "Streaming captions are unavailable.".to_string(),
+        );
+        assert!(matches!(
+            failure,
+            CaptionChunkFailure::Transient { code: Some(code), .. }
+                if code == "captions-realtime-unavailable"
+        ));
+    }
+
+    #[test]
+    fn realtime_kill_switch_remains_eligible_for_chunk_fallback() {
+        let failure = classify_caption_failure(
+            503,
+            "captions-realtime-disabled".to_string(),
+            "Streaming captions are temporarily disabled; chunked captions remain available."
+                .to_string(),
+        );
+        assert!(matches!(
+            failure,
+            CaptionChunkFailure::Transient { code: Some(code), .. }
+                if code == "captions-realtime-disabled"
+        ));
     }
 }

--- a/docs/acceptance/2026-07-11-live-captions-reliability.md
+++ b/docs/acceptance/2026-07-11-live-captions-reliability.md
@@ -1,0 +1,125 @@
+# Live captions reliability and styles — acceptance, 2026-07-11
+
+Scope: the desktop/backend work in `videorc` plus the authenticated readiness and
+canary work in `videorcweb`, following the Obsidian plan
+`2026-07-11 - Videorc Live Captions Reliability And Styles Plan`.
+
+This note separates deterministic proof completed before review from the
+real-account, destination, and platform passes that must happen during staged
+rollout. It intentionally contains no bearer, Gateway key, realtime client
+secret, WebSocket URL, transcript text, provider response body, or user data.
+
+## Recovery and deployment proof
+
+| Check                                                                         | Result              | Evidence                                                                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Live Vercel project has scoped caption Gateway auth in Preview and Production | PASS                | Configuration restored on 2026-07-11; one active scoped key, monthly spend cap configured.                                                                                                                                                                                                                        |
+| Realtime voice safety decision                                                | KILL-SWITCHED       | A redacted live-provider protocol probe showed that the voice model auto-created assistant responses despite transcription-only configuration. A direct desktop-to-provider socket also cannot be authoritatively metered by the server. Realtime remains configured for diagnosis but is unavailable to clients. |
+| Quota-aware protected-preview readiness                                       | PASS                | Authenticated readiness reported `preferredTransport: chunked`, `ready-chunked-realtime-disabled`, realtime configured + disabled + unavailable, chunked available, and a positive server-metered allowance.                                                                                                      |
+| Protected-preview realtime token route                                        | PASS — FAILS CLOSED | Authenticated request returned the expected safe `503`; no client secret or provider URL was minted.                                                                                                                                                                                                              |
+| Protected-preview chunk transcription and metering                            | PASS                | A canonical deterministic spoken WAV returned HTTP `200`, non-empty transcription, model `xai/grok-stt`, and a three-second server-derived charge. A post-request capabilities read proved the per-user/month reservation persisted; transcript text and provider bodies are omitted.                             |
+| Realtime configuration default                                                | PASS — FAILS CLOSED | Missing, blank, true, or malformed `VIDEORC_AI_CAPTIONS_REALTIME_DISABLED` values keep direct provider sockets disabled. Only an explicit false value can enable an isolated experiment.                                                                                                                          |
+| Monthly allowance concurrency and rollover                                    | PASS                | Canonical PCM duration is conditionally reserved before provider work on one server-derived row per user and UTC month. Concurrent requests serialize on the unique row; older per-session rows still count during migration, and a reused client ID cannot escape the next month.                                |
+
+Protected preview verified from deployment
+`dpl_DQEWFxLKfE2nvpNq3vnBNCkieArM`
+(`https://videorc-rj23qmg6h-orc-dev.vercel.app`). The production-safe transport
+is therefore the server-metered approximately three-second chunk path. The UI
+must describe its higher delay truthfully; this evidence does not authorize
+re-enabling the realtime voice transport.
+
+## Deterministic desktop/backend proof
+
+| Contract                              | Result | Evidence                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HTTP + realtime Gateway wire contract | PASS   | `pnpm smoke:captions-contract`; an owned debug backend proves exact config/audio, partial/final upsert, assistant-response rejection, bounded retry, and both assistant-safety and unavailable-service chunk fallback without renderer intent races.                                                                                            |
+| Mic-to-pixels live stream path        | PASS   | `pnpm smoke:captions-live`; post-controls PCM → exact realtime kill-switch response → credential-free fake chunk route → `captions.update` → real renderer PNG → compositor → local RTMP → ffprobe/ffmpeg analysis.                                                                                                                             |
+| Live artifact                         | PASS   | 640×360 H.264 at 30 fps; clean MP4 13.733 s/412 frames, RTMP FLV 13.487 s/405 frames, and captioned copy 13.733 s/412 frames. Stream analysis found 35 clean baseline frames followed by 46 consecutive caption frames; the captioned copy found 18 baseline plus 54 caption frames. Five chunks, including the final remainder, were uploaded. |
+| Runtime truth and teardown            | PASS   | Ready/Starting/Listening/Reconnecting/Degraded/Blocked/Error state model; backend-owned stop/block/sign-out clearing; renderer and detached-reader reset event. The safe deployed path reports chunked transport and higher delay instead of claiming realtime listening.                                                                       |
+| Privacy                               | PASS   | Caption tap is after live mute/gain; sign-out joins the task and purges audio tap, transcript state, pending cue work, and both overlay slots.                                                                                                                                                                                                  |
+| Transport continuity                  | PASS   | One sequence and capture-relative timeline survive realtime→chunk fallback and off/on mid-session.                                                                                                                                                                                                                                              |
+| Split outputs                         | PASS   | Primary/auxiliary overlays are revisioned independently; 4K recording and 1080p stream dimensions remain distinct. Split-only FFmpeg probing is bounded to 4,096 bytes so sequential stream-info discovery cannot starve the sibling FIFO before its reader thread starts.                                                                      |
+| Recording semantics                   | PASS   | Original stays clean; Recording selection controls the non-destructive `(captioned)` copy; stream captions force a clean-recording split when needed.                                                                                                                                                                                           |
+| Overlay coexistence                   | PASS   | Captions reserve comment-highlight safe area on the same top/bottom edge in 16:9 and 9:16 CPU/Metal layout tests.                                                                                                                                                                                                                               |
+
+## Final-review regression closure
+
+The named regressions and the final combined backend gate pass together.
+
+| Regression                                                        | Result | Evidence                                                                                                                                                                                                                                                                                     |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Explicit opt-out discards queued audio                            | PASS   | `explicit_caption_opt_out_discards_audio_already_queued_for_transcription` proves stop takes task ownership and queued PCM is not consumed after privacy opt-out.                                                                                                                            |
+| Chunk buffering and final remainder                               | PASS   | `chunk_buffer_drains_while_upload_is_pending_and_flushes_final_remainder` proves conversation continues entering a bounded queue while an upload is pending and the short final chunk is retained.                                                                                           |
+| Reconnect exhaustion is bounded                                   | PASS   | `configuration_send_failures_exhaust_realtime_retry_budget` and `configuration_ack_then_close_still_exhausts_realtime_retry_budget` prove accepting-then-closing providers fall back rather than spin.                                                                                       |
+| Off/on keeps unique sequence IDs                                  | PASS   | `caption_sequence_survives_off_on_runtime_restarts_until_capture_reset` and the realtime→chunk uniqueness test preserve one capture-owned monotonic namespace.                                                                                                                               |
+| Stop, block, terminal failure, and sign-out clear authoritatively | PASS   | Backend lifecycle regressions assert both overlay slots clear and the renderer receives `captions.cleared`; capture-end presentation clears while artifact cues remain, and sign-out abort+join completes before credential removal.                                                         |
+| Unapplied live audio controls stay truthful                       | PASS   | `live_audio_processing_update_requires_an_active_matching_session` plus the 10 `live-audio-processing` renderer tests prove `applied: false` is honored, stale responses cannot cross sessions, and unsupported live controls roll back to the last accepted values.                         |
+| Finalization work is bounded and capture-owned                    | PASS   | Cue rendering uses a generation-serialized FIFO with independent progress watchdogs; sign-out and backend shutdown cancel and join the provider plus render/burn work, remove the microphone tap, purge frame caches, and keep artifact completion separate from live-presentation clearing. |
+| Session output readiness fails closed                             | PASS   | Caption burn preflight blocks output profiles above 30 fps and mixed record/stream profiles; eligible captions-off sessions pre-arm the live leg for mid-session opt-in, while ineligible sessions report a one-session suppression instead of silently omitting captions.                   |
+
+The final integrated live-smoke artifact report was generated at
+`/var/folders/5b/08_snhzs2xb559qf1j6dth2r0000gn/T/videorc-captions-live-1783743593200/captions-live-artifact.json`.
+That path is local evidence, not a committed fixture.
+
+## UI and style proof
+
+| Check                    | Result | Evidence                                                                                                                          |
+| ------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Dedicated Captions page  | PASS   | Sidebar, command palette, routing, `⌘6`, real-aspect sticky preview, shared controls.                                             |
+| Livestream controls      | PASS   | The same `CaptionsControls` composition is reused; Studio remains a compact status/manage surface.                                |
+| Presets                  | PASS   | Classic, Glass, Lower third, and High contrast share one registry across preview, live overlays, detached reader, and final copy. |
+| Accessibility            | PASS   | Keyboard-labelled choices; partials are visual; only finalized cues enter `aria-live`; reader toggles with `⌘⇧C`.                 |
+| App themes               | PASS   | Fresh-profile dark and light screenshot sweep for Captions and Livestream.                                                        |
+| Output backgrounds/sizes | PASS   | Exact renderer contact sheets inspected over light/dark/motion at 1280×720, 1920×1080, 3840×2160, and 1080×1920.                  |
+
+Local visual evidence:
+
+- `/tmp/videorc-ui-captions-dark.png`
+- `/tmp/videorc-ui-captions-light.png`
+- `/tmp/videorc-ui-streaming-dark.png`
+- `/tmp/videorc-ui-streaming-light.png`
+- `/tmp/videorc-caption-style-sheets-final/`
+- `/tmp/videorc-captions-live-pass-stream.png`
+- `/tmp/videorc-captions-live-pass-copy.png`
+
+These are generated QA artifacts and are intentionally not committed.
+
+## Gate record
+
+| Gate                                                  | Result                | Notes                                                                                                                                                                                                                                                                                              |
+| ----------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Desktop caption/UI regressions                        | PASS                  | Included in the 774-test desktop suite; focused caption, preflight, live-audio, reader, routing, and style cases are green.                                                                                                                                                                        |
+| `pnpm typecheck` / `pnpm lint` / `pnpm format:check`  | PASS                  | Final integrated worktree.                                                                                                                                                                                                                                                                         |
+| `pnpm --filter @videorc/desktop test`                 | PASS                  | 93 files, 774 tests.                                                                                                                                                                                                                                                                               |
+| `pnpm test:scripts`                                   | PASS                  | 564 tests, including encoded caption/highlight artifact analyzers.                                                                                                                                                                                                                                 |
+| Rust tests                                            | PASS                  | 48 native-helper tests, 996 backend tests (7 ignored by design), and the content-length wire test: 1,045 passed.                                                                                                                                                                                   |
+| Rust fmt / clippy / advisory audit                    | PASS                  | `cargo fmt --check --all`, clippy with warnings denied, and `cargo audit`.                                                                                                                                                                                                                         |
+| JS production advisory audit                          | PASS WITH NOTE        | Pinned pnpm 11 passes the configured high-severity gate; one moderate advisory remains. The repo wrapper selected an incompatible global pnpm, so the exact audit command was rerun directly under pnpm 11.                                                                                        |
+| `pnpm build`                                          | PASS                  | Electron main, preload, captions reader, Captions page, and main renderer production bundles built.                                                                                                                                                                                                |
+| `pnpm smoke:captions-contract`                        | PASS                  | Owned debug backend; exact realtime contract, repeated-completion upsert, unsafe assistant-response → immediate chunk fallback, disabled-realtime fallback, and first-frame→producer-stall truth.                                                                                                  |
+| `pnpm smoke:captions-live`                            | PASS                  | Exact kill-switch code → server-metered chunk fallback → real renderer/compositor/local RTMP. Muted upload peak/RMS were zero; +6 dB produced a 1.996× amplitude ratio; stream had 35 baseline + 46 caption frames, original had zero caption frames, and captioned copy had 54 caption frames.    |
+| `pnpm smoke:recording-studio`                         | PARTIAL / ENV BLOCKED | Steps 1–21 passed, including all-layout artifacts, split stream/highlight coexistence, native preview lifecycle/placement/interaction/surface gates. Step 22 stopped because ScreenCaptureKit discovery returned no native screen source on this host.                                             |
+| Notes-window real-screen smoke                        | ENV BLOCKED           | Rerun separately; same missing ScreenCaptureKit source, before capture.                                                                                                                                                                                                                            |
+| `pnpm smoke:recording-studio:devices`                 | ENV BLOCKED           | The required ScreenCaptureKit source is unavailable, so real-device parity cannot be asserted.                                                                                                                                                                                                     |
+| Web typecheck / lint / build / targeted caption tests | PASS                  | 30 caption/readiness/canary tests; fail-closed realtime, canonical PCM validation, atomic monthly reservation, HTTPS/loopback validation, persisted canary metering, and redaction are green. Lint has one unrelated existing `<img>` warning; local and protected-preview production builds pass. |
+| Web full test suite                                   | BASELINE FAIL         | 271/273 pass. The same two unrelated `contributors` metadata/`llms.txt` expectations fail on clean `origin/main`.                                                                                                                                                                                  |
+| Web full format check                                 | BASELINE FAIL         | Existing unrelated formatting debt; every touched file is checked independently.                                                                                                                                                                                                                   |
+
+## Staged acceptance still required
+
+| Row                                                   | State   | Why / next proof                                                                                                                                                                               |
+| ----------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Real Premium macOS microphone, 60-second conversation | BLOCKED | Run after review on an owner account with microphone permission; verify truthful chunked/higher-delay status, finalized cues, SRT timing, clean original, and captioned copy.                  |
+| Unlisted/live external destination                    | BLOCKED | Requires intentionally publishing to a real destination; perform in the owner rollout.                                                                                                         |
+| Windows capture path                                  | BLOCKED | No Windows host in this workspace. Unsupported paths fail closed; parity cannot be declared until the Windows device gate passes.                                                              |
+| Realtime voice transport re-enable                    | BLOCKED | Requires an authoritative server-side relay/meter and a live provider contract that cannot create assistant responses; direct-client elapsed-time reports are not an acceptable quota control. |
+| Owner → small Premium cohort → all Premium            | BLOCKED | Operational rollout follows merge and production deployment; watch chunk latency, error rate, quota, and cost metrics.                                                                         |
+| Production canary from merged web commit              | BLOCKED | After the web PR reaches Production, run `VIDEORC_CAPTIONS_CANARY_ALLOW_CHUNKED_ONLY=true pnpm smoke:captions-production` with the authenticated deterministic WAV fixture.                    |
+
+## Review verdict
+
+The deterministic implementation is suitable for draft-PR review. The
+deployable posture is chunked-only: server-metered captions with truthful
+higher-delay status. This is not a declaration of realtime voice safety,
+Windows parity, or full Premium rollout; the blocked rows are explicit
+release-stage acceptance work, not silently waived checks.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "smoke:dev": "node scripts/smoke-dev-app.mjs",
     "smoke:backend-single-instance": "node scripts/smoke-backend-single-instance.mjs",
     "smoke:backend-resilience": "node scripts/smoke-backend-resilience.mjs",
+    "smoke:captions-contract": "cargo build -p videorc-backend && node scripts/smoke-captions-contract.mjs",
+    "smoke:captions-live": "node scripts/smoke-captions-live-app.mjs",
+    "captions:contact-sheet": "node scripts/caption-style-contact-sheet.mjs",
     "smoke:repair-encoder": "node scripts/smoke-repair-encoder.mjs",
     "smoke:obs-import": "node scripts/smoke-obs-import.mjs",
     "smoke:process-lifecycle": "node scripts/smoke-process-lifecycle.mjs",
@@ -157,6 +160,7 @@
     "eslint": "^10.4.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "prettier": "^3.8.4",
-    "typescript-eslint": "^8.61.0"
+    "typescript-eslint": "^8.61.0",
+    "ws": "^8.21.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       typescript-eslint:
         specifier: ^8.61.0
         version: 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3)
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
 
   apps/desktop:
     dependencies:
@@ -3324,6 +3327,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -6700,6 +6715,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   xmlbuilder@15.1.1: {}
 

--- a/scripts/caption-style-contact-sheet.mjs
+++ b/scripts/caption-style-contact-sheet.mjs
@@ -1,0 +1,205 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { launchDevApp } from './lib/app-launcher.mjs'
+
+const outputDirectory = resolve(
+  process.env.VIDEORC_CAPTION_STYLE_SHEET_DIR ??
+    join(tmpdir(), `videorc-caption-style-sheets-${Date.now()}`)
+)
+const stateRoot = mkdtempSync(join(tmpdir(), 'videorc-caption-style-renderer-'))
+const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 180_000)
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+const styles = [
+  { id: 'classic', label: 'Classic' },
+  { id: 'glass', label: 'Glass' },
+  { id: 'lower-third', label: 'Lower third' },
+  { id: 'high-contrast', label: 'High contrast' }
+]
+const sizes = [
+  { width: 1280, height: 720, label: '720p' },
+  { width: 1920, height: 1080, label: '1080p' },
+  { width: 3840, height: 2160, label: '4K' },
+  { width: 1080, height: 1920, label: 'Vertical' }
+]
+const backgrounds = [
+  { id: 'light', source: (size) => `color=c=#e8e9ed:s=${size.width}x${size.height}:r=1` },
+  { id: 'dark', source: (size) => `color=c=#17181d:s=${size.width}x${size.height}:r=1` },
+  { id: 'motion', source: (size) => `testsrc2=s=${size.width}x${size.height}:r=1` }
+]
+
+mkdirSync(outputDirectory, { recursive: true })
+const overlayDirectory = join(outputDirectory, 'overlays')
+const previewDirectory = join(outputDirectory, 'previews')
+mkdirSync(overlayDirectory, { recursive: true })
+mkdirSync(previewDirectory, { recursive: true })
+
+let launched
+try {
+  launched = await launchDevApp({
+    requiredMarkers: ['backend-ready', 'preview-motion-ready'],
+    timeoutMs,
+    env: {
+      VIDEORC_DISABLE_AUTO_PREVIEW: '1',
+      VIDEORC_SMOKE_COMMAND_SERVER: '1',
+      VIDEORC_SMOKE_OUTPUT_DIR: outputDirectory,
+      VIDEORC_SMOKE_STATE_DIR: stateRoot
+    }
+  })
+  const smoke = launched.connections['preview-motion-ready']
+  const manifest = []
+
+  for (const size of sizes) {
+    const previews = []
+    for (const style of styles) {
+      const pngBase64 = await renderCaptionFrame(smoke, {
+        styleId: style.id,
+        canvasWidth: size.width,
+        canvasHeight: size.height
+      })
+      const overlayPath = join(overlayDirectory, `${size.width}x${size.height}-${style.id}.png`)
+      writeFileSync(overlayPath, Buffer.from(pngBase64, 'base64'))
+
+      for (const background of backgrounds) {
+        const previewPath = join(
+          previewDirectory,
+          `${size.width}x${size.height}-${style.id}-${background.id}.png`
+        )
+        compositePreview({
+          background,
+          label: `${style.label} / ${background.id}`,
+          overlayPath,
+          previewPath,
+          size
+        })
+        previews.push(previewPath)
+        manifest.push({
+          background: background.id,
+          height: size.height,
+          label: size.label,
+          overlayPath,
+          previewPath,
+          styleId: style.id,
+          width: size.width
+        })
+      }
+    }
+    const sheetPath = join(
+      outputDirectory,
+      `caption-styles-${size.label.toLowerCase()}-${size.width}x${size.height}.png`
+    )
+    stackContactSheet(previews, sheetPath)
+    console.log(`${size.label} caption style contact sheet: ${sheetPath}`)
+  }
+
+  const manifestPath = join(outputDirectory, 'caption-style-contact-sheet.json')
+  writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        layout: {
+          columns: backgrounds.map(({ id }) => id),
+          rows: styles.map(({ id }) => id)
+        },
+        manifest
+      },
+      null,
+      2
+    )
+  )
+  console.log(
+    `Caption style contact sheets PASS — exact renderer PNGs over light/dark/motion: ${outputDirectory}`
+  )
+} finally {
+  await launched?.stop().catch(() => {})
+  rmSync(stateRoot, { force: true, recursive: true })
+}
+
+async function renderCaptionFrame(smoke, params) {
+  const response = await smokeCommand(smoke, 'eval-js', {
+    code: `
+      const { renderCaptionCueFramePng } = await import('/src/lib/caption-overlay.ts');
+      return renderCaptionCueFramePng({
+        text: 'Captions stay clear while the conversation keeps moving.',
+        canvasWidth: Number(params.canvasWidth),
+        canvasHeight: Number(params.canvasHeight),
+        position: 'bottom',
+        textSize: 'm',
+        styleId: String(params.styleId)
+      });
+    `,
+    ...params
+  })
+  const pngBase64 = response?.result
+  if (typeof pngBase64 !== 'string' || pngBase64.length < 32) {
+    throw new Error(`Renderer did not produce a PNG for ${params.styleId}.`)
+  }
+  return pngBase64
+}
+
+function compositePreview({ background, overlayPath, previewPath, size }) {
+  const filter = [
+    '[0:v][1:v]overlay=0:0:format=auto',
+    'scale=w=480:h=420:force_original_aspect_ratio=decrease',
+    'pad=480:480:(ow-iw)/2:(oh-ih)/2:color=#0b0b0d'
+  ].join(',')
+  execFileSync(
+    ffmpegPath,
+    [
+      '-y',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-f',
+      'lavfi',
+      '-i',
+      background.source(size),
+      '-i',
+      overlayPath,
+      '-filter_complex',
+      filter,
+      '-frames:v',
+      '1',
+      previewPath
+    ],
+    { stdio: 'inherit' }
+  )
+}
+
+function stackContactSheet(previews, sheetPath) {
+  if (previews.length !== styles.length * backgrounds.length) {
+    throw new Error(`Expected 12 caption previews, got ${previews.length}.`)
+  }
+  const args = ['-y', '-hide_banner', '-loglevel', 'error']
+  for (const preview of previews) args.push('-i', preview)
+  const layout = previews
+    .map((_, index) => `${(index % 3) * 480}_${Math.floor(index / 3) * 480}`)
+    .join('|')
+  args.push(
+    '-filter_complex',
+    `${previews.map((_, index) => `[${index}:v]`).join('')}xstack=inputs=${previews.length}:layout=${layout}:fill=#0b0b0d[out]`,
+    '-map',
+    '[out]',
+    '-frames:v',
+    '1',
+    sheetPath
+  )
+  execFileSync(ffmpegPath, args, { stdio: 'inherit' })
+}
+
+async function smokeCommand(smoke, command, params = {}) {
+  const response = await fetch(`http://${smoke.host}:${smoke.port}/command`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ command, params }),
+    signal: AbortSignal.timeout(timeoutMs)
+  })
+  const payload = await response.json()
+  if (!response.ok || !payload.ok) {
+    throw new Error(payload?.error ?? `${command} smoke command failed`)
+  }
+  return payload.result
+}

--- a/scripts/lib/audio-amplitude.mjs
+++ b/scripts/lib/audio-amplitude.mjs
@@ -1,0 +1,130 @@
+import { spawn } from 'node:child_process'
+
+export function measurePcm16Le(buffer) {
+  const bytes = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer ?? [])
+  const sampleCount = Math.floor(bytes.length / 2)
+  if (sampleCount === 0) {
+    return { sampleCount: 0, peak: 0, rms: 0 }
+  }
+
+  let peak = 0
+  let sumSquares = 0
+  for (let offset = 0; offset + 1 < bytes.length; offset += 2) {
+    const normalized = bytes.readInt16LE(offset) / 32_768
+    const absolute = Math.abs(normalized)
+    if (absolute > peak) peak = absolute
+    sumSquares += normalized * normalized
+  }
+  return {
+    sampleCount,
+    peak,
+    rms: Math.sqrt(sumSquares / sampleCount)
+  }
+}
+
+export function inspectPcm16Wav(wav) {
+  const bytes = Buffer.isBuffer(wav) ? wav : Buffer.from(wav ?? [])
+  if (
+    bytes.length < 44 ||
+    bytes.toString('ascii', 0, 4) !== 'RIFF' ||
+    bytes.toString('ascii', 8, 12) !== 'WAVE'
+  ) {
+    throw new Error('Caption upload did not contain a RIFF/WAVE payload.')
+  }
+
+  let format = null
+  let pcm = null
+  for (let offset = 12; offset + 8 <= bytes.length; ) {
+    const kind = bytes.toString('ascii', offset, offset + 4)
+    const length = bytes.readUInt32LE(offset + 4)
+    const payloadStart = offset + 8
+    const payloadEnd = payloadStart + length
+    if (payloadEnd > bytes.length) {
+      throw new Error(`WAV ${kind} chunk exceeded the upload body.`)
+    }
+    if (kind === 'fmt ' && length >= 16) {
+      format = {
+        audioFormat: bytes.readUInt16LE(payloadStart),
+        channels: bytes.readUInt16LE(payloadStart + 2),
+        sampleRate: bytes.readUInt32LE(payloadStart + 4),
+        bitsPerSample: bytes.readUInt16LE(payloadStart + 14)
+      }
+    } else if (kind === 'data') {
+      pcm = bytes.subarray(payloadStart, payloadEnd)
+    }
+    offset = payloadEnd + (length % 2)
+  }
+
+  if (!format || !pcm) throw new Error('Caption WAV was missing fmt or data.')
+  if (format.audioFormat !== 1 || format.bitsPerSample !== 16) {
+    throw new Error(
+      `Caption WAV must be PCM16, got format=${format.audioFormat} bits=${format.bitsPerSample}.`
+    )
+  }
+  return { ...format, ...measurePcm16Le(pcm) }
+}
+
+export function inspectMultipartPcm16Wav(body) {
+  const bytes = Buffer.isBuffer(body) ? body : Buffer.from(body ?? [])
+  const start = bytes.indexOf(Buffer.from('RIFF'))
+  if (start < 0 || start + 8 > bytes.length) {
+    throw new Error('Caption multipart upload did not contain a WAV file.')
+  }
+  const length = bytes.readUInt32LE(start + 4) + 8
+  if (length < 44 || start + length > bytes.length) {
+    throw new Error('Caption multipart upload contained a truncated WAV file.')
+  }
+  return inspectPcm16Wav(bytes.subarray(start, start + length))
+}
+
+export async function analyzeMediaAudioAmplitude(
+  filePath,
+  { ffmpegPath = 'ffmpeg', sampleRate = 16_000 } = {}
+) {
+  const pcm = await runBinary(ffmpegPath, [
+    '-nostdin',
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-i',
+    filePath,
+    '-map',
+    '0:a:0',
+    '-vn',
+    '-ac',
+    '1',
+    '-ar',
+    String(sampleRate),
+    '-f',
+    's16le',
+    'pipe:1'
+  ])
+  return {
+    file: filePath,
+    channels: 1,
+    sampleRate,
+    bitsPerSample: 16,
+    ...measurePcm16Le(pcm)
+  }
+}
+
+function runBinary(command, args) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const stdout = []
+    const stderr = []
+    child.stdout.on('data', (chunk) => stdout.push(chunk))
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => stderr.push(chunk))
+    child.on('error', rejectRun)
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolveRun(Buffer.concat(stdout))
+        return
+      }
+      rejectRun(
+        new Error(`${command} failed: code=${code} signal=${signal} ${stderr.join('').trim()}`)
+      )
+    })
+  })
+}

--- a/scripts/lib/audio-amplitude.test.mjs
+++ b/scripts/lib/audio-amplitude.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+
+import {
+  analyzeMediaAudioAmplitude,
+  inspectMultipartPcm16Wav,
+  inspectPcm16Wav,
+  measurePcm16Le
+} from './audio-amplitude.mjs'
+import { ffmpegAvailable } from './ffmpeg-available.mjs'
+
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+
+describe('caption audio amplitude evidence', () => {
+  it('measures PCM16 peak and RMS without retaining samples', () => {
+    const pcm = pcm16([-32_768, -16_384, 0, 16_384])
+    const result = measurePcm16Le(pcm)
+
+    assert.equal(result.sampleCount, 4)
+    assert.equal(result.peak, 1)
+    assert.ok(Math.abs(result.rms - Math.sqrt(0.375)) < 1e-9)
+  })
+
+  it('finds and validates the WAV inside a multipart upload', () => {
+    const wav = pcm16Wav([0, 8_192, -8_192, 16_384])
+    const multipart = Buffer.concat([
+      Buffer.from('--boundary\r\nContent-Disposition: form-data; name="audio"\r\n\r\n'),
+      wav,
+      Buffer.from('\r\n--boundary--\r\n')
+    ])
+
+    const direct = inspectPcm16Wav(wav)
+    const uploaded = inspectMultipartPcm16Wav(multipart)
+    assert.deepEqual(uploaded, direct)
+    assert.equal(uploaded.channels, 1)
+    assert.equal(uploaded.sampleRate, 16_000)
+    assert.equal(uploaded.bitsPerSample, 16)
+    assert.equal(uploaded.peak, 0.5)
+  })
+
+  it(
+    'decodes amplitude from a finished FFmpeg media artifact',
+    { skip: ffmpegAvailable(ffmpegPath) ? false : 'ffmpeg not installed' },
+    async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'videorc-caption-audio-amplitude-'))
+      const artifact = join(directory, 'tone.wav')
+      try {
+        const encoded = spawnSync(
+          ffmpegPath,
+          [
+            '-y',
+            '-hide_banner',
+            '-loglevel',
+            'error',
+            '-f',
+            'lavfi',
+            '-i',
+            'sine=frequency=440:sample_rate=48000:duration=0.25',
+            artifact
+          ],
+          { encoding: 'utf8' }
+        )
+        assert.equal(encoded.status, 0, encoded.stderr)
+
+        const result = await analyzeMediaAudioAmplitude(artifact, { ffmpegPath })
+        assert.ok(result.sampleCount >= 3_900)
+        assert.ok(result.peak > 0.1 && result.peak < 0.14, `peak=${result.peak}`)
+        assert.ok(result.rms > 0.07 && result.rms < 0.1, `rms=${result.rms}`)
+      } finally {
+        rmSync(directory, { force: true, recursive: true })
+      }
+    }
+  )
+})
+
+function pcm16(samples) {
+  const result = Buffer.alloc(samples.length * 2)
+  for (const [index, sample] of samples.entries()) result.writeInt16LE(sample, index * 2)
+  return result
+}
+
+function pcm16Wav(samples) {
+  const pcm = pcm16(samples)
+  const wav = Buffer.alloc(44 + pcm.length)
+  wav.write('RIFF', 0)
+  wav.writeUInt32LE(36 + pcm.length, 4)
+  wav.write('WAVEfmt ', 8)
+  wav.writeUInt32LE(16, 16)
+  wav.writeUInt16LE(1, 20)
+  wav.writeUInt16LE(1, 22)
+  wav.writeUInt32LE(16_000, 24)
+  wav.writeUInt32LE(32_000, 28)
+  wav.writeUInt16LE(2, 32)
+  wav.writeUInt16LE(16, 34)
+  wav.write('data', 36)
+  wav.writeUInt32LE(pcm.length, 40)
+  pcm.copy(wav, 44)
+  return wav
+}

--- a/scripts/lib/captions-live-artifact.mjs
+++ b/scripts/lib/captions-live-artifact.mjs
@@ -1,0 +1,368 @@
+import { spawn } from 'node:child_process'
+
+export const CAPTIONS_LIVE_ARTIFACT_DEFAULTS = Object.freeze({
+  sampleWidth: 640,
+  sampleHeight: 360,
+  sampleFps: 6,
+  roiTopFraction: 0.54,
+  roiBottomFraction: 0.98,
+  centralInsetFraction: 0.03,
+  darkChannelMax: 38,
+  darkChromaMax: 22,
+  brightChannelMin: 185,
+  brightChromaMax: 62,
+  minDarkRowFraction: 0.24,
+  minPlateRowFraction: 0.035,
+  minPlateWidthFraction: 0.3,
+  minPlateDarkRatio: 0.32,
+  minPlateBrightRatio: 0.002,
+  minCaptionFrames: 3,
+  minBaselineFramesBeforeCaption: 2,
+  minConsecutiveCaptionFrames: 2
+})
+
+/**
+ * Measure the actual High Contrast caption style in decoded stream frames.
+ *
+ * The synthetic source never renders near-black broad horizontal rows (its
+ * base channels start at 44). The High Contrast renderer does: an opaque
+ * #050506 plate, with bright glyphs cut through it. Requiring both a broad,
+ * sustained plate and bright pixels inside its decoded bounds is materially
+ * harder to fool than a single-color marker. Requiring baseline frames before
+ * the first match proves that the viewer-facing pixels arrived after the
+ * caption transport update instead of merely existing in the source.
+ */
+export function measureCaptionsLiveArtifactRgb(
+  rgb,
+  {
+    width = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleWidth,
+    height = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleHeight,
+    ...thresholds
+  } = {}
+) {
+  const options = { ...CAPTIONS_LIVE_ARTIFACT_DEFAULTS, ...thresholds }
+  const frameBytes = width * height * 3
+  const sampledFrames = frameBytes > 0 ? Math.floor((rgb?.length ?? 0) / frameBytes) : 0
+  const roiTop = clampInteger(Math.floor(height * options.roiTopFraction), 0, height - 1)
+  const roiBottom = clampInteger(Math.ceil(height * options.roiBottomFraction), roiTop + 1, height)
+  const left = clampInteger(Math.floor(width * options.centralInsetFraction), 0, width - 1)
+  const right = clampInteger(Math.ceil(width * (1 - options.centralInsetFraction)), left + 1, width)
+  const centralWidth = right - left
+  const minDarkPixelsPerRow = Math.max(1, Math.ceil(centralWidth * options.minDarkRowFraction))
+  const minPlateRows = Math.max(2, Math.ceil(height * options.minPlateRowFraction))
+  const frames = []
+
+  for (let frameIndex = 0; frameIndex < sampledFrames; frameIndex += 1) {
+    const frameStart = frameIndex * frameBytes
+    const qualifyingRows = []
+    const darkPixelsByRow = new Map()
+
+    for (let y = roiTop; y < roiBottom; y += 1) {
+      const rowStart = frameStart + y * width * 3
+      const darkXs = []
+      for (let x = left; x < right; x += 1) {
+        const offset = rowStart + x * 3
+        if (isDarkNeutralPixel(rgb[offset], rgb[offset + 1], rgb[offset + 2], options)) {
+          darkXs.push(x)
+        }
+      }
+      if (darkXs.length >= minDarkPixelsPerRow) {
+        qualifyingRows.push(y)
+        darkPixelsByRow.set(y, darkXs)
+      }
+    }
+
+    const rowRuns = consecutiveRuns(qualifyingRows)
+    const bestRun = rowRuns.reduce((best, run) => (run.length > best.length ? run : best), [])
+    let plate = null
+    if (bestRun.length >= minPlateRows) {
+      let plateLeft = right
+      let plateRight = left
+      for (const y of bestRun) {
+        const row = darkPixelsByRow.get(y) ?? []
+        if (row.length === 0) continue
+        plateLeft = Math.min(plateLeft, row[0])
+        plateRight = Math.max(plateRight, row.at(-1))
+      }
+      plateRight = Math.min(right, plateRight + 1)
+      const plateTop = bestRun[0]
+      const plateBottom = bestRun.at(-1) + 1
+      const plateWidth = Math.max(0, plateRight - plateLeft)
+      const plateHeight = Math.max(0, plateBottom - plateTop)
+      const platePixels = plateWidth * plateHeight
+      let darkPixels = 0
+      let brightPixels = 0
+
+      for (let y = plateTop; y < plateBottom; y += 1) {
+        const rowStart = frameStart + y * width * 3
+        for (let x = plateLeft; x < plateRight; x += 1) {
+          const offset = rowStart + x * 3
+          const red = rgb[offset]
+          const green = rgb[offset + 1]
+          const blue = rgb[offset + 2]
+          if (isDarkNeutralPixel(red, green, blue, options)) darkPixels += 1
+          if (isBrightNeutralPixel(red, green, blue, options)) brightPixels += 1
+        }
+      }
+
+      plate = {
+        left: plateLeft,
+        top: plateTop,
+        width: plateWidth,
+        height: plateHeight,
+        rowCount: bestRun.length,
+        widthFraction: width > 0 ? plateWidth / width : 0,
+        darkPixelRatio: platePixels > 0 ? darkPixels / platePixels : 0,
+        brightPixelRatio: platePixels > 0 ? brightPixels / platePixels : 0
+      }
+    }
+
+    const captionPresent = Boolean(
+      plate &&
+      plate.widthFraction >= options.minPlateWidthFraction &&
+      plate.darkPixelRatio >= options.minPlateDarkRatio &&
+      plate.brightPixelRatio >= options.minPlateBrightRatio
+    )
+    frames.push({ index: frameIndex, captionPresent, plate })
+  }
+
+  return {
+    sampleWidth: width,
+    sampleHeight: height,
+    sampledFrames,
+    roi: { left, top: roiTop, width: right - left, height: roiBottom - roiTop },
+    frames
+  }
+}
+
+export function evaluateCaptionsLiveArtifactMetrics(metrics, thresholds = {}) {
+  const options = { ...CAPTIONS_LIVE_ARTIFACT_DEFAULTS, ...thresholds }
+  const frames = Array.isArray(metrics?.frames) ? metrics.frames : []
+  const captionIndexes = frames.filter((frame) => frame.captionPresent).map((frame) => frame.index)
+  const firstCaptionFrame = captionIndexes[0] ?? null
+  const baselineFramesBeforeCaption =
+    firstCaptionFrame === null
+      ? frames.filter((frame) => !frame.captionPresent).length
+      : frames.filter((frame) => frame.index < firstCaptionFrame && !frame.captionPresent).length
+  const longestCaptionRun = Math.max(0, ...consecutiveRuns(captionIndexes).map((run) => run.length))
+  const failures = []
+
+  if ((metrics?.sampledFrames ?? 0) <= 0) {
+    failures.push('captions-live: no decoded stream frames were sampled')
+  }
+  if (baselineFramesBeforeCaption < options.minBaselineFramesBeforeCaption) {
+    failures.push(
+      `captions-live: only ${baselineFramesBeforeCaption} baseline frame(s) preceded the caption, expected at least ${options.minBaselineFramesBeforeCaption}`
+    )
+  }
+  if (captionIndexes.length < options.minCaptionFrames) {
+    failures.push(
+      `captions-live: High Contrast caption pixels appeared in ${captionIndexes.length} frame(s), expected at least ${options.minCaptionFrames}`
+    )
+  }
+  if (longestCaptionRun < options.minConsecutiveCaptionFrames) {
+    failures.push(
+      `captions-live: longest caption run was ${longestCaptionRun} frame(s), expected at least ${options.minConsecutiveCaptionFrames}`
+    )
+  }
+
+  return {
+    pass: failures.length === 0,
+    failures,
+    observations: {
+      baselineFramesBeforeCaption,
+      captionFrames: captionIndexes.length,
+      firstCaptionFrame,
+      longestCaptionRun,
+      maxPlateWidthFraction: maxPlateMetric(frames, 'widthFraction'),
+      maxPlateDarkPixelRatio: maxPlateMetric(frames, 'darkPixelRatio'),
+      maxPlateBrightPixelRatio: maxPlateMetric(frames, 'brightPixelRatio')
+    },
+    thresholds: {
+      minCaptionFrames: options.minCaptionFrames,
+      minBaselineFramesBeforeCaption: options.minBaselineFramesBeforeCaption,
+      minConsecutiveCaptionFrames: options.minConsecutiveCaptionFrames,
+      minPlateWidthFraction: options.minPlateWidthFraction,
+      minPlateDarkRatio: options.minPlateDarkRatio,
+      minPlateBrightRatio: options.minPlateBrightRatio
+    },
+    metrics
+  }
+}
+
+export async function analyzeCaptionsLiveArtifact(
+  filePath,
+  {
+    ffmpegPath = 'ffmpeg',
+    sampleWidth = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleWidth,
+    sampleHeight = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleHeight,
+    sampleFps = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleFps,
+    ...thresholds
+  } = {}
+) {
+  const rgb = await decodeRgbSamples(filePath, {
+    ffmpegPath,
+    sampleWidth,
+    sampleHeight,
+    sampleFps
+  })
+  const metrics = measureCaptionsLiveArtifactRgb(rgb, {
+    width: sampleWidth,
+    height: sampleHeight,
+    ...thresholds
+  })
+  return {
+    file: filePath,
+    ...evaluateCaptionsLiveArtifactMetrics(metrics, thresholds)
+  }
+}
+
+export function evaluateCaptionsAbsentArtifactMetrics(
+  metrics,
+  { minSampledFrames = 3, maxCaptionFrames = 0 } = {}
+) {
+  const frames = Array.isArray(metrics?.frames) ? metrics.frames : []
+  const captionFrames = frames.filter((frame) => frame.captionPresent).length
+  const failures = []
+  if ((metrics?.sampledFrames ?? 0) < minSampledFrames) {
+    failures.push(
+      `captions-clean: sampled ${metrics?.sampledFrames ?? 0} frame(s), expected at least ${minSampledFrames}`
+    )
+  }
+  if (captionFrames > maxCaptionFrames) {
+    failures.push(
+      `captions-clean: High Contrast caption pixels appeared in ${captionFrames} frame(s), expected at most ${maxCaptionFrames}`
+    )
+  }
+  return {
+    pass: failures.length === 0,
+    failures,
+    observations: {
+      captionFrames,
+      baselineFrames: frames.length - captionFrames,
+      maxPlateWidthFraction: maxPlateMetric(frames, 'widthFraction'),
+      maxPlateDarkPixelRatio: maxPlateMetric(frames, 'darkPixelRatio'),
+      maxPlateBrightPixelRatio: maxPlateMetric(frames, 'brightPixelRatio')
+    },
+    thresholds: { minSampledFrames, maxCaptionFrames },
+    metrics
+  }
+}
+
+export async function analyzeCaptionsAbsentArtifact(
+  filePath,
+  {
+    ffmpegPath = 'ffmpeg',
+    sampleWidth = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleWidth,
+    sampleHeight = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleHeight,
+    sampleFps = CAPTIONS_LIVE_ARTIFACT_DEFAULTS.sampleFps,
+    minSampledFrames = 3,
+    maxCaptionFrames = 0,
+    ...thresholds
+  } = {}
+) {
+  const rgb = await decodeRgbSamples(filePath, {
+    ffmpegPath,
+    sampleWidth,
+    sampleHeight,
+    sampleFps
+  })
+  const metrics = measureCaptionsLiveArtifactRgb(rgb, {
+    width: sampleWidth,
+    height: sampleHeight,
+    ...thresholds
+  })
+  return {
+    file: filePath,
+    ...evaluateCaptionsAbsentArtifactMetrics(metrics, { minSampledFrames, maxCaptionFrames })
+  }
+}
+
+export function formatCaptionsLiveArtifactSummary(report) {
+  const observations = report?.observations ?? {}
+  return (
+    `Captions live artifact gate: ${report?.pass ? 'PASS' : 'FAIL'} ` +
+    `frames=${report?.metrics?.sampledFrames ?? 0} ` +
+    `baseline=${observations.baselineFramesBeforeCaption ?? 0} ` +
+    `captions=${observations.captionFrames ?? 0} ` +
+    `run=${observations.longestCaptionRun ?? 0} ` +
+    `plate=${formatRatio(observations.maxPlateWidthFraction)}/` +
+    `${formatRatio(observations.maxPlateDarkPixelRatio)}/` +
+    `${formatRatio(observations.maxPlateBrightPixelRatio)}`
+  )
+}
+
+function isDarkNeutralPixel(red, green, blue, options) {
+  const max = Math.max(red, green, blue)
+  const min = Math.min(red, green, blue)
+  return max <= options.darkChannelMax && max - min <= options.darkChromaMax
+}
+
+function isBrightNeutralPixel(red, green, blue, options) {
+  const max = Math.max(red, green, blue)
+  const min = Math.min(red, green, blue)
+  return min >= options.brightChannelMin && max - min <= options.brightChromaMax
+}
+
+function consecutiveRuns(indexes) {
+  const runs = []
+  for (const index of indexes) {
+    const current = runs.at(-1)
+    if (current && current.at(-1) + 1 === index) {
+      current.push(index)
+    } else {
+      runs.push([index])
+    }
+  }
+  return runs
+}
+
+function maxPlateMetric(frames, key) {
+  return frames.reduce((max, frame) => Math.max(max, frame.plate?.[key] ?? 0), 0)
+}
+
+function clampInteger(value, min, max) {
+  return Math.min(max, Math.max(min, Math.trunc(value)))
+}
+
+function formatRatio(value) {
+  return typeof value === 'number' ? value.toFixed(3) : '0.000'
+}
+
+function decodeRgbSamples(filePath, { ffmpegPath, sampleWidth, sampleHeight, sampleFps }) {
+  const args = [
+    '-nostdin',
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-i',
+    filePath,
+    '-an',
+    '-vf',
+    `fps=${sampleFps},scale=${sampleWidth}:${sampleHeight}:flags=area,format=rgb24`,
+    '-f',
+    'rawvideo',
+    'pipe:1'
+  ]
+
+  return new Promise((resolveDecode, rejectDecode) => {
+    const child = spawn(ffmpegPath, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const stdout = []
+    const stderr = []
+    child.stdout.on('data', (chunk) => stdout.push(chunk))
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => stderr.push(chunk))
+    child.on('error', rejectDecode)
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolveDecode(Buffer.concat(stdout))
+        return
+      }
+      rejectDecode(
+        new Error(
+          `captions-live artifact ffmpeg sample failed: code=${code} signal=${signal} ${stderr.join('').trim()}`
+        )
+      )
+    })
+  })
+}

--- a/scripts/lib/captions-live-artifact.test.mjs
+++ b/scripts/lib/captions-live-artifact.test.mjs
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+
+import {
+  analyzeCaptionsLiveArtifact,
+  evaluateCaptionsAbsentArtifactMetrics,
+  evaluateCaptionsLiveArtifactMetrics,
+  measureCaptionsLiveArtifactRgb
+} from './captions-live-artifact.mjs'
+import { ffmpegAvailable } from './ffmpeg-available.mjs'
+
+const width = 64
+const height = 36
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+
+describe('captions live artifact gate', () => {
+  it('requires baseline frames followed by a sustained dark plate with bright glyphs', () => {
+    const rgb = Buffer.concat([
+      frame(),
+      frame(),
+      frame({ caption: true }),
+      frame({ caption: true }),
+      frame({ caption: true })
+    ])
+    const metrics = measureCaptionsLiveArtifactRgb(rgb, smallOptions())
+    const verdict = evaluateCaptionsLiveArtifactMetrics(metrics, {
+      minCaptionFrames: 3,
+      minBaselineFramesBeforeCaption: 2,
+      minConsecutiveCaptionFrames: 2
+    })
+
+    assert.equal(verdict.pass, true, verdict.failures.join('\n'))
+    assert.equal(verdict.observations.baselineFramesBeforeCaption, 2)
+    assert.equal(verdict.observations.captionFrames, 3)
+    assert.equal(verdict.observations.longestCaptionRun, 3)
+  })
+
+  it('rejects a dark source without bright renderer glyphs', () => {
+    const rgb = Buffer.concat([
+      frame(),
+      frame(),
+      frame({ darkPlateOnly: true }),
+      frame({ darkPlateOnly: true }),
+      frame({ darkPlateOnly: true })
+    ])
+    const metrics = measureCaptionsLiveArtifactRgb(rgb, smallOptions())
+    const verdict = evaluateCaptionsLiveArtifactMetrics(metrics, {
+      minCaptionFrames: 2,
+      minBaselineFramesBeforeCaption: 2
+    })
+
+    assert.equal(verdict.pass, false)
+    assert.equal(verdict.observations.captionFrames, 0)
+    assert.match(verdict.failures.join('\n'), /High Contrast caption pixels appeared in 0/)
+  })
+
+  it('rejects a caption-shaped source that exists from frame zero', () => {
+    const rgb = Buffer.concat([
+      frame({ caption: true }),
+      frame({ caption: true }),
+      frame({ caption: true })
+    ])
+    const metrics = measureCaptionsLiveArtifactRgb(rgb, smallOptions())
+    const verdict = evaluateCaptionsLiveArtifactMetrics(metrics, {
+      minCaptionFrames: 2,
+      minBaselineFramesBeforeCaption: 2
+    })
+
+    assert.equal(verdict.pass, false)
+    assert.equal(verdict.observations.baselineFramesBeforeCaption, 0)
+    assert.match(verdict.failures.join('\n'), /baseline frame/)
+  })
+
+  it('proves a source recording stayed clean across the sampled timeline', () => {
+    const metrics = measureCaptionsLiveArtifactRgb(
+      Buffer.concat(Array.from({ length: 6 }, () => frame())),
+      smallOptions()
+    )
+    const verdict = evaluateCaptionsAbsentArtifactMetrics(metrics, { minSampledFrames: 5 })
+
+    assert.equal(verdict.pass, true, verdict.failures.join('\n'))
+    assert.equal(verdict.observations.captionFrames, 0)
+    assert.equal(verdict.observations.baselineFrames, 6)
+  })
+
+  it('rejects a supposedly clean original when any caption frame is decoded', () => {
+    const metrics = measureCaptionsLiveArtifactRgb(
+      Buffer.concat([frame(), frame({ caption: true }), frame()]),
+      smallOptions()
+    )
+    const verdict = evaluateCaptionsAbsentArtifactMetrics(metrics)
+
+    assert.equal(verdict.pass, false)
+    assert.equal(verdict.observations.captionFrames, 1)
+    assert.match(verdict.failures.join('\n'), /expected at most 0/)
+  })
+
+  it(
+    'detects the plate and glyphs after real YUV420 video encoding',
+    { skip: ffmpegAvailable(ffmpegPath) ? false : 'ffmpeg not installed' },
+    async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'videorc-captions-live-artifact-'))
+      const videoPath = join(directory, 'captions-live.mp4')
+      try {
+        const raw = Buffer.concat([
+          ...Array.from({ length: 4 }, () => frame({ width: 320, height: 180 })),
+          ...Array.from({ length: 11 }, () => frame({ caption: true, width: 320, height: 180 }))
+        ])
+        const encoded = spawnSync(
+          ffmpegPath,
+          [
+            '-y',
+            '-hide_banner',
+            '-loglevel',
+            'error',
+            '-f',
+            'rawvideo',
+            '-pixel_format',
+            'rgb24',
+            '-video_size',
+            '320x180',
+            '-framerate',
+            '5',
+            '-i',
+            'pipe:0',
+            '-c:v',
+            'mpeg4',
+            '-q:v',
+            '5',
+            '-pix_fmt',
+            'yuv420p',
+            videoPath
+          ],
+          { input: raw, encoding: 'buffer', timeout: 30_000 }
+        )
+        assert.equal(encoded.status, 0, encoded.stderr?.toString())
+
+        const report = await analyzeCaptionsLiveArtifact(videoPath, {
+          ffmpegPath,
+          sampleWidth: 320,
+          sampleHeight: 180,
+          sampleFps: 5
+        })
+        assert.equal(report.pass, true, report.failures.join('\n'))
+        assert.ok(report.observations.captionFrames >= 3)
+        assert.ok(report.observations.baselineFramesBeforeCaption >= 2)
+      } finally {
+        rmSync(directory, { force: true, recursive: true })
+      }
+    }
+  )
+})
+
+function smallOptions() {
+  return {
+    width,
+    height,
+    minPlateRowFraction: 0.05,
+    minPlateWidthFraction: 0.3,
+    minPlateDarkRatio: 0.3,
+    minPlateBrightRatio: 0.002
+  }
+}
+
+function frame({
+  caption = false,
+  darkPlateOnly = false,
+  width: w = width,
+  height: h = height
+} = {}) {
+  const rgb = Buffer.alloc(w * h * 3)
+  fillRect(rgb, w, h, 0, 0, w, h, [78, 102, 126])
+  if (caption || darkPlateOnly) {
+    const plateWidth = Math.round(w * 0.72)
+    const plateHeight = Math.max(4, Math.round(h * 0.16))
+    const left = Math.round((w - plateWidth) / 2)
+    const top = Math.round(h * 0.73)
+    fillRect(rgb, w, h, left, top, plateWidth, plateHeight, [5, 5, 6])
+    if (caption) {
+      const glyphHeight = Math.max(1, Math.round(plateHeight * 0.3))
+      const glyphTop = top + Math.max(1, Math.floor((plateHeight - glyphHeight) / 2))
+      for (let x = left + 4; x < left + plateWidth - 4; x += Math.max(4, Math.round(w * 0.07))) {
+        fillRect(
+          rgb,
+          w,
+          h,
+          x,
+          glyphTop,
+          Math.max(2, Math.round(w * 0.025)),
+          glyphHeight,
+          [250, 250, 252]
+        )
+      }
+    }
+  }
+  return rgb
+}
+
+function fillRect(rgb, width, height, x, y, rectWidth, rectHeight, color) {
+  const left = Math.max(0, Math.round(x))
+  const top = Math.max(0, Math.round(y))
+  const right = Math.min(width, Math.round(x + rectWidth))
+  const bottom = Math.min(height, Math.round(y + rectHeight))
+  for (let row = top; row < bottom; row += 1) {
+    for (let column = left; column < right; column += 1) {
+      const offset = (row * width + column) * 3
+      rgb[offset] = color[0]
+      rgb[offset + 1] = color[1]
+      rgb[offset + 2] = color[2]
+    }
+  }
+}

--- a/scripts/lib/fake-caption-service.mjs
+++ b/scripts/lib/fake-caption-service.mjs
@@ -1,0 +1,241 @@
+import { createServer } from 'node:http'
+
+import { WebSocketServer } from 'ws'
+
+import { inspectMultipartPcm16Wav } from './audio-amplitude.mjs'
+
+/**
+ * Local, credential-free caption service used by maintained app smokes.
+ * It mirrors the authenticated Videorc HTTP routes plus the legacy Gateway
+ * realtime dialect without ever touching production or logging transcript,
+ * bearer, or client-token material.
+ */
+export async function startFakeCaptionService({
+  smokeSessionToken,
+  smokeRealtimeToken,
+  finalText = 'Caption contract passed.',
+  provisionalFinalText = 'Caption contract',
+  chunkText = 'Chunk fallback recovered.',
+  itemId = 'caption-contract-item',
+  minSpeechPeak = null
+}) {
+  const state = {
+    realtimeAvailable: true,
+    realtimeFailureCode: 'captions-realtime-unavailable',
+    configurations: [],
+    realtimeTokenRequests: 0,
+    realtimeUpgradeAttempts: 0,
+    realtimeConnections: 0,
+    audioAppends: 0,
+    emptyAudioAppends: 0,
+    assistantResponseOnNextAudio: false,
+    assistantResponses: 0,
+    chunkRequests: 0,
+    chunkAudio: [],
+    usageReports: 0
+  }
+  const gatewayProtocol = 'ai-gateway-realtime.v1'
+  const gatewayAuthProtocol = `ai-gateway-auth.${smokeRealtimeToken}`
+  const realtime = new WebSocketServer({
+    noServer: true,
+    handleProtocols(protocols) {
+      return protocols.has(gatewayProtocol) && protocols.has(gatewayAuthProtocol)
+        ? gatewayProtocol
+        : false
+    }
+  })
+  let websocketUrl = ''
+  const server = createServer(async (req, res) => {
+    if (req.headers.authorization !== `Bearer ${smokeSessionToken}`) {
+      await drain(req)
+      return json(res, 401, { error: { code: 'unauthorized', message: 'Smoke auth failed.' } })
+    }
+    if (req.method === 'POST' && req.url === '/api/ai/captions/realtime-token') {
+      await drain(req)
+      state.realtimeTokenRequests += 1
+      if (!state.realtimeAvailable) {
+        return json(res, 503, {
+          error: {
+            code: state.realtimeFailureCode,
+            message: 'Realtime is deliberately unavailable in the fallback scenario.'
+          }
+        })
+      }
+      return json(res, 200, {
+        expiresAt: Math.floor(Date.now() / 1000) + 300,
+        model: 'smoke/realtime-transcription',
+        quotaEnforced: false,
+        token: smokeRealtimeToken,
+        url: websocketUrl
+      })
+    }
+    if (req.method === 'POST' && req.url === '/api/ai/captions/chunks') {
+      let audio
+      try {
+        audio = inspectMultipartPcm16Wav(await readRequestBody(req))
+      } catch (error) {
+        return json(res, 400, {
+          error: { code: 'invalid-caption-wav', message: error.message }
+        })
+      }
+      state.chunkRequests += 1
+      state.chunkAudio.push(audio)
+      const hasSpeech = !Number.isFinite(minSpeechPeak) || audio.peak >= Math.max(0, minSpeechPeak)
+      const text = hasSpeech ? chunkText : ''
+      return json(res, 200, {
+        chunkSeconds: 3,
+        latencyMs: 5,
+        model: 'smoke/chunk-transcription',
+        monthlySecondsLimit: 3_600,
+        remainingSeconds: 3_597,
+        segments: text ? [{ text, startSecond: 0, endSecond: 3 }] : [],
+        text
+      })
+    }
+    if (req.method === 'POST' && req.url === '/api/ai/captions/usage') {
+      await drain(req)
+      state.usageReports += 1
+      return json(res, 200, { ok: true })
+    }
+    await drain(req)
+    return json(res, 404, { error: { code: 'not-found', message: 'Unknown smoke route.' } })
+  })
+
+  server.on('upgrade', (req, socket, head) => {
+    state.realtimeUpgradeAttempts += 1
+    const protocols = new Set(
+      String(req.headers['sec-websocket-protocol'] ?? '')
+        .split(',')
+        .map((protocol) => protocol.trim())
+        .filter(Boolean)
+    )
+    if (
+      req.url !== '/realtime' ||
+      (req.headers.authorization !== `Bearer ${smokeRealtimeToken}` &&
+        (!protocols.has(gatewayProtocol) || !protocols.has(gatewayAuthProtocol)))
+    ) {
+      socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n')
+      socket.destroy()
+      return
+    }
+    realtime.handleUpgrade(req, socket, head, (ws) => realtime.emit('connection', ws, req))
+  })
+
+  realtime.on('connection', (ws) => {
+    state.realtimeConnections += 1
+    let transcriptSent = false
+    ws.on('message', (data) => {
+      let message
+      try {
+        message = JSON.parse(data.toString())
+      } catch {
+        return
+      }
+      if (message.type === 'session.update') {
+        state.configurations.push(message)
+        ws.send(JSON.stringify({ type: 'session-updated' }))
+        return
+      }
+      if (message.type !== 'input_audio_buffer.append') return
+      state.audioAppends += 1
+      if (typeof message.audio !== 'string' || message.audio.length === 0) {
+        state.emptyAudioAppends += 1
+      }
+      if (state.assistantResponseOnNextAudio) {
+        state.assistantResponseOnNextAudio = false
+        state.assistantResponses += 1
+        ws.send(
+          JSON.stringify({
+            type: 'response-created',
+            rawType: 'response.created',
+            raw: { response: { id: 'unsafe-assistant-response' } }
+          })
+        )
+        return
+      }
+      if (transcriptSent) return
+      transcriptSent = true
+      ws.send(
+        JSON.stringify({
+          type: 'speech-started',
+          itemId,
+          raw: { audio_start_ms: 0, item_id: itemId }
+        })
+      )
+      ws.send(
+        JSON.stringify({
+          type: 'custom',
+          rawType: 'conversation.item.input_audio_transcription.updated',
+          raw: { item_id: itemId, transcript: provisionalFinalText }
+        })
+      )
+      setTimeout(() => {
+        if (ws.readyState !== 1) return
+        ws.send(
+          JSON.stringify({
+            type: 'input-transcription-completed',
+            itemId,
+            transcript: provisionalFinalText
+          })
+        )
+      }, 25)
+      setTimeout(() => {
+        if (ws.readyState !== 1) return
+        ws.send(
+          JSON.stringify({
+            type: 'input-transcription-completed',
+            itemId,
+            transcript: finalText
+          })
+        )
+      }, 75)
+    })
+  })
+
+  await new Promise((resolveListen, rejectListen) => {
+    server.once('error', rejectListen)
+    server.listen(0, '127.0.0.1', resolveListen)
+  })
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  const httpOrigin = `http://127.0.0.1:${port}`
+  websocketUrl = `ws://127.0.0.1:${port}/realtime`
+
+  return {
+    state,
+    httpOrigin,
+    close: async () => {
+      for (const client of realtime.clients) client.terminate()
+      realtime.close()
+      await new Promise((resolveClose) => server.close(resolveClose))
+    }
+  }
+}
+
+function json(res, status, payload) {
+  const body = JSON.stringify(payload)
+  res.writeHead(status, {
+    'content-length': Buffer.byteLength(body),
+    'content-type': 'application/json'
+  })
+  res.end(body)
+}
+
+function drain(req) {
+  return new Promise((resolveDrain) => {
+    req.on('data', () => {})
+    req.on('end', resolveDrain)
+    req.on('error', resolveDrain)
+  })
+}
+
+async function readRequestBody(req, maxBytes = 2 * 1024 * 1024) {
+  const chunks = []
+  let length = 0
+  for await (const chunk of req) {
+    length += chunk.length
+    if (length > maxBytes) throw new Error('Caption upload exceeded the fake service limit.')
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks)
+}

--- a/scripts/lib/fake-caption-service.test.mjs
+++ b/scripts/lib/fake-caption-service.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import WebSocket from 'ws'
+
+import { startFakeCaptionService } from './fake-caption-service.mjs'
+
+describe('fake caption service', () => {
+  it('accepts legacy Bearer and current Gateway subprotocol realtime upgrades', async () => {
+    const sessionToken = 'fake-caption-session'
+    const realtimeToken = 'fake-caption-realtime'
+    const fake = await startFakeCaptionService({
+      smokeSessionToken: sessionToken,
+      smokeRealtimeToken: realtimeToken
+    })
+
+    try {
+      const tokenResponse = await fetch(`${fake.httpOrigin}/api/ai/captions/realtime-token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${sessionToken}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ sessionClientId: 'fake-service-test' })
+      })
+      assert.equal(tokenResponse.status, 200)
+      const minted = await tokenResponse.json()
+
+      const legacy = new WebSocket(minted.url, {
+        headers: { authorization: `Bearer ${realtimeToken}` }
+      })
+      await configureAndClose(legacy)
+
+      const gateway = new WebSocket(minted.url, [
+        'ai-gateway-realtime.v1',
+        `ai-gateway-auth.${realtimeToken}`
+      ])
+      await configureAndClose(gateway)
+
+      assert.equal(fake.state.realtimeTokenRequests, 1)
+      assert.equal(fake.state.realtimeUpgradeAttempts, 2)
+      assert.equal(fake.state.realtimeConnections, 2)
+      assert.equal(fake.state.configurations.length, 2)
+    } finally {
+      await fake.close()
+    }
+  })
+
+  it('rejects an unauthenticated realtime upgrade without exposing token material', async () => {
+    const fake = await startFakeCaptionService({
+      smokeSessionToken: 'fake-caption-session',
+      smokeRealtimeToken: 'fake-caption-realtime'
+    })
+
+    try {
+      const socket = new WebSocket(`${fake.httpOrigin.replace('http:', 'ws:')}/realtime`)
+      const error = await new Promise((resolveError) => {
+        socket.once('error', resolveError)
+      })
+      assert.match(String(error), /401/)
+      assert.equal(fake.state.realtimeUpgradeAttempts, 1)
+      assert.equal(fake.state.realtimeConnections, 0)
+    } finally {
+      await fake.close()
+    }
+  })
+
+  it('inspects uploaded WAV amplitude and can withhold captions for muted audio', async () => {
+    const sessionToken = 'fake-caption-session'
+    const fake = await startFakeCaptionService({
+      smokeSessionToken: sessionToken,
+      smokeRealtimeToken: 'fake-caption-realtime',
+      chunkText: 'Audible caption.',
+      minSpeechPeak: 0.05
+    })
+
+    try {
+      const silent = await postCaptionChunk(fake.httpOrigin, sessionToken, pcm16Wav([0, 0, 0, 0]))
+      const audible = await postCaptionChunk(
+        fake.httpOrigin,
+        sessionToken,
+        pcm16Wav([0, 4_096, -8_192, 16_384])
+      )
+
+      assert.equal(silent.text, '')
+      assert.deepEqual(silent.segments, [])
+      assert.equal(audible.text, 'Audible caption.')
+      assert.equal(fake.state.chunkRequests, 2)
+      assert.equal(fake.state.chunkAudio[0].peak, 0)
+      assert.equal(fake.state.chunkAudio[1].peak, 0.5)
+      assert.equal(fake.state.chunkAudio[1].sampleRate, 16_000)
+      assert.equal(fake.state.chunkAudio[1].channels, 1)
+      assert.ok(!('audio' in fake.state.chunkAudio[1]), 'fake service must retain metrics only')
+    } finally {
+      await fake.close()
+    }
+  })
+})
+
+function configureAndClose(socket) {
+  return new Promise((resolveConfigured, rejectConfigured) => {
+    const timeout = setTimeout(() => {
+      socket.terminate()
+      rejectConfigured(new Error('Timed out waiting for fake caption configuration ack.'))
+    }, 5_000)
+
+    socket.once('error', (error) => {
+      clearTimeout(timeout)
+      rejectConfigured(error)
+    })
+    socket.once('open', () => {
+      socket.send(
+        JSON.stringify({
+          type: 'session.update',
+          session: {
+            input_audio_format: 'pcm16',
+            input_audio_transcription: { enabled: true },
+            turn_detection: {
+              type: 'server_vad',
+              create_response: false,
+              interrupt_response: false
+            }
+          }
+        })
+      )
+    })
+    socket.once('message', (data) => {
+      clearTimeout(timeout)
+      const message = JSON.parse(data.toString())
+      assert.equal(message.type, 'session-updated')
+      socket.once('close', resolveConfigured)
+      socket.close()
+    })
+  })
+}
+
+async function postCaptionChunk(origin, token, wav) {
+  const form = new FormData()
+  form.set('sessionClientId', 'fake-service-test')
+  form.set('audio', new Blob([wav], { type: 'audio/wav' }), 'caption.wav')
+  const response = await fetch(`${origin}/api/ai/captions/chunks`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    body: form
+  })
+  assert.equal(response.status, 200)
+  return response.json()
+}
+
+function pcm16Wav(samples) {
+  const pcm = Buffer.alloc(samples.length * 2)
+  for (const [index, sample] of samples.entries()) pcm.writeInt16LE(sample, index * 2)
+  const wav = Buffer.alloc(44 + pcm.length)
+  wav.write('RIFF', 0)
+  wav.writeUInt32LE(36 + pcm.length, 4)
+  wav.write('WAVEfmt ', 8)
+  wav.writeUInt32LE(16, 16)
+  wav.writeUInt16LE(1, 20)
+  wav.writeUInt16LE(1, 22)
+  wav.writeUInt32LE(16_000, 24)
+  wav.writeUInt32LE(32_000, 28)
+  wav.writeUInt16LE(2, 32)
+  wav.writeUInt16LE(16, 34)
+  wav.write('data', 36)
+  wav.writeUInt32LE(pcm.length, 40)
+  pcm.copy(wav, 44)
+  return wav
+}

--- a/scripts/lib/recording-studio-gates.mjs
+++ b/scripts/lib/recording-studio-gates.mjs
@@ -11,6 +11,8 @@ export function buildRecordingStudioGateSteps({
         '@videorc/desktop',
         'test',
         'capture.test.ts',
+        'caption-overlay.test.ts',
+        'captions-ui.test.ts',
         'background-assets.test.ts',
         'session-params.test.ts',
         'studio-health.test.ts',
@@ -48,6 +50,16 @@ export function buildRecordingStudioGateSteps({
 
   if (includeAppSmoke) {
     steps.push(
+      {
+        label: 'live captions transport contract smoke',
+        command: 'pnpm',
+        args: ['smoke:captions-contract']
+      },
+      {
+        label: 'live captions mute/gain and record+stream artifact smoke',
+        command: 'pnpm',
+        args: ['smoke:captions-live']
+      },
       {
         label: 'dev app all-layout recording artifact smoke',
         command: 'pnpm',

--- a/scripts/lib/recording-studio-gates.test.mjs
+++ b/scripts/lib/recording-studio-gates.test.mjs
@@ -19,6 +19,8 @@ describe('buildRecordingStudioGateSteps', () => {
       'backend scene layout tests',
       'backend recording pipeline tests',
       'backend audio pipeline tests',
+      'live captions transport contract smoke',
+      'live captions mute/gain and record+stream artifact smoke',
       'dev app all-layout recording artifact smoke',
       'imported screen image recording smoke',
       'real-user launch first-frame contract smoke',
@@ -40,6 +42,8 @@ describe('buildRecordingStudioGateSteps', () => {
       '@videorc/desktop',
       'test',
       'capture.test.ts',
+      'caption-overlay.test.ts',
+      'captions-ui.test.ts',
       'background-assets.test.ts',
       'session-params.test.ts',
       'studio-health.test.ts',
@@ -48,6 +52,8 @@ describe('buildRecordingStudioGateSteps', () => {
       'backend-isolation.test.ts'
     ])
     assert.deepEqual(steps[1].args, ['test:scripts'])
+    assert.deepEqual(steps.at(-17).args, ['smoke:captions-contract'])
+    assert.deepEqual(steps.at(-16).args, ['smoke:captions-live'])
     assert.deepEqual(steps.at(-15).args, ['smoke:dev'])
     assert.deepEqual(steps.at(-14).args, ['smoke:screens'])
     assert.deepEqual(steps.at(-13).args, ['smoke:preview-real-launch'])
@@ -101,6 +107,8 @@ describe('buildRecordingStudioGateSteps', () => {
     assert.match(report, /capture\.test\.ts/)
     assert.match(report, /test:scripts/)
     assert.match(report, /live_layout::tests::/)
+    assert.match(report, /smoke:captions-contract/)
+    assert.match(report, /smoke:captions-live/)
     assert.match(report, /smoke:dev/)
     assert.match(report, /smoke:screens/)
     assert.match(report, /smoke:layout-source-loop/)

--- a/scripts/smoke-captions-contract.mjs
+++ b/scripts/smoke-captions-contract.mjs
@@ -1,0 +1,345 @@
+import { spawn } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { devAppSpawnOptions, stopProcess } from './lib/app-launcher.mjs'
+import { startFakeCaptionService } from './lib/fake-caption-service.mjs'
+import { connectBackend, request } from './smoke-recording-session.mjs'
+
+// Maintained caption transport contract gate. This launches the real debug app/backend,
+// points its Videorc API client at a local authenticated HTTP service, upgrades the real
+// Rust realtime client into a fake Gateway WebSocket, injects deterministic post-controls
+// PCM through a debug+env double-gated seam, and proves:
+//
+//   token mint -> configuration ack -> audio append -> partial/final -> canonical cue
+//   repeated provider completions upsert one cue
+//   assistant-response event -> immediate transcription-only chunk fallback
+//   realtime-unavailable -> chunk upload fallback -> final caption
+//   first audio, then producer silence -> truthful blocked/stalled status
+//
+// No production bearer, provider credential, microphone permission, or external network is
+// involved. Release builds do not compile the audio-injection/snapshot RPCs.
+
+const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 180_000)
+const stateRoot = mkdtempSync(join(tmpdir(), 'videorc-captions-contract-'))
+const appDataDir = join(stateRoot, 'app-data')
+const backendBinary = join(process.cwd(), 'target', 'debug', 'videorc-backend')
+const smokeSessionToken = 'captions-contract-session-token'
+const smokeRealtimeToken = 'captions-contract-realtime-token'
+
+mkdirSync(appDataDir, { recursive: true })
+const secretsPath = join(appDataDir, 'videorc-secrets.json')
+writeFileSync(
+  secretsPath,
+  JSON.stringify({ 'account:videorc:session': smokeSessionToken }, null, 2)
+)
+chmodSync(secretsPath, 0o600)
+
+const fake = await startFakeCaptionService({ smokeSessionToken, smokeRealtimeToken })
+let backendProcess
+let backend
+
+try {
+  if (!existsSync(backendBinary)) {
+    throw new Error('target/debug/videorc-backend is missing; build the debug backend first.')
+  }
+  backendProcess = spawn(backendBinary, [], {
+    ...devAppSpawnOptions({
+      env: {
+        ...process.env,
+        VIDEORC_API_BASE_URL: fake.httpOrigin,
+        VIDEORC_CAPTION_CONTRACT_ALLOW_IDLE: '1',
+        VIDEORC_CAPTION_CONTRACT_TEST: '1',
+        VIDEORC_DISABLE_AUTO_PREVIEW: '1',
+        VIDEORC_DISABLE_BACKEND_REAP: '1',
+        VIDEORC_APP_DATA_DIR: appDataDir,
+        VIDEORC_DATABASE_PATH: join(appDataDir, 'videorc.sqlite3'),
+        VIDEORC_SECRETS_PATH: secretsPath,
+        VIDEORC_SMOKE_STATE_DIR: stateRoot
+      }
+    }),
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+  const ready = await waitForBackendReady(backendProcess, timeoutMs)
+  backend = await connectBackend(ready, timeoutMs)
+  const observed = collectCaptionEvents(backend)
+
+  await proveRealtimeContract({ backend, observed, fake })
+  await proveAssistantResponseFallback({ backend, observed, fake })
+  await proveChunkFallback({ backend, observed, fake })
+
+  console.log(
+    `Caption contract smoke PASS — realtime partial/final, repeated-completion upsert, ` +
+      `assistant-response safety fallback, provider-ready truth, deterministic audio, ` +
+      `and chunk fallback passed ` +
+      `with post-frame stall detection ` +
+      `(realtime appends=${fake.state.audioAppends}, chunk requests=${fake.state.chunkRequests}).`
+  )
+} finally {
+  try {
+    if (backend) {
+      await request(backend, 5_000, 'captions.stop', {}).catch(() => {})
+      backend.close()
+    }
+  } finally {
+    if (backendProcess) {
+      await stopProcess(backendProcess).catch(() => {})
+    }
+    await fake.close()
+    rmSync(stateRoot, { force: true, recursive: true })
+  }
+}
+
+function waitForBackendReady(child, deadlineMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('Backend did not print READY in time.')),
+      deadlineMs
+    )
+    let stdout = ''
+    let stderr = ''
+    const finish = (callback, value) => {
+      clearTimeout(timer)
+      callback(value)
+    }
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+      const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith('READY '))
+      if (!line) return
+      try {
+        finish(resolve, JSON.parse(line.slice('READY '.length)))
+      } catch {
+        finish(reject, new Error('Backend printed an invalid READY payload.'))
+      }
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-8_000)
+    })
+    child.once('error', (error) => finish(reject, error))
+    child.once('exit', (code, signal) =>
+      finish(
+        reject,
+        new Error(
+          `Backend exited before READY (code=${code}, signal=${signal}).${stderr ? `\n${stderr}` : ''}`
+        )
+      )
+    )
+  })
+}
+
+async function proveRealtimeContract({ backend, observed, fake }) {
+  fake.state.realtimeAvailable = true
+  const started = await request(backend, timeoutMs, 'captions.start', { language: 'en' })
+  if (started.state !== 'starting' || !started.sessionClientId) {
+    throw new Error(`Realtime captions did not enter Starting: ${JSON.stringify(started)}`)
+  }
+
+  await waitFor(() => fake.state.configurations.length === 1, timeoutMs, 'Gateway configuration')
+  const configuration = fake.state.configurations[0]
+  if (
+    configuration.type !== 'session.update' ||
+    configuration.session?.turn_detection?.create_response !== false ||
+    !configuration.session?.input_audio_transcription
+  ) {
+    throw new Error(
+      `Realtime configuration did not suppress assistant responses or enable transcription: ` +
+        JSON.stringify(configuration)
+    )
+  }
+
+  const injected = await request(backend, timeoutMs, 'captions.test.inject-audio', {
+    durationMs: 900
+  })
+  if ((injected.framesAccepted ?? 0) < 1) {
+    throw new Error(
+      `Caption contract audio did not enter the bounded bus: ${JSON.stringify(injected)}`
+    )
+  }
+
+  await waitFor(
+    () =>
+      observed.updates.some(
+        (update) =>
+          update.sessionClientId === started.sessionClientId &&
+          update.kind === 'final' &&
+          update.text === 'Caption contract passed.'
+      ),
+    timeoutMs,
+    'settled realtime caption'
+  )
+  const snapshot = await waitForSnapshot(
+    backend,
+    (candidate) =>
+      candidate.status?.state === 'listening' &&
+      candidate.status?.transport === 'realtime' &&
+      candidate.status?.providerReady === true &&
+      candidate.chunkCount === 1 &&
+      candidate.canonicalCues?.[0]?.text === 'Caption contract passed.'
+  )
+  if (snapshot.canonicalCues.length !== 1) {
+    throw new Error(`Repeated completions created duplicate cues: ${JSON.stringify(snapshot)}`)
+  }
+  if (fake.state.audioAppends < 1 || fake.state.emptyAudioAppends > 0) {
+    throw new Error(`Realtime client did not append valid PCM: ${JSON.stringify(fake.state)}`)
+  }
+
+  await request(backend, timeoutMs, 'captions.stop', {})
+}
+
+async function proveAssistantResponseFallback({ backend, observed, fake }) {
+  fake.state.realtimeAvailable = true
+  fake.state.assistantResponseOnNextAudio = true
+  const chunkRequestsBefore = fake.state.chunkRequests
+  const started = await request(backend, timeoutMs, 'captions.start', { language: 'en' })
+  if (!started.sessionClientId) {
+    throw new Error(
+      `Assistant-response safety scenario returned no session id: ${JSON.stringify(started)}`
+    )
+  }
+
+  const trigger = await request(backend, timeoutMs, 'captions.test.inject-audio', {
+    durationMs: 900
+  })
+  if ((trigger.framesAccepted ?? 0) < 1) {
+    throw new Error(
+      `Assistant-response safety scenario received no trigger PCM: ${JSON.stringify(trigger)}`
+    )
+  }
+
+  await waitForSnapshot(
+    backend,
+    (candidate) =>
+      candidate.status?.transport === 'chunked' &&
+      candidate.status?.reasonCode === 'realtime-fallback'
+  )
+  if (fake.state.assistantResponses !== 1) {
+    throw new Error(`Expected one unsafe assistant response: ${JSON.stringify(fake.state)}`)
+  }
+
+  const fallbackAudio = await request(backend, timeoutMs, 'captions.test.inject-audio', {
+    durationMs: 5_000
+  })
+  if ((fallbackAudio.framesAccepted ?? 0) < 1) {
+    throw new Error(
+      `Assistant-response chunk fallback received no deterministic PCM: ${JSON.stringify(fallbackAudio)}`
+    )
+  }
+
+  await waitFor(
+    () =>
+      observed.updates.some(
+        (update) =>
+          update.sessionClientId === started.sessionClientId &&
+          update.kind === 'final' &&
+          update.text === 'Chunk fallback recovered.'
+      ),
+    timeoutMs,
+    'assistant-response chunk fallback caption'
+  )
+  if (fake.state.chunkRequests !== chunkRequestsBefore + 1) {
+    throw new Error(
+      `Expected one chunk after the unsafe assistant response, got ${fake.state.chunkRequests - chunkRequestsBefore}.`
+    )
+  }
+
+  await request(backend, timeoutMs, 'captions.stop', {})
+}
+
+async function proveChunkFallback({ backend, observed, fake }) {
+  fake.state.realtimeAvailable = false
+  const chunkRequestsBefore = fake.state.chunkRequests
+  const started = await request(backend, timeoutMs, 'captions.start', { language: 'en' })
+  if (!started.sessionClientId) {
+    throw new Error(`Chunk fallback captions returned no session id: ${JSON.stringify(started)}`)
+  }
+
+  const injected = await request(backend, timeoutMs, 'captions.test.inject-audio', {
+    durationMs: 5_000
+  })
+  if ((injected.framesAccepted ?? 0) < 1) {
+    throw new Error(`Chunk fallback received no deterministic PCM: ${JSON.stringify(injected)}`)
+  }
+
+  await waitFor(
+    () =>
+      observed.updates.some(
+        (update) =>
+          update.sessionClientId === started.sessionClientId &&
+          update.kind === 'final' &&
+          update.text === 'Chunk fallback recovered.'
+      ),
+    timeoutMs,
+    'chunk fallback caption'
+  )
+  await waitForSnapshot(
+    backend,
+    (candidate) =>
+      candidate.status?.transport === 'chunked' &&
+      candidate.status?.providerReady === true &&
+      candidate.canonicalCues?.some((cue) => cue.text === 'Chunk fallback recovered.')
+  )
+  if (fake.state.chunkRequests !== chunkRequestsBefore + 1) {
+    throw new Error(
+      `Expected exactly one fallback chunk, got ${fake.state.chunkRequests - chunkRequestsBefore}.`
+    )
+  }
+
+  await waitForSnapshot(
+    backend,
+    (candidate) =>
+      candidate.status?.state === 'blocked' &&
+      candidate.status?.transport === 'chunked' &&
+      candidate.status?.reasonCode === 'audio-path-stalled'
+  )
+}
+
+function collectCaptionEvents(ws) {
+  const result = { statuses: [], updates: [] }
+  ws.addEventListener('message', (event) => {
+    let message
+    try {
+      message = JSON.parse(event.data)
+    } catch {
+      return
+    }
+    if (message.event === 'captions.status') result.statuses.push(message.payload)
+    if (message.event === 'captions.update') result.updates.push(message.payload)
+  })
+  return result
+}
+
+async function waitForSnapshot(backend, predicate) {
+  const startedAt = Date.now()
+  let latest
+  while (Date.now() - startedAt <= timeoutMs) {
+    latest = await request(backend, timeoutMs, 'captions.test.snapshot', {})
+    if (predicate(latest)) return latest
+    await sleep(50)
+  }
+  throw new Error(`Timed out waiting for caption contract snapshot: ${JSON.stringify(latest)}`)
+}
+
+function waitFor(predicate, deadlineMs, label) {
+  return new Promise((resolveWait, rejectWait) => {
+    const startedAt = Date.now()
+    const tick = () => {
+      if (predicate()) {
+        resolveWait()
+        return
+      }
+      if (Date.now() - startedAt > deadlineMs) {
+        rejectWait(new Error(`Timed out waiting for ${label}.`))
+        return
+      }
+      setTimeout(tick, 25)
+    }
+    tick()
+  })
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms))
+}

--- a/scripts/smoke-captions-live-app.mjs
+++ b/scripts/smoke-captions-live-app.mjs
@@ -1,0 +1,874 @@
+import { spawn } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { extname, join, resolve } from 'node:path'
+
+import { launchDevApp } from './lib/app-launcher.mjs'
+import { analyzeMediaAudioAmplitude } from './lib/audio-amplitude.mjs'
+import {
+  analyzeCaptionsAbsentArtifact,
+  analyzeCaptionsLiveArtifact,
+  formatCaptionsLiveArtifactSummary
+} from './lib/captions-live-artifact.mjs'
+import { startFakeCaptionService } from './lib/fake-caption-service.mjs'
+import { resolveFinalRecordingPath } from './lib/final-recording-path.mjs'
+import { connectBackend, request } from './smoke-recording-session.mjs'
+
+// Maintained viewer-facing live-caption gate. Unlike smoke:captions-contract,
+// which proves the backend transport state machine in isolation, this launches
+// the real renderer and the real livestream pipeline:
+//
+// deterministic pre-controls PCM -> live mute/gain -> fake authenticated chunk service ->
+// captions.update -> renderer OffscreenCanvas PNG -> backend compositor ->
+// local RTMP listener + clean recording + SRT + captioned recording copy ->
+// ffprobe metadata + ffmpeg pixel/audio analysis.
+//
+// The smoke never calls captions.overlay.set. Passing pixels therefore proves
+// that the renderer consumed the caption update and generated the PNG itself.
+
+const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 240_000)
+const baselineMs = Number(process.env.VIDEORC_CAPTIONS_LIVE_BASELINE_MS ?? 1_800)
+const captionCaptureMs = Number(process.env.VIDEORC_CAPTIONS_LIVE_CAPTURE_MS ?? 3_000)
+const listenerBindMs = Number(process.env.VIDEORC_CAPTIONS_LIVE_LISTENER_BIND_MS ?? 1_200)
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+const ffprobePath = process.env.VIDEORC_SMOKE_FFPROBE_PATH ?? 'ffprobe'
+const outputDirectory = resolve(
+  process.env.VIDEORC_SMOKE_OUTPUT_DIR ?? join(tmpdir(), `videorc-captions-live-${Date.now()}`)
+)
+const stateRoot = join(outputDirectory, 'app-state')
+const appDataDir = join(stateRoot, 'app-data')
+const receivedPath = join(outputDirectory, 'captions-live-received.flv')
+const reportPath = join(outputDirectory, 'captions-live-artifact.json')
+const smokeSessionToken = 'captions-live-session-token'
+const smokeRealtimeToken = 'captions-live-realtime-token'
+const finalText = 'VIDEORC LIVE CAPTION RENDERER PROOF'
+const captionTestMicrophoneId = 'microphone:coreaudio:4294967295'
+const rawTonePeak = 0.12
+const gainDb = 6
+const injectionMs = 3_000
+
+mkdirSync(appDataDir, { recursive: true })
+const secretsPath = join(appDataDir, 'videorc-secrets.json')
+writeFileSync(
+  secretsPath,
+  JSON.stringify({ 'account:videorc:session': smokeSessionToken }, null, 2)
+)
+chmodSync(secretsPath, 0o600)
+
+const fake = await startFakeCaptionService({
+  smokeSessionToken,
+  smokeRealtimeToken,
+  provisionalFinalText: 'VIDEORC LIVE CAPTION',
+  finalText,
+  chunkText: finalText,
+  itemId: 'captions-live-renderer-proof',
+  minSpeechPeak: 0.01
+})
+let launched
+let backend
+let listener
+let sessionActive = false
+let observed = { statuses: [], updates: [], recordingStatuses: [], healthEvents: [] }
+
+try {
+  launched = await launchDevApp({
+    requiredMarkers: ['backend-ready', 'preview-motion-ready'],
+    timeoutMs,
+    env: {
+      VIDEORC_API_BASE_URL: fake.httpOrigin,
+      VIDEORC_CAPTION_CONTRACT_TEST: '1',
+      VIDEORC_DISABLE_AUTO_PREVIEW: '1',
+      VIDEORC_SMOKE_COMMAND_SERVER: '1',
+      VIDEORC_SMOKE_PREVIEW_MOTION: '1',
+      VIDEORC_SMOKE_OUTPUT_DIR: outputDirectory,
+      VIDEORC_SMOKE_STATE_DIR: stateRoot
+    }
+  })
+  backend = await connectBackend(launched.connections['backend-ready'], timeoutMs)
+  const smoke = launched.connections['preview-motion-ready']
+  observed = collectCaptionEvents(backend)
+
+  fake.state.realtimeAvailable = false
+  fake.state.realtimeFailureCode = 'captions-realtime-disabled'
+  await seedRendererCaptionsProfile(smoke)
+  await waitForCaptionStatus(backend, (status) => {
+    return status.state === 'ready' && status.desiredEnabled === true
+  })
+  const health = await request(backend, timeoutMs, 'health.ping', { ffmpegPath })
+  if (!health?.ffmpeg?.available) {
+    throw new Error(health?.ffmpeg?.message ?? 'FFmpeg is unavailable for captions live smoke.')
+  }
+
+  const port = Number(process.env.VIDEORC_CAPTIONS_LIVE_RTMP_PORT ?? 19841)
+  const streamKey = 'captions-live'
+  const target = {
+    id: 'captions-live-local',
+    serverUrl: `rtmp://127.0.0.1:${port}/live`,
+    listenUrl: `rtmp://127.0.0.1:${port}/live/${streamKey}`,
+    streamKey
+  }
+  listener = spawnRtmpListener(target)
+  await sleep(listenerBindMs)
+  assertListenerRunning(listener)
+
+  const captureRequestedAt = Date.now()
+  const started = await request(
+    backend,
+    timeoutMs,
+    'session.start',
+    sessionParams({ outputDirectory, target })
+  )
+  if (started.state !== 'recording' || !started.sessionId || !started.outputPath) {
+    throw new Error(`Caption smoke did not enter record+stream: ${JSON.stringify(started)}`)
+  }
+  sessionActive = true
+  await hydrateRendererActiveSession(smoke)
+
+  // Captions are part of the backend session itself. No harness-side
+  // captions.start or overlay RPC is allowed: renderer events must drive both
+  // the live compositor PNG and the post-recording cue-frame round trip.
+  try {
+    await waitFor(
+      () => fake.state.realtimeTokenRequests >= 1,
+      Math.min(timeoutMs, 30_000),
+      'session-started caption fallback'
+    )
+  } catch (error) {
+    const [captionStatus, recordingStatus, rendererState] = await Promise.all([
+      request(backend, timeoutMs, 'captions.status.get', {}).catch(() => null),
+      request(backend, timeoutMs, 'recording.status', {}).catch(() => null),
+      smokeCommand(smoke, 'eval-js', {
+        code: `
+          const stored = JSON.parse(localStorage.getItem('videorc.captureConfig') ?? '{}')
+          return {
+            ready: document.readyState,
+            captions: stored.captions,
+            recordEnabled: stored.recordEnabled,
+            streamEnabled: stored.streamEnabled
+          }
+        `
+      }).catch(() => null)
+    ])
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)} ` +
+        `Fake service counters: ${JSON.stringify(safeFakeCounters(fake.state))}. ` +
+        `Caption status: ${JSON.stringify(captionStatus)}. ` +
+        `Recording status: ${JSON.stringify(recordingStatus)}. ` +
+        `Renderer state: ${JSON.stringify(rendererState?.result ?? null)}.`
+    )
+  }
+  await waitForCaptionStatus(backend, (status) => {
+    return status.state === 'degraded' && status.transport === 'chunked'
+  })
+  await sleep(baselineMs)
+
+  // The session starts muted. Raw tone packets enter the synthetic native
+  // source before controls; the fake service must receive a silent WAV and
+  // must not emit caption text. This is the privacy assertion the old direct
+  // caption-bus injector could not make.
+  const muteUpdate = await request(backend, timeoutMs, 'audio.processing.update', {
+    sessionId: started.sessionId,
+    microphoneGainDb: 0,
+    microphoneMuted: true
+  })
+  if (!muteUpdate.applied) {
+    throw new Error(`Could not mute the active native source: ${JSON.stringify(muteUpdate)}`)
+  }
+  const mutedAudioStart = fake.state.chunkAudio.length
+  const mutedInjection = await injectPreControlsPcm(backend, started.sessionId)
+  await waitFor(
+    () => fake.state.chunkAudio.length > mutedAudioStart,
+    timeoutMs,
+    'muted caption WAV inspection'
+  )
+  const mutedAudio = fake.state.chunkAudio.slice(mutedAudioStart)
+  if (mutedAudio.some((audio) => audio.peak > 0.001)) {
+    throw new Error(
+      `Muted pre-controls PCM reached captions audibly: ${JSON.stringify(mutedAudio)}`
+    )
+  }
+  if (observed.updates.some((update) => update.kind === 'final' && update.text)) {
+    throw new Error(`Muted PCM produced caption text: ${JSON.stringify(observed.updates)}`)
+  }
+
+  const baselineUpdate = await request(backend, timeoutMs, 'audio.processing.update', {
+    sessionId: started.sessionId,
+    microphoneGainDb: 0,
+    microphoneMuted: false
+  })
+  if (!baselineUpdate.applied) {
+    throw new Error(`Could not unmute the active native source: ${JSON.stringify(baselineUpdate)}`)
+  }
+  const baselineAudioStart = fake.state.chunkAudio.length
+  const baselineInjection = await injectPreControlsPcm(backend, started.sessionId)
+  await waitFor(
+    () => observed.updates.some((update) => update.kind === 'final' && update.text === finalText),
+    timeoutMs,
+    'renderer-proof final caption update'
+  )
+  await waitFor(
+    () => fake.state.chunkAudio.slice(baselineAudioStart).some((audio) => audio.peak > 0.08),
+    timeoutMs,
+    'zero-gain caption WAV inspection'
+  )
+  const baselineAudio = fake.state.chunkAudio
+    .slice(baselineAudioStart)
+    .find((audio) => audio.peak > 0.08)
+
+  const gainUpdate = await request(backend, timeoutMs, 'audio.processing.update', {
+    sessionId: started.sessionId,
+    microphoneGainDb: gainDb,
+    microphoneMuted: false
+  })
+  if (!gainUpdate.applied) {
+    throw new Error(`Could not update active native gain: ${JSON.stringify(gainUpdate)}`)
+  }
+  const gainedAudioStart = fake.state.chunkAudio.length
+  const gainedInjection = await injectPreControlsPcm(backend, started.sessionId)
+  await waitFor(
+    () =>
+      fake.state.chunkAudio
+        .slice(gainedAudioStart)
+        .some((audio) => audio.peak > baselineAudio.peak * 1.7),
+    timeoutMs,
+    'gained caption WAV inspection'
+  )
+  const gainedAudio = fake.state.chunkAudio
+    .slice(gainedAudioStart)
+    .find((audio) => audio.peak > baselineAudio.peak * 1.7)
+  const gainRatio = gainedAudio.peak / baselineAudio.peak
+  if (baselineAudio.peak < 0.1 || baselineAudio.peak > 0.14) {
+    throw new Error(`Zero-gain caption WAV peak drifted: ${JSON.stringify(baselineAudio)}`)
+  }
+  if (gainRatio < 1.85 || gainRatio > 2.15) {
+    throw new Error(
+      `Caption WAV did not reflect +${gainDb}dB before the tap: ratio=${gainRatio.toFixed(3)} ` +
+        `${JSON.stringify({ baselineAudio, gainedAudio })}`
+    )
+  }
+  await waitForCaptionStatus(backend, (status) => {
+    return (
+      status.state === 'degraded' && status.transport === 'chunked' && status.providerReady === true
+    )
+  })
+  if (fake.state.chunkRequests < 3 || fake.state.audioAppends !== 0) {
+    throw new Error(
+      `Chunked caption service did not inspect the mute/gain windows: ${JSON.stringify(
+        safeFakeCounters(fake.state)
+      )}`
+    )
+  }
+  const overlaySnapshot = await waitForCaptionOverlay(backend)
+
+  // Leave the settled line on screen long enough for multiple independently
+  // decoded frames. Its readable dwell is longer than this capture window.
+  await sleep(captionCaptureMs)
+  const stopRequestedAt = Date.now()
+  const stopped = await request(backend, timeoutMs, 'session.stop', {})
+  sessionActive = false
+  await stopRtmpListener(listener)
+
+  assertArtifactFile(receivedPath)
+  const recordingPath = await resolveFinalRecordingPath({
+    started,
+    stopped,
+    recordingStatusEvents: observed.recordingStatuses,
+    healthEvents: observed.healthEvents,
+    stopRequestedAt,
+    timeoutMs
+  })
+  if (!recordingPath) throw new Error('Record+stream captions smoke produced no recording path.')
+  assertArtifactFile(recordingPath)
+  const srtPath = replaceExtension(recordingPath, '.srt')
+  await waitFor(() => existsSync(srtPath), timeoutMs, 'caption SRT sidecar')
+  const captionedCopyPath = captionedPath(recordingPath)
+  await waitFor(
+    () =>
+      observed.healthEvents.some(
+        (event) =>
+          event.sessionId === started.sessionId && event.code === 'captions-burned-copy-ready'
+      ),
+    timeoutMs,
+    'captioned recording copy finalization'
+  )
+  assertArtifactFile(captionedCopyPath)
+
+  const [streamProbe, recordingProbe, captionedProbe] = await Promise.all([
+    probeVideoArtifact(receivedPath),
+    probeVideoArtifact(recordingPath),
+    probeVideoArtifact(captionedCopyPath)
+  ])
+  const minDurationSeconds = Math.max(3, ((stopRequestedAt - captureRequestedAt) / 1_000) * 0.8)
+  assertVideoProbe(streamProbe, 'RTMP stream', {
+    width: 640,
+    height: 360,
+    minDurationSeconds
+  })
+  assertVideoProbe(recordingProbe, 'original recording', {
+    width: 640,
+    height: 360,
+    minDurationSeconds
+  })
+  assertVideoProbe(captionedProbe, 'captioned recording copy', {
+    width: 640,
+    height: 360,
+    minDurationSeconds
+  })
+  const [streamArtifact, cleanRecording, captionedArtifact, recordingAudio] = await Promise.all([
+    analyzeCaptionsLiveArtifact(receivedPath, { ffmpegPath }),
+    analyzeCaptionsAbsentArtifact(recordingPath, { ffmpegPath }),
+    analyzeCaptionsLiveArtifact(captionedCopyPath, { ffmpegPath }),
+    analyzeMediaAudioAmplitude(recordingPath, { ffmpegPath })
+  ])
+  const srt = readFileSync(srtPath, 'utf8')
+  if (!srt.includes(finalText)) {
+    throw new Error(`SRT sidecar omitted the settled caption: ${srtPath}`)
+  }
+  if (!streamArtifact.pass || !cleanRecording.pass || !captionedArtifact.pass) {
+    throw new Error(
+      `Caption routing artifact failure: ${JSON.stringify({
+        stream: streamArtifact.failures,
+        original: cleanRecording.failures,
+        captioned: captionedArtifact.failures
+      })} (report: ${reportPath})`
+    )
+  }
+  if (recordingAudio.peak < 0.18 || recordingAudio.peak > 0.35) {
+    throw new Error(
+      `Original recording did not contain the post-gain native PCM: ${JSON.stringify(recordingAudio)}`
+    )
+  }
+  const diagnostics = await request(backend, timeoutMs, 'diagnostics.stats', {})
+  writeFileSync(
+    reportPath,
+    JSON.stringify(
+      {
+        pass: true,
+        artifacts: {
+          stream: streamArtifact,
+          original: cleanRecording,
+          captionedCopy: captionedArtifact,
+          srt: { file: srtPath, containsExpectedText: true }
+        },
+        probes: {
+          stream: streamProbe,
+          original: recordingProbe,
+          captionedCopy: captionedProbe
+        },
+        diagnostics,
+        observed,
+        proof: {
+          injections: { mutedInjection, baselineInjection, gainedInjection },
+          captionWavAmplitude: { muted: mutedAudio, baseline: baselineAudio, gained: gainedAudio },
+          gainRatio,
+          recordingAudio,
+          captionFinalObserved: true,
+          rendererProfile: {
+            styleId: 'high-contrast',
+            position: 'bottom',
+            textSize: 'l'
+          },
+          chunkRequests: fake.state.chunkRequests,
+          overlayRevision: overlaySnapshot.overlays.auxiliary.revision,
+          transport: 'chunked'
+        }
+      },
+      null,
+      2
+    )
+  )
+  console.log(formatCaptionsLiveArtifactSummary(streamArtifact))
+  console.log(formatCaptionsLiveArtifactSummary(captionedArtifact))
+
+  console.log(
+    `Captions live smoke PASS — pre-controls PCM proved mute and +${gainDb}dB ordering, the renderer ` +
+      `published captions to RTMP, the original recording stayed clean, and finalization produced ` +
+      `both SRT and a captioned copy (${streamProbe.video.width}x${streamProbe.video.height}, ` +
+      `${streamProbe.format.durationSeconds.toFixed(2)}s stream). ` +
+      `Evidence: ${outputDirectory}`
+  )
+} catch (error) {
+  const [diagnostics, recordingStatus, captionsStatus] = backend
+    ? await Promise.all([
+        requestSafe(backend, 'diagnostics.stats', {}),
+        requestSafe(backend, 'recording.status', {}),
+        requestSafe(backend, 'captions.status.get', {})
+      ])
+    : [null, null, null]
+  const failure = {
+    pass: false,
+    error: {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : null
+    },
+    diagnostics,
+    recordingStatus,
+    captionsStatus,
+    observed,
+    fake: {
+      ...safeFakeCounters(fake.state),
+      chunkAudio: fake.state.chunkAudio
+    },
+    artifacts: artifactInventory(outputDirectory)
+  }
+  writeFileSync(reportPath, JSON.stringify(failure, null, 2))
+  throw new Error(
+    `${error instanceof Error ? error.message : String(error)} Full failure evidence: ${reportPath}`,
+    { cause: error }
+  )
+} finally {
+  try {
+    if (backend) {
+      if (sessionActive) await requestSafe(backend, 'session.stop', {})
+      await requestSafe(backend, 'captions.stop', {})
+      backend.close()
+    }
+    await stopRtmpListener(listener)
+  } finally {
+    await launched?.stop().catch(() => {})
+    await fake.close()
+  }
+}
+
+async function seedRendererCaptionsProfile(smoke) {
+  const seeded = await smokeCommand(smoke, 'eval-js', {
+    code: `
+      let current = {}
+      try { current = JSON.parse(localStorage.getItem('videorc.captureConfig') ?? '{}') } catch {}
+      const next = {
+        ...current,
+        // Mirror the direct backend record+stream shape so the renderer owns
+        // both the live stream PNG and finalized cue-frame submissions.
+        recordEnabled: true,
+        streamEnabled: true,
+        streaming: { ...current.streaming, enabled: false },
+        video: { preset: 'custom', width: 640, height: 360, fps: 30, bitrateKbps: 2000 },
+        captions: {
+          enabled: true,
+          burnTarget: 'both',
+          styleId: 'high-contrast',
+          language: 'en',
+          styleRevision: 1,
+          position: 'bottom',
+          textSize: 'l'
+        }
+      }
+      localStorage.setItem('videorc.captureConfig', JSON.stringify(next))
+      localStorage.setItem('videorc.onboardingComplete', 'permissions-v1')
+      return {
+        captions: next.captions,
+        video: next.video,
+        recordEnabled: next.recordEnabled,
+        streamEnabled: next.streamEnabled,
+        hasStreamingDefaults: Boolean(next.streaming)
+      }
+    `
+  })
+  if (
+    seeded?.result?.captions?.styleId !== 'high-contrast' ||
+    seeded?.result?.captions?.enabled !== true ||
+    seeded?.result?.captions?.burnTarget !== 'both' ||
+    seeded?.result?.recordEnabled !== true ||
+    seeded?.result?.streamEnabled !== true ||
+    seeded?.result?.hasStreamingDefaults !== true
+  ) {
+    throw new Error(`Could not seed renderer caption profile: ${JSON.stringify(seeded)}`)
+  }
+  await smokeCommand(smoke, 'eval-js', {
+    code: `
+      window.setTimeout(() => window.location.reload(), 150)
+      return { reloadScheduled: true }
+    `
+  })
+  await sleep(750)
+
+  let latest = null
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      latest = await smokeCommand(smoke, 'eval-js', {
+        code: `
+          const stored = JSON.parse(localStorage.getItem('videorc.captureConfig') ?? '{}')
+          return {
+            ready: document.readyState === 'complete',
+            styleId: stored.captions?.styleId,
+            enabled: stored.captions?.enabled,
+            burnTarget: stored.captions?.burnTarget,
+            recordEnabled: stored.recordEnabled,
+            streamEnabled: stored.streamEnabled,
+            hasStreamingDefaults: Boolean(stored.streaming),
+            width: stored.video?.width,
+            height: stored.video?.height
+          }
+        `
+      })
+      const result = latest?.result
+      if (
+        result?.ready &&
+        result.styleId === 'high-contrast' &&
+        result.enabled === true &&
+        result.burnTarget === 'both' &&
+        result.recordEnabled === true &&
+        result.streamEnabled === true &&
+        result.hasStreamingDefaults === true &&
+        result.width === 640 &&
+        result.height === 360
+      ) {
+        return
+      }
+    } catch {
+      // The main window is expected to reject commands briefly while reloading.
+    }
+    await sleep(100)
+  }
+  throw new Error(`Renderer did not reload the seeded caption profile: ${JSON.stringify(latest)}`)
+}
+
+async function hydrateRendererActiveSession(smoke) {
+  const hydrated = await smokeCommand(smoke, 'eval-js', {
+    code: `
+      if (typeof window.__videorcSmokeHydrateRecordingStatus !== 'function') {
+        throw new Error('Recording-status smoke hydrator is unavailable.')
+      }
+      const recording = await window.__videorcSmokeHydrateRecordingStatus()
+      const deadline = Date.now() + 5000
+      let sessionStatus = null
+      while (Date.now() < deadline) {
+        sessionStatus = document.querySelector('[data-videorc-session-status]')?.textContent?.trim() ?? null
+        if (sessionStatus === 'Recording') break
+        await sleep(50)
+      }
+      return { recordingState: recording.state, sessionStatus }
+    `
+  })
+  if (
+    hydrated?.result?.recordingState !== 'recording' ||
+    hydrated.result.sessionStatus !== 'Recording'
+  ) {
+    throw new Error(`Renderer did not hydrate record+stream: ${JSON.stringify(hydrated)}`)
+  }
+}
+
+function sessionParams({ outputDirectory, target }) {
+  return {
+    sources: { testPattern: true, microphoneId: captionTestMicrophoneId },
+    layout: {
+      layoutPreset: 'screen-only',
+      cameraTransformMode: 'preset',
+      cameraTransform: null,
+      cameraCorner: 'bottom-right',
+      cameraSize: 'medium',
+      cameraShape: 'rectangle',
+      cameraCornerRadiusPct: 12,
+      cameraAspect: 'source',
+      cameraMargin: 32,
+      cameraFit: 'fill',
+      cameraMirror: false,
+      cameraZoom: 100,
+      cameraOffsetX: 0,
+      cameraOffsetY: 0,
+      sideBySideSplit: '70-30',
+      sideBySideCameraSide: 'right'
+    },
+    output: {
+      recordEnabled: true,
+      streamEnabled: true,
+      outputDirectory,
+      ffmpegPath,
+      video: { preset: 'custom', width: 640, height: 360, fps: 30, bitrateKbps: 2000 },
+      rtmp: { preset: 'custom', serverUrl: target.serverUrl, streamKey: target.streamKey }
+    },
+    captions: {
+      enabled: true,
+      burnTarget: 'both',
+      styleId: 'high-contrast',
+      language: 'en',
+      styleRevision: 1,
+      position: 'bottom',
+      textSize: 'l'
+    },
+    audio: { microphoneGainDb: 0, microphoneMuted: true, microphoneSyncOffsetMs: 0 }
+  }
+}
+
+function collectCaptionEvents(ws) {
+  const result = { statuses: [], updates: [], recordingStatuses: [], healthEvents: [] }
+  ws.addEventListener('message', (event) => {
+    let message
+    try {
+      message = JSON.parse(event.data)
+    } catch {
+      return
+    }
+    if (message.event === 'captions.status') result.statuses.push(message.payload)
+    if (message.event === 'captions.update') result.updates.push(message.payload)
+    if (message.event === 'recording.status') {
+      result.recordingStatuses.push({ ...message.payload, receivedAt: Date.now() })
+    }
+    if (message.event === 'health.event') {
+      result.healthEvents.push({ ...message.payload, receivedAt: Date.now() })
+    }
+  })
+  return result
+}
+
+async function waitForCaptionStatus(connection, predicate) {
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000)
+  let latest = null
+  while (Date.now() < deadline) {
+    latest = await request(connection, timeoutMs, 'captions.status.get', {})
+    if (predicate(latest)) return latest
+    await sleep(50)
+  }
+  throw new Error(`Timed out waiting for live caption status: ${JSON.stringify(latest)}`)
+}
+
+async function waitForCaptionOverlay(connection) {
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000)
+  let latest = null
+  while (Date.now() < deadline) {
+    latest = await request(connection, timeoutMs, 'captions.test.snapshot', {})
+    if (
+      latest?.overlays?.auxiliary?.active &&
+      latest.overlays.auxiliary.revision > 0 &&
+      !latest.overlays.primary.active
+    ) {
+      return latest
+    }
+    await sleep(50)
+  }
+  throw new Error(`Timed out waiting for renderer caption overlay: ${JSON.stringify(latest)}`)
+}
+
+function safeFakeCounters(state) {
+  return {
+    realtimeTokenRequests: state.realtimeTokenRequests,
+    realtimeUpgradeAttempts: state.realtimeUpgradeAttempts,
+    realtimeConnections: state.realtimeConnections,
+    configurations: state.configurations.length,
+    audioAppends: state.audioAppends,
+    emptyAudioAppends: state.emptyAudioAppends,
+    chunkRequests: state.chunkRequests,
+    chunkAudioInspections: state.chunkAudio.length,
+    usageReports: state.usageReports
+  }
+}
+
+function spawnRtmpListener(target) {
+  const stderr = []
+  const process = spawn(
+    ffmpegPath,
+    [
+      '-y',
+      '-nostdin',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-listen',
+      '1',
+      '-i',
+      target.listenUrl,
+      '-c',
+      'copy',
+      '-f',
+      'flv',
+      receivedPath
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  )
+  process.stderr.setEncoding('utf8')
+  process.stderr.on('data', (text) => stderr.push(text))
+  return { process, stderr }
+}
+
+function assertListenerRunning(listener) {
+  if (listener.process.exitCode !== null) {
+    throw new Error(
+      `Local RTMP listener exited before streaming: ${listener.stderr.join('').trim()}`
+    )
+  }
+}
+
+async function stopRtmpListener(listener) {
+  const child = listener?.process
+  if (!child?.pid || child.exitCode !== null) return
+  await waitForExit(child, 5_000)
+  if (child.exitCode !== null) return
+  child.kill('SIGTERM')
+  await waitForExit(child, 1_500)
+  if (child.exitCode === null) child.kill('SIGKILL')
+  await waitForExit(child, 1_000)
+}
+
+function waitForExit(child, timeout) {
+  if (child.exitCode !== null) return Promise.resolve()
+  return new Promise((resolveWait) => {
+    const timer = setTimeout(resolveWait, timeout)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolveWait()
+    })
+  })
+}
+
+async function probeVideoArtifact(filePath) {
+  const payload = await runProcess(ffprobePath, [
+    '-v',
+    'error',
+    '-show_entries',
+    'format=duration:stream=index,codec_type,codec_name,width,height,avg_frame_rate,channels,sample_rate',
+    '-of',
+    'json',
+    filePath
+  ])
+  const parsed = JSON.parse(payload)
+  const video = parsed.streams?.find((stream) => stream.codec_type === 'video')
+  const audio = parsed.streams?.find((stream) => stream.codec_type === 'audio')
+  return {
+    video: {
+      codec: video?.codec_name ?? null,
+      width: Number(video?.width ?? 0),
+      height: Number(video?.height ?? 0),
+      averageFrameRate: video?.avg_frame_rate ?? null
+    },
+    audio: {
+      codec: audio?.codec_name ?? null,
+      channels: Number(audio?.channels ?? 0),
+      sampleRate: Number(audio?.sample_rate ?? 0)
+    },
+    format: { durationSeconds: Number(parsed.format?.duration ?? 0) }
+  }
+}
+
+function assertVideoProbe(probe, label, expected) {
+  if (probe.video.width !== expected.width || probe.video.height !== expected.height) {
+    throw new Error(`Unexpected ${label} video dimensions: ${JSON.stringify(probe)}`)
+  }
+  if (
+    !Number.isFinite(probe.format.durationSeconds) ||
+    probe.format.durationSeconds < expected.minDurationSeconds
+  ) {
+    throw new Error(`${label} artifact was too short: ${JSON.stringify(probe)}`)
+  }
+  if (!probe.audio.codec || probe.audio.channels < 1 || probe.audio.sampleRate < 16_000) {
+    throw new Error(`${label} omitted the native audio leg: ${JSON.stringify(probe)}`)
+  }
+}
+
+function runProcess(command, args) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const stdout = []
+    const stderr = []
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (text) => stdout.push(text))
+    child.stderr.on('data', (text) => stderr.push(text))
+    child.on('error', rejectRun)
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolveRun(stdout.join(''))
+        return
+      }
+      rejectRun(
+        new Error(`${command} failed: code=${code} signal=${signal} ${stderr.join('').trim()}`)
+      )
+    })
+  })
+}
+
+function assertArtifactFile(filePath) {
+  const size = existsSync(filePath) ? statSync(filePath).size : 0
+  if (size <= 0) throw new Error(`Caption artifact is missing or empty: ${filePath}`)
+}
+
+function artifactInventory(directory) {
+  try {
+    return readdirSync(directory, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => {
+        const path = join(directory, entry.name)
+        return { path, bytes: statSync(path).size }
+      })
+  } catch {
+    return []
+  }
+}
+
+async function injectPreControlsPcm(connection, sessionId) {
+  const injection = await request(connection, timeoutMs, 'audio.test.inject-pcm', {
+    sessionId,
+    durationMs: injectionMs,
+    rawPeak: rawTonePeak
+  })
+  const expectedPackets = Math.ceil(injectionMs / 20)
+  if (injection.packetsGenerated < expectedPackets) {
+    throw new Error(
+      `Pre-controls PCM source generated too few packets: ${JSON.stringify(injection)}`
+    )
+  }
+  return injection
+}
+
+function replaceExtension(filePath, nextExtension) {
+  const extension = extname(filePath)
+  return `${filePath.slice(0, filePath.length - extension.length)}${nextExtension}`
+}
+
+function captionedPath(filePath) {
+  const extension = extname(filePath)
+  const stem = filePath.slice(0, filePath.length - extension.length)
+  return `${stem} (captioned)${extension}`
+}
+
+async function requestSafe(ws, method, params) {
+  try {
+    return await request(ws, 10_000, method, params)
+  } catch {
+    return null
+  }
+}
+
+async function smokeCommand(smoke, command, params = {}) {
+  const response = await fetch(`http://${smoke.host}:${smoke.port}/command`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ command, params }),
+    signal: AbortSignal.timeout(timeoutMs)
+  })
+  const payload = await response.json()
+  if (!response.ok || !payload.ok) {
+    throw new Error(payload?.error ?? `${command} smoke command failed`)
+  }
+  return payload.result
+}
+
+function waitFor(predicate, deadlineMs, label) {
+  return new Promise((resolveWait, rejectWait) => {
+    const startedAt = Date.now()
+    const tick = () => {
+      if (predicate()) {
+        resolveWait()
+        return
+      }
+      if (Date.now() - startedAt > deadlineMs) {
+        rejectWait(new Error(`Timed out waiting for ${label}.`))
+        return
+      }
+      setTimeout(tick, 25)
+    }
+    tick()
+  })
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms))
+}


### PR DESCRIPTION
## Summary

- restores backend-authoritative live captions with truthful Ready, Starting, Listening, Reconnecting, Degraded, Blocked, and Error states
- routes the post-mute/gain microphone bus through bounded realtime-to-chunk fallback, canonical cue upserts, watchdogs, teardown, SRT, stream overlays, and non-destructive captioned copies
- adds a dedicated Captions page plus shared Livestream controls with Classic, Glass, Lower third, and High contrast presets
- adds output-aware preflight, per-leg rasters, detached-reader parity, persistence, keyboard navigation, and explicit one-session continue-without-captions behavior
- adds maintained contract, live record+stream, amplitude/privacy, artifact, and contact-sheet gates

## Safety decision

Realtime voice remains fail-closed. A live provider probe produced assistant responses automatically, and direct desktop sockets cannot be authoritatively server-metered. The deployable path is the approximately three-second server-metered chunk transport with honest Higher delay copy.

Companion readiness and metering PR: https://github.com/TheOrcDev/videorc-web/pull/2

## Verification

- `pnpm --filter @videorc/desktop test` — 93 files, 774 passed
- `pnpm test:scripts` — 564 passed
- `cargo test -p videorc-backend` — 1,045 passed total, 7 ignored by design
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build` — passed
- `cargo fmt --check --all`, clippy with warnings denied, Rust advisory audit — passed
- JS production advisory gate — passed; one moderate advisory remains below the configured high-severity threshold
- `pnpm smoke:captions-contract` — passed
- `pnpm smoke:captions-live` — passed: mute peak/RMS zero, +6 dB ratio 1.996x, sustained caption pixels in RTMP and captioned copy, zero caption pixels in the original, valid SRT, aligned 13.7-second artifacts
- `pnpm smoke:recording-studio` — deterministic steps 1–21 passed; step 22 is environment-blocked because this host exposes no ScreenCaptureKit screen source

## Staged acceptance

Real Premium microphone, external unlisted/live destination, Windows device parity, merged-production canary, and cohort rollout remain explicit release-stage rows in the [acceptance record](docs/acceptance/2026-07-11-live-captions-reliability.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Captions workspace with live preview and configuration controls.
  * Choose caption style, position, text size, language, and output targets for streams and recordings.
  * Added a detachable captions reader with status indicators, accessibility announcements, and keyboard/command-palette controls.
  * Captions now synchronize reliably across preview, reader, stream, and recording outputs.
  * Go Live checks caption availability and offers a “Continue without captions” option when needed.
  * Added live microphone gain and mute synchronization during active sessions.

* **Bug Fixes**
  * Improved caption recovery, fallback behavior, cleanup, and overlay placement across output formats.
  * Prevented stale or duplicate caption updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->