### PR TITLE
Release 0.9.28-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.28-beta.1.md
+++ b/changelog/0.9.28-beta.1.md
@@ -1,0 +1,49 @@
+---
+version: 0.9.28-beta.1
+date: 2026-07-11
+channel: beta
+title: Publish actually publishes — real titles, clips, and social posts from your recording
+summary: The Publish tab now genuinely works — instant transcripts from live captions, hooky title options, chapters, clip exports, and social post drafts — plus rebuilt live captions with styles, a cleaner docked preview, and smoother long sessions.
+highlights:
+  - Publish now delivers — record with live captions and your transcript is ready instantly; one consent switch (it finally stays on) generates real title options, description, summary, and chapters from what you actually said.
+  - Pick from several suggested titles and set the tone — hooky, informative, or casual — then regenerate any card on its own instead of re-running everything.
+  - Clips — Videorc finds the moments where your chat lit up and exports them as ready-to-share video files, one click each.
+  - Social posts — an X post, a thread draft, and a Twitch VOD title written from your recording, ready to copy.
+  - Live captions were rebuilt — honest status states, sturdier reconnects, and new on-stream styles including Classic, Glass, Lower third, and High contrast.
+---
+
+## The Publish tab earns its name
+
+Publish used to feel broken — running "Title & description" mostly just
+extracted audio and stopped. That's fixed at the root:
+
+- If you recorded with live captions, your transcript is ready the moment you
+  open Publish — nothing uploads, nothing re-transcribes.
+- The cloud consent switch is remembered now. Before, it silently reset every
+  launch, which is why runs looked like they did nothing.
+- Whatever blocks a run, the button says it and fixes it — enable consent,
+  sign in, or view Premium. No more silent half-runs.
+- Title & description gives you several title options to choose from, with a
+  tone control (hooky / informative / casual), and every card can regenerate
+  on its own.
+- When you streamed with chat, generation also reads your chat's biggest
+  moments — and the new Clips section turns those spikes into exported video
+  files, snapped to full sentences so clips never open mid-word.
+- Social posts drafts an X post, a thread, and a Twitch VOD title from the
+  video. Export pack now writes every file it lists.
+
+## Live captions, rebuilt
+
+Captions now tell you exactly what they're doing — ready, listening,
+reconnecting, degraded, or blocked — and recover more reliably when the
+connection wobbles. A new Captions page adds on-stream styles: Classic,
+Glass, Lower third, and High contrast, with a live preview of each.
+
+## Smaller but sweet
+
+- The docked preview lost its awkward border and corner gap — video sits
+  flush, and Pop out / Close are proper buttons.
+- Long sessions run smoother on macOS thanks to runtime performance
+  hardening, with endurance tests keeping it that way.
+- Windows tester builds: recording start/stop and Library posters are more
+  reliable, and recording length in the Library now matches the actual file.


### PR DESCRIPTION
Prep for 0.9.28-beta.1 (Publish tab rework #70, live captions rework #72, docked preview chrome #69, macOS perf hardening #66, Windows recording reliability #71): bump to 0.9.28 + changelog entry (`pnpm changelog:check` valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the Publish workflow with faster transcript availability, clearer error guidance, and tone-based title and description generation.
  - Added chat-aware clip generation and social post drafting for X, threads, and Twitch VOD titles.
  - Added new on-stream caption styles: Classic, Glass, Lower third, and High contrast.
- **Bug Fixes**
  - Improved caption status handling, reconnection behavior, and recording-length accuracy in the Library.
  - Enhanced session reliability and macOS runtime performance.
- **Release**
  - Updated the desktop app to version 0.9.28 beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->