### PR TITLE
Record the 0.9.28-beta.1 release (build, upload, feed, announce)

### DIFF
--- a/docs/releases/0.9.28.md
+++ b/docs/releases/0.9.28.md
@@ -1,0 +1,59 @@
+# Videorc 0.9.28 Beta 1
+
+Videorc 0.9.28 ships the Publish tab AI rework, the rebuilt live
+captions, the docked preview chrome cleanup, macOS runtime hardening,
+and the Windows recording reliability batch.
+
+## Scope
+
+- **Publish tab useful-AI rework** (PR #70, plan: vault
+  `2026-07-11 - Videorc Publish Tab Useful AI Rework Plan`; pairs with
+  videorc-web PR #1): live-captions transcript reuse (transcript-backed
+  jobs, no audio upload), persistent consent, fix-first run buttons,
+  per-kind generation with title variants + tone + chat context
+  (capability-gated on `workflow.supports*`), chat-spike clip
+  suggestions with local ffmpeg export, social posts, 6-file pack
+  export.
+- **Live captions rework** (PR #72): backend-authoritative truthful
+  states, bounded realtime→chunk fallback, watchdogs/teardown, Captions
+  page with Classic/Glass/Lower third/High contrast presets, per-leg
+  rasters, detached-reader parity. (Includes the platform-truthful fix
+  for the Windows split-output test that blocked its gate.)
+- **Docked preview chrome** (PR #69): borderless flush frame, no
+  transport label, solid Pop out/Close.
+- **macOS runtime hardening + endurance gates** (PR #66).
+- **Windows recording + poster reliability** (PR #71), including
+  probed finalized duration persisted to the Library.
+
+## Release status
+
+- [x] Feature PRs merged via protected `main` (#66, #69, #70, #71,
+      #72); release prep PR https://github.com/TheOrcDev/videorc/pull/73.
+- [x] Built from a worktree at `origin/main` post-merge (`ca6f044a`).
+- [x] Signed + notarized (DMG stapled); `release:validate:macos` PASS
+      (codesign, Gatekeeper, stapler, bundled-secret gates); ffmpeg
+      capability probe passed in `package:preflight:macos`.
+- [x] Uploaded to R2, all 8 objects verified; feed serves
+      `version: 0.9.28` through the www redirect; `/api/changelog`
+      serves `0.9.28-beta.1` (29 entries valid).
+- [x] Discord announced (dry-run previewed first, single post).
+
+## Verification
+
+- All gates green on prep PR #73 and every feature PR (Rust
+  test+clippy+fmt, JS format+lint+tests, Windows gates, Windows
+  installer artifact).
+- Publish rework evidence (PR #70): srt-reuse workflow integration
+  test, clip-ranking/pack-file/srt-parser unit suites, 1055 Rust +
+  774 desktop tests green post-merge with the captions rework.
+
+## Pending owner acceptance
+
+- [ ] Update to 0.9.28; open Publish on a captioned recording:
+      transcript Ready instantly; enable consent once (persists);
+      Generate publish pack → title options + tone regenerate.
+- [ ] Stream with chat → Clips → Suggest → Export clip → playable file
+      next to the recording.
+- [ ] Captions page: styles preview and burn correctly on stream.
+- [ ] Docked preview sits flush (no corner wedge), solid buttons.
+- [ ] Confirm the signed-in download page shows 0.9.28.


### PR DESCRIPTION
Release record for 0.9.28-beta.1 (Publish rework #70, captions rework #72, preview chrome #69, perf hardening #66, Windows reliability #71; prep PR #73). Feed verified serving 0.9.28 through the www redirect; changelog live; Discord announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for Videorc 0.9.28 Beta 1.
  - Documented improvements to publishing, live captions, docked preview controls, macOS stability, and Windows recording and poster reliability.
  - Included release verification details and remaining acceptance checks for publishing, clip export, captions, preview layout, and downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->