### PR TITLE
Fix Windows capture, assets, and recording reliability

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -96,6 +96,7 @@ import {
   writeGpuFallbackState
 } from './gpu-fallback'
 import { createMediaPermissionGrantWatcher } from './system-permission-watch'
+import { isPathInsideAnyRoot } from './managed-asset-paths'
 import { PreviewSupervisorModel, previewWindowTargetAction } from './preview-supervisor'
 import {
   composeDockedScreenRect,
@@ -8992,9 +8993,7 @@ function backgroundAssetFileExists(assetPath: unknown): boolean {
     return false
   }
   const normalized = resolve(assetPath)
-  const inManagedRoot = managedBackgroundRoots().some((root) =>
-    normalized.startsWith(`${resolve(root)}/`)
-  )
+  const inManagedRoot = isPathInsideAnyRoot(normalized, managedBackgroundRoots())
   return inManagedRoot && existsSync(normalized)
 }
 

--- a/apps/desktop/src/main/managed-asset-paths.test.ts
+++ b/apps/desktop/src/main/managed-asset-paths.test.ts
@@ -1,0 +1,69 @@
+import { posix, win32 } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { isPathInsideRoot } from './managed-asset-paths'
+
+describe('isPathInsideRoot', () => {
+  it('accepts Windows drive children across case and separator variations', () => {
+    const root = 'C:\\Users\\Creator\\AppData\\Roaming\\Videorc\\background-assets'
+
+    expect(isPathInsideRoot(`${root}\\abc.png`, root, win32)).toBe(true)
+    expect(
+      isPathInsideRoot(
+        'c:/users/creator/appdata/roaming/videorc/background-assets/nested/abc.png',
+        root,
+        win32
+      )
+    ).toBe(true)
+  })
+
+  it('accepts Windows UNC children across case and separator variations', () => {
+    const root = '\\\\SERVER\\Share\\Videorc\\background-assets'
+
+    expect(
+      isPathInsideRoot('\\\\server\\share\\videorc\\background-assets\\abc.png', root, win32)
+    ).toBe(true)
+    expect(
+      isPathInsideRoot('//server/share/videorc/background-assets/nested/abc.png', root, win32)
+    ).toBe(true)
+  })
+
+  it('rejects roots, traversal, sibling prefixes, and other Windows volumes', () => {
+    const root = 'C:\\Videorc\\background-assets'
+
+    expect(isPathInsideRoot(root, root, win32)).toBe(false)
+    expect(isPathInsideRoot('C:\\Videorc\\background-assets\\..\\secret.png', root, win32)).toBe(
+      false
+    )
+    expect(isPathInsideRoot('C:\\Videorc\\background-assets-evil\\abc.png', root, win32)).toBe(
+      false
+    )
+    expect(isPathInsideRoot('D:\\Videorc\\background-assets\\abc.png', root, win32)).toBe(false)
+    expect(isPathInsideRoot('background-assets\\abc.png', root, win32)).toBe(false)
+    expect(
+      isPathInsideRoot(
+        '\\\\server\\other-share\\videorc\\background-assets\\abc.png',
+        '\\\\server\\share\\videorc\\background-assets',
+        win32
+      )
+    ).toBe(false)
+  })
+
+  it('preserves POSIX containment behavior', () => {
+    expect(
+      isPathInsideRoot('/managed/background-assets/abc.png', '/managed/background-assets', posix)
+    ).toBe(true)
+    expect(
+      isPathInsideRoot('/managed/background-assets', '/managed/background-assets', posix)
+    ).toBe(false)
+    expect(
+      isPathInsideRoot(
+        '/managed/background-assets-evil/abc.png',
+        '/managed/background-assets',
+        posix
+      )
+    ).toBe(false)
+    expect(isPathInsideRoot('/managed/secret.png', '/managed/background-assets', posix)).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/managed-asset-paths.ts
+++ b/apps/desktop/src/main/managed-asset-paths.ts
@@ -1,0 +1,34 @@
+import path from 'node:path'
+
+type PathApi = Pick<typeof path, 'isAbsolute' | 'relative' | 'resolve' | 'sep'>
+
+/**
+ * Returns true only when an absolute candidate resolves to a child of an
+ * absolute managed root. `path.relative` preserves each platform's separator,
+ * volume, UNC, and case rules; string-prefix checks do not.
+ */
+export function isPathInsideRoot(
+  candidate: string,
+  root: string,
+  pathApi: PathApi = path
+): boolean {
+  if (!pathApi.isAbsolute(candidate) || !pathApi.isAbsolute(root)) {
+    return false
+  }
+
+  const relativePath = pathApi.relative(pathApi.resolve(root), pathApi.resolve(candidate))
+  return (
+    relativePath.length > 0 &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${pathApi.sep}`) &&
+    !pathApi.isAbsolute(relativePath)
+  )
+}
+
+export function isPathInsideAnyRoot(
+  candidate: string,
+  roots: readonly string[],
+  pathApi: PathApi = path
+): boolean {
+  return roots.some((root) => isPathInsideRoot(candidate, root, pathApi))
+}

--- a/apps/desktop/src/renderer/src/components/tabs/assets-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/assets-tab.tsx
@@ -34,6 +34,8 @@ import {
   defaultBackgroundStyle,
   importIntoSlot,
   backgroundAssetDisplayUrl,
+  checkableBackgroundAssetPath,
+  markSlotMissingIfAssetMatches,
   markSlotStatus,
   removeSlotAsset,
   renameAsset,
@@ -94,12 +96,14 @@ export function AssetsTab(): ReactElement {
   const markMissing = (slotId: string): void => {
     const slot = registry.slots.find((entry) => entry.id === slotId)
     const asset = slot ? slotAsset(slot, registry) : null
-    const checkablePath =
-      asset?.kind === 'imported' && asset.assetPath?.startsWith('/') ? asset.assetPath : null
-    if (checkablePath && window.videorc?.backgroundAssetExists) {
+    const checkablePath = checkableBackgroundAssetPath(asset)
+    const checkedAssetId = asset?.id
+    if (checkablePath && checkedAssetId && window.videorc?.backgroundAssetExists) {
       void window.videorc.backgroundAssetExists(checkablePath).then((exists) => {
         if (!exists) {
-          setRegistry((current) => markSlotStatus(current, slotId, 'missing-file'))
+          setRegistry((current) =>
+            markSlotMissingIfAssetMatches(current, slotId, checkedAssetId, checkablePath)
+          )
         }
       })
       return

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -47,6 +47,7 @@ import {
   preparedYouTubeCompletionTargets,
   readyStreamTargetLabels,
   reconcileSourceSelection,
+  reconcileSourceSelectionForLayoutTransaction,
   rtmpDefaults,
   smokePreviewCompositorCaptureConfig,
   sourceSelectionChangeEvents,
@@ -83,6 +84,7 @@ import {
   shouldReloadSceneFromCaptureConfig
 } from '@/lib/layout-transaction-policy'
 import {
+  nativePreviewFramePollingShouldSuppress,
   nativePreviewSurfaceSyncCanCommit,
   nativePreviewSurfaceSyncNeedsCreate
 } from '@/lib/native-preview-surface-lifecycle'
@@ -2502,8 +2504,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             nativePreviewCompositorPendingRef.current = null
             const updateParams = buildNativePreviewCompositorUpdateParams(
               nextStatus,
-              recordingRef.current.state,
-              nativePreviewRendererTimingStatusFields()
+              nativePreviewRendererTimingStatusFields(),
+              {
+                recordingActive: isActiveRecordingState(recordingRef.current.state),
+                windowOpen: previewWindowRef.current.open,
+                status: previewSurfaceStatusRef.current
+              }
             )
             const presentStartedAt = performance.now()
             const surfaceStatus = await updateCompositor(updateParams)
@@ -3182,6 +3188,34 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
   }, [appendLog])
 
+  const recordAutomaticSourceFallbacks = useCallback(
+    (previous: SourceSelection, next: SourceSelection) => {
+      const fallbackEvents = sourceSelectionChangeEvents(previous, next)
+      if (fallbackEvents.length === 0) {
+        return
+      }
+      const occurredAt = new Date().toISOString()
+      const sessionState = recordingRef.current.state
+      const enrichedEvents = fallbackEvents.map((event) => ({
+        ...event,
+        occurredAt,
+        sessionState
+      }))
+      automaticSourceFallbacks.current = [
+        ...automaticSourceFallbacks.current,
+        ...enrichedEvents
+      ].slice(-50)
+
+      if (isActiveRecordingState(sessionState)) {
+        toast.warning(sourceFallbackActiveSessionMessage(sessionState), {
+          duration: 10_000,
+          id: 'source-reconciliation:active-session'
+        })
+      }
+    },
+    []
+  )
+
   useEffect(() => {
     setCaptureConfig((current) => {
       const nextSources = reconcileSourceSelection(current.sources, deviceList.devices)
@@ -3190,30 +3224,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         return current
       }
 
-      const fallbackEvents = sourceSelectionChangeEvents(current.sources, nextSources)
-      if (fallbackEvents.length > 0) {
-        const occurredAt = new Date().toISOString()
-        const sessionState = recordingRef.current.state
-        const enrichedEvents = fallbackEvents.map((event) => ({
-          ...event,
-          occurredAt,
-          sessionState
-        }))
-        automaticSourceFallbacks.current = [
-          ...automaticSourceFallbacks.current,
-          ...enrichedEvents
-        ].slice(-50)
-
-        if (isActiveRecordingState(sessionState)) {
-          toast.warning(sourceFallbackActiveSessionMessage(sessionState), {
-            duration: 10_000,
-            id: 'source-reconciliation:active-session'
-          })
-        }
-      }
+      recordAutomaticSourceFallbacks(current.sources, nextSources)
       return { ...current, sources: nextSources }
     })
-  }, [deviceList])
+  }, [deviceList, recordAutomaticSourceFallbacks])
 
   useEffect(() => {
     if (!connection) {
@@ -4690,12 +4704,24 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
       void (async () => {
         try {
-          const requestedConfig = captureConfigRef.current
           const protectedOverlayWindowIds = await currentProtectedOverlayWindowIds()
+          const requestedConfig = captureConfigRef.current
+          const requestedSources = reconcileSourceSelectionForLayoutTransaction(
+            requestedConfig.sources,
+            deviceListRef.current.devices
+          )
+          if (JSON.stringify(requestedSources) !== JSON.stringify(requestedConfig.sources)) {
+            recordAutomaticSourceFallbacks(requestedConfig.sources, requestedSources)
+            setCaptureConfig((current) =>
+              JSON.stringify(current.sources) === JSON.stringify(requestedConfig.sources)
+                ? { ...current, sources: requestedSources }
+                : current
+            )
+          }
           const method = sessionActive ? 'scene.layout.apply_live' : 'scene.layout.apply_preview'
           const status = await client.request<LayoutTransactionStatus>(method, {
             intentId,
-            sources: requestedConfig.sources,
+            sources: requestedSources,
             layout,
             video: requestedConfig.video,
             background: activeSceneBackground,
@@ -4800,6 +4826,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       applyLayoutTransactionState,
       client,
       readLayoutTransactionBackendTruth,
+      recordAutomaticSourceFallbacks,
       rememberLayoutCommit,
       rememberLayoutTransactionSnapshot,
       reportError,
@@ -5388,9 +5415,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
   }, [wsStatus])
 
-  // Frame polling serves the Electron proof surface; it is pure overhead while a
-  // session records (the compositor feeds the encoder directly) and while the
-  // detached preview window is closed (nothing presents at all) — UI rewrite U2.
+  // Frame polling serves the Electron proof surface. It is redundant during a
+  // recording only when an attached native layer owns presentation; Windows
+  // relies on proof polling for its visible preview. A closed window always
+  // suppresses polling — UI rewrite U2.
   const syncFramePollingSuppression = useCallback(() => {
     if (
       !nativePreviewSurfaceEnabled ||
@@ -5398,8 +5426,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     ) {
       return
     }
-    const suppress =
-      isActiveRecordingState(recordingRef.current.state) || !previewWindowRef.current.open
+    const suppress = nativePreviewFramePollingShouldSuppress({
+      recordingActive: isActiveRecordingState(recordingRef.current.state),
+      windowOpen: previewWindowRef.current.open,
+      status: previewSurfaceStatusRef.current
+    })
     if (nativePreviewFramePollingSuppressionRequestedRef.current === suppress) {
       return
     }

--- a/apps/desktop/src/renderer/src/lib/background-assets.test.ts
+++ b/apps/desktop/src/renderer/src/lib/background-assets.test.ts
@@ -6,6 +6,7 @@ import {
   applySlot,
   backgroundAssetDisplayUrl,
   canApplySlot,
+  checkableBackgroundAssetPath,
   clearActiveSlot,
   createDefaultRegistry,
   createImportedAsset,
@@ -13,6 +14,7 @@ import {
   effectiveSceneBackground,
   importIntoSlot,
   markSlotStatus,
+  markSlotMissingIfAssetMatches,
   reconcileRegistry,
   removeSlotAsset,
   renameAsset,
@@ -325,6 +327,30 @@ describe('background asset import and editing', () => {
     expect(registry.activeSlotId).toBe('bg-02')
     expect(slotDisplayStatus(slotById(registry, 'bg-02'), registry)).toBe('missing-file')
   })
+
+  it('does not let a stale existence result mark a replacement asset missing', () => {
+    const first = importedAsset('a1', 'Sunset')
+    const replacement = importedAsset('a2', 'Ocean')
+    let registry = importIntoSlot(createDefaultRegistry(), 'bg-02', first)
+    registry = importIntoSlot(registry, 'bg-02', replacement)
+
+    const unchanged = markSlotMissingIfAssetMatches(
+      registry,
+      'bg-02',
+      first.id,
+      first.assetPath ?? ''
+    )
+    expect(unchanged).toBe(registry)
+    expect(slotById(unchanged, 'bg-02').status).toBe('ready')
+
+    const missing = markSlotMissingIfAssetMatches(
+      registry,
+      'bg-02',
+      replacement.id,
+      replacement.assetPath ?? ''
+    )
+    expect(slotById(missing, 'bg-02').status).toBe('missing-file')
+  })
 })
 
 describe('reconcileRegistry with imported assets', () => {
@@ -449,6 +475,49 @@ describe('backgroundAssetDisplayUrl', () => {
     expect(backgroundAssetDisplayUrl('C:\\Users\\me\\videorc\\background-assets\\abc.png')).toBe(
       'videorc-asset://background/abc.png'
     )
+    expect(backgroundAssetDisplayUrl('C:/Users/me/videorc/background-assets/abc.png')).toBe(
+      'videorc-asset://background/abc.png'
+    )
+    expect(
+      backgroundAssetDisplayUrl('\\\\server\\share\\videorc\\background-assets\\abc.png')
+    ).toBe('videorc-asset://background/abc.png')
+    expect(backgroundAssetDisplayUrl('//server/share/videorc/background-assets/abc.png')).toBe(
+      'videorc-asset://background/abc.png'
+    )
+  })
+
+  it('only exposes absolute imported files to the existence oracle', () => {
+    for (const assetPath of [
+      '/managed/abc.png',
+      'C:\\Users\\me\\videorc\\background-assets\\abc.png',
+      'C:/Users/me/videorc/background-assets/abc.png',
+      '\\\\server\\share\\videorc\\background-assets\\abc.png',
+      '//server/share/videorc/background-assets/abc.png'
+    ]) {
+      expect(checkableBackgroundAssetPath({ ...readyAsset('abc', 'ABC'), assetPath })).toBe(
+        assetPath
+      )
+    }
+
+    expect(
+      checkableBackgroundAssetPath({
+        ...readyAsset('abc', 'ABC'),
+        assetPath: 'C:background-assets\\abc.png'
+      })
+    ).toBeNull()
+    expect(
+      checkableBackgroundAssetPath({
+        ...readyAsset('abc', 'ABC'),
+        assetPath: 'background-assets/abc.png'
+      })
+    ).toBeNull()
+    expect(
+      checkableBackgroundAssetPath({
+        ...readyAsset('abc', 'ABC'),
+        kind: 'builtin',
+        assetPath: '/assets/backgrounds/abc.webp'
+      })
+    ).toBeNull()
   })
 
   it('encodes basenames safely', () => {
@@ -468,6 +537,7 @@ describe('backgroundAssetDisplayUrl', () => {
       'https://example.com/img.png',
       'file:///already/url.png',
       'videorc-asset://background/five.png',
+      'C:drive-relative.png',
       'plain-name.png'
     ]) {
       expect(backgroundAssetDisplayUrl(passthrough)).toBe(passthrough)

--- a/apps/desktop/src/renderer/src/lib/background-assets.ts
+++ b/apps/desktop/src/renderer/src/lib/background-assets.ts
@@ -433,18 +433,33 @@ export function removeSlotAsset(
  */
 export function backgroundAssetDisplayUrl(path: string): string {
   if (
-    /^(blob|data|file|https?|videorc-asset):/.test(path) ||
+    /^(blob|data|file|https?|videorc-asset):/i.test(path) ||
     path.startsWith('/assets/') ||
     path.startsWith('/src/') ||
     path.startsWith('./') ||
     path.startsWith('../') ||
-    (!path.startsWith('/') && !/^[A-Za-z]:/.test(path))
+    !isAbsoluteBackgroundAssetPath(path)
   ) {
     return path
   }
   const normalized = path.replace(/\\/g, '/')
   const baseName = normalized.slice(normalized.lastIndexOf('/') + 1)
   return `videorc-asset://background/${encodeURIComponent(baseName)}`
+}
+
+/** Browser-safe absolute-path detection for paths returned by Electron. */
+export function isAbsoluteBackgroundAssetPath(path: string): boolean {
+  return (
+    path.startsWith('/') ||
+    /^[A-Za-z]:[\\/]/.test(path) ||
+    /^(?:\\\\|\/\/)[^\\/]+[\\/][^\\/]+(?:[\\/]|$)/.test(path)
+  )
+}
+
+/** Only imported absolute files are safe and useful for the main-process existence oracle. */
+export function checkableBackgroundAssetPath(asset: BackgroundAsset | null): string | null {
+  const path = asset?.assetPath
+  return asset?.kind === 'imported' && path && isAbsoluteBackgroundAssetPath(path) ? path : null
 }
 
 // Set a slot's intrinsic status — used when an <img> fails to load to surface
@@ -465,6 +480,25 @@ export function markSlotStatus(
       (entry): BackgroundAssetSlot => (entry.id === slotId ? { ...entry, status } : entry)
     )
   }
+}
+
+/** Apply an async missing-file result only while the checked asset still owns the slot. */
+export function markSlotMissingIfAssetMatches(
+  registry: BackgroundAssetRegistry,
+  slotId: string,
+  expectedAssetId: string,
+  expectedAssetPath: string
+): BackgroundAssetRegistry {
+  const slot = registry.slots.find((entry) => entry.id === slotId)
+  const currentAsset = slot ? slotAsset(slot, registry) : null
+  if (
+    currentAsset?.id !== expectedAssetId ||
+    currentAsset.assetPath !== expectedAssetPath ||
+    currentAsset.kind !== 'imported'
+  ) {
+    return registry
+  }
+  return markSlotStatus(registry, slotId, 'missing-file')
 }
 
 function numberOr(value: unknown, fallback: number): number {

--- a/apps/desktop/src/renderer/src/lib/capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.test.ts
@@ -33,6 +33,7 @@ import {
   previewDeviceRefreshSignature,
   persistableCaptureConfig,
   reconcileSourceSelection,
+  reconcileSourceSelectionForLayoutTransaction,
   resetAudioSyncCalibration,
   smokePreviewCompositorCaptureConfig,
   streamOutputVideoForTarget,
@@ -240,6 +241,28 @@ describe('reconcileSourceSelection', () => {
     expect(next.screenId).toBe('screen:screencapturekit:222')
     expect(next.screenName).toBe('Display 2')
     expect(next.windowId).toBeUndefined()
+  })
+
+  it('revalidates a stale persisted Windows source immediately before a layout transaction', () => {
+    const stale: SourceSelection = {
+      screenId: 'screen:legacy-desktop:0',
+      screenName: 'Old display'
+    }
+    const devices: Device[] = [
+      {
+        id: 'screen:dxgi:00000000000003f1:2',
+        name: 'Display 1',
+        kind: 'screen',
+        status: 'available'
+      }
+    ]
+
+    expect(reconcileSourceSelectionForLayoutTransaction(stale, devices)).toMatchObject({
+      screenId: 'screen:dxgi:00000000000003f1:2',
+      screenName: 'Display 1',
+      windowId: undefined,
+      windowName: undefined
+    })
   })
 
   it('keeps a legacy avfoundation screen source as a recording fallback when no native capture source is available', () => {

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -1593,6 +1593,19 @@ export function reconcileSourceSelection(
   return nextSources
 }
 
+/**
+ * Layout commands revalidate at dispatch time because the device snapshot and
+ * React config update on separate ticks. Without this final pass, a persisted
+ * pre-DXGI Windows id can reach the backend after discovery already supplied a
+ * valid replacement, triggering the native-compositor source blocker.
+ */
+export function reconcileSourceSelectionForLayoutTransaction(
+  sources: SourceSelection,
+  devices: Device[]
+): SourceSelection {
+  return reconcileSourceSelection(sources, devices)
+}
+
 export function sourceSelectionChangeEvents(
   previous: SourceSelection,
   next: SourceSelection

--- a/apps/desktop/src/renderer/src/lib/native-preview-present-policy.test.ts
+++ b/apps/desktop/src/renderer/src/lib/native-preview-present-policy.test.ts
@@ -48,21 +48,60 @@ describe('native preview present policy', () => {
     ).toEqual({ kind: 'disabled' })
   })
 
-  it('suppresses frame polling during active recording states', () => {
+  it('keeps Windows proof-surface polling live in fallback compositor updates while recording', () => {
     expect(
-      buildNativePreviewCompositorUpdateParams(compositorStatus(), 'recording', {
-        nativePreviewRendererPollIntervalP95Ms: 17,
-        nativePreviewRendererPollRoundTripP95Ms: 4,
-        nativePreviewRendererPresentRoundTripP95Ms: 3,
-        nativePreviewRendererPollInFlightSkips: 2
-      })
+      buildNativePreviewCompositorUpdateParams(
+        compositorStatus(),
+        {
+          nativePreviewRendererPollIntervalP95Ms: 17,
+          nativePreviewRendererPollRoundTripP95Ms: 4,
+          nativePreviewRendererPresentRoundTripP95Ms: 3,
+          nativePreviewRendererPollInFlightSkips: 2
+        },
+        {
+          recordingActive: true,
+          windowOpen: true,
+          status: {
+            state: 'live',
+            transport: 'electron-proof-surface',
+            backing: 'electron-browser-window',
+            sourcePixelsPresent: true,
+            nativePreviewHostAttached: false,
+            nativePreviewHostKind: 'proof-surface'
+          }
+        }
+      )
     ).toMatchObject({
       framesRendered: 100,
-      suppressFramePolling: true,
+      suppressFramePolling: false,
       nativePreviewRendererPollIntervalP95Ms: 17,
       nativePreviewRendererPollRoundTripP95Ms: 4,
       nativePreviewRendererPresentRoundTripP95Ms: 3,
       nativePreviewRendererPollInFlightSkips: 2
+    })
+  })
+
+  it('still suppresses fallback polling when an attached CAMetalLayer owns recording pixels', () => {
+    expect(
+      buildNativePreviewCompositorUpdateParams(
+        compositorStatus(),
+        {},
+        {
+          recordingActive: true,
+          windowOpen: true,
+          status: {
+            state: 'live',
+            transport: 'native-surface',
+            backing: 'cametal-layer',
+            sourcePixelsPresent: true,
+            nativePreviewHostAttached: true,
+            nativePreviewHostKind: 'in-process'
+          }
+        }
+      )
+    ).toMatchObject({
+      framesRendered: 100,
+      suppressFramePolling: true
     })
   })
 

--- a/apps/desktop/src/renderer/src/lib/native-preview-present-policy.ts
+++ b/apps/desktop/src/renderer/src/lib/native-preview-present-policy.ts
@@ -4,7 +4,10 @@ import type {
   PreviewSurfaceStatus,
   RecordingStatus
 } from './backend'
-import { isActiveRecordingState } from './format'
+import {
+  nativePreviewFramePollingShouldSuppress,
+  type NativePreviewFramePollingSuppressionInput
+} from './native-preview-surface-lifecycle'
 
 export type NativePreviewRendererTimingFields = Pick<
   PreviewSurfaceCompositorUpdateParams,
@@ -93,17 +96,14 @@ export function decideNativePreviewCompositorPresent(input: {
 
 export function buildNativePreviewCompositorUpdateParams(
   status: CompositorStatus,
-  recordingState: RecordingStatus['state'],
-  rendererTimingFields: NativePreviewRendererTimingFields
+  rendererTimingFields: NativePreviewRendererTimingFields,
+  framePolling: NativePreviewFramePollingSuppressionInput
 ): PreviewSurfaceCompositorUpdateParams {
-  const suppressFramePolling = isActiveRecordingState(recordingState)
-  return suppressFramePolling
-    ? {
-        ...status,
-        suppressFramePolling: true,
-        ...rendererTimingFields
-      }
-    : { ...status, ...rendererTimingFields }
+  return {
+    ...status,
+    suppressFramePolling: nativePreviewFramePollingShouldSuppress(framePolling),
+    ...rendererTimingFields
+  }
 }
 
 export function pendingCompositorStatusSupersedes(

--- a/apps/desktop/src/renderer/src/lib/native-preview-surface-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/src/lib/native-preview-surface-lifecycle.test.ts
@@ -1,11 +1,63 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  nativePreviewFramePollingShouldSuppress,
   nativePreviewSurfaceSyncCanCommit,
   nativePreviewSurfaceSyncNeedsCreate
 } from './native-preview-surface-lifecycle'
 
 describe('native preview surface lifecycle', () => {
+  it('keeps the Windows proof surface polling while a recording is active', () => {
+    expect(
+      nativePreviewFramePollingShouldSuppress({
+        recordingActive: true,
+        windowOpen: true,
+        status: {
+          state: 'live',
+          transport: 'electron-proof-surface',
+          backing: 'electron-browser-window',
+          sourcePixelsPresent: true,
+          nativePreviewHostAttached: false,
+          nativePreviewHostKind: 'proof-surface'
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('suppresses the hidden proof poller when an attached CAMetalLayer owns pixels', () => {
+    expect(
+      nativePreviewFramePollingShouldSuppress({
+        recordingActive: true,
+        windowOpen: true,
+        status: {
+          state: 'live',
+          transport: 'native-surface',
+          backing: 'cametal-layer',
+          sourcePixelsPresent: true,
+          nativePreviewHostAttached: true,
+          nativePreviewHostKind: 'in-process'
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('always suppresses polling when the preview window is closed', () => {
+    expect(
+      nativePreviewFramePollingShouldSuppress({
+        recordingActive: false,
+        windowOpen: false,
+        status: {
+          state: 'live',
+          transport: 'electron-proof-surface',
+          backing: 'electron-browser-window',
+          sourcePixelsPresent: true,
+          nativePreviewHostAttached: false,
+          nativePreviewHostKind: 'proof-surface'
+        }
+      })
+    ).toBe(true)
+  })
+
   it('rejects an old sync after close even when the supervisor generation is unchanged', () => {
     expect(
       nativePreviewSurfaceSyncCanCommit(

--- a/apps/desktop/src/renderer/src/lib/native-preview-surface-lifecycle.ts
+++ b/apps/desktop/src/renderer/src/lib/native-preview-surface-lifecycle.ts
@@ -1,8 +1,50 @@
+import type { PreviewSurfaceStatus } from '../../../shared/backend'
+
 interface NativePreviewWindowLifecycleSnapshot {
   open: boolean
   supervisor: {
     generation: number
   }
+}
+
+type PreviewPresentationSnapshot = Pick<
+  PreviewSurfaceStatus,
+  | 'backing'
+  | 'nativePreviewHostAttached'
+  | 'nativePreviewHostKind'
+  | 'sourcePixelsPresent'
+  | 'state'
+  | 'transport'
+>
+
+export interface NativePreviewFramePollingSuppressionInput {
+  recordingActive: boolean
+  windowOpen: boolean
+  status: PreviewPresentationSnapshot
+}
+
+/**
+ * The Electron proof surface is Windows' production pixel transport, so an
+ * active recording must not suppress it. Only an attached native surface can
+ * make proof polling redundant while the preview window remains open.
+ */
+export function nativePreviewFramePollingShouldSuppress(
+  input: NativePreviewFramePollingSuppressionInput
+): boolean {
+  if (!input.windowOpen) {
+    return true
+  }
+
+  const status = input.status
+  const attachedNativePixels =
+    status.state === 'live' &&
+    status.transport === 'native-surface' &&
+    status.backing === 'cametal-layer' &&
+    status.sourcePixelsPresent === true &&
+    status.nativePreviewHostAttached === true &&
+    status.nativePreviewHostKind !== 'proof-surface'
+
+  return input.recordingActive && attachedNativePixels
 }
 
 /**

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1724,6 +1724,8 @@ export interface DiagnosticStats {
   encoderBridgeCompositorWaitP95Ms?: number
   /** P95 time spent submitting retained targets into VideoToolbox. */
   encoderBridgeVideoToolboxSubmitP95Ms?: number
+  /** P95 time the raw-video FIFO worker spent writing one frame into FFmpeg. */
+  encoderBridgeRawVideoFifoWriteP95Ms?: number
   /** P95 time spent writing completed VideoToolbox H.264 access units into FFmpeg. */
   encoderBridgeVideoToolboxFifoWriteP95Ms?: number
   /** P95 time spent waiting to enqueue encoded VideoToolbox frames for the FIFO writer. */

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -4924,6 +4924,7 @@ mod tests {
             bytes: vec![0, 0, 0, 255],
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now(),
         });
         assert!(!should_blocking_refresh_live_source(1, Some(&fresh_frame)));
@@ -4941,6 +4942,7 @@ mod tests {
             bytes: vec![0, 0, 0, 255],
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now()
                 - COMPOSITOR_LIVE_SOURCE_CONTENDED_RECOVERY_AFTER
                 - Duration::from_millis(1),
@@ -4963,6 +4965,7 @@ mod tests {
             bytes: vec![0, 0, 0, 255],
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now()
                 - COMPOSITOR_LIVE_SOURCE_STALE_RECOVERY_AFTER
                 - Duration::from_millis(1),
@@ -5439,6 +5442,7 @@ mod tests {
             bytes: [255, 0, 0, 255].repeat(16),
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now(),
         });
         let camera_frame = Arc::new(crate::frame_store::StoredFrame {
@@ -5450,6 +5454,7 @@ mod tests {
             bytes: [0, 0, 255, 255].repeat(16),
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now(),
         });
 
@@ -5543,6 +5548,7 @@ mod tests {
             bytes: [255, 0, 0, 255].repeat(100 * 100),
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now(),
         });
 
@@ -7647,6 +7653,7 @@ mod tests {
             bytes: [255, 0, 0, 255].repeat(100 * 100),
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now(),
         });
         let mut bytes = vec![0; raw_yuv420p_len(100, 100)];
@@ -7843,6 +7850,7 @@ mod tests {
             bytes: [0, 0, 255, 255].repeat(16),
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: Instant::now(),
         });
         let mut bytes = vec![0; raw_yuv420p_len(4, 4)];
@@ -8019,6 +8027,7 @@ mod tests {
             bytes: [0, 0, 255, 255].repeat(16),
             source_iosurface: None,
             source_pixel_buffer: None,
+            recycle_pool: None,
             captured_at: camera_captured_at,
         });
         let mut live_sources = CompositorLiveSources {

--- a/crates/videorc-backend/src/diagnostics.rs
+++ b/crates/videorc-backend/src/diagnostics.rs
@@ -176,6 +176,7 @@ pub fn idle_diagnostics() -> DiagnosticStats {
         encoder_bridge_separate_output_encoders_active: false,
         encoder_bridge_compositor_wait_p95_ms: None,
         encoder_bridge_video_toolbox_submit_p95_ms: None,
+        encoder_bridge_raw_video_fifo_write_p95_ms: None,
         encoder_bridge_video_toolbox_fifo_write_p95_ms: None,
         encoder_bridge_video_toolbox_fifo_enqueue_p95_ms: None,
         encoder_bridge_video_toolbox_fifo_enqueue_max_ms: None,
@@ -754,6 +755,7 @@ pub struct EncoderBridgeDiagnosticSnapshot {
     pub separate_output_encoders_active: bool,
     pub compositor_wait_p95_ms: Option<f64>,
     pub video_toolbox_submit_p95_ms: Option<f64>,
+    pub raw_video_fifo_write_p95_ms: Option<f64>,
     pub video_toolbox_fifo_write_p95_ms: Option<f64>,
     pub video_toolbox_fifo_enqueue_p95_ms: Option<f64>,
     pub video_toolbox_fifo_enqueue_max_ms: Option<f64>,
@@ -837,6 +839,7 @@ pub fn apply_encoder_bridge_stats(
     stats.encoder_bridge_separate_output_encoders_active = bridge.separate_output_encoders_active;
     stats.encoder_bridge_compositor_wait_p95_ms = bridge.compositor_wait_p95_ms;
     stats.encoder_bridge_video_toolbox_submit_p95_ms = bridge.video_toolbox_submit_p95_ms;
+    stats.encoder_bridge_raw_video_fifo_write_p95_ms = bridge.raw_video_fifo_write_p95_ms;
     stats.encoder_bridge_video_toolbox_fifo_write_p95_ms = bridge.video_toolbox_fifo_write_p95_ms;
     stats.encoder_bridge_video_toolbox_fifo_enqueue_p95_ms =
         bridge.video_toolbox_fifo_enqueue_p95_ms;
@@ -2219,6 +2222,7 @@ mod tests {
                 separate_output_encoders_active: false,
                 compositor_wait_p95_ms: None,
                 video_toolbox_submit_p95_ms: None,
+                raw_video_fifo_write_p95_ms: None,
                 video_toolbox_fifo_write_p95_ms: None,
                 video_toolbox_fifo_enqueue_p95_ms: None,
                 video_toolbox_fifo_enqueue_max_ms: None,
@@ -2303,6 +2307,7 @@ mod tests {
                 separate_output_encoders_active: true,
                 compositor_wait_p95_ms: Some(5.0),
                 video_toolbox_submit_p95_ms: Some(2.0),
+                raw_video_fifo_write_p95_ms: Some(11.0),
                 video_toolbox_fifo_write_p95_ms: Some(3.0),
                 video_toolbox_fifo_enqueue_p95_ms: Some(7.0),
                 video_toolbox_fifo_enqueue_max_ms: Some(14.0),
@@ -2415,6 +2420,10 @@ mod tests {
             4096
         );
         assert!(lagging.encoder_bridge_separate_output_encoders_active);
+        assert_eq!(
+            lagging.encoder_bridge_raw_video_fifo_write_p95_ms,
+            Some(11.0)
+        );
         assert_eq!(lagging.encoder_bridge_deadline_lag_p95_ms, Some(4.0));
         assert_eq!(lagging.encoder_bridge_deadline_lag_max_ms, Some(9.0));
         assert_eq!(
@@ -2459,6 +2468,8 @@ mod tests {
             lagging.encoder_bridge_stream_video_toolbox_fifo_enqueue_max_ms,
             Some(18.0)
         );
+        let wire = serde_json::to_value(&lagging).expect("serialize diagnostics");
+        assert_eq!(wire["encoderBridgeRawVideoFifoWriteP95Ms"], 11.0);
         assert_eq!(lagging.bottleneck, DiagnosticBottleneck::Encoder);
     }
 

--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc as std_mpsc;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::thread;
 use std::time::Instant;
 
@@ -59,6 +59,7 @@ const STREAM_OUTPUT_QUEUE_COALESCE_FRAMES: usize = 4;
 const STREAM_OUTPUT_QUEUE_COALESCE_AGE: Duration = Duration::from_millis(100);
 const STREAM_OUTPUT_QUEUE_MAX_FRAMES: usize = 8;
 const STREAM_OUTPUT_QUEUE_MAX_AGE: Duration = Duration::from_millis(150);
+const RAW_VIDEO_FIFO_QUEUE_MAX_FRAMES: usize = 4;
 const VIDEOTOOLBOX_OUTPUT_DRAIN_MAX_FRAMES_PER_TICK: usize = 8;
 const VIDEOTOOLBOX_PROBE_ENV: &str = "VIDEORC_ENCODER_BRIDGE_VIDEOTOOLBOX_PROBE";
 
@@ -309,6 +310,8 @@ struct EncoderBridgeRuntimeStats {
     video_toolbox_output_encode_ms: Option<u64>,
     compositor_wait_p95_ms: Option<f64>,
     video_toolbox_submit_p95_ms: Option<f64>,
+    /// P95 time the raw-video FIFO worker spent writing one frame into FFmpeg.
+    raw_video_fifo_write_p95_ms: Option<f64>,
     video_toolbox_fifo_write_p95_ms: Option<f64>,
     video_toolbox_fifo_enqueue_p95_ms: Option<f64>,
     video_toolbox_fifo_enqueue_max_ms: Option<f64>,
@@ -357,9 +360,11 @@ fn classify_bridge_frame(last_fed: Option<u64>, fed: Option<u64>) -> BridgeFrame
     }
 }
 
-/// Lag past which the schedule stops trying to catch up frame-by-frame and
-/// re-anchors with an EXPLICIT, counted gap (app nap, display sleep). Below
-/// this, late loops converge by feeding repeats with a zero fresh-frame wait.
+/// Lag past which the schedule stops trying to catch up frame-by-frame. A
+/// timestamped output re-anchors with an explicit counted gap; untimestamped
+/// rawvideo fails explicitly because neither skipping nor bursting frames is
+/// safe (app nap, display sleep). Below this, late loops converge by feeding
+/// repeats with a zero fresh-frame wait.
 const ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD: Duration = Duration::from_secs(2);
 
 /// Per-tick schedule decision (plan 026). The writer schedule is ABSOLUTE
@@ -378,25 +383,48 @@ struct BridgeTickPlan {
     /// Whole intervals dropped from the schedule as an explicit stall gap.
     /// Zero in every healthy tick.
     reanchor_skipped_intervals: u64,
+    /// Untimestamped rawvideo cannot represent a wall-time gap without either
+    /// compressing the recording or bursting stale frames into the encoder.
+    /// Stop that output explicitly when the bridge misses the bounded stall
+    /// threshold instead of manufacturing a glitchy catch-up burst.
+    fail_untimestamped_output: bool,
 }
 
-fn plan_bridge_tick(lag: Duration, frame_interval: Duration) -> BridgeTickPlan {
+fn plan_bridge_tick(
+    video_output: EncoderBridgeVideoOutput,
+    lag: Duration,
+    frame_interval: Duration,
+) -> BridgeTickPlan {
     if frame_interval.is_zero() {
         return BridgeTickPlan {
             skip_fresh_wait: false,
             reanchor_skipped_intervals: 0,
+            fail_untimestamped_output: false,
         };
     }
-    if lag >= ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD {
+    if video_output == EncoderBridgeVideoOutput::RawYuv420p
+        && lag >= ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD
+    {
+        return BridgeTickPlan {
+            skip_fresh_wait: false,
+            reanchor_skipped_intervals: 0,
+            fail_untimestamped_output: true,
+        };
+    }
+    if video_output != EncoderBridgeVideoOutput::RawYuv420p
+        && lag >= ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD
+    {
         let skipped = (lag.as_nanos() / frame_interval.as_nanos()) as u64;
         return BridgeTickPlan {
             skip_fresh_wait: true,
             reanchor_skipped_intervals: skipped,
+            fail_untimestamped_output: false,
         };
     }
     BridgeTickPlan {
         skip_fresh_wait: lag > Duration::ZERO,
         reanchor_skipped_intervals: 0,
+        fail_untimestamped_output: false,
     }
 }
 
@@ -422,9 +450,27 @@ fn videotoolbox_fresh_frame_grace(frame_interval: Duration) -> Duration {
     frame_interval.saturating_sub(VIDEOTOOLBOX_FRESH_FRAME_HEADROOM)
 }
 
+fn record_encoder_bridge_terminal_failure(
+    signal: &Arc<StdMutex<Option<String>>>,
+    message: impl Into<String>,
+) -> String {
+    let mut failure = signal
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    failure.get_or_insert_with(|| message.into()).clone()
+}
+
+fn read_encoder_bridge_terminal_failure(signal: &Arc<StdMutex<Option<String>>>) -> Option<String> {
+    signal
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+}
+
 #[derive(Debug)]
 pub struct EncoderBridgeRecordingSession {
     stop: Arc<AtomicBool>,
+    terminal_failure: Arc<StdMutex<Option<String>>>,
     fifo_path: PathBuf,
     writer: Option<thread::JoinHandle<()>>,
     diagnostics_task: Option<TokioJoinHandle<()>>,
@@ -433,6 +479,15 @@ pub struct EncoderBridgeRecordingSession {
 impl EncoderBridgeRecordingSession {
     pub fn stop(&self) {
         self.stop.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns the first terminal media-path failure reported by the bridge.
+    ///
+    /// FFmpeg can exit successfully after the bridge closes its FIFO at a
+    /// complete raw-video frame boundary. Recording finalization must inspect
+    /// this signal so that a shortened file is not published as successful.
+    pub fn terminal_failure(&self) -> Option<String> {
+        read_encoder_bridge_terminal_failure(&self.terminal_failure)
     }
 }
 
@@ -646,7 +701,9 @@ pub fn start_synthetic_recording_bridge(
 ) -> Result<EncoderBridgeRecordingSession> {
     let byte_len = raw_yuv420p_len(width, height)?;
     let stop = Arc::new(AtomicBool::new(false));
+    let terminal_failure = Arc::new(StdMutex::new(None));
     let writer_stop = stop.clone();
+    let writer_terminal_failure = terminal_failure.clone();
     let writer_fifo_path = fifo_path.clone();
     let (diagnostics_tx, mut diagnostics_rx) =
         watch::channel::<Option<EncoderBridgeWriterEvent>>(None);
@@ -682,6 +739,7 @@ pub fn start_synthetic_recording_bridge(
                 bitrate_kbps,
                 diagnostics_context,
                 stop: writer_stop,
+                terminal_failure: writer_terminal_failure,
                 diagnostics_tx,
                 video_epoch,
             };
@@ -691,6 +749,7 @@ pub fn start_synthetic_recording_bridge(
 
     Ok(EncoderBridgeRecordingSession {
         stop,
+        terminal_failure,
         fifo_path,
         writer: Some(writer),
         diagnostics_task: Some(diagnostics_task),
@@ -867,6 +926,7 @@ struct SyntheticRecordingWriterParams {
     height: u32,
     byte_len: usize,
     stop: Arc<AtomicBool>,
+    terminal_failure: Arc<StdMutex<Option<String>>>,
     fifo_path: PathBuf,
     frame_store: Option<CompositorFrameStore>,
     video_output: EncoderBridgeVideoOutput,
@@ -893,6 +953,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
         height,
         byte_len,
         stop,
+        terminal_failure,
         fifo_path,
         frame_store,
         video_output,
@@ -902,32 +963,36 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
         video_epoch,
     } = params;
     let output_queue_policy = encoder_bridge_output_queue_policy(diagnostics_context);
-    let fifo =
-        match open_recording_fifo_writer(&fifo_path, &stop, video_output.uses_video_toolbox()) {
-            Ok(fifo) => fifo,
-            Err(error) => {
-                emit_encoder_bridge_diagnostics_from_thread(
-                    &diagnostics_tx,
-                    session_id.clone(),
-                    target_fps,
-                    EncoderBridgeRuntimeStats {
-                        queue_depth: 0,
-                        input_fps: None,
-                        dropped_frames: 0,
-                        encoder_speed: None,
-                        ..Default::default()
-                    },
-                    diagnostics_context,
-                    Some(format!(
-                        "Could not open recording encoder bridge FIFO {}: {error}",
-                        fifo_path.display()
-                    )),
-                );
-                return;
-            }
-        };
+    let fifo = match open_recording_fifo_writer(&fifo_path, &stop, true) {
+        Ok(fifo) => fifo,
+        Err(error) => {
+            let error = record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "Could not open recording encoder bridge FIFO {}: {error}",
+                    fifo_path.display()
+                ),
+            );
+            emit_encoder_bridge_diagnostics_from_thread(
+                &diagnostics_tx,
+                session_id.clone(),
+                target_fps,
+                EncoderBridgeRuntimeStats {
+                    queue_depth: 0,
+                    input_fps: None,
+                    dropped_frames: 0,
+                    encoder_speed: None,
+                    ..Default::default()
+                },
+                diagnostics_context,
+                Some(error),
+            );
+            return;
+        }
+    };
     #[cfg(target_os = "macos")]
-    let (mut raw_fifo, mut video_toolbox_fifo_writer) = if video_output.uses_video_toolbox() {
+    let (mut raw_fifo_writer, mut video_toolbox_fifo_writer) = if video_output.uses_video_toolbox()
+    {
         (
             None,
             Some(VideoToolboxFifoWriter::start(
@@ -938,10 +1003,23 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             )),
         )
     } else {
-        (Some(fifo), None)
+        (
+            Some(RawVideoFifoWriter::start(
+                fifo,
+                output_queue_policy,
+                stop.clone(),
+                terminal_failure.clone(),
+            )),
+            None,
+        )
     };
     #[cfg(not(target_os = "macos"))]
-    let mut raw_fifo = Some(fifo);
+    let mut raw_fifo_writer = Some(RawVideoFifoWriter::start(
+        fifo,
+        output_queue_policy,
+        stop.clone(),
+        terminal_failure.clone(),
+    ));
     let frame_interval = Duration::from_secs_f64(1.0 / f64::from(target_fps.max(1)));
     let source = SyntheticMovingSource;
     let mut bytes = vec![0; byte_len];
@@ -969,6 +1047,9 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
     let mut max_video_toolbox_output_encode_ms: Option<u64> = None;
     let mut pending_video_toolbox_output_frames = 0_u64;
     let mut pending_video_toolbox_fifo_frames = 0_u64;
+    let mut pending_raw_fifo_frames = 0_u64;
+    let mut pending_raw_fifo_started_at = VecDeque::<Instant>::new();
+    let mut recycled_raw_buffers = Vec::<Vec<u8>>::new();
     #[cfg(target_os = "macos")]
     let mut pending_video_toolbox_output_started_at = HashMap::<u64, Instant>::new();
     #[cfg(target_os = "macos")]
@@ -978,16 +1059,26 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
     #[cfg(target_os = "macos")]
     macro_rules! oldest_output_queue_age {
         () => {
-            oldest_pending_video_toolbox_frame_age(
-                &pending_video_toolbox_output_started_at,
-                &pending_video_toolbox_fifo_started_at,
-            )
+            if matches!(video_output, EncoderBridgeVideoOutput::RawYuv420p) {
+                pending_raw_fifo_started_at
+                    .front()
+                    .copied()
+                    .map(|started_at| started_at.elapsed())
+            } else {
+                oldest_pending_video_toolbox_frame_age(
+                    &pending_video_toolbox_output_started_at,
+                    &pending_video_toolbox_fifo_started_at,
+                )
+            }
         };
     }
     #[cfg(not(target_os = "macos"))]
     macro_rules! oldest_output_queue_age {
         () => {
-            None
+            pending_raw_fifo_started_at
+                .front()
+                .copied()
+                .map(|started_at| started_at.elapsed())
         };
     }
     #[cfg(target_os = "macos")]
@@ -999,12 +1090,13 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
     #[cfg(not(target_os = "macos"))]
     macro_rules! oldest_output_queue_age_ms {
         () => {
-            None
+            oldest_output_queue_age!().map(|age| age.as_millis() as u64)
         };
     }
     let mut compositor_wait_times_ms = Vec::with_capacity(128);
     let mut video_toolbox_submit_times_ms = Vec::with_capacity(128);
     let mut video_toolbox_fifo_write_times_ms = Vec::with_capacity(128);
+    let mut raw_video_fifo_write_times_ms = Vec::with_capacity(128);
     let mut video_toolbox_fifo_enqueue_times_ms = Vec::with_capacity(128);
     let mut max_video_toolbox_fifo_enqueue_ms: Option<f64> = None;
     let mut writer_loop_times_ms = Vec::with_capacity(128);
@@ -1026,6 +1118,10 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
     if video_output.uses_video_toolbox()
         && let Err(error) = video_toolbox_probe.prepare_session()
     {
+        let error = record_encoder_bridge_terminal_failure(
+            &terminal_failure,
+            format!("Could not prepare VideoToolbox encoder bridge output: {error}"),
+        );
         emit_encoder_bridge_diagnostics_from_thread(
             &diagnostics_tx,
             session_id.clone(),
@@ -1038,9 +1134,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                 ..Default::default()
             },
             diagnostics_context,
-            Some(format!(
-                "Could not prepare VideoToolbox encoder bridge output: {error}"
-            )),
+            Some(error),
         );
         return;
     }
@@ -1054,6 +1148,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
     let mut first_frame_wait_sequence =
         initial_bridge_wait_sequence(video_output, frame_store.as_ref());
     let mut consecutive_repeated_frames = 0_u64;
+    let mut terminal_writer_error = None;
 
     macro_rules! current_runtime_stats {
         ($depth:expr) => {
@@ -1086,6 +1181,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                 video_toolbox_output_encode_ms: max_video_toolbox_output_encode_ms,
                 compositor_wait_p95_ms: p95_ms(&compositor_wait_times_ms),
                 video_toolbox_submit_p95_ms: p95_ms(&video_toolbox_submit_times_ms),
+                raw_video_fifo_write_p95_ms: p95_ms(&raw_video_fifo_write_times_ms),
                 video_toolbox_fifo_write_p95_ms: p95_ms(&video_toolbox_fifo_write_times_ms),
                 video_toolbox_fifo_enqueue_p95_ms: p95_ms(&video_toolbox_fifo_enqueue_times_ms),
                 video_toolbox_fifo_enqueue_max_ms: max_video_toolbox_fifo_enqueue_ms,
@@ -1101,6 +1197,37 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
     }
 
     while !stop.load(Ordering::Relaxed) {
+        if let Some(writer) = raw_fifo_writer.as_mut()
+            && let Err(error) = drain_raw_video_fifo_writer_results(
+                writer,
+                &mut pending_raw_fifo_frames,
+                &mut pending_raw_fifo_started_at,
+                &mut recycled_raw_buffers,
+                &mut raw_video_copied_frames,
+                &mut metal_target_frames,
+                &mut metal_target_copied_frames,
+                &mut metal_target_handle_frames,
+                &mut raw_video_fifo_write_times_ms,
+            )
+        {
+            let error = record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "{} raw-video encoder output stopped: {error}",
+                    encoder_bridge_output_role_label(output_queue_policy.role)
+                ),
+            );
+            terminal_writer_error = Some(error.clone());
+            emit_encoder_bridge_diagnostics_from_thread(
+                &diagnostics_tx,
+                session_id.clone(),
+                target_fps,
+                current_runtime_stats!(pending_raw_fifo_frames),
+                diagnostics_context,
+                Some(error),
+            );
+            break;
+        }
         let loop_started_at = Instant::now();
         let now = Instant::now();
         let tick_lag = now.saturating_duration_since(next_frame_at);
@@ -1111,7 +1238,27 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                 Some(max_deadline_lag_ms.map_or(lag_ms, |current| current.max(lag_ms)));
             late_deadline_ticks = late_deadline_ticks.saturating_add(1);
         }
-        let tick_plan = plan_bridge_tick(tick_lag, frame_interval);
+        let tick_plan = plan_bridge_tick(video_output, tick_lag, frame_interval);
+        if tick_plan.fail_untimestamped_output {
+            let error = record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "{} raw-video encoder schedule stalled for {}ms; stopping instead of bursting untimestamped frames into the recording",
+                    encoder_bridge_output_role_label(output_queue_policy.role),
+                    tick_lag.as_millis()
+                ),
+            );
+            terminal_writer_error = Some(error.clone());
+            emit_encoder_bridge_diagnostics_from_thread(
+                &diagnostics_tx,
+                session_id.clone(),
+                target_fps,
+                current_runtime_stats!(pending_raw_fifo_frames),
+                diagnostics_context,
+                Some(error),
+            );
+            break;
+        }
         if tick_plan.reanchor_skipped_intervals > 0 {
             // Pathological stall: drop whole intervals as an EXPLICIT gap. The
             // schedule stays wall-true (sequence advances by the same count,
@@ -1186,7 +1333,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
         queue_depth = if video_output.uses_video_toolbox() {
             pending_video_toolbox_output_frames.saturating_add(pending_video_toolbox_fifo_frames)
         } else {
-            0
+            pending_raw_fifo_frames
         };
         let admission = if pipeline_error.is_some() || !video_output.uses_video_toolbox() {
             EncoderBridgePreEncodeAdmission::Submit
@@ -1219,6 +1366,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                     compositor_wait_times_ms.clear();
                     video_toolbox_submit_times_ms.clear();
                     video_toolbox_fifo_write_times_ms.clear();
+                    raw_video_fifo_write_times_ms.clear();
                     video_toolbox_fifo_enqueue_times_ms.clear();
                     writer_loop_times_ms.clear();
                     writer_sleep_times_ms.clear();
@@ -1315,6 +1463,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                             video_toolbox_output_encode_ms: max_video_toolbox_output_encode_ms,
                             compositor_wait_p95_ms: p95_ms(&compositor_wait_times_ms),
                             video_toolbox_submit_p95_ms: p95_ms(&video_toolbox_submit_times_ms),
+                            raw_video_fifo_write_p95_ms: p95_ms(&raw_video_fifo_write_times_ms),
                             video_toolbox_fifo_write_p95_ms: p95_ms(
                                 &video_toolbox_fifo_write_times_ms,
                             ),
@@ -1401,28 +1550,35 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
         queue_depth = if video_output.uses_video_toolbox() {
             pending_video_toolbox_output_frames.saturating_add(pending_video_toolbox_fifo_frames)
         } else {
-            1
+            pending_raw_fifo_frames
         };
         let write_result = if let Some(error) = pipeline_error {
             Err(error)
         } else {
             match video_output {
-                EncoderBridgeVideoOutput::RawYuv420p => raw_fifo
-                    .as_mut()
-                    .expect("raw encoder bridge FIFO must be open")
-                    .write_all(&bytes)
-                    .map(|()| {
-                        raw_video_copied_frames = raw_video_copied_frames.saturating_add(1);
-                        if wrote_metal_target_frame {
-                            metal_target_frames = metal_target_frames.saturating_add(1);
-                            metal_target_copied_frames =
-                                metal_target_copied_frames.saturating_add(1);
-                        }
-                        if wrote_metal_target_handle {
-                            metal_target_handle_frames =
-                                metal_target_handle_frames.saturating_add(1);
-                        }
-                    }),
+                EncoderBridgeVideoOutput::RawYuv420p => {
+                    let submitted_at = Instant::now();
+                    let next_buffer = recycled_raw_buffers
+                        .pop()
+                        .unwrap_or_else(|| vec![0; byte_len]);
+                    let frame_bytes = std::mem::replace(&mut bytes, next_buffer);
+                    raw_fifo_writer
+                        .as_ref()
+                        .expect("raw encoder bridge FIFO writer must be running")
+                        .enqueue(
+                            QueuedRawVideoFrame {
+                                bytes: frame_bytes,
+                                submitted_at,
+                                had_metal_target: wrote_metal_target_frame,
+                                had_metal_export_handle: wrote_metal_target_handle,
+                            },
+                            &mut output_queue_capacity_pressure_events,
+                        )
+                        .map(|()| {
+                            pending_raw_fifo_frames = pending_raw_fifo_frames.saturating_add(1);
+                            pending_raw_fifo_started_at.push_back(submitted_at);
+                        })
+                }
                 EncoderBridgeVideoOutput::VideoToolboxH264AnnexB
                 | EncoderBridgeVideoOutput::VideoToolboxH264MpegTs => {
                     #[cfg(target_os = "macos")]
@@ -1490,6 +1646,14 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             }
         };
         if let Err(error) = write_result {
+            let error = record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "{} encoder output stopped: {error}",
+                    encoder_bridge_output_role_label(output_queue_policy.role)
+                ),
+            );
+            terminal_writer_error = Some(error.clone());
             emit_encoder_bridge_diagnostics_from_thread(
                 &diagnostics_tx,
                 session_id.clone(),
@@ -1523,6 +1687,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                     video_toolbox_output_encode_ms: max_video_toolbox_output_encode_ms,
                     compositor_wait_p95_ms: p95_ms(&compositor_wait_times_ms),
                     video_toolbox_submit_p95_ms: p95_ms(&video_toolbox_submit_times_ms),
+                    raw_video_fifo_write_p95_ms: p95_ms(&raw_video_fifo_write_times_ms),
                     video_toolbox_fifo_write_p95_ms: p95_ms(&video_toolbox_fifo_write_times_ms),
                     video_toolbox_fifo_enqueue_p95_ms: p95_ms(&video_toolbox_fifo_enqueue_times_ms),
                     video_toolbox_fifo_enqueue_max_ms: max_video_toolbox_fifo_enqueue_ms,
@@ -1535,10 +1700,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                     schedule_skipped_ms,
                 },
                 diagnostics_context,
-                Some(format!(
-                    "{} encoder output stopped: {error}",
-                    encoder_bridge_output_role_label(output_queue_policy.role)
-                )),
+                Some(error),
             );
             break;
         }
@@ -1573,6 +1735,14 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                 )
             })
         {
+            let error = record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "{} VideoToolbox output stopped: {error}",
+                    encoder_bridge_output_role_label(output_queue_policy.role)
+                ),
+            );
+            terminal_writer_error = Some(error.clone());
             emit_encoder_bridge_diagnostics_from_thread(
                 &diagnostics_tx,
                 session_id.clone(),
@@ -1607,6 +1777,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                     video_toolbox_output_encode_ms: max_video_toolbox_output_encode_ms,
                     compositor_wait_p95_ms: p95_ms(&compositor_wait_times_ms),
                     video_toolbox_submit_p95_ms: p95_ms(&video_toolbox_submit_times_ms),
+                    raw_video_fifo_write_p95_ms: p95_ms(&raw_video_fifo_write_times_ms),
                     video_toolbox_fifo_write_p95_ms: p95_ms(&video_toolbox_fifo_write_times_ms),
                     video_toolbox_fifo_enqueue_p95_ms: p95_ms(&video_toolbox_fifo_enqueue_times_ms),
                     video_toolbox_fifo_enqueue_max_ms: max_video_toolbox_fifo_enqueue_ms,
@@ -1619,17 +1790,45 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                     schedule_skipped_ms,
                 },
                 diagnostics_context,
-                Some(format!(
-                    "{} VideoToolbox output stopped: {error}",
+                Some(error),
+            );
+            break;
+        }
+        if let Some(writer) = raw_fifo_writer.as_mut()
+            && let Err(error) = drain_raw_video_fifo_writer_results(
+                writer,
+                &mut pending_raw_fifo_frames,
+                &mut pending_raw_fifo_started_at,
+                &mut recycled_raw_buffers,
+                &mut raw_video_copied_frames,
+                &mut metal_target_frames,
+                &mut metal_target_copied_frames,
+                &mut metal_target_handle_frames,
+                &mut raw_video_fifo_write_times_ms,
+            )
+        {
+            let error = record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "{} raw-video encoder output stopped: {error}",
                     encoder_bridge_output_role_label(output_queue_policy.role)
-                )),
+                ),
+            );
+            terminal_writer_error = Some(error.clone());
+            emit_encoder_bridge_diagnostics_from_thread(
+                &diagnostics_tx,
+                session_id.clone(),
+                target_fps,
+                current_runtime_stats!(pending_raw_fifo_frames),
+                diagnostics_context,
+                Some(error),
             );
             break;
         }
         queue_depth = if video_output.uses_video_toolbox() {
             pending_video_toolbox_output_frames.saturating_add(pending_video_toolbox_fifo_frames)
         } else {
-            0
+            pending_raw_fifo_frames
         };
         writer_active_times_ms.push(active_started_at.elapsed().as_secs_f64() * 1000.0);
         writer_loop_times_ms.push(loop_started_at.elapsed().as_secs_f64() * 1000.0);
@@ -1677,6 +1876,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                     video_toolbox_output_encode_ms: max_video_toolbox_output_encode_ms,
                     compositor_wait_p95_ms: p95_ms(&compositor_wait_times_ms),
                     video_toolbox_submit_p95_ms: p95_ms(&video_toolbox_submit_times_ms),
+                    raw_video_fifo_write_p95_ms: p95_ms(&raw_video_fifo_write_times_ms),
                     video_toolbox_fifo_write_p95_ms: p95_ms(&video_toolbox_fifo_write_times_ms),
                     video_toolbox_fifo_enqueue_p95_ms: p95_ms(&video_toolbox_fifo_enqueue_times_ms),
                     video_toolbox_fifo_enqueue_max_ms: max_video_toolbox_fifo_enqueue_ms,
@@ -1696,6 +1896,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             compositor_wait_times_ms.clear();
             video_toolbox_submit_times_ms.clear();
             video_toolbox_fifo_write_times_ms.clear();
+            raw_video_fifo_write_times_ms.clear();
             video_toolbox_fifo_enqueue_times_ms.clear();
             writer_loop_times_ms.clear();
             writer_sleep_times_ms.clear();
@@ -1765,9 +1966,27 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             pending_video_toolbox_output_frames.saturating_add(pending_video_toolbox_fifo_frames);
     }
 
-    if let Some(mut fifo) = raw_fifo.take() {
-        let _ = fifo.flush();
-        drop(fifo);
+    if let Some(writer) = raw_fifo_writer.as_mut() {
+        writer.close_and_join();
+        if let Err(error) = drain_raw_video_fifo_writer_results(
+            writer,
+            &mut pending_raw_fifo_frames,
+            &mut pending_raw_fifo_started_at,
+            &mut recycled_raw_buffers,
+            &mut raw_video_copied_frames,
+            &mut metal_target_frames,
+            &mut metal_target_copied_frames,
+            &mut metal_target_handle_frames,
+            &mut raw_video_fifo_write_times_ms,
+        ) {
+            terminal_writer_error.get_or_insert_with(|| {
+                format!(
+                    "{} raw-video encoder output stopped while draining: {error}",
+                    encoder_bridge_output_role_label(output_queue_policy.role)
+                )
+            });
+        }
+        queue_depth = pending_raw_fifo_frames;
     }
     emit_encoder_bridge_diagnostics_from_thread(
         &diagnostics_tx,
@@ -1802,6 +2021,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             video_toolbox_output_encode_ms: max_video_toolbox_output_encode_ms,
             compositor_wait_p95_ms: p95_ms(&compositor_wait_times_ms),
             video_toolbox_submit_p95_ms: p95_ms(&video_toolbox_submit_times_ms),
+            raw_video_fifo_write_p95_ms: p95_ms(&raw_video_fifo_write_times_ms),
             video_toolbox_fifo_write_p95_ms: p95_ms(&video_toolbox_fifo_write_times_ms),
             video_toolbox_fifo_enqueue_p95_ms: p95_ms(&video_toolbox_fifo_enqueue_times_ms),
             video_toolbox_fifo_enqueue_max_ms: max_video_toolbox_fifo_enqueue_ms,
@@ -1814,7 +2034,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             schedule_skipped_ms,
         },
         diagnostics_context,
-        None,
+        terminal_writer_error,
     );
 }
 
@@ -2031,6 +2251,216 @@ impl EncoderBridgeVideoToolboxProbe {
     }
 }
 
+struct RawVideoFifoWriter {
+    frame_tx: Option<std_mpsc::SyncSender<QueuedRawVideoFrame>>,
+    result_rx: std_mpsc::Receiver<RawVideoFifoWriterResult>,
+    join: Option<thread::JoinHandle<()>>,
+    max_frames: usize,
+    role: EncoderBridgeOutputRole,
+}
+
+struct QueuedRawVideoFrame {
+    bytes: Vec<u8>,
+    submitted_at: Instant,
+    had_metal_target: bool,
+    had_metal_export_handle: bool,
+}
+
+#[derive(Debug)]
+enum RawVideoFifoWriterResult {
+    FrameWritten {
+        buffer: Vec<u8>,
+        write_ms: f64,
+        had_metal_target: bool,
+        had_metal_export_handle: bool,
+    },
+    Error {
+        buffer: Option<Vec<u8>>,
+        message: String,
+    },
+}
+
+impl RawVideoFifoWriter {
+    fn start(
+        fifo: File,
+        policy: EncoderBridgeOutputQueuePolicy,
+        stop: Arc<AtomicBool>,
+        terminal_failure: Arc<StdMutex<Option<String>>>,
+    ) -> Self {
+        let max_frames = policy.max_frames.min(RAW_VIDEO_FIFO_QUEUE_MAX_FRAMES);
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(max_frames);
+        // Queue + one in-flight result + one terminal flush result.
+        let (result_tx, result_rx) = std_mpsc::sync_channel(max_frames + 2);
+        let join = thread::Builder::new()
+            .name(format!("videorc-{:?}-raw-video-fifo-writer", policy.role))
+            .spawn(move || {
+                run_raw_video_fifo_writer_loop(
+                    fifo,
+                    frame_rx,
+                    result_tx,
+                    stop,
+                    policy.max_age,
+                    terminal_failure,
+                    policy.role,
+                );
+            })
+            .expect("could not start raw-video FIFO writer thread");
+        Self {
+            frame_tx: Some(frame_tx),
+            result_rx,
+            join: Some(join),
+            max_frames,
+            role: policy.role,
+        }
+    }
+
+    fn enqueue(
+        &self,
+        frame: QueuedRawVideoFrame,
+        capacity_pressure_events: &mut u64,
+    ) -> io::Result<()> {
+        let tx = self.frame_tx.as_ref().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "raw-video FIFO writer closed")
+        })?;
+        match offer_preserving_output_frame(tx, frame) {
+            Ok(PreservingOutputFrameOffer::Enqueued) => Ok(()),
+            Ok(PreservingOutputFrameOffer::CapacityPressure(_frame)) => {
+                *capacity_pressure_events = capacity_pressure_events.saturating_add(1);
+                Err(io::Error::other(format!(
+                    "{} raw-video FIFO reached its {}-frame safety ceiling; stopping this output because untimestamped raw frames cannot be dropped or coalesced safely",
+                    encoder_bridge_output_role_label(self.role),
+                    self.max_frames
+                )))
+            }
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "raw-video FIFO writer stopped",
+            )),
+        }
+    }
+
+    fn try_recv_result(&mut self) -> Option<RawVideoFifoWriterResult> {
+        self.result_rx.try_recv().ok()
+    }
+
+    fn close_and_join(&mut self) {
+        self.frame_tx.take();
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+impl Drop for RawVideoFifoWriter {
+    fn drop(&mut self) {
+        self.close_and_join();
+    }
+}
+
+fn run_raw_video_fifo_writer_loop<W: StdWrite>(
+    mut sink: W,
+    frame_rx: std_mpsc::Receiver<QueuedRawVideoFrame>,
+    result_tx: std_mpsc::SyncSender<RawVideoFifoWriterResult>,
+    stop: Arc<AtomicBool>,
+    max_frame_age: Duration,
+    terminal_failure: Arc<StdMutex<Option<String>>>,
+    role: EncoderBridgeOutputRole,
+) {
+    while let Ok(frame) = frame_rx.recv() {
+        let write_started_at = Instant::now();
+        let deadline = frame.submitted_at + max_frame_age;
+        // Once any raw frame bytes reach FFmpeg, stopping mid-frame would
+        // misalign every following YUV plane and can corrupt the final file.
+        // Finish the in-flight frame within its existing age deadline; closing
+        // the queue prevents any new work from being admitted during stop.
+        match write_all_until(&mut sink, &frame.bytes, &stop, deadline, false) {
+            Ok(()) => {
+                let _ = result_tx.send(RawVideoFifoWriterResult::FrameWritten {
+                    buffer: frame.bytes,
+                    write_ms: write_started_at.elapsed().as_secs_f64() * 1000.0,
+                    had_metal_target: frame.had_metal_target,
+                    had_metal_export_handle: frame.had_metal_export_handle,
+                });
+            }
+            Err(error) => {
+                let message = record_encoder_bridge_terminal_failure(
+                    &terminal_failure,
+                    format!(
+                        "{} raw-video encoder output stopped: {error}",
+                        encoder_bridge_output_role_label(role)
+                    ),
+                );
+                let _ = result_tx.send(RawVideoFifoWriterResult::Error {
+                    buffer: Some(frame.bytes),
+                    message,
+                });
+                return;
+            }
+        }
+    }
+    if !stop.load(Ordering::Relaxed)
+        && let Err(error) = sink.flush()
+    {
+        let message = record_encoder_bridge_terminal_failure(
+            &terminal_failure,
+            format!(
+                "{} raw-video encoder output flush failed: {error}",
+                encoder_bridge_output_role_label(role)
+            ),
+        );
+        let _ = result_tx.send(RawVideoFifoWriterResult::Error {
+            buffer: None,
+            message,
+        });
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn drain_raw_video_fifo_writer_results(
+    fifo_writer: &mut RawVideoFifoWriter,
+    pending_frames: &mut u64,
+    pending_started_at: &mut VecDeque<Instant>,
+    recycled_buffers: &mut Vec<Vec<u8>>,
+    raw_video_copied_frames: &mut u64,
+    metal_target_frames: &mut u64,
+    metal_target_copied_frames: &mut u64,
+    metal_target_handle_frames: &mut u64,
+    fifo_write_times_ms: &mut Vec<f64>,
+) -> io::Result<()> {
+    while let Some(result) = fifo_writer.try_recv_result() {
+        match result {
+            RawVideoFifoWriterResult::FrameWritten {
+                buffer,
+                write_ms,
+                had_metal_target,
+                had_metal_export_handle,
+            } => {
+                *pending_frames = pending_frames.saturating_sub(1);
+                pending_started_at.pop_front();
+                *raw_video_copied_frames = raw_video_copied_frames.saturating_add(1);
+                if had_metal_target {
+                    *metal_target_frames = metal_target_frames.saturating_add(1);
+                    *metal_target_copied_frames = metal_target_copied_frames.saturating_add(1);
+                }
+                if had_metal_export_handle {
+                    *metal_target_handle_frames = metal_target_handle_frames.saturating_add(1);
+                }
+                fifo_write_times_ms.push(write_ms);
+                recycled_buffers.push(buffer);
+            }
+            RawVideoFifoWriterResult::Error { buffer, message } => {
+                if let Some(buffer) = buffer {
+                    recycled_buffers.push(buffer);
+                }
+                *pending_frames = 0;
+                pending_started_at.clear();
+                return Err(io::Error::other(message));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(target_os = "macos")]
 struct VideoToolboxFifoWriter {
     frame_tx: Option<std_mpsc::SyncSender<QueuedVideoToolboxFrame>>,
@@ -2131,13 +2561,11 @@ impl VideoToolboxFifoWriter {
     }
 }
 
-#[cfg(target_os = "macos")]
 enum PreservingOutputFrameOffer<T> {
     Enqueued,
     CapacityPressure(T),
 }
 
-#[cfg(target_os = "macos")]
 fn offer_preserving_output_frame<T>(
     tx: &std_mpsc::SyncSender<T>,
     frame: T,
@@ -2233,7 +2661,7 @@ impl VideoToolboxH264PipeWriter {
         deadline: Instant,
     ) -> io::Result<()> {
         let bytes = self.frame_bytes(frame)?;
-        write_all_until(sink, bytes, stop, deadline)
+        write_all_until(sink, bytes, stop, deadline, true)
     }
 
     fn frame_bytes<'a>(
@@ -2271,32 +2699,30 @@ impl VideoToolboxH264PipeWriter {
     }
 }
 
-#[cfg(target_os = "macos")]
 fn write_all_until<W: StdWrite>(
     sink: &mut W,
     mut bytes: &[u8],
     stop: &AtomicBool,
     deadline: Instant,
+    cancel_on_stop: bool,
 ) -> io::Result<()> {
     while !bytes.is_empty() {
-        if stop.load(Ordering::Relaxed) {
+        if cancel_on_stop && stop.load(Ordering::Relaxed) {
             return Err(io::Error::new(
                 io::ErrorKind::Interrupted,
-                "VideoToolbox FIFO writer stopped during a bounded write",
+                "Encoder FIFO writer stopped during a bounded write",
             ));
         }
         if Instant::now() >= deadline {
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
-                "VideoToolbox FIFO write exceeded the output queue age budget",
+                "Encoder FIFO write exceeded the output queue age budget",
             ));
         }
         match sink.write(bytes) {
             Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "VideoToolbox FIFO writer made no progress",
-                ));
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                thread::sleep(remaining.min(Duration::from_millis(2)));
             }
             Ok(written) => bytes = &bytes[written..],
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
@@ -2560,7 +2986,9 @@ fn open_recording_fifo_writer(
         // Keep Unix FIFOs nonblocking. The VideoToolbox writer applies a
         // role-specific deadline and cancellation check around every partial
         // write, so a stalled FFmpeg reader cannot retain a worker forever.
-        // Windows ignores this flag and the VideoToolbox path is macOS-only.
+        // Windows keeps the named pipe in PIPE_NOWAIT for the same bounded
+        // writer contract; full buffers surface as zero-byte writes and retry
+        // only until the role-specific deadline.
         !nonblocking_writes,
         "recording encoder bridge writer stopped before FIFO opened",
     )
@@ -2994,6 +3422,7 @@ async fn emit_encoder_bridge_diagnostics(
                     .separate_output_encoders_active,
                 compositor_wait_p95_ms: runtime.compositor_wait_p95_ms,
                 video_toolbox_submit_p95_ms: runtime.video_toolbox_submit_p95_ms,
+                raw_video_fifo_write_p95_ms: runtime.raw_video_fifo_write_p95_ms,
                 video_toolbox_fifo_write_p95_ms: runtime.video_toolbox_fifo_write_p95_ms,
                 video_toolbox_fifo_enqueue_p95_ms,
                 video_toolbox_fifo_enqueue_max_ms,
@@ -3209,7 +3638,6 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn bounded_fifo_offer_reports_pressure_without_blocking_the_realtime_bridge() {
         let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
@@ -3221,6 +3649,140 @@ mod tests {
         };
         assert_eq!(preserved, 2);
         assert_eq!(frame_rx.recv().expect("drain oldest frame"), 1);
+    }
+
+    #[test]
+    fn recording_session_exposes_the_first_terminal_bridge_failure() {
+        let terminal_failure = Arc::new(StdMutex::new(None));
+        let session = EncoderBridgeRecordingSession {
+            stop: Arc::new(AtomicBool::new(false)),
+            terminal_failure: terminal_failure.clone(),
+            fifo_path: std::env::temp_dir().join(format!(
+                "videorc-missing-terminal-signal-test-{}",
+                Uuid::new_v4()
+            )),
+            writer: None,
+            diagnostics_task: None,
+        };
+
+        assert_eq!(session.terminal_failure(), None);
+        record_encoder_bridge_terminal_failure(&terminal_failure, "raw FIFO timed out");
+        record_encoder_bridge_terminal_failure(&terminal_failure, "later secondary error");
+
+        assert_eq!(
+            session.terminal_failure().as_deref(),
+            Some("raw FIFO timed out")
+        );
+    }
+
+    #[test]
+    fn raw_fifo_writer_returns_the_owned_buffer_after_an_ordered_write() {
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(2);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(4);
+        let sink = SharedCountingSink::default();
+        frame_tx
+            .send(QueuedRawVideoFrame {
+                bytes: vec![1, 2, 3, 4],
+                submitted_at: Instant::now(),
+                had_metal_target: false,
+                had_metal_export_handle: false,
+            })
+            .expect("queue raw frame");
+        drop(frame_tx);
+
+        run_raw_video_fifo_writer_loop(
+            sink.clone(),
+            frame_rx,
+            result_tx,
+            Arc::new(AtomicBool::new(false)),
+            Duration::from_millis(250),
+            Arc::new(StdMutex::new(None)),
+            EncoderBridgeOutputRole::Recording,
+        );
+
+        assert_eq!(sink.bytes(), vec![1, 2, 3, 4]);
+        let result = result_rx.recv().expect("raw writer result");
+        let RawVideoFifoWriterResult::FrameWritten { buffer, .. } = result else {
+            panic!("raw frame must be reported as written")
+        };
+        assert_eq!(buffer, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn raw_fifo_writer_finishes_an_inflight_frame_when_stop_arrives_mid_write() {
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(3);
+        let stop = Arc::new(AtomicBool::new(false));
+        let written = SharedCountingSink::default();
+        let frame = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        frame_tx
+            .send(QueuedRawVideoFrame {
+                bytes: frame.clone(),
+                submitted_at: Instant::now(),
+                had_metal_target: false,
+                had_metal_export_handle: false,
+            })
+            .expect("queue raw frame");
+        drop(frame_tx);
+
+        run_raw_video_fifo_writer_loop(
+            StopAfterPartialWriteSink {
+                written: written.clone(),
+                stop: stop.clone(),
+                first_write: true,
+            },
+            frame_rx,
+            result_tx,
+            stop,
+            Duration::from_millis(250),
+            Arc::new(StdMutex::new(None)),
+            EncoderBridgeOutputRole::Recording,
+        );
+
+        assert_eq!(written.bytes(), frame);
+        let result = result_rx.recv().expect("raw writer result");
+        assert!(matches!(
+            result,
+            RawVideoFifoWriterResult::FrameWritten { .. }
+        ));
+    }
+
+    #[test]
+    fn stalled_raw_fifo_writer_times_out_without_blocking_the_scheduler() {
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(3);
+        frame_tx
+            .send(QueuedRawVideoFrame {
+                bytes: vec![0x44; 64],
+                submitted_at: Instant::now(),
+                had_metal_target: false,
+                had_metal_export_handle: false,
+            })
+            .expect("queue raw frame");
+        drop(frame_tx);
+
+        let started_at = Instant::now();
+        let terminal_failure = Arc::new(StdMutex::new(None));
+        run_raw_video_fifo_writer_loop(
+            AlwaysWouldBlockSink,
+            frame_rx,
+            result_tx,
+            Arc::new(AtomicBool::new(false)),
+            Duration::from_millis(20),
+            terminal_failure.clone(),
+            EncoderBridgeOutputRole::Recording,
+        );
+
+        assert!(started_at.elapsed() < Duration::from_millis(500));
+        let result = result_rx.recv().expect("terminal raw writer result");
+        let RawVideoFifoWriterResult::Error { message, .. } = result else {
+            panic!("stalled raw writer must fail explicitly")
+        };
+        assert!(message.contains("queue age budget"));
+        assert_eq!(
+            read_encoder_bridge_terminal_failure(&terminal_failure).as_deref(),
+            Some(message.as_str())
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -3949,13 +4511,67 @@ mod tests {
         assert!(error.contains("queue age budget"));
     }
 
-    #[cfg(target_os = "macos")]
     struct AlwaysWouldBlockSink;
 
-    #[cfg(target_os = "macos")]
     impl StdWrite for AlwaysWouldBlockSink {
         fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
             Err(io::Error::from(io::ErrorKind::WouldBlock))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct SharedCountingSink(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl SharedCountingSink {
+        fn bytes(&self) -> Vec<u8> {
+            self.0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    impl StdWrite for SharedCountingSink {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct StopAfterPartialWriteSink {
+        written: SharedCountingSink,
+        stop: Arc<AtomicBool>,
+        first_write: bool,
+    }
+
+    impl StdWrite for StopAfterPartialWriteSink {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            let written = if self.first_write {
+                bytes.len().div_ceil(2)
+            } else {
+                bytes.len()
+            };
+            self.written
+                .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .extend_from_slice(&bytes[..written]);
+            if self.first_write {
+                self.first_write = false;
+                self.stop.store(true, Ordering::Relaxed);
+            }
+            Ok(written)
         }
 
         fn flush(&mut self) -> io::Result<()> {
@@ -4138,11 +4754,12 @@ mod tests {
 
         while wall < simulated {
             let lag = wall.saturating_sub(next_frame_at);
-            let plan = plan_bridge_tick(lag, interval);
+            let plan = plan_bridge_tick(EncoderBridgeVideoOutput::RawYuv420p, lag, interval);
             assert_eq!(
                 plan.reanchor_skipped_intervals, 0,
                 "a merely-slow compositor must never trigger the stall gap"
             );
+            assert!(!plan.fail_untimestamped_output);
             if wall < next_frame_at {
                 wall = next_frame_at; // sleep to the deadline
             }
@@ -4173,19 +4790,56 @@ mod tests {
         let interval = Duration::from_nanos(1_000_000_000 / 30);
 
         // Sub-threshold lag: catch up with repeats, never drop intervals.
-        let behind = plan_bridge_tick(Duration::from_millis(500), interval);
+        let behind = plan_bridge_tick(
+            EncoderBridgeVideoOutput::RawYuv420p,
+            Duration::from_millis(500),
+            interval,
+        );
         assert!(behind.skip_fresh_wait);
         assert_eq!(behind.reanchor_skipped_intervals, 0);
+        assert!(!behind.fail_untimestamped_output);
 
         // On schedule: normal fresh-frame wait.
-        let on_time = plan_bridge_tick(Duration::ZERO, interval);
+        let on_time = plan_bridge_tick(
+            EncoderBridgeVideoOutput::RawYuv420p,
+            Duration::ZERO,
+            interval,
+        );
         assert!(!on_time.skip_fresh_wait);
         assert_eq!(on_time.reanchor_skipped_intervals, 0);
+        assert!(!on_time.fail_untimestamped_output);
 
         // Pathological stall (app nap): drop WHOLE intervals as an explicit,
         // counted gap so PTS stay wall-true instead of compressing.
-        let stalled = plan_bridge_tick(Duration::from_secs(5), interval);
-        assert!(stalled.skip_fresh_wait);
-        assert_eq!(stalled.reanchor_skipped_intervals, 150); // 5s / 33.33ms
+        let raw_stalled = plan_bridge_tick(
+            EncoderBridgeVideoOutput::RawYuv420p,
+            Duration::from_secs(5),
+            interval,
+        );
+        assert!(!raw_stalled.skip_fresh_wait);
+        assert_eq!(raw_stalled.reanchor_skipped_intervals, 0);
+        assert!(raw_stalled.fail_untimestamped_output);
+
+        let raw_just_below_threshold = plan_bridge_tick(
+            EncoderBridgeVideoOutput::RawYuv420p,
+            ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD - Duration::from_nanos(1),
+            interval,
+        );
+        assert!(!raw_just_below_threshold.fail_untimestamped_output);
+        let raw_at_threshold = plan_bridge_tick(
+            EncoderBridgeVideoOutput::RawYuv420p,
+            ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD,
+            interval,
+        );
+        assert!(raw_at_threshold.fail_untimestamped_output);
+
+        let timestamped_stalled = plan_bridge_tick(
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+            Duration::from_secs(5),
+            interval,
+        );
+        assert!(timestamped_stalled.skip_fresh_wait);
+        assert_eq!(timestamped_stalled.reanchor_skipped_intervals, 150); // 5s / 33.33ms
+        assert!(!timestamped_stalled.fail_untimestamped_output);
     }
 }

--- a/crates/videorc-backend/src/fifo.rs
+++ b/crates/videorc-backend/src/fifo.rs
@@ -189,7 +189,9 @@ pub fn open_writer(
     use std::os::windows::io::AsRawHandle;
     use std::sync::atomic::Ordering;
     use windows::Win32::Foundation::{ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, HANDLE};
-    use windows::Win32::System::Pipes::{ConnectNamedPipe, PIPE_READMODE_BYTE, PIPE_WAIT};
+    use windows::Win32::System::Pipes::{
+        ConnectNamedPipe, PIPE_NOWAIT, PIPE_READMODE_BYTE, PIPE_WAIT,
+    };
 
     let owned = {
         let mut registry = pipe_registry()
@@ -222,13 +224,17 @@ pub fn open_writer(
         }
     }
 
-    // Always restore blocking writes, even when the Unix arm would honour
-    // `clear_nonblock = false`: a PIPE_NOWAIT write against a full buffer
-    // reports success with zero bytes written, which callers must treat as
-    // WriteZero corruption. Blocking writes on the dedicated writer threads
-    // degrade to reader backpressure instead.
-    let _ = clear_nonblock;
-    let mode = PIPE_READMODE_BYTE | PIPE_WAIT;
+    // Bounded media writers keep PIPE_NOWAIT so cancellation/deadline checks
+    // remain observable when FFmpeg stops draining. Windows reports a full
+    // byte pipe as a zero-byte write; their write loop treats that as transient
+    // pressure until its explicit deadline. Other FIFO users retain blocking
+    // behavior through `clear_nonblock = true`.
+    let wait_mode = if clear_nonblock {
+        PIPE_WAIT
+    } else {
+        PIPE_NOWAIT
+    };
+    let mode = PIPE_READMODE_BYTE | wait_mode;
     unsafe { SetNamedPipeHandleStateChecked(handle, mode) }?;
 
     Ok(File::from(owned))

--- a/crates/videorc-backend/src/frame_store.rs
+++ b/crates/videorc-backend/src/frame_store.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, Weak};
 use std::time::Instant;
 
 #[cfg(target_os = "macos")]
@@ -83,6 +83,37 @@ pub struct RetainedIoSurface;
 #[derive(Debug, Clone)]
 pub struct RetainedPixelBuffer;
 
+#[derive(Debug)]
+pub(crate) struct FrameBufferPool {
+    spare_buffers: Vec<Vec<u8>>,
+    max_spare_buffers: usize,
+    buffer_allocations: u64,
+}
+
+impl FrameBufferPool {
+    fn checkout(&mut self, byte_len: usize, zero_fill: bool) -> Vec<u8> {
+        let mut buffer = self.spare_buffers.pop().unwrap_or_else(|| {
+            self.buffer_allocations = self.buffer_allocations.saturating_add(1);
+            Vec::with_capacity(byte_len)
+        });
+        if buffer.capacity() < byte_len {
+            self.buffer_allocations = self.buffer_allocations.saturating_add(1);
+            buffer = Vec::with_capacity(byte_len);
+        }
+        buffer.resize(byte_len, 0);
+        if zero_fill {
+            buffer.fill(0);
+        }
+        buffer
+    }
+
+    fn retain(&mut self, bytes: Vec<u8>) {
+        if self.spare_buffers.len() < self.max_spare_buffers {
+            self.spare_buffers.push(bytes);
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StoredFrame<P, M = ()> {
     pub sequence: u64,
@@ -98,7 +129,24 @@ pub struct StoredFrame<P, M = ()> {
     /// Retained source CVPixelBuffer for CoreVideo-to-Metal import where the source path supports
     /// it. `bytes` remains the fallback and artifact path.
     pub source_pixel_buffer: Option<RetainedPixelBuffer>,
+    #[doc(hidden)]
+    pub(crate) recycle_pool: Option<Weak<StdMutex<FrameBufferPool>>>,
     pub captured_at: Instant,
+}
+
+impl<P, M> Drop for StoredFrame<P, M> {
+    fn drop(&mut self) {
+        let Some(pool) = self.recycle_pool.as_ref().and_then(Weak::upgrade) else {
+            return;
+        };
+        let bytes = std::mem::take(&mut self.bytes);
+        if bytes.capacity() == 0 {
+            return;
+        }
+        pool.lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .retain(bytes);
+    }
 }
 
 pub type FrameHandle<P, M = ()> = Arc<StoredFrame<P, M>>;
@@ -114,10 +162,8 @@ pub struct FrameStoreStats {
 #[derive(Debug)]
 pub struct FrameStore<P, M = ()> {
     latest: Option<FrameHandle<P, M>>,
-    spare_buffers: Vec<Vec<u8>>,
-    max_spare_buffers: usize,
+    buffer_pool: Arc<StdMutex<FrameBufferPool>>,
     frames_replaced: u64,
-    buffer_allocations: u64,
 }
 
 impl<P, M> Default for FrameStore<P, M> {
@@ -130,10 +176,12 @@ impl<P, M> FrameStore<P, M> {
     pub fn new(max_spare_buffers: usize) -> Self {
         Self {
             latest: None,
-            spare_buffers: Vec::new(),
-            max_spare_buffers,
+            buffer_pool: Arc::new(StdMutex::new(FrameBufferPool {
+                spare_buffers: Vec::new(),
+                max_spare_buffers,
+                buffer_allocations: 0,
+            })),
             frames_replaced: 0,
-            buffer_allocations: 0,
         }
     }
 
@@ -142,29 +190,43 @@ impl<P, M> FrameStore<P, M> {
     }
 
     pub fn checkout_buffer(&mut self, byte_len: usize) -> Vec<u8> {
-        let mut buffer = self.spare_buffers.pop().unwrap_or_else(|| {
-            self.buffer_allocations = self.buffer_allocations.saturating_add(1);
-            Vec::with_capacity(byte_len)
-        });
-        if buffer.capacity() < byte_len {
-            self.buffer_allocations = self.buffer_allocations.saturating_add(1);
-            buffer = Vec::with_capacity(byte_len);
-        }
-        buffer.resize(byte_len, 0);
-        buffer
+        self.buffer_pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .checkout(byte_len, true)
+    }
+
+    /// Checkout a buffer for an operation such as `read_exact` that overwrites
+    /// every byte. Reused buffers keep their initialized length without paying
+    /// for a redundant full-frame zero fill.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+    pub fn checkout_overwrite_buffer(&mut self, byte_len: usize) -> Vec<u8> {
+        self.buffer_pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .checkout(byte_len, false)
     }
 
     pub fn checkout_spare_buffer(&mut self, byte_len: usize) -> Option<Vec<u8>> {
-        let mut buffer = self.spare_buffers.pop()?;
+        let mut pool = self
+            .buffer_pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut buffer = pool.spare_buffers.pop()?;
         if buffer.capacity() < byte_len {
             return None;
         }
         buffer.resize(byte_len, 0);
+        buffer.fill(0);
         Some(buffer)
     }
 
     pub fn record_buffer_allocation(&mut self) {
-        self.buffer_allocations = self.buffer_allocations.saturating_add(1);
+        let mut pool = self
+            .buffer_pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        pool.buffer_allocations = pool.buffer_allocations.saturating_add(1);
     }
 
     #[cfg(test)]
@@ -257,11 +319,8 @@ impl<P, M> FrameStore<P, M> {
         source_iosurface: Option<RetainedIoSurface>,
         source_pixel_buffer: Option<RetainedPixelBuffer>,
     ) -> FrameHandle<P, M> {
-        if let Some(previous) = self.latest.take() {
+        if self.latest.take().is_some() {
             self.frames_replaced = self.frames_replaced.saturating_add(1);
-            if let Ok(previous) = Arc::try_unwrap(previous) {
-                self.retain_spare_buffer(previous.bytes);
-            }
         }
 
         let frame = Arc::new(StoredFrame {
@@ -273,6 +332,7 @@ impl<P, M> FrameStore<P, M> {
             bytes,
             source_iosurface,
             source_pixel_buffer,
+            recycle_pool: Some(Arc::downgrade(&self.buffer_pool)),
             captured_at,
         });
         self.latest = Some(Arc::clone(&frame));
@@ -285,25 +345,21 @@ impl<P, M> FrameStore<P, M> {
             .as_ref()
             .map(|frame| frame.bytes.len() as u64)
             .unwrap_or(0);
-        let spare_bytes = self
+        let pool = self
+            .buffer_pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let spare_bytes = pool
             .spare_buffers
             .iter()
             .map(|buffer| buffer.capacity() as u64)
             .sum::<u64>();
         FrameStoreStats {
-            buffer_count: self.latest.iter().count() as u64 + self.spare_buffers.len() as u64,
+            buffer_count: self.latest.iter().count() as u64 + pool.spare_buffers.len() as u64,
             bytes_retained: latest_bytes.saturating_add(spare_bytes),
             frames_dropped: self.frames_replaced,
-            buffer_allocations: self.buffer_allocations,
+            buffer_allocations: pool.buffer_allocations,
         }
-    }
-
-    fn retain_spare_buffer(&mut self, mut bytes: Vec<u8>) {
-        if self.spare_buffers.len() >= self.max_spare_buffers {
-            return;
-        }
-        bytes.clear();
-        self.spare_buffers.push(bytes);
     }
 }
 
@@ -410,6 +466,48 @@ mod tests {
         assert_eq!(stats.buffer_count, 1);
         assert_eq!(stats.bytes_retained, 256);
         assert_eq!(handles.len(), 5);
+    }
+
+    #[test]
+    fn released_external_handles_return_buffers_to_the_store_pool() {
+        let mut store: FrameStore<TestPixelFormat> = FrameStore::new(2);
+        let first = store.checkout_buffer(1024);
+        let retained = store.publish(1, 16, 16, TestPixelFormat::Rgba, Instant::now(), first);
+        let second = store.checkout_buffer(1024);
+        store.publish(2, 16, 16, TestPixelFormat::Rgba, Instant::now(), second);
+
+        assert_eq!(store.stats().buffer_allocations, 2);
+        drop(retained);
+
+        let recycled = store.checkout_buffer(1024);
+        assert_eq!(recycled.len(), 1024);
+        assert_eq!(store.stats().buffer_allocations, 2);
+    }
+
+    #[test]
+    fn overlapping_consumers_stabilize_buffer_allocations_after_warmup() {
+        let mut store: FrameStore<TestPixelFormat> = FrameStore::new(2);
+        let mut buffer = store.checkout_buffer(1024);
+        let mut retained_consumer = None;
+
+        for sequence in 1..=120 {
+            let next_consumer = store.publish(
+                sequence,
+                16,
+                16,
+                TestPixelFormat::Rgba,
+                Instant::now(),
+                buffer,
+            );
+            buffer = store.checkout_buffer(1024);
+            // Keep frame N alive through publication of frame N+1, matching a
+            // compositor/PNG consumer that overlaps the capture callback.
+            drop(retained_consumer.take());
+            retained_consumer = Some(next_consumer);
+        }
+        drop(retained_consumer);
+
+        assert!(store.stats().buffer_allocations <= 3);
     }
 
     #[test]

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -38,6 +38,8 @@ const CAMERA_OVERLAY_CAPTURE_MIN_WIDTH: u32 = 1280;
 const CAMERA_OVERLAY_CAPTURE_MIN_HEIGHT: u32 = 720;
 const CAMERA_CAPTURE_CPU_COPY_ENV: &str = "VIDEORC_CAMERA_CAPTURE_CPU_COPY";
 const WINDOWS_CAMERA_PREVIEW_STARTUP_TIMEOUT: Duration = Duration::from_secs(12);
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_CAMERA_RATE_CAP_EPSILON_SECONDS: f64 = 0.000_001;
 
 fn native_camera_preview_thread_startup_timeout() -> Duration {
     if cfg!(target_os = "windows") {
@@ -1341,12 +1343,25 @@ fn windows_camera_preview_ffmpeg_args_opts(
         &config.unique_id,
         request_fps,
     );
+    let mut filters = Vec::with_capacity(3);
+    if request_fps.is_none() {
+        // The retry lets dshow negotiate a native cadence. Cap devices whose
+        // default exceeds the session target without manufacturing duplicates
+        // for 10/15/25fps cameras (the `fps` filter does both).
+        filters.push(format!(
+            "select='isnan(prev_selected_t)+gte(t-prev_selected_t+{WINDOWS_CAMERA_RATE_CAP_EPSILON_SECONDS:.6}\\,1/{fps})'"
+        ));
+    }
+    filters.push(format!(
+        "scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2"
+    ));
+    filters.push("format=bgra".to_string());
     args.extend([
         "-an".to_string(),
         "-vf".to_string(),
-        format!(
-            "fps={fps},scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,format=bgra"
-        ),
+        filters.join(","),
+        "-fps_mode".to_string(),
+        "passthrough".to_string(),
         "-f".to_string(),
         "rawvideo".to_string(),
         "-pix_fmt".to_string(),
@@ -1597,17 +1612,16 @@ mod windows {
             spawn_stop_flag_killer(Arc::clone(&child), Arc::clone(&done), Arc::clone(stop_flag));
 
         let mut startup_sent = false;
-        let mut buffer = vec![0; frame_len];
+        let mut buffer = shared
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .frame_store
+            .checkout_overwrite_buffer(frame_len);
         let mut outcome = CameraPreviewAttempt::FailedBeforeFirstFrame;
         loop {
             match stdout.read_exact(&mut buffer) {
                 Ok(()) => {
-                    publish_bgra_frame(
-                        shared,
-                        width,
-                        height,
-                        std::mem::replace(&mut buffer, vec![0; frame_len]),
-                    );
+                    buffer = publish_bgra_frame(shared, width, height, buffer);
                     if !startup_sent {
                         let _ = startup_tx.send(NativeCameraStartup::Live {
                             requested_width: width,
@@ -1699,10 +1713,11 @@ mod windows {
         width: u32,
         height: u32,
         bytes: Vec<u8>,
-    ) {
+    ) -> Vec<u8> {
         let callback_started_at = Instant::now();
         let publish_started_at = Instant::now();
-        let frame_bytes = bytes.len() as u64;
+        let frame_len = bytes.len();
+        let frame_bytes = frame_len as u64;
         let mut guard = shared
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1730,10 +1745,12 @@ mod windows {
             now,
             bytes,
         );
+        let next_buffer = guard.frame_store.checkout_overwrite_buffer(frame_len);
         let publish_ms = publish_started_at.elapsed().as_secs_f64() * 1000.0;
         guard
             .capture_timings
             .record_valid_frame(0.0, 0.0, publish_ms, frame_bytes);
+        next_buffer
     }
 
     fn stderr_suffix(stderr: &Arc<StdMutex<Vec<u8>>>) -> String {
@@ -2765,9 +2782,61 @@ mod tests {
                 .any(|pair| pair == ["-i", "video=USB Camera"])
         );
         assert!(args.iter().any(|arg| arg.contains("scale=1920:1080")));
+        assert!(!args.iter().any(|arg| arg.starts_with("fps=")));
         assert!(args.windows(2).any(|pair| pair == ["-pix_fmt", "bgra"]));
         assert!(args.windows(2).any(|pair| pair == ["-f", "rawvideo"]));
         assert_eq!(args.last().map(String::as_str), Some("-"));
+    }
+
+    #[test]
+    fn windows_camera_default_format_retry_caps_high_fps_without_duplicating_low_fps() {
+        fn selected_frame_count(source_fps: u32, target_fps: u32) -> usize {
+            let mut previous_selected_t = None;
+            let mut selected = 0;
+            for frame_index in 0..source_fps {
+                let timestamp = f64::from(frame_index) / f64::from(source_fps);
+                let should_select = previous_selected_t.is_none_or(|previous| {
+                    timestamp - previous + WINDOWS_CAMERA_RATE_CAP_EPSILON_SECONDS
+                        >= 1.0 / f64::from(target_fps)
+                });
+                if should_select {
+                    previous_selected_t = Some(timestamp);
+                    selected += 1;
+                }
+            }
+            selected
+        }
+
+        let config = NativeCameraPreviewConfig {
+            camera_id: "camera:windows-dshow:5553422043616d657261".to_string(),
+            unique_id: "USB Camera".to_string(),
+            ffmpeg_path: "C:\\ffmpeg\\bin\\ffmpeg.exe".to_string(),
+            video: test_video(),
+            layout: test_layout(false),
+        };
+
+        let args = windows_camera_preview_ffmpeg_args_opts(&config, 1920, 1080, 30, None);
+        let filter = args
+            .windows(2)
+            .find_map(|pair| (pair[0] == "-vf").then_some(pair[1].as_str()))
+            .expect("video filter");
+
+        assert!(!args.iter().any(|arg| arg == "-framerate"));
+        assert!(filter.contains("select='isnan(prev_selected_t)"));
+        assert!(filter.contains("gte(t-prev_selected_t+0.000001\\,1/30)"));
+        assert!(!filter.starts_with("fps="));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["-fps_mode", "passthrough"])
+        );
+        assert_eq!(selected_frame_count(60, 30), 30);
+        assert_eq!(selected_frame_count(15, 30), 15);
+
+        let just_below_boundary = (1.0 / 30.0) - (WINDOWS_CAMERA_RATE_CAP_EPSILON_SECONDS / 2.0);
+        assert!(
+            just_below_boundary + WINDOWS_CAMERA_RATE_CAP_EPSILON_SECONDS >= 1.0 / 30.0,
+            "the epsilon must retain a frame whose timestamp rounds just below the boundary"
+        );
     }
 
     #[test]

--- a/crates/videorc-backend/src/preview_screen.rs
+++ b/crates/videorc-backend/src/preview_screen.rs
@@ -1101,8 +1101,14 @@ fn windows_screen_preview_ffmpeg_args(
         "-an".to_string(),
         "-vf".to_string(),
         format!(
-            "fps={fps},scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,format=bgra"
+            "scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,format=bgra"
         ),
+        // Preserve the capture filter's real cadence. FFmpeg's default output
+        // sync can otherwise manufacture duplicate raw frames when desktop
+        // capture misses a requested tick, hiding the stall from diagnostics
+        // and making the Windows preview/recording visibly hitch.
+        "-fps_mode".to_string(),
+        "passthrough".to_string(),
         "-f".to_string(),
         "rawvideo".to_string(),
         "-pix_fmt".to_string(),
@@ -1638,16 +1644,15 @@ mod windows {
         let stop_thread = spawn_stop_killer(Arc::clone(&child), Arc::clone(&done), stop_rx);
 
         let mut startup_sent = false;
-        let mut buffer = vec![0; frame_len];
+        let mut buffer = shared
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .frame_store
+            .checkout_overwrite_buffer(frame_len);
         loop {
             match stdout.read_exact(&mut buffer) {
                 Ok(()) => {
-                    publish_bgra_frame(
-                        &shared,
-                        width,
-                        height,
-                        std::mem::replace(&mut buffer, vec![0; frame_len]),
-                    );
+                    buffer = publish_bgra_frame(&shared, width, height, buffer);
                     if !startup_sent {
                         let _ = startup_tx.send(NativeScreenStartup::Live {
                             native_width: width,
@@ -1740,10 +1745,11 @@ mod windows {
         width: u32,
         height: u32,
         bytes: Vec<u8>,
-    ) {
+    ) -> Vec<u8> {
         let callback_started_at = Instant::now();
         let publish_started_at = Instant::now();
-        let frame_bytes = bytes.len() as u64;
+        let frame_len = bytes.len();
+        let frame_bytes = frame_len as u64;
         let mut guard = shared
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1771,10 +1777,12 @@ mod windows {
             now,
             bytes,
         );
+        let next_buffer = guard.frame_store.checkout_overwrite_buffer(frame_len);
         let publish_ms = publish_started_at.elapsed().as_secs_f64() * 1000.0;
         guard
             .capture_timings
             .record_valid_frame(0.0, 0.0, publish_ms, frame_bytes);
+        next_buffer
     }
 
     fn stderr_suffix(stderr: &Arc<StdMutex<Vec<u8>>>) -> String {
@@ -2899,6 +2907,11 @@ mod tests {
         assert!(args.iter().any(|arg| arg.contains("ddagrab=output_idx=2")));
         assert!(args.iter().any(|arg| arg.contains("draw_mouse=1")));
         assert!(args.iter().any(|arg| arg.contains("scale=1920:1080")));
+        assert!(!args.iter().any(|arg| arg.starts_with("fps=")));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["-fps_mode", "passthrough"])
+        );
         assert!(args.windows(2).any(|pair| pair == ["-pix_fmt", "bgra"]));
         assert!(args.windows(2).any(|pair| pair == ["-f", "rawvideo"]));
         assert_eq!(args.last().map(String::as_str), Some("-"));

--- a/crates/videorc-backend/src/process_job.rs
+++ b/crates/videorc-backend/src/process_job.rs
@@ -34,6 +34,50 @@ pub fn output_owned_std(command: &mut StdCommand) -> io::Result<ProcessOutput> {
     spawn_owned_std(command)?.wait_with_output()
 }
 
+#[cfg(unix)]
+pub fn process_is_running(pid: u32) -> io::Result<bool> {
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if result == 0 {
+        return Ok(true);
+    }
+    let error = io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ESRCH) => Ok(false),
+        Some(libc::EPERM) => Ok(true),
+        _ => Err(error),
+    }
+}
+
+#[cfg(unix)]
+pub fn terminate_process(pid: u32, force: bool) -> io::Result<()> {
+    let signal = if force { libc::SIGKILL } else { libc::SIGTERM };
+    if unsafe { libc::kill(pid as libc::pid_t, signal) } == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+pub fn process_is_running(_pid: u32) -> io::Result<bool> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "PID liveness probing is unsupported on this platform",
+    ))
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+pub fn terminate_process(_pid: u32, _force: bool) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "PID termination is unsupported on this platform",
+    ))
+}
+
 #[cfg(not(target_os = "windows"))]
 fn assign_tokio_child(_child: &TokioChild) -> io::Result<()> {
     Ok(())
@@ -51,11 +95,16 @@ mod windows_job {
     use std::sync::OnceLock;
 
     use tokio::process::Child as TokioChild;
-    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Foundation::{
+        CloseHandle, ERROR_INVALID_PARAMETER, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    };
     use windows::Win32::System::JobObjects::{
         AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
         SetInformationJobObject,
+    };
+    use windows::Win32::System::Threading::{
+        OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
     };
     use windows::core::PCWSTR;
 
@@ -72,6 +121,35 @@ mod windows_job {
 
     pub(super) fn assign_std_child(child: &StdChild) -> io::Result<()> {
         assign_raw_process_handle(child.as_raw_handle())
+    }
+
+    pub(super) fn process_is_running(pid: u32) -> io::Result<bool> {
+        let handle = match unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, pid) } {
+            Ok(handle) => handle,
+            Err(error) if error.code() == ERROR_INVALID_PARAMETER.to_hresult() => return Ok(false),
+            Err(error) => return Err(io::Error::other(error)),
+        };
+        let wait = unsafe { WaitForSingleObject(handle, 0) };
+        let _ = unsafe { CloseHandle(handle) };
+        if wait == WAIT_TIMEOUT {
+            Ok(true)
+        } else if wait == WAIT_OBJECT_0 {
+            Ok(false)
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    pub(super) fn terminate_process(pid: u32) -> io::Result<()> {
+        let handle =
+            match unsafe { OpenProcess(PROCESS_TERMINATE | PROCESS_SYNCHRONIZE, false, pid) } {
+                Ok(handle) => handle,
+                Err(error) if error.code() == ERROR_INVALID_PARAMETER.to_hresult() => return Ok(()),
+                Err(error) => return Err(io::Error::other(error)),
+            };
+        let result = unsafe { TerminateProcess(handle, 1) }.map_err(io::Error::other);
+        let _ = unsafe { CloseHandle(handle) };
+        result
     }
 
     fn assign_raw_process_handle(raw_handle: RawHandle) -> io::Result<()> {
@@ -117,6 +195,19 @@ fn assign_std_child(child: &StdChild) -> io::Result<()> {
     windows_job::assign_std_child(child)
 }
 
+#[cfg(target_os = "windows")]
+pub fn process_is_running(pid: u32) -> io::Result<bool> {
+    windows_job::process_is_running(pid)
+}
+
+#[cfg(target_os = "windows")]
+pub fn terminate_process(pid: u32, _force: bool) -> io::Result<()> {
+    // Win32 has no POSIX-style graceful signal for an arbitrary console child.
+    // The recording finalizer has already closed every owned FIFO before this
+    // fallback, so forced termination is the only truthful bounded action.
+    windows_job::terminate_process(pid)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -143,5 +234,32 @@ mod tests {
             .wait()
             .expect("child should wait");
         assert!(status.success());
+    }
+
+    fn long_running_command() -> StdCommand {
+        #[cfg(target_os = "windows")]
+        {
+            let mut command = StdCommand::new("cmd");
+            command.args(["/C", "ping", "-n", "30", "127.0.0.1"]);
+            command
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            let mut command = StdCommand::new("sleep");
+            command.arg("30");
+            command
+        }
+    }
+
+    #[test]
+    fn owned_process_can_be_probed_and_terminated_by_pid() {
+        let mut child = spawn_owned_std(&mut long_running_command()).expect("child should spawn");
+        let pid = child.id();
+
+        assert!(process_is_running(pid).expect("probe child"));
+        terminate_process(pid, true).expect("terminate child");
+        child.wait().expect("reap terminated child");
+        assert!(!process_is_running(pid).expect("probe reaped child"));
     }
 }

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1281,6 +1281,9 @@ pub struct DiagnosticStats {
     /// P95 time the bridge writer spent submitting a retained target to VideoToolbox.
     #[serde(default)]
     pub encoder_bridge_video_toolbox_submit_p95_ms: Option<f64>,
+    /// P95 time the raw-video FIFO worker spent writing one frame into FFmpeg.
+    #[serde(default)]
+    pub encoder_bridge_raw_video_fifo_write_p95_ms: Option<f64>,
     /// P95 time the bridge writer spent writing encoded H.264 bytes into FFmpeg.
     #[serde(default)]
     pub encoder_bridge_video_toolbox_fifo_write_p95_ms: Option<f64>,

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -59,7 +59,10 @@ use crate::preview_camera::{
     preview_camera_latest_frame_info, reset_preview_camera_capture_timings,
 };
 use crate::preview_screen::preview_screen_latest_frame_info;
-use crate::process_job::{spawn_owned_tokio, status_owned_tokio};
+use crate::process_job::{
+    process_is_running as process_is_running_by_pid, spawn_owned_tokio, status_owned_tokio,
+    terminate_process,
+};
 use crate::protocol::{
     AudioProcessingUpdateParams, AudioProcessingUpdateResult, AudioSettings, AudioTrack,
     AudioTrackSource, BackgroundFit, CameraAspect, CameraCorner, CameraFit, CameraShape,
@@ -197,6 +200,7 @@ const IDLE_PREVIEW_JPEG_QUALITY: u32 = 4;
 const CAMERA_REFERENCE_WIDTH: u32 = 1280;
 const CAMERA_REFERENCE_HEIGHT: u32 = 720;
 const STOP_FINALIZE_TIMEOUT: Duration = Duration::from_secs(20);
+const FINAL_DURATION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const STOP_TERM_DELAY: Duration = Duration::from_secs(3);
 const STOP_KILL_DELAY: Duration = Duration::from_secs(3);
 // Sessions with a live RTMP leg get a longer quit grace: the tee/fifo leg
@@ -367,6 +371,17 @@ impl ActiveRecording {
             overlay.set_image_path(path)?;
         }
         Ok(())
+    }
+
+    fn encoder_bridge_terminal_failure(&self) -> Option<String> {
+        self.encoder_bridge
+            .as_ref()
+            .and_then(EncoderBridgeRecordingSession::terminal_failure)
+            .or_else(|| {
+                self.encoder_bridge_stream
+                    .as_ref()
+                    .and_then(EncoderBridgeRecordingSession::terminal_failure)
+            })
     }
 }
 
@@ -2672,22 +2687,12 @@ async fn wait_for_final_recording_status(
 }
 
 async fn send_process_signal(pid: u32, signal: &str) -> Result<()> {
-    Command::new("kill")
-        .arg(format!("-{signal}"))
-        .arg(pid.to_string())
-        .status()
-        .await
-        .with_context(|| format!("Could not send SIG{signal} to FFmpeg"))?;
-    Ok(())
+    terminate_process(pid, signal.eq_ignore_ascii_case("KILL"))
+        .with_context(|| format!("Could not send {signal} termination to FFmpeg process {pid}"))
 }
 
 async fn process_is_running(pid: u32) -> bool {
-    Command::new("kill")
-        .arg("-0")
-        .arg(pid.to_string())
-        .status()
-        .await
-        .is_ok_and(|status| status.success())
+    process_is_running_by_pid(pid).unwrap_or(false)
 }
 
 async fn wait_for_process_exit(pid: u32, wait: Duration) -> bool {
@@ -2833,6 +2838,7 @@ async fn monitor_session(
             });
             MonitoredRecording {
                 stop_requested: active.stop_requested,
+                encoder_bridge_terminal_failure: active.encoder_bridge_terminal_failure(),
                 ffmpeg_path: active.ffmpeg_path.clone(),
                 started_at: active.started_at.clone(),
                 pipeline: active.pipeline.clone(),
@@ -2939,8 +2945,16 @@ async fn monitor_session(
     let ended_at = Utc::now().to_rfc3339();
     let duration_ms = recording_duration_ms(&monitored_recording.started_at, &ended_at);
     let final_diagnostics = final_session_diagnostics_snapshot(&state, &session_id).await;
+    let encoder_bridge_terminal_failure =
+        monitored_recording.encoder_bridge_terminal_failure.clone();
     match status {
-        Ok(exit_status) if exit_status.success() || monitored_recording.stop_requested => {
+        Ok(exit_status)
+            if should_finalize_recording_session(
+                exit_status.success(),
+                monitored_recording.stop_requested,
+                encoder_bridge_terminal_failure.as_deref(),
+            ) =>
+        {
             let message = if exit_status.success() {
                 "Capture session finalized.".to_string()
             } else {
@@ -3030,12 +3044,28 @@ async fn monitor_session(
             // timeline than wall time, so persist the probed finalized duration
             // and retain elapsed time only as a fallback when probing fails.
             let duration_ms = match mp4_path.as_ref().or(output_path.as_ref()) {
-                Some(final_path) => crate::session_ops::probe_duration_ms(
-                    &monitored_recording.ffmpeg_path,
-                    final_path,
+                Some(final_path) => match timeout(
+                    FINAL_DURATION_PROBE_TIMEOUT,
+                    crate::session_ops::probe_duration_ms(
+                        &monitored_recording.ffmpeg_path,
+                        final_path,
+                    ),
                 )
                 .await
-                .or(duration_ms),
+                {
+                    Ok(probed) => probed.or(duration_ms),
+                    Err(_) => {
+                        state.emit_log(
+                            "warn",
+                            format!(
+                                "Final duration probe timed out after {}s for {}; keeping the wall-duration fallback.",
+                                FINAL_DURATION_PROBE_TIMEOUT.as_secs(),
+                                final_path.display()
+                            ),
+                        );
+                        duration_ms
+                    }
+                },
                 None => duration_ms,
             };
             let _ = state.database.finish_session(
@@ -3104,10 +3134,26 @@ async fn monitor_session(
             }
         }
         Ok(exit_status) => {
-            let message = format!("FFmpeg exited with {exit_status}");
+            let (failed_stage, health_code, message) = if let Some(error) =
+                encoder_bridge_terminal_failure.as_deref()
+            {
+                (
+                    RecordingPipelineStage::VideoEncoder,
+                    "encoder-bridge-failed",
+                    format!(
+                        "Encoder bridge stopped before capture finalization: {error} (FFmpeg exit: {exit_status})"
+                    ),
+                )
+            } else {
+                (
+                    RecordingPipelineStage::Muxer,
+                    "ffmpeg-exit",
+                    format!("FFmpeg exited with {exit_status}"),
+                )
+            };
             monitored_recording
                 .pipeline
-                .mark_failed(RecordingPipelineStage::Muxer, &message);
+                .mark_failed(failed_stage, &message);
             state.emit_log("error", &message);
             let _ = state.database.finish_session(
                 &session_id,
@@ -3123,7 +3169,7 @@ async fn monitor_session(
                 &state,
                 Some(&session_id),
                 HealthLevel::Error,
-                "ffmpeg-exit",
+                health_code,
                 &message,
             );
             state.emit_event(
@@ -3780,11 +3826,20 @@ struct NativeAudioStats {
 #[derive(Debug)]
 struct MonitoredRecording {
     stop_requested: bool,
+    encoder_bridge_terminal_failure: Option<String>,
     ffmpeg_path: String,
     started_at: String,
     pipeline: RecordingPipeline,
     captioned_copy_requested: bool,
     native_audio_stats: Option<NativeAudioStats>,
+}
+
+fn should_finalize_recording_session(
+    ffmpeg_exit_success: bool,
+    stop_requested: bool,
+    encoder_bridge_terminal_failure: Option<&str>,
+) -> bool {
+    encoder_bridge_terminal_failure.is_none() && (ffmpeg_exit_success || stop_requested)
 }
 
 fn should_begin_captioned_copy_render(requested: bool, caption_chunk_count: usize) -> bool {
@@ -10848,6 +10903,23 @@ mod tests {
 
         assert!(matches!(status.state, RecordingState::Idle));
         assert_eq!(status.output_path.as_deref(), Some("/tmp/videorc-test.mkv"));
+    }
+
+    #[test]
+    fn bridge_terminal_failure_prevents_successful_ffmpeg_exit_from_finalizing() {
+        assert!(should_finalize_recording_session(true, false, None));
+        assert!(should_finalize_recording_session(false, true, None));
+
+        assert!(!should_finalize_recording_session(
+            true,
+            false,
+            Some("recording raw-video encoder output stopped: FIFO timed out")
+        ));
+        assert!(!should_finalize_recording_session(
+            false,
+            true,
+            Some("recording raw-video encoder output stopped: FIFO timed out")
+        ));
     }
 
     #[test]

--- a/crates/videorc-backend/src/session_ops.rs
+++ b/crates/videorc-backend/src/session_ops.rs
@@ -4,7 +4,9 @@
 //! durations probed, posters extracted.
 
 use anyhow::{Context, Result, bail};
+use std::io;
 use std::path::{Path, PathBuf};
+use std::process::Output as ProcessOutput;
 
 use crate::process_job::output_owned_tokio;
 use crate::state::AppState;
@@ -104,13 +106,20 @@ pub(crate) async fn probe_duration_ms(ffmpeg_path: &str, file: &Path) -> Option<
         .arg(file)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    let output = output_owned_tokio(&mut command).await.ok()?;
+    let output = output_duration_probe(&mut command).await.ok()?;
     if !output.status.success() {
         return None;
     }
     let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
     let seconds: f64 = parsed["format"]["duration"].as_str()?.parse().ok()?;
     (seconds.is_finite() && seconds > 0.0).then_some((seconds * 1000.0) as i64)
+}
+
+async fn output_duration_probe(command: &mut tokio::process::Command) -> io::Result<ProcessOutput> {
+    // Finalization bounds this probe with `tokio::time::timeout`. Without this,
+    // dropping `wait_with_output` leaves ffprobe running after that timeout.
+    command.kill_on_drop(true);
+    output_owned_tokio(command).await
 }
 
 /// Duplicate the session's VISIBLE file + row. Returns the new session id.
@@ -272,6 +281,75 @@ pub async fn import_recording(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn long_running_probe_command(pid_file: &Path) -> tokio::process::Command {
+        #[cfg(target_os = "windows")]
+        {
+            let escaped_pid_file = pid_file.display().to_string().replace('\'', "''");
+            let script = format!(
+                "[System.IO.File]::WriteAllText('{escaped_pid_file}', [string]$PID); Start-Sleep -Seconds 30"
+            );
+            let mut command = tokio::process::Command::new("powershell.exe");
+            command.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+            command
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            let mut command = tokio::process::Command::new("sh");
+            command
+                .args([
+                    "-c",
+                    "printf '%s\\n' \"$$\" > \"$1\"; exec sleep 30",
+                    "videorc-duration-probe-test",
+                ])
+                .arg(pid_file);
+            command
+        }
+    }
+
+    #[tokio::test]
+    async fn timed_out_duration_probe_terminates_its_child() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-duration-probe-timeout-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let pid_file = base.join("pid");
+        let mut command = long_running_probe_command(&pid_file);
+        command
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            output_duration_probe(&mut command),
+        )
+        .await;
+        assert!(result.is_err(), "probe child should exceed the timeout");
+
+        let pid = std::fs::read_to_string(&pid_file)
+            .expect("probe child should publish its pid before sleeping")
+            .trim()
+            .parse::<u32>()
+            .expect("probe child pid should be numeric");
+        let stopped = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if !crate::process_job::process_is_running(pid).expect("probe child liveness") {
+                    return true;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or(false);
+        if !stopped {
+            let _ = crate::process_job::terminate_process(pid, true);
+        }
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert!(stopped, "timed-out duration probe child {pid} stayed alive");
+    }
 
     #[test]
     fn duplicate_names_count_upward() {

--- a/scripts/preflight-windows-package.mjs
+++ b/scripts/preflight-windows-package.mjs
@@ -15,6 +15,18 @@ import { probeWindowsFfmpegCapabilities } from './lib/windows-ffmpeg-capabilitie
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const ffmpegExe = join(repoRoot, 'vendor', 'ffmpeg', 'windows-x64', 'bin', 'ffmpeg.exe')
+const bundledBackgrounds = [
+  'code-demo.webp',
+  'dark-mode.webp',
+  'focus.webp',
+  'light-mode.webp',
+  'livestream.webp',
+  'minimal-desk.webp',
+  'podcast.webp',
+  'product-launch.webp',
+  'tutorial.webp',
+  'webinar.webp'
+]
 
 const inputs = [
   {
@@ -30,7 +42,21 @@ const inputs = [
     // (ffmpeg.rs); repair/import/probe break without it.
     path: join(repoRoot, 'vendor', 'ffmpeg', 'windows-x64', 'bin', 'ffprobe.exe'),
     remedy: 'pnpm ffmpeg:fetch:windows'
-  }
+  },
+  ...bundledBackgrounds.map((fileName) => ({
+    path: join(
+      repoRoot,
+      'apps',
+      'desktop',
+      'src',
+      'renderer',
+      'src',
+      'assets',
+      'backgrounds',
+      fileName
+    ),
+    remedy: 'restore the bundled background assets before packaging'
+  }))
 ]
 
 const missing = inputs.filter((input) => !existsSync(input.path))


### PR DESCRIPTION
## Summary

- revalidate persisted screen/window selections at layout dispatch so stale Windows IDs cannot reach the native compositor
- make imported and bundled backgrounds work with Windows drive-letter and UNC paths, and verify every bundled background during package preflight
- keep the Windows proof preview live while recording, including renderer takeover when the main presentation pump is unavailable
- remove per-frame BGRA allocation/zeroing from Windows screen and camera capture and preserve real FFmpeg cadence without manufactured duplicates
- bound raw-video FIFO backpressure, finish in-flight raw frames safely, and fail shortened/stalled recordings truthfully even when FFmpeg exits successfully
- replace POSIX-only recording finalization with cross-platform process control and kill timed-out ffprobe children
- expose raw FIFO queue age and write latency in diagnostics

## Verification

- `pnpm --filter @videorc/desktop test` — 94 files, 785 tests passed
- `cargo test -p videorc-backend` — 48 helper tests, 1,016 backend tests, and 1 wire test passed
- `cargo clippy -p videorc-backend -- -D warnings`
- `pnpm check:windows`
- `pnpm typecheck`
- `pnpm lint` — no errors; one pre-existing hook dependency warning
- `pnpm format:check` and `cargo fmt --check --all`
- `pnpm test:scripts` — 564 tests passed
- `pnpm build` — all ten bundled backgrounds emitted
- `pnpm smoke:dev` — every layout plus asset-background recordings passed artifact and A/V checks
- `pnpm probe:preview-lifecycle` — 100 cycles passed
- exact FFmpeg cadence probes: camera 60→30, camera 15→15, and selected screen frames remained 15 with passthrough sync
- `pnpm smoke:recording-studio` passed all available gates through native preview reattach; the real ScreenCaptureKit device gate was blocked because this host currently exposed no native screen source

## Windows follow-up

The PR's Windows workflows provide the native Windows compile/unit/package coverage that cannot run on this macOS host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recording reliability when video pipelines stall or encounter encoder errors.
  - Prevented outdated background-asset checks from marking replacement assets as missing.
  - Improved Windows preview frame-rate handling and reduced unnecessary frame-buffer allocation.
  - Fixed source selections that reference unavailable capture devices.

- **Improvements**
  - Enhanced preview polling behavior during recording and when preview surfaces change.
  - Added clearer recording failure reporting and safer duration finalization.
  - Added diagnostic reporting for raw-video encoding performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->