### PR TITLE
Release 0.9.29-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.29-beta.1.md
+++ b/changelog/0.9.29-beta.1.md
@@ -1,0 +1,40 @@
+---
+version: 0.9.29-beta.1
+date: 2026-07-11
+channel: beta
+title: Recordings that fail now say so — reliability hardening under the hood
+summary: A reliability patch on top of this morning's release — recordings that stall or come out short now fail honestly instead of pretending to succeed, capture uses less memory per frame, and Windows tester builds got a big stability pass.
+highlights:
+  - A recording that stalls or ends up shorter than what you recorded now fails loudly with a real error, instead of quietly saving a broken file.
+  - Screen and camera capture allocate less memory per frame, so long recordings run leaner.
+  - Recording finalization is sturdier — stuck probe processes are cleaned up instead of hanging the save step.
+  - Windows tester builds — capture, the live proof preview while recording, and imported backgrounds on any drive path are all far more reliable.
+---
+
+## Truthful recordings
+
+The worst kind of recording bug is the silent one: everything looks fine,
+and the saved file is short, stalled, or broken. This release makes the
+recorder honest about failure:
+
+- If the video pipeline stalls or the encoder falls behind past recovery,
+  the recording fails with a clear error at that moment — you find out
+  while you can still re-record, not after the moment is gone.
+- A recording whose saved length doesn't match what you actually recorded
+  is now treated as a failure, even when the encoder claimed success.
+- The save step cleans up stuck helper processes instead of hanging.
+
+## Leaner capture
+
+Screen and camera capture no longer allocate and clear a fresh frame
+buffer for every single frame, and frame pacing follows the real capture
+cadence instead of manufacturing duplicate frames. Long sessions run
+lighter for it.
+
+## Windows tester builds
+
+For everyone kicking the tires on Windows: saved screen and window
+selections are re-checked before they reach the recorder (so a stale
+monitor ID can't break capture), the proof preview stays live while
+recording, and imported or bundled backgrounds now load correctly from
+any drive letter or network path.


### PR DESCRIPTION
Cuts **0.9.29-beta.1**, a reliability patch on top of this morning's 0.9.28-beta.1, shipping the recording hardening from #75.

- `apps/desktop/package.json` → `0.9.29` (the update-feed key)
- `changelog/0.9.29-beta.1.md` — user-facing entry; `pnpm changelog:check` passes (30 entries valid, latest 0.9.29-beta.1)

What ships (from #75):
- Stalled or shortened recordings fail truthfully with a clear error instead of silently saving a broken file (bounded FIFO backpressure, honest duration check, encoder-error surfacing).
- Leaner capture: no per-frame BGRA allocation/zeroing; real FFmpeg cadence without manufactured duplicate frames.
- Cross-platform recording finalization with timed-out ffprobe cleanup.
- Windows tester builds: stale screen/window selections revalidated before dispatch, live proof preview while recording, backgrounds work from drive-letter/UNC paths.

Build → validate → upload → feed verify → Discord follow after merge, per docs/releases/release-runbook.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recordings that stall, end prematurely, or have mismatched durations now report errors instead of producing broken output.
  * Finalization more reliably cleans up stuck processes and avoids hanging.
  * Windows recording setup now revalidates selected screens and windows to prevent stale selections.
  * Backgrounds load correctly from different drives and network locations.

* **Performance Improvements**
  * Screen and camera capture use less memory and better match the actual capture cadence.
  * Windows recording previews remain live during recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->