### PR TITLE
Record the 0.9.29-beta.1 release (build, upload, feed, announce)

### DIFF
--- a/docs/releases/0.9.29.md
+++ b/docs/releases/0.9.29.md
@@ -1,0 +1,63 @@
+# Videorc 0.9.29 Beta 1
+
+Videorc 0.9.29 is a same-day reliability patch on top of 0.9.28,
+shipping the cross-platform recording hardening and Windows capture
+batch from PR #75.
+
+## Scope
+
+- **Truthful recording failure** (PR #75): bounded raw-video FIFO
+  backpressure, in-flight raw frames finished safely, shortened or
+  stalled recordings fail with a real error even when FFmpeg exits
+  successfully, encoder errors surfaced at the moment they happen.
+- **Leaner capture** (PR #75): per-frame BGRA allocation/zeroing
+  removed from Windows screen and camera capture; real FFmpeg cadence
+  preserved without manufactured duplicate frames.
+- **Cross-platform finalization** (PR #75): POSIX-only recording
+  finalization replaced with cross-platform process control;
+  timed-out ffprobe children are killed instead of hanging the save.
+- **Windows tester-build reliability** (PR #75): persisted
+  screen/window selections revalidated at layout dispatch, live proof
+  preview during recording (renderer takeover when the presentation
+  pump is unavailable), imported/bundled backgrounds work from
+  drive-letter and UNC paths with package-preflight verification.
+- **Diagnostics** (PR #75): raw FIFO queue age and write latency
+  exposed.
+
+## Release status
+
+- [x] Feature PR merged via protected `main` (#75); release prep PR
+      https://github.com/TheOrcDev/videorc/pull/76.
+- [x] Built from `main` post-merge (`aa8c6451`).
+- [x] Signed + notarized (DMG stapled); `release:validate:macos` PASS
+      (codesign, Gatekeeper, stapler, bundled-secret gates).
+- [x] Uploaded to R2, all 8 objects verified; feed serves
+      `version: 0.9.29` through the www redirect (zip resolves 200);
+      `/api/changelog` serves `0.9.29-beta.1` (30 entries valid);
+      `/releases/0.9.29-beta.1` renders.
+- [x] Discord announced (dry-run previewed first, single post).
+- [ ] Real-device screen gates and strict provider readiness were NOT
+      re-run for this patch (agent-cut release; #75's own run had the
+      ScreenCaptureKit device gate blocked on this host). 0.9.28
+      passed acceptance on this machine earlier the same day; delta is
+      #75 only.
+
+## Verification
+
+- All gates green on #75 (785 desktop tests, 1,016 backend tests,
+  clippy/fmt, Windows workflows, smoke:dev artifact + A/V checks,
+  100-cycle preview lifecycle probe, exact FFmpeg cadence probes).
+- `pnpm changelog:check`: 30 entries valid, latest 0.9.29-beta.1.
+
+## Pending owner acceptance
+
+- [ ] Update to 0.9.29 via Settings → About & updates; confirm the
+      feed offers and applies it.
+- [ ] Record a short session; confirm it saves and plays with correct
+      duration.
+- [ ] Simulate a stall (e.g. saturate disk/CPU) or trust the gates:
+      confirm a bad recording fails loudly rather than saving short.
+- [ ] Windows tester build: recording with a previously-saved screen
+      selection, live proof preview while recording, imported
+      background from a non-C: path.
+- [ ] Confirm the signed-in download page serves 0.9.29.


### PR DESCRIPTION
Internal release record for 0.9.29-beta.1, following the 0.9.28 template.

Pipeline results: signed + notarized + stapled, `release:validate:macos` PASS, all 8 R2 objects uploaded and verified, feed serves `version: 0.9.29` through www (zip 200), `/api/changelog` and `/releases/0.9.29-beta.1` live, Discord announced after a dry-run preview.

Honest deviation, called out in the record: the real-device screen gates and strict provider readiness were **not** re-run for this same-day patch (0.9.28 passed acceptance on this machine earlier today; the delta is #75 only, whose own gates were green apart from the host-blocked ScreenCaptureKit device gate). Owner acceptance checklist included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Videorc 0.9.29 Beta 1.
  * Documented more reliable recording failure handling and improved behavior during recording stalls.
  * Documented reduced duplicate-frame issues and more dependable recording finalization across platforms.
  * Documented Windows tester-build improvements, including better screen and window selection validation and support for drive-letter and network paths.
  * Included verification results and an acceptance checklist for updates, playback, recording failures, and downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->