### PR TITLE
fix: let the docked preview stand alone without panel chrome

### DIFF
--- a/apps/desktop/src/renderer/src/components/preview-stage.tsx
+++ b/apps/desktop/src/renderer/src/components/preview-stage.tsx
@@ -1,5 +1,5 @@
 import { ArrowSquareOut, PushPinSimple, VideoCamera, Warning } from '@phosphor-icons/react'
-import type { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -18,6 +18,10 @@ type PreviewStageProps = {
   previewLiveStatus?: PreviewLiveStatus
   previewSurfaceStatus?: PreviewSurfaceStatus
   nativePreviewSurfaceEnabled?: boolean
+  /** Rendered at the left of the docked frame's control row (session status
+   * badge) — the docked preview stands alone, without the Studio panel header
+   * that normally carries it. */
+  dockedFooterStart?: ReactNode
   onRetry?: () => void
   onOpenPermissions?: () => void
   className?: string
@@ -27,6 +31,7 @@ export function PreviewStage({
   previewLiveStatus,
   previewSurfaceStatus,
   nativePreviewSurfaceEnabled = false,
+  dockedFooterStart,
   onRetry,
   onOpenPermissions,
   className
@@ -54,6 +59,7 @@ export function PreviewStage({
           height: captureConfig.video.height
         }}
         className={className}
+        footerStart={dockedFooterStart}
         previewSurfaceStatus={previewSurfaceStatus}
         previewWindow={previewWindow}
         slotRef={slotRef}
@@ -98,6 +104,7 @@ function DockedPreviewFrame({
   previewSurfaceStatus,
   aspect,
   slotRef,
+  footerStart,
   onPopOut,
   onClose,
   onOpenPermissions,
@@ -107,6 +114,7 @@ function DockedPreviewFrame({
   previewSurfaceStatus?: PreviewSurfaceStatus
   aspect: { width: number; height: number }
   slotRef: (element: HTMLElement | null) => void
+  footerStart?: ReactNode
   onPopOut: () => void
   onClose: () => void
   onOpenPermissions?: () => void
@@ -145,7 +153,11 @@ function DockedPreviewFrame({
           <span className="text-xs text-[#A1A1AA]">{status.detail}</span>
         </div>
       </div>
-      <div className="flex items-center justify-end gap-1.5 px-3 py-1.5">
+      {/* Slim control row under the bare strip (the docked preview has no
+          panel around it): session status left, dock controls right, flush
+          with the video edges. */}
+      <div className="flex items-center justify-end gap-1.5 pt-2">
+        {footerStart ? <div className="mr-auto flex items-center">{footerStart}</div> : null}
         {showPermissionAction && onOpenPermissions ? (
           <Button size="sm" variant="outline" onClick={onOpenPermissions}>
             Open permissions

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -210,21 +210,58 @@ function StudioPreviewPanel(): ReactElement {
   const { diagnosticStats, previewSurfaceStatus } = useStudioDiagnostics()
   const active = isSessionTransportActive(recording.state)
   const previewHealth = studioHealth(diagnosticStats, active, runtimeInfo?.platform)
+  const docked =
+    nativePreviewSurfaceEnabled && previewWindow.open && previewWindow.mode === 'docked'
+
+  // data hook: the backend-resilience smoke reads this badge (the old probe
+  // grepped for a "Status" text prefix that died with the session-panel
+  // declutter). It must exist in every preview mode, docked included.
+  const sessionStatusBadge = (
+    <span data-videorc-session-status>
+      <StatusBadge
+        tone={sessionStatusTone(recording.state, wsStatus)}
+        value={sessionStatusLabel(recording.state, wsStatus)}
+      />
+    </span>
+  )
+
+  const healthErrorRow =
+    previewHealth.tone === 'error' && previewHealth.detail ? (
+      <div className="flex items-center gap-2 rounded-row border border-destructive/30 bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive">
+        <WarningCircle className="size-4 shrink-0" weight="fill" />
+        <span className="min-w-0">{previewHealth.detail}</span>
+      </div>
+    ) : null
+
+  const previewStage = (
+    <PreviewStage
+      dockedFooterStart={sessionStatusBadge}
+      nativePreviewSurfaceEnabled={nativePreviewSurfaceEnabled}
+      previewLiveStatus={previewLiveStatus}
+      previewSurfaceStatus={previewSurfaceStatus}
+      onOpenPermissions={openPreviewPermissions}
+      onRetry={refreshPreview}
+    />
+  )
+
+  // Docked ("stick") mode: the preview stands alone — no glass card, no
+  // border, no panel header. The native surface and its black frame ARE the
+  // panel; the docked frame's own control row carries status and dock actions.
+  if (docked) {
+    return (
+      <div className="flex min-w-0 flex-col gap-3">
+        {previewStage}
+        {healthErrorRow}
+      </div>
+    )
+  }
 
   return (
     <PanelSection
       title="Preview"
       action={
         <div className="flex items-center gap-1.5">
-          {/* data hook: the backend-resilience smoke reads this badge
-              (the old probe grepped for a "Status" text prefix that
-              died with the session-panel declutter). */}
-          <span data-videorc-session-status>
-            <StatusBadge
-              tone={sessionStatusTone(recording.state, wsStatus)}
-              value={sessionStatusLabel(recording.state, wsStatus)}
-            />
-          </span>
+          {sessionStatusBadge}
           {previewWindow.open && previewWindow.mode === 'floating' ? (
             <Button
               aria-label="Stick preview into the app"
@@ -262,19 +299,8 @@ function StudioPreviewPanel(): ReactElement {
         </div>
       }
     >
-      <PreviewStage
-        nativePreviewSurfaceEnabled={nativePreviewSurfaceEnabled}
-        previewLiveStatus={previewLiveStatus}
-        previewSurfaceStatus={previewSurfaceStatus}
-        onOpenPermissions={openPreviewPermissions}
-        onRetry={refreshPreview}
-      />
-      {previewHealth.tone === 'error' && previewHealth.detail ? (
-        <div className="flex items-center gap-2 rounded-row border border-destructive/30 bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive">
-          <WarningCircle className="size-4 shrink-0" weight="fill" />
-          <span className="min-w-0">{previewHealth.detail}</span>
-        </div>
-      ) : null}
+      {previewStage}
+      {healthErrorRow}
     </PanelSection>
   )
 }


### PR DESCRIPTION
## What changed

When the preview is sticked ("docked") into the app, the Studio no longer wraps it in the Preview glass card — no border, no panel header, no card padding. The preview renders bare, full-bleed to its grid column, so the video's black frame (including the pillarbox bars at its left and right) runs edge-to-edge with nothing holding it.

- `studio-tab.tsx` — `StudioPreviewPanel` branches on docked mode: docked returns the bare stage + health row; detached/closed keep the `PanelSection` card exactly as before.
- `preview-stage.tsx` — the docked frame's control row is retuned for standing alone: flush with the video edges, with the session status badge (previously in the removed panel header) at its left and Pop out / Close at the right.

## Why

Owner feedback: when docked, the preview should just be alone — keep the black bars at its sides, remove the bordered card that held it.

## Notes for review

- The `data-videorc-session-status` hook is read by `smoke-backend-resilience` and `smoke-captions-live-app`; moving the badge into the docked control row keeps it present in every preview mode. `data-videorc-preview-card`, `data-videorc-preview-docked`, `data-videorc-dock-slot`, and `data-videorc-preview-pop-out` are all unchanged.
- The docked frame stays square-cornered on purpose: the native surface is a separate window CSS cannot clip, so rounding the frame leaves corner wedges peeking around the video (documented inline).
- Removing the card padding makes the dock slot wider; `pnpm probe:preview-window` passes end-to-end, so the native surface still glues to the slot exactly (drawable = slot points × scale, move/overlay/scroll/tab-switch/undock all aligned).

## Verification

- `pnpm typecheck`, `pnpm lint` (one pre-existing warning in `use-studio.tsx`), `pnpm format:check`
- `pnpm --filter @videorc/desktop test` — 785/785 pass
- `pnpm probe:preview-window` — PASS
- `pnpm probe:preview-lifecycle` — completes 100/100 cycles with clean teardown; exits on the pre-existing `electron-main process count 4 exceeded 1` memory gate, which fails identically on clean main (known dead gate, task already spawned 2026-07-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying custom content in the left side of the docked preview footer.

* **Improvements**
  * Refined the docked preview layout for a cleaner, more compact footer.
  * Improved preview rendering across docked and standard modes while preserving existing controls and status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->