### PR TITLE
Fix Windows recording timing and recording-time preview

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -106,6 +106,32 @@ jobs:
         # testers will see a SmartScreen warning until signing lands.
         run: pnpm dist:desktop:windows
 
+      - name: Verify packaged 1080p recording duration and A/V
+        run: pnpm smoke:packaged:bundled
+        env:
+          VIDEORC_PACKAGED_APP_EXECUTABLE: apps/desktop/release/win-unpacked/Videorc.exe
+          VIDEORC_SMOKE_OUTPUT_DIR: ${{ runner.temp }}/videorc-windows-recording-smoke
+          VIDEORC_SMOKE_RECORDING_MS: '5000'
+          VIDEORC_SMOKE_TIMEOUT_MS: '120000'
+          VIDEORC_SMOKE_VIDEO_WIDTH: '1920'
+          VIDEORC_SMOKE_VIDEO_HEIGHT: '1080'
+          VIDEORC_SMOKE_VIDEO_FPS: '30'
+          VIDEORC_SMOKE_VIDEO_BITRATE_KBPS: '6000'
+
+      - name: Verify Windows preview stays live while recording
+        run: pnpm smoke:recording-native-preview
+        env:
+          VIDEORC_SMOKE_OUTPUT_DIR: ${{ runner.temp }}/videorc-windows-preview-recording-smoke
+          VIDEORC_SMOKE_FFMPEG_PATH: ${{ github.workspace }}\apps\desktop\release\win-unpacked\resources\ffmpeg\bin\ffmpeg.exe
+          VIDEORC_SMOKE_FFPROBE_PATH: ${{ github.workspace }}\apps\desktop\release\win-unpacked\resources\ffmpeg\bin\ffprobe.exe
+          VIDEORC_SMOKE_TIMEOUT_MS: '180000'
+          VIDEORC_NATIVE_PREVIEW_RECORDING_MS: '8000'
+          VIDEORC_NATIVE_PREVIEW_WARMUP_MS: '2000'
+          VIDEORC_NATIVE_PREVIEW_MEASUREMENT_MS: '4000'
+          VIDEORC_EXPECT_NATIVE_METAL_PREVIEW: '0'
+          VIDEORC_NATIVE_PREVIEW_EXERCISE_PROOF_POLLING: '1'
+          VIDEORC_ENCODER_BRIDGE_VIDEO_OUTPUT: raw-yuv420p
+
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Verify Windows preview stays live while recording
         run: pnpm smoke:recording-native-preview
         env:
+          VIDEORC_PERF_APP_EXECUTABLE: apps/desktop/release/win-unpacked/Videorc.exe
           VIDEORC_SMOKE_OUTPUT_DIR: ${{ runner.temp }}/videorc-windows-preview-recording-smoke
           VIDEORC_SMOKE_FFMPEG_PATH: ${{ github.workspace }}\apps\desktop\release\win-unpacked\resources\ffmpeg\bin\ffmpeg.exe
           VIDEORC_SMOKE_FFPROBE_PATH: ${{ github.workspace }}\apps\desktop\release\win-unpacked\resources\ffmpeg\bin\ffprobe.exe

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -116,15 +116,21 @@ import {
 } from './avatar-cache'
 import { DARK_WINDOW_PALETTE, windowPalette } from './window-palette'
 import {
+  assessProofSourceFrame,
   assessFirstFrame,
   assessPresenting,
   emptyFirstFrameLedger,
   emptyPresentingWatch,
+  nativePreviewFirstFrameWatchdogEnabled,
   type FirstFrameLedger,
   type FirstFrameSnapshot,
   type PresentingAssessment,
   type PresentingWatchState
 } from './native-preview-first-frame'
+import {
+  nativePreviewProofPollingProfile,
+  nativePreviewProofPollingProfileKey
+} from '../shared/native-preview-proof-polling'
 import {
   DEFAULT_MAIN_PUMP_FRAME_STALL_TIMEOUT_MS,
   mainPumpFrameDeliveryStalled,
@@ -297,6 +303,9 @@ const nativePreviewPlacementQueue = new NativePreviewPlacementQueue(
 )
 let nativePreviewSurfaceStatus: PreviewSurfaceStatus = idleNativePreviewSurfaceStatus()
 let nativePreviewSurfaceFramePollingSuppressed = false
+let nativePreviewProofPollingRecordingActive = false
+let nativePreviewAppliedProofPollingProfile: string | null = null
+let nativePreviewProofPollingProfileSerial = 0
 let nativePreviewNativeOwnsProofPollingSuppression = false
 let nativePreviewNativeFailureFallbackActive = false
 let nativePreviewAppliedProofPollingSuppression: boolean | null = null
@@ -2951,8 +2960,17 @@ async function openPreviewWindow(): Promise<PreviewWindowState> {
   void setNativePreviewSurfaceFramePollingSuppressed(false)
   pushPreviewWindowPlacement()
   emitPreviewWindowState()
-  // The first-frame contract clock starts the moment the window is up.
-  startFirstFrameWatchdog()
+  // The first-frame watchdog proves and heals the macOS CAMetalLayer chain.
+  // Windows uses the Electron proof surface; running the Metal watchdog there
+  // guarantees false resets because an IOSurface can never appear.
+  if (nativePreviewFirstFrameWatchdogEnabled(process.platform)) {
+    startFirstFrameWatchdog()
+  } else {
+    stopFirstFrameWatchdog()
+    firstFrameLastHint = null
+    setFirstFrameStatus('pending', 'Waiting for the Windows preview surface to deliver pixels.')
+    updatePreviewWindowWaitDetail('Waiting for the Windows preview surface to deliver pixels.')
+  }
   return previewWindowState()
 }
 
@@ -3193,6 +3211,16 @@ function backendPreviewFrameUrl(
     !backendConnection
   ) {
     return undefined
+  }
+  if (process.env.VIDEORC_SMOKE_PREVIEW_FRAME_POLLING === '1') {
+    const address = smokePreviewMotionServer?.address()
+    if (address && typeof address !== 'string') {
+      const params = new URLSearchParams()
+      if (typeof maxWidth === 'number' && Number.isFinite(maxWidth) && maxWidth > 0) {
+        params.set('maxWidth', String(Math.max(1, Math.round(maxWidth))))
+      }
+      return `http://${address.address}:${address.port}/preview-frame.png?${params.toString()}`
+    }
   }
   const params = new URLSearchParams({ token: backendConnection.token })
   if (typeof maxWidth === 'number' && Number.isFinite(maxWidth) && maxWidth > 0) {
@@ -3637,6 +3665,8 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
         const pollers = new Map();
         const sourceFrames = new Map();
         let framePollingSuppressed = false;
+        let framePollingIntervalMs = 40;
+        let framePollingMaxWidth = 1920;
         let proofSurfaceSuspended = false;
         let animationFrameId = null;
         let compositorStatus = null;
@@ -3661,6 +3691,20 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
           return url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
         }
 
+        function profiledFrameUrl(url) {
+          try {
+            const parsed = new URL(url);
+            const requested = Number(parsed.searchParams.get('maxWidth'));
+            const maxWidth = Number.isFinite(requested) && requested > 0
+              ? Math.min(requested, framePollingMaxWidth)
+              : framePollingMaxWidth;
+            parsed.searchParams.set('maxWidth', String(Math.max(1, Math.round(maxWidth))));
+            return parsed.toString();
+          } catch {
+            return url;
+          }
+        }
+
         function cropStyle(transform) {
           const cropLeft = Math.max(0, Number(transform?.cropLeft ?? 0));
           const cropRight = Math.max(0, Number(transform?.cropRight ?? 0));
@@ -3678,6 +3722,10 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
 
         function markLive(kind, sourceId) {
           sourceFrames.set(sourceId, (sourceFrames.get(sourceId) ?? 0) + 1);
+          const poller = pollers.get(sourceId);
+          if (poller) {
+            poller.lastSuccessAt = performance.now();
+          }
           liveLayerCount = [...layers.values()].filter(({ image }) => image?.dataset.live === '1').length;
           if (liveLayerCount > 0) {
             document.body.classList.add('surface-live');
@@ -3715,6 +3763,17 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
           }
         }
 
+        function setFramePollingProfile(profile) {
+          const intervalMs = Number(profile?.intervalMs);
+          const maxWidth = Number(profile?.maxWidth);
+          if (Number.isFinite(intervalMs) && intervalMs >= 20) {
+            framePollingIntervalMs = Math.round(intervalMs);
+          }
+          if (Number.isFinite(maxWidth) && maxWidth >= 1) {
+            framePollingMaxWidth = Math.round(maxWidth);
+          }
+        }
+
         function startFramePolling(id, kind, image, url) {
           if (framePollingSuppressed) {
             stopLayerPoller(id);
@@ -3729,7 +3788,14 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
           if (existing) {
             existing.cancelled = true;
           }
-          const poller = { url, image, cancelled: false, pending: false };
+          const poller = {
+            url,
+            image,
+            cancelled: false,
+            pending: false,
+            startedAt: performance.now(),
+            lastSuccessAt: null
+          };
           pollers.set(id, poller);
 
           const poll = () => {
@@ -3737,7 +3803,7 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
               return;
             }
             if (poller.pending) {
-              window.setTimeout(poll, 40);
+              window.setTimeout(poll, framePollingIntervalMs);
               return;
             }
             poller.pending = true;
@@ -3750,17 +3816,13 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
                 markLive(kind, id);
               }
               poller.pending = false;
-              // ~25fps idle poll ceiling: trims idle CPU now that preview frames
-              // render at a higher resolution (preview-sizing fix), while staying
-              // visually smooth. Frame polling is suppressed entirely while
-              // recording (the compositor surface takes over).
-              window.setTimeout(poll, 40);
+              window.setTimeout(poll, framePollingIntervalMs);
             };
             next.onerror = () => {
               poller.pending = false;
-              window.setTimeout(poll, 250);
+              window.setTimeout(poll, Math.max(250, framePollingIntervalMs));
             };
-            next.src = cacheBust(url);
+            next.src = cacheBust(profiledFrameUrl(url));
           };
 
           poll();
@@ -3859,6 +3921,7 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
 
         window.__videorcSetPreviewScene = applyScene;
         window.__videorcSetFramePollingSuppressed = setFramePollingSuppressed;
+        window.__videorcSetFramePollingProfile = setFramePollingProfile;
 
         function applyCompositorStatus(nextStatus) {
           pendingCompositorStatus = nextStatus;
@@ -3965,6 +4028,17 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
               return sorted[index];
             };
             const elapsed = Math.max(1, performance.now() - startedAt);
+            const sourceFrameAges = [...pollers.values()].map((poller) =>
+              Math.max(0, performance.now() - (poller.lastSuccessAt ?? poller.startedAt))
+            );
+            const sourceFrameAgeMs = sourceFrameAges.length > 0
+              ? Math.max(...sourceFrameAges)
+              : null;
+            const sourceFreshnessBudgetMs = Math.max(1500, framePollingIntervalMs * 8);
+            const freshSourceLayerCount = [...pollers.values()].filter((poller) =>
+              poller.lastSuccessAt != null &&
+              performance.now() - poller.lastSuccessAt <= sourceFreshnessBudgetMs
+            ).length;
             return {
               frames,
               measuredFps: frames / elapsed * 1000,
@@ -3984,12 +4058,17 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
               inputToPresentLatencyP99Ms: percentile(inputToPresentLatencies, 99),
               compositorSources: compositorStatus?.sources ?? [],
               layerCount: layers.size,
+              sourcePollerCount: pollers.size,
               liveLayerCount,
+              freshSourceLayerCount,
               sourceFrames: Object.fromEntries(sourceFrames),
+              sourceFrameAgeMs,
               intervalP50Ms: percentile(intervals, 50),
               intervalP95Ms: percentile(intervals, 95),
               intervalP99Ms: percentile(intervals, 99),
               framePollingSuppressed,
+              framePollingIntervalMs,
+              framePollingMaxWidth,
               proofSurfaceSuspended,
               sourcePixelsPresent: liveLayerCount > 0,
               blankFrames: 0,
@@ -4072,6 +4151,7 @@ async function createNativePreviewSurfaceWindow(generation: number): Promise<voi
       if (nativePreviewSurfaceWindow === surfaceWindow) {
         nativePreviewSurfaceWindow = null
         nativePreviewAppliedProofPollingSuppression = null
+        nativePreviewAppliedProofPollingProfile = null
         nativePreviewProofAnimationSuspended = null
         nativePreviewSurfaceStatus = idleNativePreviewSurfaceStatus()
       }
@@ -4103,6 +4183,7 @@ async function createNativePreviewSurfaceWindow(generation: number): Promise<voi
         }
         return
       }
+      await syncNativePreviewProofPollingProfile()
       const proofPollingSuppressed = nativePreviewProofPollingIsSuppressed()
       if (proofPollingSuppressed) {
         await waitForNativePreviewSurfaceScript(surfaceWindow)
@@ -4243,6 +4324,8 @@ async function createNativePreviewSurface(
     intervalP99Ms: nativePreviewSurfaceStatus.intervalP99Ms,
     framePollingSuppressed: nativePreviewProofPollingIsSuppressed(),
     sourcePixelsPresent: nativePreviewSurfaceStatus.sourcePixelsPresent,
+    firstFrameContract: nativePreviewSurfaceStatus.firstFrameContract,
+    firstFrameReason: nativePreviewSurfaceStatus.firstFrameReason,
     nativePreviewHostKind: preserveNativeSurface
       ? nativePreviewSurfaceStatus.nativePreviewHostKind
       : 'proof-surface',
@@ -4816,7 +4899,9 @@ async function presentNativePreviewSurfaceCompositor(
   const presentFps = finiteMetric(metrics?.measuredFps)
   const intervalP95Ms = finiteMetric(metrics?.intervalP95Ms)
   const intervalP99Ms = finiteMetric(metrics?.intervalP99Ms)
-  const liveLayerCount = finiteMetric(metrics?.liveLayerCount) ?? 0
+  const freshSourceLayerCount = finiteMetric(metrics?.freshSourceLayerCount) ?? 0
+  const sourcePollerCount = finiteMetric(metrics?.sourcePollerCount) ?? 0
+  const sourceFrameAgeMs = finiteMetric(metrics?.sourceFrameAgeMs)
   nativePreviewSurfaceStatus = {
     ...nativePreviewSurfaceStatus,
     ...nativePreviewRendererTimingStatusFields(effectiveStatus),
@@ -4839,7 +4924,7 @@ async function presentNativePreviewSurfaceCompositor(
     intervalP95Ms,
     intervalP99Ms,
     framePollingSuppressed: nativePreviewProofPollingIsSuppressed(),
-    sourcePixelsPresent: liveLayerCount > 0,
+    sourcePixelsPresent: freshSourceLayerCount > 0,
     nativePreviewHostKind: 'proof-surface',
     nativePreviewHostAttached: false,
     updatedAt: new Date().toISOString(),
@@ -4848,6 +4933,27 @@ async function presentNativePreviewSurfaceCompositor(
       realSurfaceAttempt.reason,
       process.platform
     )
+  }
+  const proofSourceAssessment = assessProofSourceFrame({
+    platform: process.platform,
+    framePollingSuppressed: nativePreviewProofPollingIsSuppressed(),
+    sourcePollerCount,
+    freshSourceLayerCount,
+    sourceFrameAgeMs
+  })
+  if (proofSourceAssessment === 'met') {
+    if (nativePreviewSurfaceStatus.firstFrameContract !== 'met') {
+      setFirstFrameStatus('met', 'Windows preview pixels are live.')
+      updatePreviewWindowWaitDetail(null)
+      logBackend('info', '[proof-preview] source frame delivery is live')
+    }
+  } else if (proofSourceAssessment === 'stalled') {
+    if (nativePreviewSurfaceStatus.firstFrameContract !== 'fallback') {
+      const reason = `Windows preview source frames have not advanced for ${Math.round(sourceFrameAgeMs ?? 0)}ms; keeping the last good frame while polling retries.`
+      setFirstFrameStatus('fallback', reason)
+      updatePreviewWindowWaitDetail(reason)
+      logBackend('warn', `[proof-preview] ${reason}`)
+    }
   }
   previewSupervisor.surfaceFallback(
     previewWindowSurfaceGeneration(),
@@ -5172,20 +5278,69 @@ async function tryPresentNativePreviewRealSurfaceCompositor(
 }
 
 async function setNativePreviewSurfaceFramePollingSuppressed(
-  suppressed: boolean
+  suppressed: boolean,
+  recordingActive?: boolean
 ): Promise<PreviewSurfaceStatus> {
+  if (typeof recordingActive === 'boolean') {
+    nativePreviewProofPollingRecordingActive = recordingActive
+  }
   const wasSuppressed = nativePreviewSurfaceFramePollingSuppressed
   nativePreviewSurfaceFramePollingSuppressed = suppressed
   if (suppressed && !wasSuppressed) {
     resetNativePreviewMainHandoffMetrics()
     nativePreviewRealSurfaceDriver?.resetMetrics?.()
   }
+  await syncNativePreviewProofPollingProfile()
   const effectiveSuppression = await syncNativePreviewProofPollingSuppression()
   nativePreviewSurfaceStatus = nativePreviewFramePollingSuppressionStatus(
     nativePreviewSurfaceStatus,
     effectiveSuppression
   )
   return nativePreviewSurfaceStatus
+}
+
+async function syncNativePreviewProofPollingProfile(): Promise<void> {
+  const profile = nativePreviewProofPollingProfile(nativePreviewProofPollingRecordingActive)
+  const surfaceWindow = nativePreviewSurfaceWindow
+  if (!surfaceWindow || surfaceWindow.isDestroyed()) {
+    nativePreviewAppliedProofPollingProfile = null
+    return
+  }
+  const profileKey = nativePreviewProofPollingProfileKey(surfaceWindow.id, profile)
+  if (nativePreviewAppliedProofPollingProfile === profileKey) {
+    return
+  }
+  const requestSerial = ++nativePreviewProofPollingProfileSerial
+  await waitForNativePreviewSurfaceScript(surfaceWindow)
+  if (
+    requestSerial !== nativePreviewProofPollingProfileSerial ||
+    profileKey !==
+      nativePreviewProofPollingProfileKey(
+        surfaceWindow.id,
+        nativePreviewProofPollingProfile(nativePreviewProofPollingRecordingActive)
+      ) ||
+    surfaceWindow.isDestroyed() ||
+    nativePreviewSurfaceWindow !== surfaceWindow
+  ) {
+    nativePreviewAppliedProofPollingProfile = null
+    return
+  }
+  await surfaceWindow.webContents.executeJavaScript(
+    `window.__videorcSetFramePollingProfile?.(${jsonForInlineScript(profile)})`,
+    true
+  )
+  if (
+    requestSerial === nativePreviewProofPollingProfileSerial &&
+    profileKey ===
+      nativePreviewProofPollingProfileKey(
+        surfaceWindow.id,
+        nativePreviewProofPollingProfile(nativePreviewProofPollingRecordingActive)
+      ) &&
+    !surfaceWindow.isDestroyed() &&
+    nativePreviewSurfaceWindow === surfaceWindow
+  ) {
+    nativePreviewAppliedProofPollingProfile = profileKey
+  }
 }
 
 function nativePreviewProofPollingIsSuppressed(): boolean {
@@ -5269,6 +5424,20 @@ async function readNativePreviewSurfaceMetricsAfterPaint(): Promise<Record<
 
 function finiteMetric(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function proofSourceFrameTotal(metrics: unknown): number {
+  if (!metrics || typeof metrics !== 'object') {
+    return 0
+  }
+  const sourceFrames = (metrics as { sourceFrames?: unknown }).sourceFrames
+  if (!sourceFrames || typeof sourceFrames !== 'object') {
+    return 0
+  }
+  return Object.values(sourceFrames).reduce<number>(
+    (total, value) => total + (typeof value === 'number' && Number.isFinite(value) ? value : 0),
+    0
+  )
 }
 
 // The renderer hands main the backend's own per-frame compositor.status with
@@ -5582,6 +5751,8 @@ function destroyNativePreviewSurface(
   nativePreviewNativeOwnsProofPollingSuppression = false
   nativePreviewNativeFailureFallbackActive = false
   nativePreviewAppliedProofPollingSuppression = null
+  nativePreviewAppliedProofPollingProfile = null
+  nativePreviewProofPollingProfileSerial += 1
   nativePreviewProofAnimationSuspended = null
   clearNativePreviewNativePlacementAuthority()
   void applyNativePreviewRealSurfaceHostCommands([{ kind: 'destroy' }], { startIfNeeded: false })
@@ -6718,6 +6889,19 @@ async function handleSmokePreviewMotionRequest(
   request: IncomingMessage,
   response: HttpResponse
 ): Promise<void> {
+  if (request.method === 'GET' && request.url?.startsWith('/preview-frame.png')) {
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      'base64'
+    )
+    response.writeHead(200, {
+      'Content-Type': 'image/png',
+      'Content-Length': String(png.length),
+      'Cache-Control': 'no-store'
+    })
+    response.end(png)
+    return
+  }
   if (request.method === 'GET' && request.url === '/health') {
     writeSmokeJson(response, 200, { ok: true })
     return
@@ -6925,6 +7109,15 @@ async function runSmokePreviewMotionCommand(
     const durationMs = typeof params.durationMs === 'number' ? params.durationMs : 2500
     resetNativePreviewMainHandoffMetrics()
     nativePreviewRealSurfaceDriver?.resetMetrics?.()
+    const measuringProofSurface = !nativePreviewSurfaceStatusIsRealSurface(
+      nativePreviewSurfaceStatus
+    )
+    const initialProofMetrics = measuringProofSurface
+      ? await nativePreviewSurfaceWindow.webContents.executeJavaScript(
+          'window.__videorcNativePreviewMetrics?.() ?? null',
+          true
+        )
+      : null
     await new Promise((resolveMeasure) => setTimeout(resolveMeasure, durationMs))
     if (nativePreviewSurfaceStatusIsRealSurface(nativePreviewSurfaceStatus)) {
       return nativePreviewSurfaceStatusMetrics(nativePreviewSurfaceStatus)
@@ -6937,7 +7130,11 @@ async function runSmokePreviewMotionCommand(
       throw new Error('Native preview surface did not expose metrics.')
     }
     const presentedFrameId = finiteMetric(metrics.presentedCompositorFrame)
-    const liveLayerCount = finiteMetric(metrics.liveLayerCount) ?? 0
+    const freshSourceLayerCount = finiteMetric(metrics.freshSourceLayerCount) ?? 0
+    const sourceFrameDelta = Math.max(
+      0,
+      proofSourceFrameTotal(metrics) - proofSourceFrameTotal(initialProofMetrics)
+    )
     nativePreviewSurfaceStatus = {
       ...nativePreviewSurfaceStatus,
       framesRendered: Number(metrics.frames ?? nativePreviewSurfaceStatus.framesRendered),
@@ -6957,11 +7154,12 @@ async function runSmokePreviewMotionCommand(
       intervalP95Ms: finiteMetric(metrics.intervalP95Ms),
       intervalP99Ms: finiteMetric(metrics.intervalP99Ms),
       framePollingSuppressed: Boolean(metrics.framePollingSuppressed),
-      sourcePixelsPresent: liveLayerCount > 0,
+      sourcePixelsPresent: freshSourceLayerCount > 0,
       updatedAt: new Date().toISOString()
     }
     return {
       ...metrics,
+      sourceFrameDelta,
       status: nativePreviewSurfaceStatus
     }
   }
@@ -9537,15 +9735,23 @@ app.whenReady().then(async () => {
         : rejectedNativePreviewCompositorUpdateStatus()
     }
   )
-  ipcMain.handle('preview-surface:set-frame-polling-suppressed', (_event, suppressed: boolean) => {
-    // With the preview window closed, polling stays suppressed no matter what
-    // the renderer's (possibly stale, post-close) state events request — an
-    // un-suppress race here left polling running against a destroyed surface.
-    if (!suppressed && (!previewWindow || previewWindow.isDestroyed())) {
-      return nativePreviewSurfaceFramePollingSuppressed
+  ipcMain.handle(
+    'preview-surface:set-frame-polling-suppressed',
+    (_event, suppressed: boolean, recordingActive?: boolean) => {
+      if (typeof recordingActive === 'boolean') {
+        nativePreviewProofPollingRecordingActive = recordingActive
+      }
+      // With the preview window closed, polling stays suppressed no matter what
+      // the renderer's (possibly stale, post-close) state events request — an
+      // un-suppress race here left polling running against a destroyed surface.
+      // Keep the recording state above so a preview opened mid-recording starts
+      // with the contained Windows proof-polling profile.
+      if (!suppressed && (!previewWindow || previewWindow.isDestroyed())) {
+        return nativePreviewSurfaceFramePollingSuppressed
+      }
+      return setNativePreviewSurfaceFramePollingSuppressed(suppressed, recordingActive)
     }
-    return setNativePreviewSurfaceFramePollingSuppressed(suppressed)
-  })
+  )
   ipcMain.handle('preview-surface:destroy', (_event, generation) => {
     nativePreviewPlacementQueue.cancelPending()
     return runNativePreviewSurfaceMutation(() =>

--- a/apps/desktop/src/main/native-preview-first-frame.test.ts
+++ b/apps/desktop/src/main/native-preview-first-frame.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  assessProofSourceFrame,
   assessFirstFrame,
   assessPresenting,
   DEFAULT_FIRST_FRAME_BUDGETS,
@@ -9,6 +10,7 @@ import {
   emptyPresentingWatch,
   firstFrameBlockedReason,
   firstFrameContractMet,
+  nativePreviewFirstFrameWatchdogEnabled,
   type FirstFrameSnapshot,
   type PresentingWatchState
 } from './native-preview-first-frame'
@@ -27,6 +29,82 @@ function snapshot(overrides: Partial<FirstFrameSnapshot> = {}): FirstFrameSnapsh
     ...overrides
   }
 }
+
+describe('nativePreviewFirstFrameWatchdogEnabled', () => {
+  it('runs the Metal first-frame contract only on macOS', () => {
+    expect(nativePreviewFirstFrameWatchdogEnabled('darwin')).toBe(true)
+    expect(nativePreviewFirstFrameWatchdogEnabled('win32')).toBe(false)
+    expect(nativePreviewFirstFrameWatchdogEnabled('linux')).toBe(false)
+  })
+})
+
+describe('assessProofSourceFrame', () => {
+  it('treats fresh Windows source frames as live and sustained gaps as stalled', () => {
+    expect(
+      assessProofSourceFrame({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        sourcePollerCount: 1,
+        freshSourceLayerCount: 1,
+        sourceFrameAgeMs: 125
+      })
+    ).toBe('met')
+    expect(
+      assessProofSourceFrame({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        sourcePollerCount: 1,
+        freshSourceLayerCount: 0,
+        sourceFrameAgeMs: 1_501
+      })
+    ).toBe('stalled')
+  })
+
+  it('does not diagnose intentional suppression or apply the proof contract to macOS', () => {
+    expect(
+      assessProofSourceFrame({
+        platform: 'win32',
+        framePollingSuppressed: true,
+        sourcePollerCount: 1,
+        freshSourceLayerCount: 0,
+        sourceFrameAgeMs: 10_000
+      })
+    ).toBe('paused')
+    expect(
+      assessProofSourceFrame({
+        platform: 'darwin',
+        framePollingSuppressed: false,
+        sourcePollerCount: 1,
+        freshSourceLayerCount: 0,
+        sourceFrameAgeMs: 10_000
+      })
+    ).toBe('not-applicable')
+  })
+
+  it('does not report a stale prior source after switching to a static scene', () => {
+    expect(
+      assessProofSourceFrame({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        sourcePollerCount: 0,
+        freshSourceLayerCount: 0,
+        sourceFrameAgeMs: 10_000
+      })
+    ).toBe('not-applicable')
+  })
+
+  it('requires every active source poller to remain fresh', () => {
+    expect(
+      assessProofSourceFrame({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        sourcePollerCount: 2,
+        freshSourceLayerCount: 1,
+        sourceFrameAgeMs: 1_501
+      })
+    ).toBe('stalled')
+  })
+})
 
 describe('firstFrameContractMet', () => {
   it('is met only when the whole chain agrees and advances', () => {

--- a/apps/desktop/src/main/native-preview-first-frame.ts
+++ b/apps/desktop/src/main/native-preview-first-frame.ts
@@ -55,6 +55,50 @@ export const DEFAULT_FIRST_FRAME_BUDGETS: FirstFrameBudgets = {
   declareFallbackAfterMs: 15000
 }
 
+/**
+ * This watchdog proves a CAMetalLayer/IOSurface chain and may reset that native
+ * presenter while healing. Windows uses the Electron proof surface instead, so
+ * running the Metal contract there guarantees false healing and visible resets.
+ */
+export function nativePreviewFirstFrameWatchdogEnabled(platform: NodeJS.Platform): boolean {
+  return platform === 'darwin'
+}
+
+export const DEFAULT_PROOF_SOURCE_FRAME_STALE_MS = 1500
+
+export type ProofSourceFrameAssessment = 'not-applicable' | 'paused' | 'pending' | 'met' | 'stalled'
+
+export function assessProofSourceFrame(params: {
+  platform: NodeJS.Platform
+  framePollingSuppressed: boolean
+  sourcePollerCount: number
+  freshSourceLayerCount: number
+  sourceFrameAgeMs?: number
+  staleAfterMs?: number
+}): ProofSourceFrameAssessment {
+  if (params.platform === 'darwin') {
+    return 'not-applicable'
+  }
+  if (params.framePollingSuppressed) {
+    return 'paused'
+  }
+  if (params.sourcePollerCount <= 0) {
+    return 'not-applicable'
+  }
+  const staleAfterMs = params.staleAfterMs ?? DEFAULT_PROOF_SOURCE_FRAME_STALE_MS
+  if (
+    params.freshSourceLayerCount >= params.sourcePollerCount &&
+    params.sourceFrameAgeMs != null &&
+    params.sourceFrameAgeMs <= staleAfterMs
+  ) {
+    return 'met'
+  }
+  if (params.sourceFrameAgeMs != null && params.sourceFrameAgeMs > staleAfterMs) {
+    return 'stalled'
+  }
+  return 'pending'
+}
+
 export type FirstFrameAssessment =
   | { kind: 'met' }
   | { kind: 'pending'; reason: string }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -185,8 +185,8 @@ const api: VideorcApi = {
     ipcRenderer.invoke('preview-surface:update-scene', scene),
   updateNativePreviewSurfaceCompositor: (status) =>
     ipcRenderer.invoke('preview-surface:update-compositor', status),
-  setNativePreviewSurfaceFramePollingSuppressed: (suppressed) =>
-    ipcRenderer.invoke('preview-surface:set-frame-polling-suppressed', suppressed),
+  setNativePreviewSurfaceFramePollingSuppressed: (suppressed, recordingActive) =>
+    ipcRenderer.invoke('preview-surface:set-frame-polling-suppressed', suppressed, recordingActive),
   destroyNativePreviewSurface: (generation) =>
     ipcRenderer.invoke('preview-surface:destroy', generation),
   getNativePreviewSurfaceStatus: () => ipcRenderer.invoke('preview-surface:status'),

--- a/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
@@ -1175,8 +1175,10 @@ function formatEncodeBackend(backend?: string): string {
       return 'Software (x264)'
     case 'hardware-videotoolbox':
       return 'Hardware (VideoToolbox)'
-    case 'hardware-mediafoundation':
+    case 'hardware-media-foundation':
       return 'Hardware (MediaFoundation)'
+    case 'software-media-foundation':
+      return 'Software (MediaFoundation)'
     default:
       return '--'
   }

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -2094,7 +2094,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   // Late-bound mirror so applyRecordingStatus (declared earlier) can trigger the
   // consolidated frame-polling suppression defined with the preview window state.
   const syncFramePollingSuppressionRef = useRef<(() => void) | null>(null)
-  const nativePreviewFramePollingSuppressionRequestedRef = useRef<boolean | null>(null)
+  const nativePreviewFramePollingRequestKeyRef = useRef<string | null>(null)
   const nativePreviewCameraKeyRef = useRef<string | null>(null)
   const nativePreviewScreenKeyRef = useRef<string | null>(null)
   const nativePreviewCommittedSceneRef = useRef<{
@@ -5426,25 +5426,27 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     ) {
       return
     }
+    const recordingActive = isActiveRecordingState(recordingRef.current.state)
     const suppress = nativePreviewFramePollingShouldSuppress({
-      recordingActive: isActiveRecordingState(recordingRef.current.state),
+      recordingActive,
       windowOpen: previewWindowRef.current.open,
       status: previewSurfaceStatusRef.current
     })
-    if (nativePreviewFramePollingSuppressionRequestedRef.current === suppress) {
+    const requestKey = `${suppress}:${recordingActive}`
+    if (nativePreviewFramePollingRequestKeyRef.current === requestKey) {
       return
     }
-    nativePreviewFramePollingSuppressionRequestedRef.current = suppress
+    nativePreviewFramePollingRequestKeyRef.current = requestKey
     void window.videorc
-      .setNativePreviewSurfaceFramePollingSuppressed(suppress)
+      .setNativePreviewSurfaceFramePollingSuppressed(suppress, recordingActive)
       .then((status) => {
-        if (nativePreviewFramePollingSuppressionRequestedRef.current === suppress) {
+        if (nativePreviewFramePollingRequestKeyRef.current === requestKey) {
           applyPreviewSurfaceStatus(status)
         }
       })
       .catch((error: unknown) => {
-        if (nativePreviewFramePollingSuppressionRequestedRef.current === suppress) {
-          nativePreviewFramePollingSuppressionRequestedRef.current = null
+        if (nativePreviewFramePollingRequestKeyRef.current === requestKey) {
+          nativePreviewFramePollingRequestKeyRef.current = null
         }
         console.error('Native preview frame-polling suppression failed:', error)
       })

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1109,7 +1109,11 @@ export type PreviewTransport =
 /** Which encoder a recording session requested. Hardware encoders may still fall back
  * internally, so this is the requested backend; the final-file codec/encoder tag is the
  * corroborating output-side signal. */
-export type EncodeBackend = 'software-x264' | 'hardware-videotoolbox' | 'hardware-mediafoundation'
+export type EncodeBackend =
+  | 'software-x264'
+  | 'hardware-videotoolbox'
+  | 'hardware-media-foundation'
+  | 'software-media-foundation'
 export type CompositorBackend = 'metal' | 'cpu' | 'cpu-fallback'
 
 /** Cumulative request counts for the HTTP image-polling preview transports. A native
@@ -2720,7 +2724,8 @@ export interface VideorcApi {
   getNativePreviewMainPumpActive: () => Promise<boolean>
   onNativePreviewMainPumpActive: (callback: (active: boolean) => void) => () => void
   setNativePreviewSurfaceFramePollingSuppressed: (
-    suppressed: boolean
+    suppressed: boolean,
+    recordingActive?: boolean
   ) => Promise<PreviewSurfaceStatus>
   destroyNativePreviewSurface: (generation?: number) => Promise<PreviewSurfaceStatus>
   getNativePreviewSurfaceStatus: () => Promise<PreviewSurfaceStatus>

--- a/apps/desktop/src/shared/native-preview-proof-polling.test.ts
+++ b/apps/desktop/src/shared/native-preview-proof-polling.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  nativePreviewProofPollingProfile,
+  nativePreviewProofPollingProfileKey
+} from './native-preview-proof-polling'
+
+describe('nativePreviewProofPollingProfile', () => {
+  it('keeps the full-quality idle preview profile', () => {
+    expect(nativePreviewProofPollingProfile(false)).toEqual({
+      intervalMs: 40,
+      maxWidth: 1920
+    })
+  })
+
+  it('contains proof-PNG work while recording without blanking the Windows preview', () => {
+    expect(nativePreviewProofPollingProfile(true)).toEqual({
+      intervalMs: 125,
+      maxWidth: 960
+    })
+  })
+
+  it('invalidates an applied profile when the proof window is recreated', () => {
+    const profile = nativePreviewProofPollingProfile(true)
+
+    expect(nativePreviewProofPollingProfileKey(41, profile)).not.toBe(
+      nativePreviewProofPollingProfileKey(42, profile)
+    )
+  })
+})

--- a/apps/desktop/src/shared/native-preview-proof-polling.ts
+++ b/apps/desktop/src/shared/native-preview-proof-polling.ts
@@ -1,0 +1,32 @@
+export interface NativePreviewProofPollingProfile {
+  intervalMs: number
+  maxWidth: number
+}
+
+const IDLE_PROOF_POLLING_PROFILE: NativePreviewProofPollingProfile = {
+  intervalMs: 40,
+  maxWidth: 1920
+}
+
+const RECORDING_PROOF_POLLING_PROFILE: NativePreviewProofPollingProfile = {
+  // Windows' proof surface is production preview, so it must stay live while
+  // recording. Keep it useful without spending the recording's CPU budget on
+  // 25 full-resolution channel swaps, Lanczos resizes, and PNG encodes/sec.
+  intervalMs: 125,
+  maxWidth: 960
+}
+
+export function nativePreviewProofPollingProfile(
+  recordingActive: boolean
+): NativePreviewProofPollingProfile {
+  return recordingActive
+    ? { ...RECORDING_PROOF_POLLING_PROFILE }
+    : { ...IDLE_PROOF_POLLING_PROFILE }
+}
+
+export function nativePreviewProofPollingProfileKey(
+  surfaceWindowId: number,
+  profile: NativePreviewProofPollingProfile
+): string {
+  return `${surfaceWindowId}:${profile.intervalMs}:${profile.maxWidth}`
+}

--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -14,7 +14,7 @@ use std::time::Instant;
 use anyhow::{Context, Result, bail};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
-use tokio::sync::{Mutex, watch};
+use tokio::sync::{Mutex, oneshot, watch};
 use tokio::task::JoinHandle as TokioJoinHandle;
 use tokio::time::{Duration, MissedTickBehavior};
 use uuid::Uuid;
@@ -59,7 +59,15 @@ const STREAM_OUTPUT_QUEUE_COALESCE_FRAMES: usize = 4;
 const STREAM_OUTPUT_QUEUE_COALESCE_AGE: Duration = Duration::from_millis(100);
 const STREAM_OUTPUT_QUEUE_MAX_FRAMES: usize = 8;
 const STREAM_OUTPUT_QUEUE_MAX_AGE: Duration = Duration::from_millis(150);
-const RAW_VIDEO_FIFO_QUEUE_MAX_FRAMES: usize = 4;
+// Raw frames receive wall-clock PTS at FFmpeg demux. Keep no stale waiting
+// frames: the writer accepts the latest scheduler frame only when it is ready
+// for another complete write; busy ticks are explicitly coalesced and the
+// decoder holds the last VFR frame across the wall-time gap.
+const RAW_VIDEO_FIFO_QUEUE_MAX_FRAMES: usize = 0;
+const FIFO_FRAME_WRITE_HARD_TIMEOUT: Duration = Duration::from_secs(2);
+const RAW_VIDEO_FIFO_STARTUP_PRIME_TIMEOUT: Duration = Duration::from_millis(2500);
+const FIFO_WRITE_PROGRESS_YIELD_BUDGET: u32 = 64;
+const FIFO_WRITE_STALL_BACKOFF: Duration = Duration::from_micros(250);
 const VIDEOTOOLBOX_OUTPUT_DRAIN_MAX_FRAMES_PER_TICK: usize = 8;
 const VIDEOTOOLBOX_PROBE_ENV: &str = "VIDEORC_ENCODER_BRIDGE_VIDEOTOOLBOX_PROBE";
 
@@ -360,11 +368,10 @@ fn classify_bridge_frame(last_fed: Option<u64>, fed: Option<u64>) -> BridgeFrame
     }
 }
 
-/// Lag past which the schedule stops trying to catch up frame-by-frame. A
-/// timestamped output re-anchors with an explicit counted gap; untimestamped
-/// rawvideo fails explicitly because neither skipping nor bursting frames is
-/// safe (app nap, display sleep). Below this, late loops converge by feeding
-/// repeats with a zero fresh-frame wait.
+/// Lag past which the schedule stops trying to catch up frame-by-frame and
+/// re-anchors with an explicit counted wall-time gap (app nap, display sleep).
+/// Raw FIFO frames are demuxed with wall-clock PTS, so they can use the same
+/// honest re-anchor as timestamped encoded outputs.
 const ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD: Duration = Duration::from_secs(2);
 
 /// Per-tick schedule decision (plan 026). The writer schedule is ABSOLUTE
@@ -383,48 +390,25 @@ struct BridgeTickPlan {
     /// Whole intervals dropped from the schedule as an explicit stall gap.
     /// Zero in every healthy tick.
     reanchor_skipped_intervals: u64,
-    /// Untimestamped rawvideo cannot represent a wall-time gap without either
-    /// compressing the recording or bursting stale frames into the encoder.
-    /// Stop that output explicitly when the bridge misses the bounded stall
-    /// threshold instead of manufacturing a glitchy catch-up burst.
-    fail_untimestamped_output: bool,
 }
 
-fn plan_bridge_tick(
-    video_output: EncoderBridgeVideoOutput,
-    lag: Duration,
-    frame_interval: Duration,
-) -> BridgeTickPlan {
+fn plan_bridge_tick(lag: Duration, frame_interval: Duration) -> BridgeTickPlan {
     if frame_interval.is_zero() {
         return BridgeTickPlan {
             skip_fresh_wait: false,
             reanchor_skipped_intervals: 0,
-            fail_untimestamped_output: false,
         };
     }
-    if video_output == EncoderBridgeVideoOutput::RawYuv420p
-        && lag >= ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD
-    {
-        return BridgeTickPlan {
-            skip_fresh_wait: false,
-            reanchor_skipped_intervals: 0,
-            fail_untimestamped_output: true,
-        };
-    }
-    if video_output != EncoderBridgeVideoOutput::RawYuv420p
-        && lag >= ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD
-    {
+    if lag >= ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD {
         let skipped = (lag.as_nanos() / frame_interval.as_nanos()) as u64;
         return BridgeTickPlan {
             skip_fresh_wait: true,
             reanchor_skipped_intervals: skipped,
-            fail_untimestamped_output: false,
         };
     }
     BridgeTickPlan {
         skip_fresh_wait: lag > Duration::ZERO,
         reanchor_skipped_intervals: 0,
-        fail_untimestamped_output: false,
     }
 }
 
@@ -467,10 +451,20 @@ fn read_encoder_bridge_terminal_failure(signal: &Arc<StdMutex<Option<String>>>) 
         .clone()
 }
 
+fn signal_encoder_bridge_startup(
+    sender: &mut Option<oneshot::Sender<std::result::Result<(), String>>>,
+    result: std::result::Result<(), String>,
+) {
+    if let Some(sender) = sender.take() {
+        let _ = sender.send(result);
+    }
+}
+
 #[derive(Debug)]
 pub struct EncoderBridgeRecordingSession {
     stop: Arc<AtomicBool>,
     terminal_failure: Arc<StdMutex<Option<String>>>,
+    startup_ready: Option<oneshot::Receiver<std::result::Result<(), String>>>,
     fifo_path: PathBuf,
     writer: Option<thread::JoinHandle<()>>,
     diagnostics_task: Option<TokioJoinHandle<()>>,
@@ -488,6 +482,18 @@ impl EncoderBridgeRecordingSession {
     /// this signal so that a shortened file is not published as successful.
     pub fn terminal_failure(&self) -> Option<String> {
         read_encoder_bridge_terminal_failure(&self.terminal_failure)
+    }
+
+    pub async fn wait_until_ready(&mut self) -> Result<()> {
+        let Some(startup_ready) = self.startup_ready.take() else {
+            return Ok(());
+        };
+        match tokio::time::timeout(Duration::from_secs(4), startup_ready).await {
+            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Err(message))) => bail!(message),
+            Ok(Err(_)) => bail!("Encoder bridge stopped before its first frame was ready"),
+            Err(_) => bail!("Encoder bridge first-frame priming timed out"),
+        }
     }
 }
 
@@ -702,6 +708,7 @@ pub fn start_synthetic_recording_bridge(
     let byte_len = raw_yuv420p_len(width, height)?;
     let stop = Arc::new(AtomicBool::new(false));
     let terminal_failure = Arc::new(StdMutex::new(None));
+    let (startup_ready_tx, startup_ready_rx) = oneshot::channel();
     let writer_stop = stop.clone();
     let writer_terminal_failure = terminal_failure.clone();
     let writer_fifo_path = fifo_path.clone();
@@ -740,6 +747,7 @@ pub fn start_synthetic_recording_bridge(
                 diagnostics_context,
                 stop: writer_stop,
                 terminal_failure: writer_terminal_failure,
+                startup_ready_tx: Some(startup_ready_tx),
                 diagnostics_tx,
                 video_epoch,
             };
@@ -750,6 +758,7 @@ pub fn start_synthetic_recording_bridge(
     Ok(EncoderBridgeRecordingSession {
         stop,
         terminal_failure,
+        startup_ready: Some(startup_ready_rx),
         fifo_path,
         writer: Some(writer),
         diagnostics_task: Some(diagnostics_task),
@@ -927,6 +936,7 @@ struct SyntheticRecordingWriterParams {
     byte_len: usize,
     stop: Arc<AtomicBool>,
     terminal_failure: Arc<StdMutex<Option<String>>>,
+    startup_ready_tx: Option<oneshot::Sender<std::result::Result<(), String>>>,
     fifo_path: PathBuf,
     frame_store: Option<CompositorFrameStore>,
     video_output: EncoderBridgeVideoOutput,
@@ -954,6 +964,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
         byte_len,
         stop,
         terminal_failure,
+        mut startup_ready_tx,
         fifo_path,
         frame_store,
         video_output,
@@ -973,6 +984,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                     fifo_path.display()
                 ),
             );
+            signal_encoder_bridge_startup(&mut startup_ready_tx, Err(error.clone()));
             emit_encoder_bridge_diagnostics_from_thread(
                 &diagnostics_tx,
                 session_id.clone(),
@@ -1122,6 +1134,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             &terminal_failure,
             format!("Could not prepare VideoToolbox encoder bridge output: {error}"),
         );
+        signal_encoder_bridge_startup(&mut startup_ready_tx, Err(error.clone()));
         emit_encoder_bridge_diagnostics_from_thread(
             &diagnostics_tx,
             session_id.clone(),
@@ -1196,6 +1209,152 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
         };
     }
 
+    if matches!(video_output, EncoderBridgeVideoOutput::RawYuv420p) {
+        // FFmpeg can take hundreds of milliseconds to initialise its input
+        // graph and hardware encoder after opening the raw FIFO. Advancing the
+        // 30fps clock during that one-time warmup creates avoidable pressure
+        // before the wall-clock-stamped input has delivered any usable video.
+        // Deliver exactly one complete priming frame first; only then start the
+        // wall-clock input schedule and publish the recording as ready.
+        let prime_wait_started_at = Instant::now();
+        let prime_frame = copy_next_compositor_frame(
+            frame_store.as_ref(),
+            &mut bytes,
+            first_frame_wait_sequence,
+            frame_interval + frame_interval,
+        );
+        compositor_wait_times_ms.push(prime_wait_started_at.elapsed().as_secs_f64() * 1000.0);
+        if prime_frame.is_none() {
+            synthetic_fallback_frames = synthetic_fallback_frames.saturating_add(1);
+            let frame = source.render(1, width, height);
+            render_synthetic_yuv420p_frame(&frame, &mut bytes);
+        }
+        let submitted_at = Instant::now();
+        let next_buffer = recycled_raw_buffers
+            .pop()
+            .unwrap_or_else(|| vec![0; byte_len]);
+        let frame_bytes = std::mem::replace(&mut bytes, next_buffer);
+        let had_metal_target = prime_frame
+            .as_ref()
+            .is_some_and(|frame| frame.has_metal_iosurface_target);
+        let had_metal_export_handle = prime_frame
+            .as_ref()
+            .is_some_and(|frame| frame.has_metal_export_handle);
+        let prime_enqueue = raw_fifo_writer
+            .as_ref()
+            .expect("raw encoder bridge FIFO writer must be running")
+            .enqueue_startup(QueuedRawVideoFrame {
+                bytes: frame_bytes,
+                submitted_at,
+                had_metal_target,
+                had_metal_export_handle,
+            });
+        if let Err(error) = prime_enqueue {
+            let error = record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "{} raw-video encoder startup prime failed: {error}",
+                    encoder_bridge_output_role_label(output_queue_policy.role)
+                ),
+            );
+            signal_encoder_bridge_startup(&mut startup_ready_tx, Err(error.clone()));
+            emit_encoder_bridge_diagnostics_from_thread(
+                &diagnostics_tx,
+                session_id.clone(),
+                target_fps,
+                current_runtime_stats!(0),
+                diagnostics_context,
+                Some(error),
+            );
+            return;
+        }
+        pending_raw_fifo_frames = 1;
+        pending_raw_fifo_started_at.push_back(submitted_at);
+        let prime_deadline = Instant::now() + RAW_VIDEO_FIFO_STARTUP_PRIME_TIMEOUT;
+        while pending_raw_fifo_frames > 0 && !stop.load(Ordering::Relaxed) {
+            let writer = raw_fifo_writer
+                .as_mut()
+                .expect("raw encoder bridge FIFO writer must be running");
+            if let Err(error) = drain_raw_video_fifo_writer_results(
+                writer,
+                &mut pending_raw_fifo_frames,
+                &mut pending_raw_fifo_started_at,
+                &mut recycled_raw_buffers,
+                &mut raw_video_copied_frames,
+                &mut metal_target_frames,
+                &mut metal_target_copied_frames,
+                &mut metal_target_handle_frames,
+                &mut raw_video_fifo_write_times_ms,
+            ) {
+                let error = record_encoder_bridge_terminal_failure(
+                    &terminal_failure,
+                    format!(
+                        "{} raw-video encoder startup prime stopped: {error}",
+                        encoder_bridge_output_role_label(output_queue_policy.role)
+                    ),
+                );
+                signal_encoder_bridge_startup(&mut startup_ready_tx, Err(error.clone()));
+                emit_encoder_bridge_diagnostics_from_thread(
+                    &diagnostics_tx,
+                    session_id.clone(),
+                    target_fps,
+                    current_runtime_stats!(pending_raw_fifo_frames),
+                    diagnostics_context,
+                    Some(error),
+                );
+                return;
+            }
+            if pending_raw_fifo_frames == 0 {
+                break;
+            }
+            if Instant::now() >= prime_deadline {
+                let error = record_encoder_bridge_terminal_failure(
+                    &terminal_failure,
+                    format!(
+                        "{} raw-video encoder did not accept a complete startup frame within {}ms",
+                        encoder_bridge_output_role_label(output_queue_policy.role),
+                        RAW_VIDEO_FIFO_STARTUP_PRIME_TIMEOUT.as_millis()
+                    ),
+                );
+                signal_encoder_bridge_startup(&mut startup_ready_tx, Err(error.clone()));
+                emit_encoder_bridge_diagnostics_from_thread(
+                    &diagnostics_tx,
+                    session_id.clone(),
+                    target_fps,
+                    current_runtime_stats!(pending_raw_fifo_frames),
+                    diagnostics_context,
+                    Some(error),
+                );
+                return;
+            }
+            thread::sleep(Duration::from_millis(2));
+        }
+        if stop.load(Ordering::Relaxed) {
+            signal_encoder_bridge_startup(
+                &mut startup_ready_tx,
+                Err("Encoder bridge stopped during raw-video startup priming".to_string()),
+            );
+            return;
+        }
+        if let Some(frame) = prime_frame {
+            last_fed_sequence = Some(frame.sequence);
+            let source_age_ms = frame.captured_at.elapsed().as_millis() as u64;
+            max_source_to_encode_age_ms = Some(source_age_ms);
+            source_to_encode_age_times_ms.push(source_age_ms as f64);
+        }
+        // Audio captured while FFmpeg was initialising is pre-roll. Start its
+        // shared epoch only after the complete video prime reached the reader.
+        let _ = video_epoch.set(Instant::now());
+        sequence = 1;
+        frames_in_window = 1;
+        window_started_at = Instant::now();
+        next_frame_at = window_started_at + frame_interval;
+        first_frame_wait_sequence = None;
+        signal_encoder_bridge_startup(&mut startup_ready_tx, Ok(()));
+    } else {
+        signal_encoder_bridge_startup(&mut startup_ready_tx, Ok(()));
+    }
+
     while !stop.load(Ordering::Relaxed) {
         if let Some(writer) = raw_fifo_writer.as_mut()
             && let Err(error) = drain_raw_video_fifo_writer_results(
@@ -1238,27 +1397,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                 Some(max_deadline_lag_ms.map_or(lag_ms, |current| current.max(lag_ms)));
             late_deadline_ticks = late_deadline_ticks.saturating_add(1);
         }
-        let tick_plan = plan_bridge_tick(video_output, tick_lag, frame_interval);
-        if tick_plan.fail_untimestamped_output {
-            let error = record_encoder_bridge_terminal_failure(
-                &terminal_failure,
-                format!(
-                    "{} raw-video encoder schedule stalled for {}ms; stopping instead of bursting untimestamped frames into the recording",
-                    encoder_bridge_output_role_label(output_queue_policy.role),
-                    tick_lag.as_millis()
-                ),
-            );
-            terminal_writer_error = Some(error.clone());
-            emit_encoder_bridge_diagnostics_from_thread(
-                &diagnostics_tx,
-                session_id.clone(),
-                target_fps,
-                current_runtime_stats!(pending_raw_fifo_frames),
-                diagnostics_context,
-                Some(error),
-            );
-            break;
-        }
+        let tick_plan = plan_bridge_tick(tick_lag, frame_interval);
         if tick_plan.reanchor_skipped_intervals > 0 {
             // Pathological stall: drop whole intervals as an EXPLICIT gap. The
             // schedule stays wall-true (sequence advances by the same count,
@@ -1562,7 +1701,7 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                         .pop()
                         .unwrap_or_else(|| vec![0; byte_len]);
                     let frame_bytes = std::mem::replace(&mut bytes, next_buffer);
-                    raw_fifo_writer
+                    match raw_fifo_writer
                         .as_ref()
                         .expect("raw encoder bridge FIFO writer must be running")
                         .enqueue(
@@ -1573,11 +1712,20 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                                 had_metal_export_handle: wrote_metal_target_handle,
                             },
                             &mut output_queue_capacity_pressure_events,
-                        )
-                        .map(|()| {
+                        ) {
+                        Ok(RawVideoFifoEnqueueOutcome::Enqueued) => {
                             pending_raw_fifo_frames = pending_raw_fifo_frames.saturating_add(1);
                             pending_raw_fifo_started_at.push_back(submitted_at);
-                        })
+                            Ok(())
+                        }
+                        Ok(RawVideoFifoEnqueueOutcome::Coalesced(frame)) => {
+                            output_queue_dropped_frames =
+                                output_queue_dropped_frames.saturating_add(1);
+                            recycled_raw_buffers.push(frame.bytes);
+                            Ok(())
+                        }
+                        Err(error) => Err(error),
+                    }
                 }
                 EncoderBridgeVideoOutput::VideoToolboxH264AnnexB
                 | EncoderBridgeVideoOutput::VideoToolboxH264MpegTs => {
@@ -2255,8 +2403,6 @@ struct RawVideoFifoWriter {
     frame_tx: Option<std_mpsc::SyncSender<QueuedRawVideoFrame>>,
     result_rx: std_mpsc::Receiver<RawVideoFifoWriterResult>,
     join: Option<thread::JoinHandle<()>>,
-    max_frames: usize,
-    role: EncoderBridgeOutputRole,
 }
 
 struct QueuedRawVideoFrame {
@@ -2264,6 +2410,11 @@ struct QueuedRawVideoFrame {
     submitted_at: Instant,
     had_metal_target: bool,
     had_metal_export_handle: bool,
+}
+
+enum RawVideoFifoEnqueueOutcome {
+    Enqueued,
+    Coalesced(QueuedRawVideoFrame),
 }
 
 #[derive(Debug)]
@@ -2287,7 +2438,7 @@ impl RawVideoFifoWriter {
         stop: Arc<AtomicBool>,
         terminal_failure: Arc<StdMutex<Option<String>>>,
     ) -> Self {
-        let max_frames = policy.max_frames.min(RAW_VIDEO_FIFO_QUEUE_MAX_FRAMES);
+        let max_frames = RAW_VIDEO_FIFO_QUEUE_MAX_FRAMES;
         let (frame_tx, frame_rx) = std_mpsc::sync_channel(max_frames);
         // Queue + one in-flight result + one terminal flush result.
         let (result_tx, result_rx) = std_mpsc::sync_channel(max_frames + 2);
@@ -2309,8 +2460,6 @@ impl RawVideoFifoWriter {
             frame_tx: Some(frame_tx),
             result_rx,
             join: Some(join),
-            max_frames,
-            role: policy.role,
         }
     }
 
@@ -2318,25 +2467,33 @@ impl RawVideoFifoWriter {
         &self,
         frame: QueuedRawVideoFrame,
         capacity_pressure_events: &mut u64,
-    ) -> io::Result<()> {
+    ) -> io::Result<RawVideoFifoEnqueueOutcome> {
         let tx = self.frame_tx.as_ref().ok_or_else(|| {
             io::Error::new(io::ErrorKind::BrokenPipe, "raw-video FIFO writer closed")
         })?;
         match offer_preserving_output_frame(tx, frame) {
-            Ok(PreservingOutputFrameOffer::Enqueued) => Ok(()),
-            Ok(PreservingOutputFrameOffer::CapacityPressure(_frame)) => {
+            Ok(PreservingOutputFrameOffer::Enqueued) => Ok(RawVideoFifoEnqueueOutcome::Enqueued),
+            Ok(PreservingOutputFrameOffer::CapacityPressure(frame)) => {
                 *capacity_pressure_events = capacity_pressure_events.saturating_add(1);
-                Err(io::Error::other(format!(
-                    "{} raw-video FIFO reached its {}-frame safety ceiling; stopping this output because untimestamped raw frames cannot be dropped or coalesced safely",
-                    encoder_bridge_output_role_label(self.role),
-                    self.max_frames
-                )))
+                Ok(RawVideoFifoEnqueueOutcome::Coalesced(frame))
             }
             Err(_) => Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "raw-video FIFO writer stopped",
             )),
         }
+    }
+
+    fn enqueue_startup(&self, frame: QueuedRawVideoFrame) -> io::Result<()> {
+        let tx = self.frame_tx.as_ref().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "raw-video FIFO writer closed")
+        })?;
+        tx.send(frame).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "raw-video FIFO writer stopped during startup priming",
+            )
+        })
     }
 
     fn try_recv_result(&mut self) -> Option<RawVideoFifoWriterResult> {
@@ -2373,7 +2530,15 @@ fn run_raw_video_fifo_writer_loop<W: StdWrite>(
         // misalign every following YUV plane and can corrupt the final file.
         // Finish the in-flight frame within its existing age deadline; closing
         // the queue prevents any new work from being admitted during stop.
-        match write_all_until(&mut sink, &frame.bytes, &stop, deadline, false) {
+        match write_all_until(
+            &mut sink,
+            &frame.bytes,
+            &stop,
+            deadline,
+            max_frame_age,
+            FIFO_FRAME_WRITE_HARD_TIMEOUT,
+            false,
+        ) {
             Ok(()) => {
                 let _ = result_tx.send(RawVideoFifoWriterResult::FrameWritten {
                     buffer: frame.bytes,
@@ -2599,7 +2764,13 @@ fn run_video_toolbox_fifo_writer_loop<W: StdWrite>(
         let encoded_bytes = queued.frame.bytes.len() as u64;
         let write_started_at = Instant::now();
         let deadline = queued.submitted_at + max_frame_age;
-        match h264_pipe_writer.write_frame_until(&mut sink, &queued.frame, &stop, deadline) {
+        match h264_pipe_writer.write_frame_until(
+            &mut sink,
+            &queued.frame,
+            &stop,
+            deadline,
+            max_frame_age,
+        ) {
             Ok(()) => {
                 let _ = result_tx.send(VideoToolboxFifoWriterResult::FrameWritten {
                     encoded_bytes,
@@ -2659,9 +2830,18 @@ impl VideoToolboxH264PipeWriter {
         frame: &VideoToolboxH264AnnexBFrame,
         stop: &AtomicBool,
         deadline: Instant,
+        max_frame_age: Duration,
     ) -> io::Result<()> {
         let bytes = self.frame_bytes(frame)?;
-        write_all_until(sink, bytes, stop, deadline, true)
+        write_all_until(
+            sink,
+            bytes,
+            stop,
+            deadline,
+            max_frame_age,
+            FIFO_FRAME_WRITE_HARD_TIMEOUT,
+            true,
+        )
     }
 
     fn frame_bytes<'a>(
@@ -2703,9 +2883,15 @@ fn write_all_until<W: StdWrite>(
     sink: &mut W,
     mut bytes: &[u8],
     stop: &AtomicBool,
-    deadline: Instant,
+    mut deadline: Instant,
+    progress_timeout: Duration,
+    hard_timeout: Duration,
     cancel_on_stop: bool,
 ) -> io::Result<()> {
+    let hard_deadline = Instant::now()
+        .checked_add(hard_timeout)
+        .unwrap_or_else(Instant::now);
+    let mut consecutive_no_progress = 0_u32;
     while !bytes.is_empty() {
         if cancel_on_stop && stop.load(Ordering::Relaxed) {
             return Err(io::Error::new(
@@ -2713,27 +2899,58 @@ fn write_all_until<W: StdWrite>(
                 "Encoder FIFO writer stopped during a bounded write",
             ));
         }
-        if Instant::now() >= deadline {
+        if Instant::now() >= deadline || Instant::now() >= hard_deadline {
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
-                "Encoder FIFO write exceeded the output queue age budget",
+                "Encoder FIFO write exceeded the complete-frame delivery budget",
             ));
         }
         match sink.write(bytes) {
             Ok(0) => {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                thread::sleep(remaining.min(Duration::from_millis(2)));
+                consecutive_no_progress = consecutive_no_progress.saturating_add(1);
+                wait_for_fifo_write_progress(consecutive_no_progress, deadline.min(hard_deadline));
             }
-            Ok(written) => bytes = &bytes[written..],
+            Ok(written) => {
+                bytes = &bytes[written..];
+                consecutive_no_progress = 0;
+                // Raw frames are indivisible. Once part of one reaches FFmpeg,
+                // aborting on the original queue-age deadline leaves a terminal
+                // short packet and corrupts/truncates the recording. Continued
+                // byte progress proves the reader is alive, so use a sliding
+                // no-progress deadline until this frame is complete.
+                if !bytes.is_empty() {
+                    deadline = Instant::now()
+                        .checked_add(progress_timeout)
+                        .unwrap_or_else(Instant::now)
+                        .min(hard_deadline);
+                }
+            }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                thread::sleep(remaining.min(Duration::from_millis(2)));
+                consecutive_no_progress = consecutive_no_progress.saturating_add(1);
+                wait_for_fifo_write_progress(consecutive_no_progress, deadline.min(hard_deadline));
             }
             Err(error) => return Err(error),
         }
     }
     Ok(())
+}
+
+fn wait_for_fifo_write_progress(consecutive_no_progress: u32, deadline: Instant) {
+    // A 1080p YUV420 frame is 3.11 MiB, while Unix FIFOs commonly accept only
+    // a few KiB per nonblocking write. Sleeping milliseconds after every full
+    // pipe therefore turns one frame into hundreds of sleeps (~800ms in the
+    // Windows regression repro). While the reader is actively draining, yield
+    // so it can run and retry immediately. Only back off once repeated attempts
+    // show that no progress is being made; the caller's deadlines stay binding.
+    if consecutive_no_progress <= FIFO_WRITE_PROGRESS_YIELD_BUDGET {
+        thread::yield_now();
+        return;
+    }
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if !remaining.is_zero() {
+        thread::sleep(remaining.min(FIFO_WRITE_STALL_BACKOFF));
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -3652,11 +3869,42 @@ mod tests {
     }
 
     #[test]
+    fn busy_raw_fifo_coalesces_the_current_frame_without_stopping_wall_time() {
+        let (frame_tx, _frame_rx) = std_mpsc::sync_channel(0);
+        let (_result_tx, result_rx) = std_mpsc::sync_channel(1);
+        let writer = RawVideoFifoWriter {
+            frame_tx: Some(frame_tx),
+            result_rx,
+            join: None,
+        };
+        let mut pressure_events = 0;
+
+        let outcome = writer
+            .enqueue(
+                QueuedRawVideoFrame {
+                    bytes: vec![1, 2, 3, 4],
+                    submitted_at: Instant::now(),
+                    had_metal_target: false,
+                    had_metal_export_handle: false,
+                },
+                &mut pressure_events,
+            )
+            .expect("a busy timestamped raw writer coalesces instead of failing");
+
+        let RawVideoFifoEnqueueOutcome::Coalesced(frame) = outcome else {
+            panic!("zero-waiting-frame FIFO must retain only the in-flight frame")
+        };
+        assert_eq!(frame.bytes, vec![1, 2, 3, 4]);
+        assert_eq!(pressure_events, 1);
+    }
+
+    #[test]
     fn recording_session_exposes_the_first_terminal_bridge_failure() {
         let terminal_failure = Arc::new(StdMutex::new(None));
         let session = EncoderBridgeRecordingSession {
             stop: Arc::new(AtomicBool::new(false)),
             terminal_failure: terminal_failure.clone(),
+            startup_ready: None,
             fifo_path: std::env::temp_dir().join(format!(
                 "videorc-missing-terminal-signal-test-{}",
                 Uuid::new_v4()
@@ -3748,6 +3996,100 @@ mod tests {
     }
 
     #[test]
+    fn raw_fifo_writer_finishes_a_frame_while_the_reader_keeps_making_progress() {
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(3);
+        let written = SharedCountingSink::default();
+        let frame = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        frame_tx
+            .send(QueuedRawVideoFrame {
+                bytes: frame.clone(),
+                submitted_at: Instant::now(),
+                had_metal_target: false,
+                had_metal_export_handle: false,
+            })
+            .expect("queue raw frame");
+        drop(frame_tx);
+
+        run_raw_video_fifo_writer_loop(
+            SlowProgressSink {
+                written: written.clone(),
+                chunk_size: 2,
+                delay: Duration::from_millis(12),
+            },
+            frame_rx,
+            result_tx,
+            Arc::new(AtomicBool::new(false)),
+            Duration::from_millis(20),
+            Arc::new(StdMutex::new(None)),
+            EncoderBridgeOutputRole::Recording,
+        );
+
+        assert_eq!(written.bytes(), frame);
+        let result = result_rx.recv().expect("raw writer result");
+        assert!(matches!(
+            result,
+            RawVideoFifoWriterResult::FrameWritten { .. }
+        ));
+    }
+
+    #[test]
+    fn intermittent_pipe_pressure_does_not_throttle_a_full_hd_raw_frame() {
+        for pressure in [PipePressure::WouldBlock, PipePressure::ZeroWrite] {
+            let mut sink = AlternatingBackpressureSink {
+                written: 0,
+                chunk_size: 8 * 1024,
+                pressure_next: true,
+                pressure,
+            };
+            let stop = AtomicBool::new(false);
+            let bytes = vec![7; raw_yuv420p_len(1920, 1080).expect("1080p frame size")];
+            let deadline = Instant::now() + Duration::from_millis(250);
+
+            write_all_until(
+                &mut sink,
+                &bytes,
+                &stop,
+                deadline,
+                Duration::from_millis(250),
+                Duration::from_millis(250),
+                false,
+            )
+            .expect("active FIFO draining must not pay a millisecond sleep per pipe-sized chunk");
+
+            assert_eq!(sink.written, bytes.len());
+        }
+    }
+
+    #[test]
+    fn progressing_fifo_write_still_honors_a_complete_frame_hard_limit() {
+        let written = SharedCountingSink::default();
+        let mut sink = SlowProgressSink {
+            written: written.clone(),
+            chunk_size: 1,
+            delay: Duration::from_millis(10),
+        };
+        let stop = AtomicBool::new(false);
+        let bytes = vec![7; 100];
+        let started_at = Instant::now();
+
+        let error = write_all_until(
+            &mut sink,
+            &bytes,
+            &stop,
+            Instant::now() + Duration::from_millis(20),
+            Duration::from_millis(20),
+            Duration::from_millis(55),
+            false,
+        )
+        .expect_err("continuous one-byte progress must not keep shutdown blocked forever");
+
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(started_at.elapsed() < Duration::from_millis(250));
+        assert!(written.bytes().len() < bytes.len());
+    }
+
+    #[test]
     fn stalled_raw_fifo_writer_times_out_without_blocking_the_scheduler() {
         let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
         let (result_tx, result_rx) = std_mpsc::sync_channel(3);
@@ -3778,7 +4120,7 @@ mod tests {
         let RawVideoFifoWriterResult::Error { message, .. } = result else {
             panic!("stalled raw writer must fail explicitly")
         };
-        assert!(message.contains("queue age budget"));
+        assert!(message.contains("complete-frame delivery budget"));
         assert_eq!(
             read_encoder_bridge_terminal_failure(&terminal_failure).as_deref(),
             Some(message.as_str())
@@ -4508,7 +4850,7 @@ mod tests {
         let VideoToolboxFifoWriterResult::Error(error) = result else {
             panic!("stalled writer must fail explicitly")
         };
-        assert!(error.contains("queue age budget"));
+        assert!(error.contains("complete-frame delivery budget"));
     }
 
     struct AlwaysWouldBlockSink;
@@ -4553,6 +4895,62 @@ mod tests {
         written: SharedCountingSink,
         stop: Arc<AtomicBool>,
         first_write: bool,
+    }
+
+    struct SlowProgressSink {
+        written: SharedCountingSink,
+        chunk_size: usize,
+        delay: Duration,
+    }
+
+    #[derive(Clone, Copy)]
+    enum PipePressure {
+        WouldBlock,
+        ZeroWrite,
+    }
+
+    struct AlternatingBackpressureSink {
+        written: usize,
+        chunk_size: usize,
+        pressure_next: bool,
+        pressure: PipePressure,
+    }
+
+    impl StdWrite for AlternatingBackpressureSink {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.pressure_next {
+                self.pressure_next = false;
+                return match self.pressure {
+                    PipePressure::WouldBlock => Err(io::Error::from(io::ErrorKind::WouldBlock)),
+                    PipePressure::ZeroWrite => Ok(0),
+                };
+            }
+            self.pressure_next = true;
+            let written = bytes.len().min(self.chunk_size);
+            self.written += written;
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl StdWrite for SlowProgressSink {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            thread::sleep(self.delay);
+            let written = bytes.len().min(self.chunk_size);
+            self.written
+                .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .extend_from_slice(&bytes[..written]);
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
     }
 
     impl StdWrite for StopAfterPartialWriteSink {
@@ -4754,12 +5152,11 @@ mod tests {
 
         while wall < simulated {
             let lag = wall.saturating_sub(next_frame_at);
-            let plan = plan_bridge_tick(EncoderBridgeVideoOutput::RawYuv420p, lag, interval);
+            let plan = plan_bridge_tick(lag, interval);
             assert_eq!(
                 plan.reanchor_skipped_intervals, 0,
                 "a merely-slow compositor must never trigger the stall gap"
             );
-            assert!(!plan.fail_untimestamped_output);
             if wall < next_frame_at {
                 wall = next_frame_at; // sleep to the deadline
             }
@@ -4790,56 +5187,31 @@ mod tests {
         let interval = Duration::from_nanos(1_000_000_000 / 30);
 
         // Sub-threshold lag: catch up with repeats, never drop intervals.
-        let behind = plan_bridge_tick(
-            EncoderBridgeVideoOutput::RawYuv420p,
-            Duration::from_millis(500),
-            interval,
-        );
+        let behind = plan_bridge_tick(Duration::from_millis(500), interval);
         assert!(behind.skip_fresh_wait);
         assert_eq!(behind.reanchor_skipped_intervals, 0);
-        assert!(!behind.fail_untimestamped_output);
 
         // On schedule: normal fresh-frame wait.
-        let on_time = plan_bridge_tick(
-            EncoderBridgeVideoOutput::RawYuv420p,
-            Duration::ZERO,
-            interval,
-        );
+        let on_time = plan_bridge_tick(Duration::ZERO, interval);
         assert!(!on_time.skip_fresh_wait);
         assert_eq!(on_time.reanchor_skipped_intervals, 0);
-        assert!(!on_time.fail_untimestamped_output);
 
         // Pathological stall (app nap): drop WHOLE intervals as an explicit,
         // counted gap so PTS stay wall-true instead of compressing.
-        let raw_stalled = plan_bridge_tick(
-            EncoderBridgeVideoOutput::RawYuv420p,
-            Duration::from_secs(5),
-            interval,
-        );
-        assert!(!raw_stalled.skip_fresh_wait);
-        assert_eq!(raw_stalled.reanchor_skipped_intervals, 0);
-        assert!(raw_stalled.fail_untimestamped_output);
+        let raw_stalled = plan_bridge_tick(Duration::from_secs(5), interval);
+        assert!(raw_stalled.skip_fresh_wait);
+        assert_eq!(raw_stalled.reanchor_skipped_intervals, 150);
 
         let raw_just_below_threshold = plan_bridge_tick(
-            EncoderBridgeVideoOutput::RawYuv420p,
             ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD - Duration::from_nanos(1),
             interval,
         );
-        assert!(!raw_just_below_threshold.fail_untimestamped_output);
-        let raw_at_threshold = plan_bridge_tick(
-            EncoderBridgeVideoOutput::RawYuv420p,
-            ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD,
-            interval,
-        );
-        assert!(raw_at_threshold.fail_untimestamped_output);
+        assert_eq!(raw_just_below_threshold.reanchor_skipped_intervals, 0);
+        let raw_at_threshold = plan_bridge_tick(ENCODER_BRIDGE_STALL_REANCHOR_THRESHOLD, interval);
+        assert!(raw_at_threshold.reanchor_skipped_intervals > 0);
 
-        let timestamped_stalled = plan_bridge_tick(
-            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
-            Duration::from_secs(5),
-            interval,
-        );
+        let timestamped_stalled = plan_bridge_tick(Duration::from_secs(5), interval);
         assert!(timestamped_stalled.skip_fresh_wait);
         assert_eq!(timestamped_stalled.reanchor_skipped_intervals, 150); // 5s / 33.33ms
-        assert!(!timestamped_stalled.fail_untimestamped_output);
     }
 }

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -791,6 +791,18 @@ pub async fn latest_preview_camera_png(
         (guard.frame_store.latest()?, layout)
     };
 
+    let max_width = preview_camera_png_max_width(requested_max_width);
+    tokio::task::spawn_blocking(move || encode_preview_camera_png(frame, layout, max_width))
+        .await
+        .ok()
+        .flatten()
+}
+
+fn encode_preview_camera_png(
+    frame: FrameHandle<PreviewCameraPixelFormat>,
+    layout: LayoutSettings,
+    max_width: u32,
+) -> Option<Vec<u8>> {
     let expected_len = frame.width as usize * frame.height as usize * 4;
     if frame.bytes.len() < expected_len {
         return None;
@@ -802,12 +814,8 @@ pub async fn latest_preview_camera_png(
     if layout.camera_mirror {
         mirror_rgba_in_place(&mut rgba, frame.width as usize, frame.height as usize);
     }
-    let (rgba, width, height) = downscale_rgba_for_preview(
-        rgba,
-        frame.width,
-        frame.height,
-        preview_camera_png_max_width(requested_max_width),
-    );
+    let (rgba, width, height) =
+        downscale_rgba_for_preview(rgba, frame.width, frame.height, max_width);
 
     let mut png = Vec::new();
     let encoder = PngEncoder::new(&mut png);

--- a/crates/videorc-backend/src/preview_screen.rs
+++ b/crates/videorc-backend/src/preview_screen.rs
@@ -831,6 +831,17 @@ pub async fn latest_preview_screen_png(
         guard.frame_store.latest()?
     };
 
+    let max_width = preview_screen_png_max_width(requested_max_width);
+    tokio::task::spawn_blocking(move || encode_preview_screen_png(frame, max_width))
+        .await
+        .ok()
+        .flatten()
+}
+
+fn encode_preview_screen_png(
+    frame: FrameHandle<PreviewScreenPixelFormat>,
+    max_width: u32,
+) -> Option<Vec<u8>> {
     let expected_len = frame.width as usize * frame.height as usize * 4;
     if frame.bytes.len() < expected_len {
         return None;
@@ -839,12 +850,8 @@ pub async fn latest_preview_screen_png(
     for pixel in frame.bytes.chunks_exact(4) {
         rgba.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
     }
-    let (rgba, width, height) = downscale_rgba_for_preview(
-        rgba,
-        frame.width,
-        frame.height,
-        preview_screen_png_max_width(requested_max_width),
-    );
+    let (rgba, width, height) =
+        downscale_rgba_for_preview(rgba, frame.width, frame.height, max_width);
 
     let mut png = Vec::new();
     let encoder = PngEncoder::new(&mut png);

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1102,6 +1102,8 @@ pub enum EncodeBackend {
     HardwareVideotoolbox,
     /// h264_mf (MediaFoundation hardware/software hybrid), used by Windows builds.
     HardwareMediaFoundation,
+    /// h264_mf's software MFT fallback after the exact hardware profile probe failed.
+    SoftwareMediaFoundation,
 }
 
 /// Which compositor rendered the active shared-compositor frame.
@@ -3084,6 +3086,18 @@ mod tests {
         assert_eq!(
             serde_json::to_value(LayoutPreset::SideBySide).unwrap(),
             serde_json::json!("side-by-side")
+        );
+    }
+
+    #[test]
+    fn media_foundation_backends_match_the_desktop_wire_contract() {
+        assert_eq!(
+            serde_json::to_value(EncodeBackend::HardwareMediaFoundation).unwrap(),
+            serde_json::json!("hardware-media-foundation")
+        );
+        assert_eq!(
+            serde_json::to_value(EncodeBackend::SoftwareMediaFoundation).unwrap(),
+            serde_json::json!("software-media-foundation")
         );
     }
 

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -612,6 +612,7 @@ pub async fn start_session(
     }
 
     let ffmpeg_path = resolve_ffmpeg_path(params.output.ffmpeg_path.clone());
+    select_windows_media_foundation_encoder(&state, &ffmpeg_path, &params.output.video).await;
     let output_dir = resolve_output_directory(params.output.output_directory.as_deref())?;
 
     if params.output.record_enabled {
@@ -1163,6 +1164,18 @@ pub async fn start_session(
         child.stdin.take()
     };
     let pid = child.id().unwrap_or_default();
+    // FFmpeg opens every declared input before it starts draining raw video.
+    // Attach the native-audio FIFO now, before waiting for the raw-video prime,
+    // or FFmpeg can block opening audio while the bridge waits for video bytes
+    // to be consumed. The writer already waits on `video_epoch`, so pre-roll is
+    // still trimmed at the completed priming frame.
+    let attached_native_audio = native_audio_source.take().map(|prepared| {
+        attach_fifo_writer(
+            prepared.source,
+            prepared.fifo_path,
+            use_encoder_bridge.then(|| video_epoch.clone()),
+        )
+    });
     let (encoder_bridge, encoder_bridge_stream) = if use_encoder_bridge {
         let bridge_fifo_path = encoder_bridge_fifo
             .clone()
@@ -1178,7 +1191,7 @@ pub async fn start_session(
             encoder_bridge_video_output,
             encoder_bridge_stream_profile.is_some(),
         );
-        let recording_bridge = start_synthetic_recording_bridge(
+        let mut recording_bridge = start_synthetic_recording_bridge(
             state.clone(),
             session_id.clone(),
             params.output.video.fps,
@@ -1191,7 +1204,7 @@ pub async fn start_session(
             recording_diagnostics_context,
             video_epoch.clone(),
         )?;
-        let stream_bridge = match (
+        let mut stream_bridge = match (
             encoder_bridge_stream_fifo.clone(),
             encoder_bridge_stream_profile.as_ref(),
             encoder_bridge_stream_frame_store.clone(),
@@ -1220,6 +1233,10 @@ pub async fn start_session(
             }
             _ => None,
         };
+        recording_bridge.wait_until_ready().await?;
+        if let Some(stream_bridge) = stream_bridge.as_mut() {
+            stream_bridge.wait_until_ready().await?;
+        }
         (Some(recording_bridge), stream_bridge)
     } else {
         (None, None)
@@ -1251,13 +1268,7 @@ pub async fn start_session(
         mode: mode.to_string(),
         audio_tracks,
         pipeline,
-        native_audio: native_audio_source.map(|prepared| {
-            attach_fifo_writer(
-                prepared.source,
-                prepared.fifo_path,
-                use_encoder_bridge.then(|| video_epoch.clone()),
-            )
-        }),
+        native_audio: attached_native_audio,
         screen_overlay: match screen_overlay_fifo {
             Some(screen_overlay_fifo) => Some(ScreenOverlaySession::start(
                 screen_overlay_fifo,
@@ -4418,8 +4429,41 @@ fn bool_label(value: bool) -> &'static str {
 #[allow(dead_code)]
 enum FfmpegH264Platform {
     Macos,
-    Windows,
+    WindowsHardware,
+    WindowsSoftware,
     Other,
+}
+
+#[cfg(target_os = "windows")]
+static WINDOWS_MEDIA_FOUNDATION_HARDWARE_SELECTED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "windows")]
+static WINDOWS_MEDIA_FOUNDATION_PROBE_CACHE: std::sync::OnceLock<
+    StdMutex<std::collections::HashMap<WindowsMediaFoundationProbeKey, bool>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(any(test, target_os = "windows"))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct WindowsMediaFoundationProbeKey {
+    ffmpeg_path: PathBuf,
+    width: u32,
+    height: u32,
+    fps: u32,
+    bitrate_kbps: u32,
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_media_foundation_probe_key(
+    ffmpeg_path: &str,
+    video: &VideoSettings,
+) -> WindowsMediaFoundationProbeKey {
+    let path = PathBuf::from(ffmpeg_path);
+    WindowsMediaFoundationProbeKey {
+        ffmpeg_path: std::fs::canonicalize(&path).unwrap_or(path),
+        width: video.width,
+        height: video.height,
+        fps: video.fps,
+        bitrate_kbps: video.bitrate_kbps,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4436,7 +4480,11 @@ fn current_ffmpeg_h264_platform() -> FfmpegH264Platform {
     }
     #[cfg(target_os = "windows")]
     {
-        FfmpegH264Platform::Windows
+        if WINDOWS_MEDIA_FOUNDATION_HARDWARE_SELECTED.load(Ordering::Relaxed) {
+            FfmpegH264Platform::WindowsHardware
+        } else {
+            FfmpegH264Platform::WindowsSoftware
+        }
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
@@ -4451,12 +4499,17 @@ fn ffmpeg_h264_encoder(platform: FfmpegH264Platform) -> FfmpegH264Encoder {
             pix_fmt: "yuv420p",
             backend: EncodeBackend::HardwareVideotoolbox,
         },
-        FfmpegH264Platform::Windows => FfmpegH264Encoder {
+        FfmpegH264Platform::WindowsHardware => FfmpegH264Encoder {
             codec: "h264_mf",
             // FFmpeg's MediaFoundation wrapper accepts yuv420p on some encoders,
             // but nv12 is the safer input shape for hardware-backed devices.
             pix_fmt: "nv12",
             backend: EncodeBackend::HardwareMediaFoundation,
+        },
+        FfmpegH264Platform::WindowsSoftware => FfmpegH264Encoder {
+            codec: "h264_mf",
+            pix_fmt: "nv12",
+            backend: EncodeBackend::SoftwareMediaFoundation,
         },
         FfmpegH264Platform::Other => FfmpegH264Encoder {
             codec: "libx264",
@@ -4464,6 +4517,125 @@ fn ffmpeg_h264_encoder(platform: FfmpegH264Platform) -> FfmpegH264Encoder {
             backend: EncodeBackend::SoftwareX264,
         },
     }
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_media_foundation_hardware_probe_args(video: &VideoSettings) -> Vec<String> {
+    vec![
+        "-hide_banner".to_string(),
+        "-loglevel".to_string(),
+        "error".to_string(),
+        "-f".to_string(),
+        "lavfi".to_string(),
+        "-i".to_string(),
+        format!(
+            "color=c=black:s={}x{}:r={}",
+            video.width.max(1),
+            video.height.max(1),
+            video.fps.max(1)
+        ),
+        "-frames:v".to_string(),
+        "3".to_string(),
+        "-an".to_string(),
+        "-pix_fmt".to_string(),
+        "nv12".to_string(),
+        "-c:v".to_string(),
+        "h264_mf".to_string(),
+        "-hw_encoding".to_string(),
+        "1".to_string(),
+        "-rate_control".to_string(),
+        "ld_vbr".to_string(),
+        "-scenario".to_string(),
+        "live_streaming".to_string(),
+        "-b:v".to_string(),
+        format!("{}k", video.bitrate_kbps.max(1)),
+        "-f".to_string(),
+        "null".to_string(),
+        "-".to_string(),
+    ]
+}
+
+#[cfg(target_os = "windows")]
+async fn select_windows_media_foundation_encoder(
+    state: &AppState,
+    ffmpeg_path: &str,
+    video: &VideoSettings,
+) {
+    let probe_key = windows_media_foundation_probe_key(ffmpeg_path, video);
+    let probe_cache = WINDOWS_MEDIA_FOUNDATION_PROBE_CACHE
+        .get_or_init(|| StdMutex::new(std::collections::HashMap::new()));
+    if let Some(hardware_selected) = probe_cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&probe_key)
+        .copied()
+    {
+        WINDOWS_MEDIA_FOUNDATION_HARDWARE_SELECTED.store(hardware_selected, Ordering::Relaxed);
+        state.emit_log(
+            "info",
+            if hardware_selected {
+                "Using the cached Media Foundation hardware H.264 probe result."
+            } else {
+                "Using the cached Media Foundation software H.264 fallback result."
+            },
+        );
+        return;
+    }
+    let mut command = Command::new(ffmpeg_path);
+    command
+        .args(windows_media_foundation_hardware_probe_args(video))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let probe = timeout(Duration::from_secs(8), command.output()).await;
+    let (hardware_selected, detail) = match probe {
+        Ok(Ok(output)) if output.status.success() => (
+            true,
+            format!(
+                "Media Foundation hardware H.264 passed the {}x{}@{} startup probe.",
+                video.width, video.height, video.fps
+            ),
+        ),
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            (
+                false,
+                format!(
+                    "Media Foundation hardware H.264 was unavailable for {}x{}@{} ({}); using the software MFT fallback.",
+                    video.width,
+                    video.height,
+                    video.fps,
+                    stderr.trim().chars().take(240).collect::<String>()
+                ),
+            )
+        }
+        Ok(Err(error)) => (
+            false,
+            format!(
+                "Media Foundation hardware H.264 probe could not start ({error}); using the software MFT fallback."
+            ),
+        ),
+        Err(_) => (
+            false,
+            "Media Foundation hardware H.264 probe timed out; using the software MFT fallback."
+                .to_string(),
+        ),
+    };
+    probe_cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(probe_key, hardware_selected);
+    WINDOWS_MEDIA_FOUNDATION_HARDWARE_SELECTED.store(hardware_selected, Ordering::Relaxed);
+    state.emit_log(if hardware_selected { "info" } else { "warn" }, &detail);
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn select_windows_media_foundation_encoder(
+    _state: &AppState,
+    _ffmpeg_path: &str,
+    _video: &VideoSettings,
+) {
 }
 
 fn default_h264_encode_backend() -> EncodeBackend {
@@ -4474,15 +4646,38 @@ fn append_h264_encoding_args(args: &mut Vec<String>, video: &VideoSettings) {
     append_h264_encoding_args_for_platform(args, video, current_ffmpeg_h264_platform());
 }
 
+fn append_h264_encoding_args_preserving_input_timestamps(
+    args: &mut Vec<String>,
+    video: &VideoSettings,
+) {
+    append_h264_encoding_args_for_platform_with_timing(
+        args,
+        video,
+        current_ffmpeg_h264_platform(),
+        false,
+    );
+    args.extend(["-fps_mode".to_string(), "vfr".to_string()]);
+}
+
 fn append_h264_encoding_args_for_platform(
     args: &mut Vec<String>,
     video: &VideoSettings,
     platform: FfmpegH264Platform,
 ) {
+    append_h264_encoding_args_for_platform_with_timing(args, video, platform, true);
+}
+
+fn append_h264_encoding_args_for_platform_with_timing(
+    args: &mut Vec<String>,
+    video: &VideoSettings,
+    platform: FfmpegH264Platform,
+    force_output_fps: bool,
+) {
     let encoder = ffmpeg_h264_encoder(platform);
+    if force_output_fps {
+        args.extend(["-r".to_string(), video.fps.to_string()]);
+    }
     args.extend([
-        "-r".to_string(),
-        video.fps.to_string(),
         "-pix_fmt".to_string(),
         encoder.pix_fmt.to_string(),
         "-c:v".to_string(),
@@ -4499,11 +4694,19 @@ fn append_h264_encoding_args_for_platform(
                 "1".to_string(),
             ]);
         }
-        FfmpegH264Platform::Windows => {
+        FfmpegH264Platform::WindowsHardware => {
+            args.extend(["-hw_encoding".to_string(), "1".to_string()]);
+            args.extend([
+                "-rate_control".to_string(),
+                "ld_vbr".to_string(),
+                "-scenario".to_string(),
+                "live_streaming".to_string(),
+            ]);
+        }
+        FfmpegH264Platform::WindowsSoftware => {
             // Keep the low-delay Media Foundation profile, but let the encoder
-            // select an available implementation. Forcing hardware encoding
-            // makes h264_mf fail outright on systems without a compatible
-            // hardware MFT.
+            // select its software implementation only after the exact hardware
+            // probe failed for this output profile.
             args.extend([
                 "-rate_control".to_string(),
                 "ld_vbr".to_string(),
@@ -4550,7 +4753,8 @@ fn compositor_backend_label(backend: Option<CompositorBackend>) -> &'static str 
 fn encode_backend_label(backend: Option<EncodeBackend>) -> &'static str {
     match backend {
         Some(EncodeBackend::HardwareVideotoolbox) => "hardware-videotoolbox",
-        Some(EncodeBackend::HardwareMediaFoundation) => "hardware-mediafoundation",
+        Some(EncodeBackend::HardwareMediaFoundation) => "hardware-media-foundation",
+        Some(EncodeBackend::SoftwareMediaFoundation) => "software-media-foundation",
         Some(EncodeBackend::SoftwareX264) => "software-x264",
         None => "unknown",
     }
@@ -5061,7 +5265,10 @@ fn bridge_compositor_ffmpeg_args(
         append_audio_output_args(&mut args, &input_layout);
         match video_output {
             EncoderBridgeVideoOutput::RawYuv420p => {
-                append_h264_encoding_args(&mut args, &params.output.video);
+                append_h264_encoding_args_preserving_input_timestamps(
+                    &mut args,
+                    &params.output.video,
+                );
             }
             EncoderBridgeVideoOutput::VideoToolboxH264AnnexB
             | EncoderBridgeVideoOutput::VideoToolboxH264MpegTs => {
@@ -5322,14 +5529,16 @@ fn append_bridge_recording_input_args(
     let video_input_index = next_input_index;
     match video_output {
         EncoderBridgeVideoOutput::RawYuv420p => {
-            // rawvideo carries pixels only—there are no per-frame timestamps to
-            // preserve. `-use_wallclock_as_timestamps` therefore collapses or
-            // otherwise retimes FIFO input on Windows. Keep the declared CFR
-            // timestamps and require the selected encoder to sustain the output
-            // cadence instead.
+            // Raw frames carry no source PTS. Timestamp each complete FIFO frame
+            // at demux arrival so transport pressure cannot compress wall duration.
+            // The downstream fps filter fills isolated missing source ticks at the
+            // requested cadence; rendezvous/latest admission in encoder_bridge.rs
+            // prevents a stale raw backlog from accumulating behind it.
             args.extend([
                 "-thread_queue_size".to_string(),
                 ENCODER_BRIDGE_RAW_VIDEO_INPUT_QUEUE_FRAMES.to_string(),
+                "-use_wallclock_as_timestamps".to_string(),
+                "1".to_string(),
                 "-f".to_string(),
                 "rawvideo".to_string(),
                 "-pix_fmt".to_string(),
@@ -8262,7 +8471,11 @@ mod tests {
         );
         assert_eq!(
             encode_backend_label(Some(EncodeBackend::HardwareMediaFoundation)),
-            "hardware-mediafoundation"
+            "hardware-media-foundation"
+        );
+        assert_eq!(
+            encode_backend_label(Some(EncodeBackend::SoftwareMediaFoundation)),
+            "software-media-foundation"
         );
         assert_eq!(
             encode_backend_label(Some(EncodeBackend::SoftwareX264)),
@@ -8293,13 +8506,23 @@ mod tests {
         append_h264_encoding_args_for_platform(
             &mut windows_args,
             &video,
-            FfmpegH264Platform::Windows,
+            FfmpegH264Platform::WindowsHardware,
         );
         assert_eq!(arg_value(&windows_args, "-c:v"), Some("h264_mf"));
         assert_eq!(arg_value(&windows_args, "-pix_fmt"), Some("nv12"));
+        assert_eq!(arg_value(&windows_args, "-hw_encoding"), Some("1"));
         assert_eq!(arg_value(&windows_args, "-allow_sw"), None);
         assert_eq!(arg_value(&windows_args, "-realtime"), None);
         assert_eq!(arg_value(&windows_args, "-prio_speed"), None);
+
+        let mut windows_software_args = Vec::new();
+        append_h264_encoding_args_for_platform(
+            &mut windows_software_args,
+            &video,
+            FfmpegH264Platform::WindowsSoftware,
+        );
+        assert_eq!(arg_value(&windows_software_args, "-c:v"), Some("h264_mf"));
+        assert_eq!(arg_value(&windows_software_args, "-hw_encoding"), None);
 
         let mut fallback_args = Vec::new();
         append_h264_encoding_args_for_platform(
@@ -8312,7 +8535,12 @@ mod tests {
         assert_eq!(arg_value(&fallback_args, "-preset"), Some("ultrafast"));
         assert_eq!(arg_value(&fallback_args, "-tune"), Some("zerolatency"));
 
-        for args in [&macos_args, &windows_args, &fallback_args] {
+        for args in [
+            &macos_args,
+            &windows_args,
+            &windows_software_args,
+            &fallback_args,
+        ] {
             assert_eq!(arg_value(args, "-b:v"), Some("6000k"));
             assert_eq!(arg_value(args, "-maxrate"), Some("6000k"));
             assert_eq!(arg_value(args, "-bufsize"), Some("12000k"));
@@ -8332,12 +8560,51 @@ mod tests {
             EncodeBackend::HardwareVideotoolbox
         );
         assert_eq!(
-            ffmpeg_h264_encoder(FfmpegH264Platform::Windows).backend,
+            ffmpeg_h264_encoder(FfmpegH264Platform::WindowsHardware).backend,
             EncodeBackend::HardwareMediaFoundation
+        );
+        assert_eq!(
+            ffmpeg_h264_encoder(FfmpegH264Platform::WindowsSoftware).backend,
+            EncodeBackend::SoftwareMediaFoundation
         );
         assert_eq!(
             ffmpeg_h264_encoder(FfmpegH264Platform::Other).backend,
             EncodeBackend::SoftwareX264
+        );
+    }
+
+    #[test]
+    fn windows_hardware_encoder_probe_uses_the_exact_output_profile() {
+        let video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            bitrate_kbps: 6_000,
+        };
+        let args = windows_media_foundation_hardware_probe_args(&video);
+
+        assert_eq!(arg_value(&args, "-c:v"), Some("h264_mf"));
+        assert_eq!(arg_value(&args, "-hw_encoding"), Some("1"));
+        assert_eq!(arg_value(&args, "-b:v"), Some("6000k"));
+        assert!(
+            args.iter()
+                .any(|arg| arg == "color=c=black:s=1920x1080:r=30")
+        );
+        assert_eq!(arg_value(&args, "-frames:v"), Some("3"));
+
+        let key = windows_media_foundation_probe_key("ffmpeg", &video);
+        let mut higher_fps = video.clone();
+        higher_fps.fps = 60;
+        assert_ne!(
+            key,
+            windows_media_foundation_probe_key("ffmpeg", &higher_fps),
+            "hardware results must not leak across output profiles"
+        );
+        assert_ne!(
+            key,
+            windows_media_foundation_probe_key("alternate-ffmpeg", &video),
+            "hardware results must not leak across FFmpeg binaries"
         );
     }
 
@@ -9515,11 +9782,19 @@ mod tests {
                 assert_eq!(arg_value(args, "-realtime"), Some("1"));
                 assert_eq!(arg_value(args, "-prio_speed"), Some("1"));
             }
-            FfmpegH264Platform::Windows => {
+            FfmpegH264Platform::WindowsHardware => {
                 assert_eq!(arg_value(args, "-allow_sw"), None);
                 assert_eq!(arg_value(args, "-realtime"), None);
                 assert_eq!(arg_value(args, "-prio_speed"), None);
+                assert_eq!(arg_value(args, "-hw_encoding"), Some("1"));
                 assert_eq!(encoder.backend, EncodeBackend::HardwareMediaFoundation);
+            }
+            FfmpegH264Platform::WindowsSoftware => {
+                assert_eq!(arg_value(args, "-allow_sw"), None);
+                assert_eq!(arg_value(args, "-realtime"), None);
+                assert_eq!(arg_value(args, "-prio_speed"), None);
+                assert_eq!(arg_value(args, "-hw_encoding"), None);
+                assert_eq!(encoder.backend, EncodeBackend::SoftwareMediaFoundation);
             }
             FfmpegH264Platform::Other => {
                 assert_eq!(arg_value(args, "-allow_sw"), None);
@@ -9582,8 +9857,8 @@ mod tests {
                 &fifo_path.display().to_string(),
                 "-use_wallclock_as_timestamps"
             ),
-            None,
-            "rawvideo carries no per-frame timestamps, so it must retain its declared CFR timeline"
+            Some("1"),
+            "rawvideo must derive PTS from FIFO arrival so slow delivery preserves wall duration"
         );
         assert!(!input_has_arg(
             &args,
@@ -9599,6 +9874,8 @@ mod tests {
 
         let filter = arg_value(&args, "-filter_complex").unwrap();
         assert_eq!(filter, "[0:v]fps=30[v_main]");
+        assert_eq!(arg_value(&args, "-fps_mode"), Some("vfr"));
+        assert_eq!(arg_value(&args, "-r"), None);
         assert!(!args.iter().any(|arg| arg == "pipe:1"));
         assert!(!args.iter().any(|arg| arg == "pipe:0"));
     }

--- a/scripts/lib/native-preview-diagnostics.mjs
+++ b/scripts/lib/native-preview-diagnostics.mjs
@@ -1,3 +1,23 @@
+export function resolveNativePreviewLatencyBudgets({
+  configuredP95Ms,
+  configuredP99Ms,
+  sourceCompleteScene = false,
+  expectNativeMetalPreview = true,
+  exerciseProofFramePolling = false
+}) {
+  const usesContainedProofSurface =
+    !expectNativeMetalPreview && exerciseProofFramePolling
+  const usesExpandedBudget = sourceCompleteScene || usesContainedProofSurface
+
+  // The Electron proof surface shares renderer/main-loop scheduling and is not
+  // governed by the CAMetal presenter contract. Keep it firmly bounded while
+  // the smoke separately proves advancing, fresh source pixels and no blanks.
+  return {
+    p95Ms: usesExpandedBudget ? Math.max(configuredP95Ms, 100) : configuredP95Ms,
+    p99Ms: usesExpandedBudget ? Math.max(configuredP99Ms, 150) : configuredP99Ms
+  }
+}
+
 export function summarizeNativePreviewRecordingDiagnostics(
   samples,
   {

--- a/scripts/lib/native-preview-diagnostics.test.mjs
+++ b/scripts/lib/native-preview-diagnostics.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { summarizeNativePreviewRecordingDiagnostics } from './native-preview-diagnostics.mjs'
+import {
+  resolveNativePreviewLatencyBudgets,
+  summarizeNativePreviewRecordingDiagnostics
+} from './native-preview-diagnostics.mjs'
 
 const baseOptions = {
   targetFps: 30,
@@ -11,6 +14,54 @@ const baseOptions = {
   expectedSurfaceTransport: 'electron-proof-surface',
   expectedSurfaceBacking: 'electron-browser-window'
 }
+
+test('native preview latency budgets distinguish native Metal from contained proof polling', () => {
+  const configured = {
+    configuredP95Ms: 50,
+    configuredP99Ms: 100
+  }
+
+  assert.deepEqual(
+    resolveNativePreviewLatencyBudgets({
+      ...configured,
+      expectNativeMetalPreview: true,
+      exerciseProofFramePolling: true
+    }),
+    { p95Ms: 50, p99Ms: 100 }
+  )
+  assert.deepEqual(
+    resolveNativePreviewLatencyBudgets({
+      ...configured,
+      expectNativeMetalPreview: false,
+      exerciseProofFramePolling: false
+    }),
+    { p95Ms: 50, p99Ms: 100 }
+  )
+  assert.deepEqual(
+    resolveNativePreviewLatencyBudgets({
+      ...configured,
+      expectNativeMetalPreview: false,
+      exerciseProofFramePolling: true
+    }),
+    { p95Ms: 100, p99Ms: 150 }
+  )
+  assert.deepEqual(
+    resolveNativePreviewLatencyBudgets({
+      ...configured,
+      sourceCompleteScene: true
+    }),
+    { p95Ms: 100, p99Ms: 150 }
+  )
+  assert.deepEqual(
+    resolveNativePreviewLatencyBudgets({
+      configuredP95Ms: 125,
+      configuredP99Ms: 200,
+      expectNativeMetalPreview: false,
+      exerciseProofFramePolling: true
+    }),
+    { p95Ms: 125, p99Ms: 200 }
+  )
+})
 
 test('native preview diagnostics summarize only steady active recording samples when available', () => {
   const summary = summarizeNativePreviewRecordingDiagnostics(

--- a/scripts/lib/recording-duration-gate.mjs
+++ b/scripts/lib/recording-duration-gate.mjs
@@ -1,0 +1,20 @@
+export function evaluateRecordingWallDuration({
+  expectedDurationMs,
+  actualDurationSeconds,
+  minRatio = 0.8
+}) {
+  if (!(expectedDurationMs > 0)) {
+    return ['expected recording duration must be positive']
+  }
+  if (!(Number.isFinite(actualDurationSeconds) && actualDurationSeconds > 0)) {
+    return ['final artifact did not report a positive media duration']
+  }
+  const expectedSeconds = expectedDurationMs / 1000
+  const ratio = actualDurationSeconds / expectedSeconds
+  if (ratio < minRatio) {
+    return [
+      `final artifact duration ${actualDurationSeconds.toFixed(2)}s was only ${(ratio * 100).toFixed(1)}% of the requested ${expectedSeconds.toFixed(2)}s`
+    ]
+  }
+  return []
+}

--- a/scripts/lib/recording-duration-gate.test.mjs
+++ b/scripts/lib/recording-duration-gate.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { evaluateRecordingWallDuration } from './recording-duration-gate.mjs'
+
+describe('recording wall-duration gate', () => {
+  it('rejects the Windows one-third-duration regression', () => {
+    assert.deepEqual(
+      evaluateRecordingWallDuration({
+        expectedDurationMs: 30_000,
+        actualDurationSeconds: 10
+      }),
+      ['final artifact duration 10.00s was only 33.3% of the requested 30.00s']
+    )
+  })
+
+  it('accepts normal stop-boundary variance', () => {
+    assert.deepEqual(
+      evaluateRecordingWallDuration({
+        expectedDurationMs: 5_000,
+        actualDurationSeconds: 4.65
+      }),
+      []
+    )
+  })
+
+  it('fails closed when duration evidence is missing', () => {
+    assert.deepEqual(
+      evaluateRecordingWallDuration({
+        expectedDurationMs: 5_000,
+        actualDurationSeconds: null
+      }),
+      ['final artifact did not report a positive media duration']
+    )
+  })
+})

--- a/scripts/lib/startup-resolution-analyzer.mjs
+++ b/scripts/lib/startup-resolution-analyzer.mjs
@@ -7,7 +7,7 @@
 
 import { spawn } from 'node:child_process'
 import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import {
   maxConsecutiveRun,
@@ -24,6 +24,10 @@ export const DEFAULT_STARTUP_GATES = Object.freeze({
   blackFramePercent: 98,
   blackFrameThreshold: 32,
 })
+
+export function startupReportBaseName(file) {
+  return basename(file.replaceAll('\\', '/')).replace(/\.[^.]+$/, '')
+}
 
 // ---------------------------------------------------------------------------
 // Pure parsers / evaluators
@@ -583,7 +587,7 @@ export function renderStartupMarkdownReport(report) {
 export async function writeStartupReports(report, { outDir, ffmpegPath = 'ffmpeg', thumbnails = true } = {}) {
   const dir = outDir ?? dirname(report.file)
   mkdirSync(dir, { recursive: true })
-  const base = report.file.split('/').pop().replace(/\.[^.]+$/, '')
+  const base = startupReportBaseName(report.file)
   const jsonPath = join(dir, `${base}.startup.json`)
   const mdPath = join(dir, `${base}.startup.md`)
   writeFileSync(jsonPath, JSON.stringify(report, null, 2))

--- a/scripts/lib/startup-resolution-analyzer.mjs
+++ b/scripts/lib/startup-resolution-analyzer.mjs
@@ -337,7 +337,7 @@ export async function runStartupCropdetect(filePath, { ffmpegPath = 'ffmpeg', fr
 export async function writeStartupThumbnailSheet(report, { ffmpegPath = 'ffmpeg', outDir } = {}) {
   const dir = outDir ?? dirname(report.file)
   mkdirSync(dir, { recursive: true })
-  const base = report.file.split('/').pop().replace(/\.[^.]+$/, '')
+  const base = startupReportBaseName(report.file)
   const imagePath = join(dir, `${base}.startup-thumbnails.jpg`)
   const columns = 10
   const rows = Math.ceil(report.metrics.hashes.length / columns) || 1

--- a/scripts/lib/startup-resolution-analyzer.test.mjs
+++ b/scripts/lib/startup-resolution-analyzer.test.mjs
@@ -17,12 +17,24 @@ import {
   parseBlackframe,
   parseCropdetect,
   renderStartupMarkdownReport,
+  startupReportBaseName,
   summarizeDimensionRuns,
 } from './startup-resolution-analyzer.mjs'
 import { ffmpegAvailable } from './ffmpeg-available.mjs'
 
 const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
 const ffprobePath = process.env.VIDEORC_SMOKE_FFPROBE_PATH ?? 'ffprobe'
+
+describe('startupReportBaseName', () => {
+  it('extracts a report stem from an absolute Windows path on every host', () => {
+    assert.equal(
+      startupReportBaseName(
+        String.raw`D:\a\_temp\videorc-windows-preview-recording-smoke\videorc-session-20260711-230120.mp4`
+      ),
+      'videorc-session-20260711-230120'
+    )
+  })
+})
 
 describe('parseBlackframe', () => {
   it('parses frame number, pblack and timestamp', () => {

--- a/scripts/smoke-packaged-app.mjs
+++ b/scripts/smoke-packaged-app.mjs
@@ -30,6 +30,7 @@ const ffmpegPath =
   process.env.VIDEORC_SMOKE_FFMPEG_PATH ??
   (existsSync(bundledFfmpegPath) ? bundledFfmpegPath : 'ffmpeg')
 const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 45000)
+const recordingMs = Number(process.env.VIDEORC_SMOKE_RECORDING_MS ?? 2000)
 const launchAttempts = Number(process.env.VIDEORC_PACKAGED_SMOKE_LAUNCH_ATTEMPTS ?? 2)
 
 if (!existsSync(appExecutable)) {
@@ -45,6 +46,7 @@ try {
     ffmpegPath,
     outputDirectory,
     timeoutMs,
+    recordingMs,
     label: 'Packaged app',
     onHealth: async () => {
       if (

--- a/scripts/smoke-recording-native-preview-app.mjs
+++ b/scripts/smoke-recording-native-preview-app.mjs
@@ -7,7 +7,10 @@ import { assertEncoderBridgeVideoOutputHealthy } from './lib/encoder-bridge-outp
 import { performanceAppSpawnSpec, smokeAppEnv, stopProcess } from './lib/app-launcher.mjs'
 import { assertSourceCompleteCompositorHealthy } from './lib/native-preview-source-gates.mjs'
 import { analyzeRecording, writeReports } from './lib/recording-analyzer.mjs'
-import { summarizeNativePreviewRecordingDiagnostics } from './lib/native-preview-diagnostics.mjs'
+import {
+  resolveNativePreviewLatencyBudgets,
+  summarizeNativePreviewRecordingDiagnostics
+} from './lib/native-preview-diagnostics.mjs'
 import { createPreviewSurfaceOutputGuard } from './lib/smoke-output-guards.mjs'
 import { evaluateRecordingWallDuration } from './lib/recording-duration-gate.mjs'
 import {
@@ -68,6 +71,13 @@ const expectedSurfaceBacking = expectNativeMetalPreview
   ? 'cametal-layer'
   : 'electron-browser-window'
 const exerciseProofFramePolling = process.env.VIDEORC_NATIVE_PREVIEW_EXERCISE_PROOF_POLLING === '1'
+const previewLatencyBudgets = resolveNativePreviewLatencyBudgets({
+  configuredP95Ms: maxPreviewInputToPresentLatencyP95Ms,
+  configuredP99Ms: maxPreviewInputToPresentLatencyP99Ms,
+  sourceCompleteScene,
+  expectNativeMetalPreview,
+  exerciseProofFramePolling
+})
 
 const visibleScenarios = [
   ...(process.env.VIDEORC_NATIVE_PREVIEW_INCLUDE_1440 === '1'
@@ -739,15 +749,11 @@ function nativeMeasurementMaxIntervalP95Ms() {
 }
 
 function previewInputToPresentP95BudgetMs() {
-  return sourceCompleteScene
-    ? Math.max(maxPreviewInputToPresentLatencyP95Ms, 100)
-    : maxPreviewInputToPresentLatencyP95Ms
+  return previewLatencyBudgets.p95Ms
 }
 
 function previewInputToPresentP99BudgetMs() {
-  return sourceCompleteScene
-    ? Math.max(maxPreviewInputToPresentLatencyP99Ms, 150)
-    : maxPreviewInputToPresentLatencyP99Ms
+  return previewLatencyBudgets.p99Ms
 }
 
 function formatBridgeCopySummary(stats) {

--- a/scripts/smoke-recording-native-preview-app.mjs
+++ b/scripts/smoke-recording-native-preview-app.mjs
@@ -9,6 +9,7 @@ import { assertSourceCompleteCompositorHealthy } from './lib/native-preview-sour
 import { analyzeRecording, writeReports } from './lib/recording-analyzer.mjs'
 import { summarizeNativePreviewRecordingDiagnostics } from './lib/native-preview-diagnostics.mjs'
 import { createPreviewSurfaceOutputGuard } from './lib/smoke-output-guards.mjs'
+import { evaluateRecordingWallDuration } from './lib/recording-duration-gate.mjs'
 import {
   analyzeStartupResolution,
   writeStartupReports
@@ -66,6 +67,7 @@ const expectedSurfaceTransport = expectNativeMetalPreview
 const expectedSurfaceBacking = expectNativeMetalPreview
   ? 'cametal-layer'
   : 'electron-browser-window'
+const exerciseProofFramePolling = process.env.VIDEORC_NATIVE_PREVIEW_EXERCISE_PROOF_POLLING === '1'
 
 const visibleScenarios = [
   ...(process.env.VIDEORC_NATIVE_PREVIEW_INCLUDE_1440 === '1'
@@ -702,6 +704,26 @@ function assertNativeMeasurement(scenario, measurement) {
   if ((measurement.blankFrames ?? 0) > 0) {
     throw new Error(`Native preview reported ${measurement.blankFrames} blank frame(s).`)
   }
+  if (!expectNativeMetalPreview && exerciseProofFramePolling) {
+    if ((measurement.sourceFrameDelta ?? 0) < 2) {
+      throw new Error(
+        `Windows proof preview source frames did not advance during recording: delta ${measurement.sourceFrameDelta ?? 0}.`
+      )
+    }
+    if (measurement.framePollingIntervalMs !== 125 || measurement.framePollingMaxWidth !== 960) {
+      throw new Error(
+        `Windows recording preview did not apply the contained 125ms/960px polling profile: ${JSON.stringify({ intervalMs: measurement.framePollingIntervalMs, maxWidth: measurement.framePollingMaxWidth })}`
+      )
+    }
+    if (
+      (measurement.freshSourceLayerCount ?? 0) <= 0 ||
+      (measurement.sourceFrameAgeMs ?? Number.POSITIVE_INFINITY) > 1500
+    ) {
+      throw new Error(
+        `Windows proof preview source liveness failed during recording: ${JSON.stringify({ freshLayers: measurement.freshSourceLayerCount, sourceFrameAgeMs: measurement.sourceFrameAgeMs })}`
+      )
+    }
+  }
 }
 
 function nativeMeasurementMinFps(scenario) {
@@ -751,6 +773,13 @@ function assertRecordingDurationHealthy(scenario, report, expectedDurationMs) {
   const duration = report.metrics.durationSeconds
   if (!Number.isFinite(duration)) {
     throw new Error(`[${scenario.label}] Final recording duration was unavailable.`)
+  }
+  const wallDurationFailures = evaluateRecordingWallDuration({
+    expectedDurationMs,
+    actualDurationSeconds: duration
+  })
+  if (wallDurationFailures.length > 0) {
+    throw new Error(`[${scenario.label}] ${wallDurationFailures.join('; ')}`)
   }
   const toleranceSeconds = 1.5
   if (
@@ -815,7 +844,7 @@ function assertStatsHealthyStrict(scenario, stats, reports = {}, options = {}) {
   if (stats.droppedFrames > 0) {
     throw new Error(`[${scenario.label}] FFmpeg reported ${stats.droppedFrames} dropped frame(s).`)
   }
-  if ((stats.maxEncoderBridgeMetalTargetFrames ?? 0) <= 0) {
+  if (expectNativeMetalPreview && (stats.maxEncoderBridgeMetalTargetFrames ?? 0) <= 0) {
     throw new Error(
       `[${scenario.label}] Recording diagnostics never observed IOSurface-backed Metal target frames.`
     )
@@ -1068,12 +1097,19 @@ function launchAndReadConnections() {
 
     appProcess = spawn('pnpm', ['dev'], {
       cwd: repoRoot,
-      detached: true,
+      // Windows loses the pnpm child's marker pipes when launched as a detached
+      // process group. stopProcess uses taskkill there, so detachment is only
+      // needed for Unix process-group cleanup.
+      detached: process.platform !== 'win32',
+      shell: process.platform === 'win32',
       env: smokeAppEnv({
         VIDEORC_USER_DATA_DIR: userDataDir,
         VIDEORC_SMOKE_OUTPUT_DIR: outputDirectory,
         VIDEORC_NATIVE_PREVIEW_SURFACE: '1',
-        VIDEORC_SMOKE_PREVIEW_MOTION: '1',
+        VIDEORC_SMOKE_COMMAND_SERVER: '1',
+        ...(exerciseProofFramePolling
+          ? { VIDEORC_SMOKE_PREVIEW_FRAME_POLLING: '1' }
+          : { VIDEORC_SMOKE_PREVIEW_MOTION: '1' }),
         VIDEORC_SMOKE_PRINT_BACKEND_READY: '1'
       }),
       stdio: ['ignore', 'pipe', 'pipe']

--- a/scripts/smoke-recording-native-preview-app.mjs
+++ b/scripts/smoke-recording-native-preview-app.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
 import { assertEncoderBridgeVideoOutputHealthy } from './lib/encoder-bridge-output-gates.mjs'
-import { smokeAppEnv, stopProcess } from './lib/app-launcher.mjs'
+import { performanceAppSpawnSpec, smokeAppEnv, stopProcess } from './lib/app-launcher.mjs'
 import { assertSourceCompleteCompositorHealthy } from './lib/native-preview-source-gates.mjs'
 import { analyzeRecording, writeReports } from './lib/recording-analyzer.mjs'
 import { summarizeNativePreviewRecordingDiagnostics } from './lib/native-preview-diagnostics.mjs'
@@ -1094,14 +1094,19 @@ function launchAndReadConnections() {
       rejectConnections(new Error(`Timed out waiting for smoke connections after ${timeoutMs}ms.`))
     }, timeoutMs)
     const connections = { backend: null, smoke: null }
+    const packagedSpawnSpec = performanceAppSpawnSpec()
+    const spawnCommand = packagedSpawnSpec?.command ?? 'pnpm'
+    const spawnArgs = packagedSpawnSpec?.args ?? ['dev']
 
-    appProcess = spawn('pnpm', ['dev'], {
-      cwd: repoRoot,
+    appProcess = spawn(spawnCommand, spawnArgs, {
+      cwd: packagedSpawnSpec?.cwd ?? repoRoot,
       // Windows loses the pnpm child's marker pipes when launched as a detached
-      // process group. stopProcess uses taskkill there, so detachment is only
-      // needed for Unix process-group cleanup.
+      // process group. A packaged executable also launches directly without a
+      // shell, avoiding a redundant debug Rust build in the Windows installer
+      // job. stopProcess uses taskkill there, so detachment is only needed for
+      // Unix process-group cleanup.
       detached: process.platform !== 'win32',
-      shell: process.platform === 'win32',
+      shell: process.platform === 'win32' && !packagedSpawnSpec,
       env: smokeAppEnv({
         VIDEORC_USER_DATA_DIR: userDataDir,
         VIDEORC_SMOKE_OUTPUT_DIR: outputDirectory,

--- a/scripts/smoke-recording-native-preview-app.mjs
+++ b/scripts/smoke-recording-native-preview-app.mjs
@@ -211,7 +211,7 @@ async function runNativePreviewRecordingScenario(
   }
   await assertSameRunningSession(ws, started.sessionId)
   await waitForActiveSceneDiagnostics(ws, activeSceneRevision, 'record')
-  if (expectsPreview) {
+  if (expectsPreview && expectNativeMetalPreview) {
     const pumpReconnect = await smokeCommand(smoke, 'exercise-main-present-pump-reconnect')
     assertMainPumpReconnectDuringRecording(scenario, pumpReconnect)
   }

--- a/scripts/smoke-recording-native-preview-app.mjs
+++ b/scripts/smoke-recording-native-preview-app.mjs
@@ -666,13 +666,17 @@ function assertNativeMeasurement(scenario, measurement) {
   const maxMeasurementIntervalP95Ms = nativeMeasurementMaxIntervalP95Ms()
   const maxInputToPresentP95Ms = previewInputToPresentP95BudgetMs()
   const maxInputToPresentP99Ms = previewInputToPresentP99BudgetMs()
+  const requireAnimationCadence = expectNativeMetalPreview || !exerciseProofFramePolling
 
-  if ((measurement.measuredFps ?? 0) < minMeasurementFps) {
+  if (requireAnimationCadence && (measurement.measuredFps ?? 0) < minMeasurementFps) {
     throw new Error(
       `Native preview measured ${format(measurement.measuredFps)}fps, below ${format(minMeasurementFps)}.`
     )
   }
-  if ((measurement.intervalP95Ms ?? Number.POSITIVE_INFINITY) > maxMeasurementIntervalP95Ms) {
+  if (
+    requireAnimationCadence &&
+    (measurement.intervalP95Ms ?? Number.POSITIVE_INFINITY) > maxMeasurementIntervalP95Ms
+  ) {
     throw new Error(
       `Native preview p95 interval ${format(measurement.intervalP95Ms)}ms exceeded ${format(maxMeasurementIntervalP95Ms)}ms.`
     )

--- a/scripts/smoke-recording-session.mjs
+++ b/scripts/smoke-recording-session.mjs
@@ -3,8 +3,12 @@ import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { analyzeRecording, writeReports } from './lib/recording-analyzer.mjs'
+import { evaluateRecordingWallDuration } from './lib/recording-duration-gate.mjs'
 
-const SMOKE_VIDEO_FPS = 30
+const SMOKE_VIDEO_FPS = positiveInteger(process.env.VIDEORC_SMOKE_VIDEO_FPS, 30)
+const SMOKE_VIDEO_WIDTH = positiveInteger(process.env.VIDEORC_SMOKE_VIDEO_WIDTH, 640)
+const SMOKE_VIDEO_HEIGHT = positiveInteger(process.env.VIDEORC_SMOKE_VIDEO_HEIGHT, 360)
+const SMOKE_VIDEO_BITRATE_KBPS = positiveInteger(process.env.VIDEORC_SMOKE_VIDEO_BITRATE_KBPS, 2000)
 const TEST_PATTERN_GATES = Object.freeze({
   // Synthetic source/layout smoke proves file health and timing. Some synthetic
   // layouts are intentionally static, so motion artifacts remain warnings here.
@@ -144,6 +148,16 @@ async function recordScenario({
   if (!quality.verdict.pass) {
     throw new Error(
       `[${scenario.label}] Recording quality gate failed: ${quality.verdict.failures.join('; ')} ` +
+        `(report: ${reportPaths.mdPath})`
+    )
+  }
+  const durationFailures = evaluateRecordingWallDuration({
+    expectedDurationMs: recordingMs,
+    actualDurationSeconds: quality.metrics.durationSeconds
+  })
+  if (durationFailures.length > 0) {
+    throw new Error(
+      `[${scenario.label}] Recording duration gate failed: ${durationFailures.join('; ')} ` +
         `(report: ${reportPaths.mdPath})`
     )
   }
@@ -330,10 +344,10 @@ function sessionParams({ outputDirectory, ffmpegPath, preset = 'screen-camera', 
       ffmpegPath,
       video: {
         preset: 'custom',
-        width: 640,
-        height: 360,
-        fps: 30,
-        bitrateKbps: 2000
+        width: SMOKE_VIDEO_WIDTH,
+        height: SMOKE_VIDEO_HEIGHT,
+        fps: SMOKE_VIDEO_FPS,
+        bitrateKbps: SMOKE_VIDEO_BITRATE_KBPS
       },
       rtmp: {
         preset: 'custom',
@@ -343,6 +357,11 @@ function sessionParams({ outputDirectory, ffmpegPath, preset = 'screen-camera', 
     },
     scene: background ? sceneWithAssetBackground(background) : undefined
   }
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback
 }
 
 function sceneWithAssetBackground(background) {


### PR DESCRIPTION
## Summary
- preserve recording wall time and A/V alignment when the Windows encoder bridge is under pressure
- remove the per-pipe-chunk retry delay that throttled 1080p raw frames, bound complete-frame writes, and probe Media Foundation hardware truthfully
- keep the Windows proof preview live during recording with a contained polling profile, blocking-worker PNG encoding, and Windows-specific liveness instead of the macOS Metal reset ladder
- add packaged Windows duration/A-V coverage plus recording-time preview source-liveness coverage

## Verification
- exact 1080p forced-raw production artifact: 337 frames over 11.233s at 30fps, 12ms A/V skew, no freezes, repeat bursts, audio gaps, or decode errors; preview remained live through forced pump reconnect
- desktop tests: 793 passed
- Node script tests: 567 passed
- Rust tests: 1,071 passed, 7 ignored
- typecheck, lint, format, build, cargo fmt, clippy, and Windows xwin check passed
- recording-studio gates passed through unit, artifact, captions, layout, streaming, preview stress, 100-cycle lifecycle, placement, and native-surface steps; real ScreenCaptureKit stimulus was blocked by the host macOS screencapture permission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows recording now automatically chooses a compatible hardware or software Media Foundation encoder.
  * Enhanced native preview frame/proof monitoring improves first-frame readiness and keeps Windows previews live during recording.
  * Recording startup provides clearer readiness and status behavior.

* **Bug Fixes**
  * Improved recording timing consistency with stronger wall-duration health validation.
  * Reduced startup delays/stalls by improving recording bridge readiness and FIFO/write progress handling.
  * Diagnostics now display MediaFoundation encoder types correctly.

* **Tests**
  * Added additional packaged Windows smoke verification and expanded first-frame/proof polling test coverage (plus recording duration gating unit tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->