### PR TITLE
feat: rework Studio audio UI on ElevenLabs bar visualizer and live waveform

### DIFF
--- a/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
@@ -1,24 +1,32 @@
 import { Microphone, SpeakerHigh, SpeakerSlash, WaveSine } from '@phosphor-icons/react'
-import type { ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 
 import { PanelSection } from '@/components/panel-section'
 import { StatusBadge } from '@/components/status-badge'
+import { BarVisualizer } from '@/components/ui/bar-visualizer'
 import { Button } from '@/components/ui/button'
 import { useWorkspaceNav } from '@/components/workspace-nav'
-import { useMicLevelMeter, type MicLevelMeter } from '@/hooks/use-mic-level-meter'
+import { useDocumentVisible } from '@/hooks/use-document-visible'
+import { useMicLevelMeter } from '@/hooks/use-mic-level-meter'
+import { useMicStream } from '@/hooks/use-mic-stream'
 import { useStudioAudio, useStudioCore, useStudioDiagnostics } from '@/hooks/use-studio'
 import { formatDb } from '@/lib/format'
+import { advanceClipHoldDeadline, fallbackBandLevels } from '@/lib/mic-meter'
 import { cn } from '@/lib/utils'
 
+const MIXER_BAR_COUNT = 28
+
 /**
- * Audio mixer (SD4 + post-0.9.4 fix F7 + 2026-07-10 live-meter fix). The
- * VISUAL meter runs on a renderer WebAudio analyser at display rate, driven
- * imperatively (use-mic-level-meter) — instant response with peak hold, both
- * idle and in-session. The backend stays the capture/health authority: its
- * 1 Hz `micLiveLevel` and the on-demand 700 ms "Check level" sample remain
- * the fallback whenever the analyser cannot open the selected device.
- * System audio shows its honest "unavailable — pending native adapter" state;
- * real capture is Phase-2 (F3).
+ * Audio mixer (SD4 + post-0.9.4 fix F7 + 2026-07-10 live-meter fix + Studio
+ * audio ElevenLabs rework S3). The VISUAL is a multi-band bar visualizer over
+ * the shared renderer mic stream (use-mic-stream) at display rate, with the
+ * WebAudio ballistics meter kept for the peak-dB label and clip hold. The
+ * backend stays the capture/health authority: its 1 Hz `micLiveLevel` and the
+ * on-demand 700 ms "Check level" sample drive a deterministic coarse-band
+ * fallback whenever the analyser cannot open the selected device. The stream
+ * releases while the document is hidden (idle-CPU discipline). System audio
+ * shows its honest "unavailable — pending native adapter" state; real capture
+ * is Phase-2 (F3).
  */
 export function AudioMixer(): ReactElement {
   const { captureConfig, setCaptureConfig, selectedMicrophone, sampleAudioMeter, deviceList } =
@@ -28,11 +36,14 @@ export function AudioMixer(): ReactElement {
   const { openStudioPanel } = useWorkspaceNav()
 
   const muted = captureConfig.audio.microphoneMuted
-  const micMeter = useMicLevelMeter({
+  const documentVisible = useDocumentVisible()
+  const micStream = useMicStream({
     deviceName: selectedMicrophone?.name,
-    enabled: Boolean(selectedMicrophone),
-    muted
+    enabled: Boolean(selectedMicrophone) && documentVisible
   })
+  const micMeter = useMicLevelMeter({ stream: micStream.stream, muted })
+  const clipping = useClipIndicator(micMeter.peakDb)
+
   const liveLevel =
     typeof diagnosticStats?.micLiveLevel === 'number' ? diagnosticStats.micLiveLevel : null
   const hasReading = audioMeter !== null && typeof audioMeter.level === 'number'
@@ -46,6 +57,28 @@ export function AudioMixer(): ReactElement {
           ? formatDb(audioMeter.peakDb)
           : formatDb(captureConfig.audio.microphoneGainDb)
   const systemAudio = deviceList.devices.find((device) => device.kind === 'system-audio')
+
+  // Explicit visual state map (plan S3) — every path states what drives it:
+  // - live analyser: bars from the stream, chrome tone;
+  // - muted: flat dim bars (the analyser sees pre-mute signal — dancing bars
+  //   under a mute would lie about the recording);
+  // - coarse fallback (backend 1 Hz / sampled level): deterministic
+  //   center-weighted bands from the real level;
+  // - silent/no-frames: warning tone over whatever level path is active;
+  // - no mic: flat dim bars.
+  const meterStatus = micMeter.active || liveLevel !== null ? 'ready' : audioMeter?.status
+  const analyserDriven = micStream.active && !muted
+  const visualLevels = analyserDriven
+    ? undefined
+    : fallbackBandLevels(muted || !selectedMicrophone ? 0 : level, MIXER_BAR_COUNT)
+  const meterTone =
+    muted || !selectedMicrophone
+      ? 'text-muted-foreground/50'
+      : meterStatus === 'silent' || meterStatus === 'no-frames'
+        ? 'text-warning'
+        : meterStatus === 'ready'
+          ? 'text-foreground/80'
+          : 'text-muted-foreground/70'
 
   return (
     <PanelSection
@@ -66,6 +99,18 @@ export function AudioMixer(): ReactElement {
             </span>
           </span>
           <span className="flex shrink-0 items-center gap-1.5">
+            {/* Clip hold keeps its width reserved so the label row never shifts. */}
+            <span
+              aria-hidden={!clipping}
+              className={cn(
+                'flex items-center gap-1 text-xs font-medium text-warning transition-opacity duration-150',
+                clipping ? 'opacity-100' : 'opacity-0'
+              )}
+              data-videorc-mic-clip={clipping || undefined}
+            >
+              <span className="size-1.5 rounded-full bg-warning" />
+              Clip
+            </span>
             <span className="text-xs tabular-nums text-muted-foreground">{dbLabel}</span>
             {selectedMicrophone ? (
               <Button
@@ -90,12 +135,16 @@ export function AudioMixer(): ReactElement {
             ) : null}
           </span>
         </div>
-        <div className="flex items-center gap-2">
-          <MeterBar
-            level={micMeter.active ? null : level}
-            live={micMeter.active ? micMeter : undefined}
-            muted={muted}
-            status={micMeter.active || liveLevel !== null ? 'ready' : audioMeter?.status}
+        <div className="flex items-center gap-3">
+          <BarVisualizer
+            centerAlign
+            barCount={MIXER_BAR_COUNT}
+            className={cn('h-12 min-w-0 flex-1', meterTone)}
+            data-videorc-mic-visualizer
+            levels={visualLevels}
+            mediaStream={micStream.stream}
+            minHeight={8}
+            state="speaking"
           />
           {micMeter.active || liveLevel !== null ? (
             <span className="shrink-0 text-xs text-muted-foreground">Live</span>
@@ -111,6 +160,17 @@ export function AudioMixer(): ReactElement {
             </Button>
           )}
         </div>
+        {meterStatus === 'silent' || meterStatus === 'no-frames' ? (
+          <span className="text-xs text-warning">
+            {meterStatus === 'silent'
+              ? 'The mic delivered only silence on the last check.'
+              : 'The mic opened but did not send audio frames.'}
+          </span>
+        ) : meterStatus === 'permission-required' ? (
+          <span className="text-xs text-warning">
+            Microphone permission is required before levels can be read.
+          </span>
+        ) : null}
       </div>
 
       {/* System audio — honest unavailable state until the native adapter lands. */}
@@ -132,49 +192,34 @@ export function AudioMixer(): ReactElement {
   )
 }
 
-function MeterBar({
-  level,
-  live,
-  status,
-  muted
-}: {
-  /** Static level for the fallback paths; null while the analyser drives the bar. */
-  level: number | null
-  /** When set, fill width and peak marker are written imperatively at rAF rate. */
-  live?: Pick<MicLevelMeter, 'fillRef' | 'peakRef'>
-  status?: string
-  muted: boolean
-}): ReactElement {
-  const pct = level === null ? 0 : Math.min(100, Math.max(0, Math.round(level * 100)))
-  const tone = muted
-    ? 'bg-muted-foreground/40'
-    : status === 'ready'
-      ? 'bg-success'
-      : status === 'silent' || status === 'no-frames'
-        ? 'bg-warning'
-        : 'bg-muted-foreground/40'
-  return (
-    <span className="relative h-2 min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
-      <span
-        ref={live?.fillRef}
-        // The analyser's own ballistics animate the live bar; a CSS width
-        // transition would smear every frame. Keep it only on the 1 Hz
-        // fallback paths so their jumps stay readable.
-        className={cn(
-          'block h-full rounded-full',
-          !live && 'transition-[width] duration-100',
-          tone
-        )}
-        style={live ? undefined : { width: `${pct}%` }}
-      />
-      {live ? (
-        <span
-          ref={live.peakRef}
-          aria-hidden
-          className="absolute top-0 h-full w-0.5 rounded-full bg-foreground/70"
-          style={{ left: 0, opacity: 0 }}
-        />
-      ) : null}
-    </span>
-  )
+/**
+ * Clip indicator with hold: peaks at/above the clip threshold arm it and the
+ * deadline extends while the input stays hot (advanceClipHoldDeadline), so a
+ * single hot transient stays readable for MIC_CLIP_HOLD_MS.
+ */
+function useClipIndicator(peakDb: number | null): boolean {
+  const deadlineRef = useRef(0)
+  const [clipping, setClipping] = useState(false)
+
+  useEffect(() => {
+    const now = performance.now()
+    deadlineRef.current = advanceClipHoldDeadline(deadlineRef.current, peakDb, now)
+    if (now < deadlineRef.current) {
+      setClipping(true)
+    }
+  }, [peakDb])
+
+  useEffect(() => {
+    if (!clipping) {
+      return
+    }
+    const interval = window.setInterval(() => {
+      if (performance.now() >= deadlineRef.current) {
+        setClipping(false)
+      }
+    }, 250)
+    return () => window.clearInterval(interval)
+  }, [clipping])
+
+  return clipping
 }

--- a/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react'
+
+import { LiveWaveform } from '@/components/ui/live-waveform'
+import { useDocumentVisible } from '@/hooks/use-document-visible'
+import { useMicStream } from '@/hooks/use-mic-stream'
+
+/**
+ * See-before-you-pick mic preview (Studio audio rework S4): a scrolling live
+ * waveform of the selected device rendered under the mic pickers, so choosing
+ * a microphone is never blind. One shared composition for both picker homes
+ * (Quick Settings popover, Sources panel). The stream opens through
+ * use-mic-stream while the preview is mounted and visible, and hard-stops on
+ * unmount (popover close, panel leave) — it must never linger. Failures show
+ * an honest inline reason, never a fake wave and never a toast.
+ */
+export function MicPickerPreview({
+  deviceName
+}: {
+  /** Backend name of the mic to preview; undefined renders the idle line. */
+  deviceName: string | undefined
+}): ReactElement {
+  const documentVisible = useDocumentVisible()
+  const enabled = Boolean(deviceName) && documentVisible
+  const micStream = useMicStream({ deviceName, enabled })
+
+  return (
+    <div className="flex flex-col gap-1" data-videorc-mic-preview>
+      <div className="rounded-row border bg-muted/20 px-2 py-1 text-foreground/70">
+        <LiveWaveform
+          barGap={1}
+          barWidth={2}
+          height={28}
+          mediaStream={micStream.stream}
+          mode="scrolling"
+          processing={enabled && micStream.status === 'acquiring'}
+        />
+      </div>
+      {enabled && micStream.status === 'unavailable' ? (
+        <span className="text-xs text-muted-foreground">
+          Live preview unavailable — the mic may be in use or needs permission. Recording is
+          unaffected.
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -9,7 +9,7 @@ import {
   SpeakerSlash,
   type Icon
 } from '@phosphor-icons/react'
-import type { ReactElement, ReactNode } from 'react'
+import { Suspense, lazy, type ReactElement, type ReactNode } from 'react'
 
 import { SourceSelect } from '@/components/source-select'
 import { Button } from '@/components/ui/button'
@@ -37,6 +37,13 @@ import {
   layoutPresetNeedsCamera,
   layoutPresetNeedsScreen
 } from '@/lib/capture'
+
+// Lazy like the tab chunks (app-shell): the preview (and the live-waveform it
+// pulls in) loads on first popover open, keeping it out of the eager renderer
+// bundle (check:renderer-assets budget).
+const MicPickerPreview = lazy(async () => ({
+  default: (await import('@/components/studio/mic-picker-preview')).MicPickerPreview
+}))
 
 const QUICK_PRESETS: { id: LayoutPreset; label: string }[] = [
   { id: 'screen-camera', label: 'Screen + Cam' },
@@ -218,6 +225,12 @@ export function QuickSettings(): ReactElement {
                 }))
               }
             />
+            {/* See-before-you-pick: live waveform of the selected mic while the
+                popover is open. Mounted only with the popover, so the preview
+                stream releases the device on close. */}
+            <Suspense fallback={<div className="h-[38px] rounded-row border bg-muted/20" />}>
+              <MicPickerPreview deviceName={selectedMicrophone?.name} />
+            </Suspense>
             {selectedMicrophone ? (
               <Button
                 aria-pressed={muted}

--- a/apps/desktop/src/renderer/src/components/studio/session-mic-sliver.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-mic-sliver.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react'
+
+import { BarVisualizer } from '@/components/ui/bar-visualizer'
+import { useDocumentVisible } from '@/hooks/use-document-visible'
+import { useMicStream } from '@/hooks/use-mic-stream'
+import { fallbackBandLevels } from '@/lib/mic-meter'
+import { cn } from '@/lib/utils'
+
+const SLIVER_BAR_COUNT = 5
+
+/**
+ * In-session mic confidence sliver (Studio audio rework S5): a passive 5-bar
+ * mini visualizer beside the session status badge — one home, rendered by the
+ * status cluster wherever it lives (Preview panel header or the docked
+ * frame's control row). Visible only while a session runs with a mic
+ * selected; its width is reserved for the whole session so mute toggles never
+ * shift layout (muted shows flat dim bars). No click target — the mixer owns
+ * the controls. The stream releases while the document is hidden.
+ */
+export function SessionMicSliver({
+  sessionActive,
+  deviceName,
+  muted
+}: {
+  sessionActive: boolean
+  deviceName: string | undefined
+  muted: boolean
+}): ReactElement | null {
+  const documentVisible = useDocumentVisible()
+  const enabled = sessionActive && Boolean(deviceName) && !muted && documentVisible
+  const micStream = useMicStream({ deviceName, enabled })
+
+  if (!sessionActive || !deviceName) {
+    return null
+  }
+
+  return (
+    <span
+      className="flex w-9 shrink-0 items-center"
+      data-videorc-session-mic-sliver
+      title={muted ? 'Microphone muted' : 'Live microphone signal'}
+    >
+      <BarVisualizer
+        centerAlign
+        barCount={SLIVER_BAR_COUNT}
+        className={cn(
+          'h-4 w-full gap-0.5',
+          muted ? 'text-muted-foreground/50' : 'text-foreground/70'
+        )}
+        levels={muted || !micStream.active ? fallbackBandLevels(0, SLIVER_BAR_COUNT) : undefined}
+        mediaStream={micStream.stream}
+        minHeight={12}
+        state="speaking"
+      />
+    </span>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
@@ -15,6 +15,7 @@ import { useRef, useState, type ReactElement } from 'react'
 import { ConfigGrid } from '@/components/page'
 import { PanelSection } from '@/components/panel-section'
 import { SourceSelect } from '@/components/source-select'
+import { MicPickerPreview } from '@/components/studio/mic-picker-preview'
 import { StatusBadge, type StatusTone } from '@/components/status-badge'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -406,6 +407,9 @@ export function SourcesTab(): ReactElement {
             }))
           }
         />
+        {/* See-before-you-pick: live waveform of the selected mic (shared with
+            the Quick Settings popover). */}
+        <MicPickerPreview deviceName={selectedMicrophone?.name} />
         <div className="flex items-center justify-between text-sm">
           <span className="flex items-center gap-2 text-muted-foreground">
             {captureConfig.audio.microphoneMuted ? (

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -11,6 +11,7 @@ import { StatusBadge } from '@/components/status-badge'
 import { AudioMixer } from '@/components/studio/audio-mixer'
 import { QuickSettings } from '@/components/studio/quick-settings'
 import { ScenesGallery } from '@/components/studio/scenes-gallery'
+import { SessionMicSliver } from '@/components/studio/session-mic-sliver'
 import { SessionPanel } from '@/components/studio/session-panel'
 import { Button } from '@/components/ui/button'
 import type { StudioPanel, WorkspaceTab } from '@/components/workspace-nav'
@@ -196,12 +197,14 @@ export function StudioTab(): ReactElement {
 
 function StudioPreviewPanel(): ReactElement {
   const {
+    captureConfig,
     nativePreviewSurfaceEnabled,
     openPreviewPermissions,
     openPreviewWindow,
     previewWindow,
     refreshPreview,
     runtimeInfo,
+    selectedMicrophone,
     setPreviewWindowMode,
     wsStatus
   } = useStudioCore()
@@ -215,13 +218,22 @@ function StudioPreviewPanel(): ReactElement {
 
   // data hook: the backend-resilience smoke reads this badge (the old probe
   // grepped for a "Status" text prefix that died with the session-panel
-  // declutter). It must exist in every preview mode, docked included.
+  // declutter). It must exist in every preview mode, docked included. The mic
+  // sliver rides the same cluster so it has exactly one home wherever the
+  // status renders (panel header or docked control row).
   const sessionStatusBadge = (
-    <span data-videorc-session-status>
-      <StatusBadge
-        tone={sessionStatusTone(recording.state, wsStatus)}
-        value={sessionStatusLabel(recording.state, wsStatus)}
+    <span className="flex items-center gap-1.5">
+      <SessionMicSliver
+        deviceName={selectedMicrophone?.name}
+        muted={captureConfig.audio.microphoneMuted}
+        sessionActive={active}
       />
+      <span data-videorc-session-status>
+        <StatusBadge
+          tone={sessionStatusTone(recording.state, wsStatus)}
+          value={sessionStatusLabel(recording.state, wsStatus)}
+        />
+      </span>
     </span>
   )
 

--- a/apps/desktop/src/renderer/src/components/ui/bar-visualizer.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/bar-visualizer.tsx
@@ -1,0 +1,319 @@
+import { forwardRef, memo, useEffect, useMemo, useRef, useState, type HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * Vendored from ElevenLabs UI (ui.elevenlabs.io, registry item `bar-visualizer`)
+ * and adapted for Videorc:
+ * - bars render in `currentColor` so the parent's text token drives the tone
+ *   (chrome when live, muted when idle, warning when silent) — no hardcoded
+ *   palette, per the videorc-design "color is information" rule;
+ * - the container ships unstyled (no bg/radius/padding) — content sits
+ *   directly on the glass panel;
+ * - `useBarAnimator` no longer runs a rAF loop for single-frame sequences
+ *   (the `speaking`/undefined states used by the mixer), keeping idle CPU at
+ *   baseline; multi-frame state animations still animate.
+ * The caller owns the MediaStream lifecycle (see use-mic-stream).
+ */
+
+export interface AudioAnalyserOptions {
+  fftSize?: number
+  smoothingTimeConstant?: number
+  minDecibels?: number
+  maxDecibels?: number
+}
+
+function createAudioAnalyser(
+  mediaStream: MediaStream,
+  options: AudioAnalyserOptions = {}
+): { analyser: AnalyserNode; audioContext: AudioContext; cleanup: () => void } {
+  const audioContext = new AudioContext()
+  const source = audioContext.createMediaStreamSource(mediaStream)
+  const analyser = audioContext.createAnalyser()
+
+  if (options.fftSize) analyser.fftSize = options.fftSize
+  if (options.smoothingTimeConstant !== undefined) {
+    analyser.smoothingTimeConstant = options.smoothingTimeConstant
+  }
+  if (options.minDecibels !== undefined) analyser.minDecibels = options.minDecibels
+  if (options.maxDecibels !== undefined) analyser.maxDecibels = options.maxDecibels
+
+  source.connect(analyser)
+
+  const cleanup = (): void => {
+    source.disconnect()
+    void audioContext.close().catch(() => undefined)
+  }
+
+  return { analyser, audioContext, cleanup }
+}
+
+export interface MultiBandVolumeOptions {
+  bands?: number
+  loPass?: number
+  hiPass?: number
+  updateInterval?: number
+  analyserOptions?: AudioAnalyserOptions
+}
+
+const multibandDefaults: Required<Omit<MultiBandVolumeOptions, 'analyserOptions'>> & {
+  analyserOptions: AudioAnalyserOptions
+} = {
+  bands: 5,
+  loPass: 100,
+  hiPass: 600,
+  updateInterval: 32,
+  analyserOptions: { fftSize: 2048 }
+}
+
+function normalizeDb(value: number): number {
+  if (value === -Infinity) return 0
+  const minDb = -100
+  const maxDb = -10
+  const db = 1 - (Math.max(minDb, Math.min(maxDb, value)) * -1) / 100
+  return Math.sqrt(db)
+}
+
+/** Track volume across multiple frequency bands of a MediaStream (0-1 each). */
+export function useMultibandVolume(
+  mediaStream?: MediaStream | null,
+  options: MultiBandVolumeOptions = {}
+): number[] {
+  const { bands, loPass, hiPass, updateInterval, analyserOptions } = {
+    ...multibandDefaults,
+    ...options
+  }
+  const fftSize = analyserOptions.fftSize
+  const smoothing = analyserOptions.smoothingTimeConstant
+
+  const [frequencyBands, setFrequencyBands] = useState<number[]>(() => new Array(bands).fill(0))
+  const bandsRef = useRef<number[]>(new Array(bands).fill(0))
+
+  useEffect(() => {
+    if (!mediaStream) {
+      const emptyBands = new Array(bands).fill(0)
+      setFrequencyBands(emptyBands)
+      bandsRef.current = emptyBands
+      return
+    }
+
+    const { analyser, cleanup } = createAudioAnalyser(mediaStream, {
+      fftSize,
+      smoothingTimeConstant: smoothing
+    })
+
+    const dataArray = new Float32Array(analyser.frequencyBinCount)
+    const sliceStart = loPass
+    const sliceEnd = hiPass
+    const chunkSize = Math.ceil((sliceEnd - sliceStart) / bands)
+
+    let frameId = 0
+    let lastUpdate = 0
+
+    const updateVolume = (timestamp: number): void => {
+      if (timestamp - lastUpdate >= updateInterval) {
+        analyser.getFloatFrequencyData(dataArray)
+
+        const chunks = new Array<number>(bands)
+        for (let i = 0; i < bands; i++) {
+          let sum = 0
+          let count = 0
+          const startIdx = sliceStart + i * chunkSize
+          const endIdx = Math.min(sliceStart + (i + 1) * chunkSize, sliceEnd)
+          for (let j = startIdx; j < endIdx; j++) {
+            sum += normalizeDb(dataArray[j])
+            count++
+          }
+          chunks[i] = count > 0 ? sum / count : 0
+        }
+
+        // Only commit React state when a band moved visibly.
+        const changed = chunks.some((chunk, i) => Math.abs(chunk - bandsRef.current[i]) > 0.01)
+        if (changed) {
+          bandsRef.current = chunks
+          setFrequencyBands(chunks)
+        }
+        lastUpdate = timestamp
+      }
+      frameId = requestAnimationFrame(updateVolume)
+    }
+
+    frameId = requestAnimationFrame(updateVolume)
+
+    return () => {
+      cleanup()
+      cancelAnimationFrame(frameId)
+    }
+  }, [mediaStream, bands, loPass, hiPass, updateInterval, fftSize, smoothing])
+
+  return frequencyBands
+}
+
+export type AgentState = 'connecting' | 'initializing' | 'listening' | 'speaking' | 'thinking'
+
+function generateConnectingSequenceBar(columns: number): number[][] {
+  const seq: number[][] = []
+  for (let x = 0; x < columns; x++) {
+    seq.push([x, columns - 1 - x])
+  }
+  return seq
+}
+
+function generateListeningSequenceBar(columns: number): number[][] {
+  const center = Math.floor(columns / 2)
+  return [[center], [-1]]
+}
+
+/** Highlighted bar indices for the current state; animates only multi-frame sequences. */
+export function useBarAnimator(
+  state: AgentState | undefined,
+  columns: number,
+  interval: number
+): number[] {
+  const indexRef = useRef(0)
+  const [currentFrame, setCurrentFrame] = useState<number[]>([])
+
+  const sequence = useMemo(() => {
+    if (state === 'thinking' || state === 'listening') {
+      return generateListeningSequenceBar(columns)
+    }
+    if (state === 'connecting' || state === 'initializing') {
+      return generateConnectingSequenceBar(columns)
+    }
+    if (state === undefined || state === 'speaking') {
+      return [new Array(columns).fill(0).map((_, idx) => idx)]
+    }
+    return [[]]
+  }, [state, columns])
+
+  useEffect(() => {
+    indexRef.current = 0
+    setCurrentFrame(sequence[0] ?? [])
+    // Single-frame sequences (speaking/idle) need no animation loop — keeping
+    // a rAF alive for them would burn idle CPU for a static highlight.
+    if (sequence.length <= 1) {
+      return
+    }
+
+    let frameId = 0
+    let startTime = performance.now()
+
+    const animate = (time: number): void => {
+      if (time - startTime >= interval) {
+        indexRef.current = (indexRef.current + 1) % sequence.length
+        setCurrentFrame(sequence[indexRef.current] ?? [])
+        startTime = time
+      }
+      frameId = requestAnimationFrame(animate)
+    }
+
+    frameId = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(frameId)
+  }, [interval, sequence])
+
+  return currentFrame
+}
+
+export interface BarVisualizerProps extends HTMLAttributes<HTMLDivElement> {
+  /** Voice/meter state driving highlight animation; `speaking` lights every bar. */
+  state?: AgentState
+  /** Number of bars to display. */
+  barCount?: number
+  /** Audio source; the caller owns its lifecycle. */
+  mediaStream?: MediaStream | null
+  /**
+   * Explicit band levels (0-1). Overrides stream analysis — the honest way to
+   * render coarse fallback readings (backend 1 Hz level) without fake data.
+   */
+  levels?: number[]
+  /** Band update interval in ms; slower saves renderer CPU. Default 48. */
+  updateInterval?: number
+  /** Min/max bar height as a percentage of the container. */
+  minHeight?: number
+  maxHeight?: number
+  /** Align bars from center instead of bottom. */
+  centerAlign?: boolean
+}
+
+const BarVisualizerComponent = forwardRef<HTMLDivElement, BarVisualizerProps>(
+  (
+    {
+      state,
+      barCount = 15,
+      mediaStream,
+      levels,
+      updateInterval = 48,
+      minHeight = 20,
+      maxHeight = 100,
+      centerAlign = false,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const streamBands = useMultibandVolume(levels ? null : mediaStream, {
+      bands: barCount,
+      loPass: 100,
+      hiPass: 200,
+      updateInterval
+    })
+    const volumeBands = levels ?? streamBands
+
+    const highlightedIndices = useBarAnimator(
+      state,
+      barCount,
+      state === 'connecting'
+        ? 2000 / barCount
+        : state === 'thinking'
+          ? 150
+          : state === 'listening'
+            ? 500
+            : 1000
+    )
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'relative flex h-16 w-full justify-center gap-1 overflow-hidden',
+          centerAlign ? 'items-center' : 'items-end',
+          className
+        )}
+        data-state={state}
+        {...props}
+      >
+        {volumeBands.map((volume, index) => (
+          <Bar
+            key={index}
+            heightPct={Math.min(maxHeight, Math.max(minHeight, volume * 100 + 5))}
+            isHighlighted={highlightedIndices?.includes(index) ?? false}
+          />
+        ))}
+      </div>
+    )
+  }
+)
+
+// Bars paint in currentColor: the parent's text token is the single tone knob.
+// Height changes are NOT CSS-transitioned: band updates arrive faster than any
+// transition would finish, so a height transition perpetually restarts and
+// burns style/layout work — the analyser's own 0.8 smoothing already smooths
+// the motion. Only the highlight opacity transitions.
+const Bar = memo<{ heightPct: number; isHighlighted: boolean }>(({ heightPct, isHighlighted }) => (
+  <div
+    className={cn(
+      'min-w-1 max-w-2 flex-1 rounded-full bg-current transition-opacity duration-150',
+      isHighlighted ? 'opacity-90' : 'opacity-30'
+    )}
+    data-highlighted={isHighlighted}
+    style={{ height: `${heightPct}%` }}
+  />
+))
+
+Bar.displayName = 'Bar'
+BarVisualizerComponent.displayName = 'BarVisualizerComponent'
+
+const BarVisualizer = memo(BarVisualizerComponent)
+BarVisualizer.displayName = 'BarVisualizer'
+
+export { BarVisualizer }

--- a/apps/desktop/src/renderer/src/components/ui/live-waveform.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/live-waveform.tsx
@@ -1,0 +1,376 @@
+import { useEffect, useRef, type HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * Vendored from ElevenLabs UI (ui.elevenlabs.io, registry item `live-waveform`)
+ * and adapted for Videorc:
+ * - the component no longer acquires a microphone itself. Upstream it called
+ *   getUserMedia for the OS-default mic; in Videorc the backend-selected
+ *   device is the only truth, so the caller passes a `mediaStream` (from
+ *   use-mic-stream) and owns its lifecycle. The stream's tracks are never
+ *   stopped here.
+ * - bars paint in `currentColor` (upstream default) so the parent text token
+ *   drives the tone; no hardcoded palette.
+ * - the canvas rAF loop exits when idle with nothing left to draw instead of
+ *   spinning forever; state changes restart it via effect deps.
+ */
+
+export type LiveWaveformProps = HTMLAttributes<HTMLDivElement> & {
+  /** Analyze and render this stream; null/undefined renders the idle line. */
+  mediaStream?: MediaStream | null
+  /** Show the animated "waiting" wave while a stream is being prepared. */
+  processing?: boolean
+  barWidth?: number
+  barHeight?: number
+  barGap?: number
+  barRadius?: number
+  fadeEdges?: boolean
+  fadeWidth?: number
+  height?: string | number
+  sensitivity?: number
+  smoothingTimeConstant?: number
+  fftSize?: number
+  historySize?: number
+  updateRate?: number
+  mode?: 'scrolling' | 'static'
+}
+
+export const LiveWaveform = ({
+  mediaStream,
+  processing = false,
+  barWidth = 3,
+  barGap = 1,
+  barRadius = 1.5,
+  fadeEdges = true,
+  fadeWidth = 24,
+  barHeight: baseBarHeight = 4,
+  height = 64,
+  sensitivity = 1,
+  smoothingTimeConstant = 0.8,
+  fftSize = 256,
+  historySize = 60,
+  updateRate = 30,
+  mode = 'static',
+  className,
+  ...props
+}: LiveWaveformProps): React.JSX.Element => {
+  const active = Boolean(mediaStream)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const historyRef = useRef<number[]>([])
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const animationLastUpdateRef = useRef(0)
+  const lastActiveDataRef = useRef<number[]>([])
+  const transitionProgressRef = useRef(0)
+  const staticBarsRef = useRef<number[]>([])
+  const needsRedrawRef = useRef(true)
+  const gradientCacheRef = useRef<CanvasGradient | null>(null)
+  const lastWidthRef = useRef(0)
+
+  const heightStyle = typeof height === 'number' ? `${height}px` : height
+
+  // Handle canvas resizing (HiDPI aware).
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const container = containerRef.current
+    if (!canvas || !container) return
+
+    const resizeObserver = new ResizeObserver(() => {
+      const rect = container.getBoundingClientRect()
+      const dpr = window.devicePixelRatio || 1
+
+      canvas.width = rect.width * dpr
+      canvas.height = rect.height * dpr
+      canvas.style.width = `${rect.width}px`
+      canvas.style.height = `${rect.height}px`
+
+      const ctx = canvas.getContext('2d')
+      if (ctx) {
+        ctx.scale(dpr, dpr)
+      }
+
+      gradientCacheRef.current = null
+      lastWidthRef.current = rect.width
+      needsRedrawRef.current = true
+    })
+
+    resizeObserver.observe(container)
+    return () => resizeObserver.disconnect()
+  }, [])
+
+  // Processing wave / fade-to-idle animations.
+  useEffect(() => {
+    if (processing && !active) {
+      let time = 0
+      let frameId = 0
+      transitionProgressRef.current = 0
+
+      const animateProcessing = (): void => {
+        time += 0.03
+        transitionProgressRef.current = Math.min(1, transitionProgressRef.current + 0.02)
+
+        const processingData: number[] = []
+        const barCount = Math.floor(
+          (containerRef.current?.getBoundingClientRect().width || 200) / (barWidth + barGap)
+        )
+        const halfCount = Math.max(1, Math.floor(barCount / 2))
+
+        for (let i = 0; i < barCount; i++) {
+          const normalizedPosition = (i - halfCount) / halfCount
+          const centerWeight = 1 - Math.abs(normalizedPosition) * 0.4
+
+          const wave1 = Math.sin(time * 1.5 + normalizedPosition * 3) * 0.25
+          const wave2 = Math.sin(time * 0.8 - normalizedPosition * 2) * 0.2
+          const wave3 = Math.cos(time * 2 + normalizedPosition) * 0.15
+          const processingValue = (0.2 + wave1 + wave2 + wave3) * centerWeight
+
+          let finalValue = processingValue
+          if (lastActiveDataRef.current.length > 0 && transitionProgressRef.current < 1) {
+            const lastDataIndex = Math.min(i, lastActiveDataRef.current.length - 1)
+            const lastValue = lastActiveDataRef.current[lastDataIndex] || 0
+            finalValue =
+              lastValue * (1 - transitionProgressRef.current) +
+              processingValue * transitionProgressRef.current
+          }
+
+          processingData.push(Math.max(0.05, Math.min(1, finalValue)))
+        }
+
+        if (mode === 'static') {
+          staticBarsRef.current = processingData
+        } else {
+          historyRef.current = processingData
+        }
+
+        needsRedrawRef.current = true
+        frameId = requestAnimationFrame(animateProcessing)
+      }
+
+      animateProcessing()
+      return () => cancelAnimationFrame(frameId)
+    }
+
+    if (!active && !processing) {
+      const hasData =
+        mode === 'static' ? staticBarsRef.current.length > 0 : historyRef.current.length > 0
+      if (!hasData) {
+        return
+      }
+      let frameId = 0
+      let fadeProgress = 0
+      const fadeToIdle = (): void => {
+        fadeProgress += 0.03
+        if (fadeProgress < 1) {
+          if (mode === 'static') {
+            staticBarsRef.current = staticBarsRef.current.map((value) => value * (1 - fadeProgress))
+          } else {
+            historyRef.current = historyRef.current.map((value) => value * (1 - fadeProgress))
+          }
+          needsRedrawRef.current = true
+          frameId = requestAnimationFrame(fadeToIdle)
+        } else {
+          staticBarsRef.current = []
+          historyRef.current = []
+          needsRedrawRef.current = true
+        }
+      }
+      fadeToIdle()
+      return () => cancelAnimationFrame(frameId)
+    }
+
+    return undefined
+  }, [processing, active, barWidth, barGap, mode])
+
+  // Analyser over the CALLER's stream — never acquires or stops tracks here.
+  useEffect(() => {
+    if (!mediaStream) {
+      analyserRef.current = null
+      return
+    }
+
+    const audioContext = new AudioContext()
+    const analyser = audioContext.createAnalyser()
+    analyser.fftSize = fftSize
+    analyser.smoothingTimeConstant = smoothingTimeConstant
+    const source = audioContext.createMediaStreamSource(mediaStream)
+    source.connect(analyser)
+    analyserRef.current = analyser
+    historyRef.current = []
+
+    return () => {
+      analyserRef.current = null
+      source.disconnect()
+      void audioContext.close().catch(() => undefined)
+    }
+  }, [mediaStream, fftSize, smoothingTimeConstant])
+
+  // Draw loop: runs while there is signal, a processing wave, or a pending
+  // redraw; otherwise it exits (effect deps restart it on state changes).
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    let rafId = 0
+
+    const animate = (currentTime: number): void => {
+      const rect = canvas.getBoundingClientRect()
+
+      if (active && currentTime - animationLastUpdateRef.current > updateRate) {
+        animationLastUpdateRef.current = currentTime
+
+        const analyser = analyserRef.current
+        if (analyser) {
+          const dataArray = new Uint8Array(analyser.frequencyBinCount)
+          analyser.getByteFrequencyData(dataArray)
+          const startFreq = Math.floor(dataArray.length * 0.05)
+          const endFreq = Math.floor(dataArray.length * 0.4)
+          const relevantData = dataArray.slice(startFreq, endFreq)
+
+          if (mode === 'static') {
+            const barCount = Math.floor(rect.width / (barWidth + barGap))
+            const halfCount = Math.floor(barCount / 2)
+            const newBars: number[] = []
+
+            // Mirror the data for symmetric display.
+            for (let i = halfCount - 1; i >= 0; i--) {
+              const dataIndex = Math.floor((i / halfCount) * relevantData.length)
+              newBars.push(
+                Math.max(0.05, Math.min(1, (relevantData[dataIndex] / 255) * sensitivity))
+              )
+            }
+            for (let i = 0; i < halfCount; i++) {
+              const dataIndex = Math.floor((i / halfCount) * relevantData.length)
+              newBars.push(
+                Math.max(0.05, Math.min(1, (relevantData[dataIndex] / 255) * sensitivity))
+              )
+            }
+
+            staticBarsRef.current = newBars
+            lastActiveDataRef.current = newBars
+          } else {
+            let sum = 0
+            for (let i = 0; i < relevantData.length; i++) {
+              sum += relevantData[i]
+            }
+            const average = (sum / relevantData.length / 255) * sensitivity
+            historyRef.current.push(Math.min(1, Math.max(0.05, average)))
+            lastActiveDataRef.current = [...historyRef.current]
+            if (historyRef.current.length > historySize) {
+              historyRef.current.shift()
+            }
+          }
+          needsRedrawRef.current = true
+        }
+      }
+
+      if (!needsRedrawRef.current && !active && !processing) {
+        // Idle with a settled canvas: stop scheduling frames entirely.
+        rafId = 0
+        return
+      }
+
+      needsRedrawRef.current = active || processing
+      ctx.clearRect(0, 0, rect.width, rect.height)
+
+      const computedBarColor = getComputedStyle(canvas).color || '#888'
+      const step = barWidth + barGap
+      const barCount = Math.floor(rect.width / step)
+      const centerY = rect.height / 2
+
+      const drawBar = (x: number, value: number): void => {
+        const barHeight = Math.max(baseBarHeight, value * rect.height * 0.8)
+        const y = centerY - barHeight / 2
+        ctx.fillStyle = computedBarColor
+        ctx.globalAlpha = 0.4 + value * 0.6
+        if (barRadius > 0) {
+          ctx.beginPath()
+          ctx.roundRect(x, y, barWidth, barHeight, barRadius)
+          ctx.fill()
+        } else {
+          ctx.fillRect(x, y, barWidth, barHeight)
+        }
+      }
+
+      if (mode === 'static') {
+        const dataToRender = staticBarsRef.current
+        for (let i = 0; i < barCount && i < dataToRender.length; i++) {
+          drawBar(i * step, dataToRender[i] || 0.1)
+        }
+      } else {
+        for (let i = 0; i < barCount && i < historyRef.current.length; i++) {
+          const dataIndex = historyRef.current.length - 1 - i
+          drawBar(rect.width - (i + 1) * step, historyRef.current[dataIndex] || 0.1)
+        }
+      }
+
+      // Fade the strip's edges out via destination-out gradient.
+      if (fadeEdges && fadeWidth > 0 && rect.width > 0) {
+        if (!gradientCacheRef.current || lastWidthRef.current !== rect.width) {
+          const gradient = ctx.createLinearGradient(0, 0, rect.width, 0)
+          const fadePercent = Math.min(0.3, fadeWidth / rect.width)
+          gradient.addColorStop(0, 'rgba(255,255,255,1)')
+          gradient.addColorStop(fadePercent, 'rgba(255,255,255,0)')
+          gradient.addColorStop(1 - fadePercent, 'rgba(255,255,255,0)')
+          gradient.addColorStop(1, 'rgba(255,255,255,1)')
+          gradientCacheRef.current = gradient
+          lastWidthRef.current = rect.width
+        }
+
+        ctx.globalCompositeOperation = 'destination-out'
+        ctx.fillStyle = gradientCacheRef.current
+        ctx.fillRect(0, 0, rect.width, rect.height)
+        ctx.globalCompositeOperation = 'source-over'
+      }
+
+      ctx.globalAlpha = 1
+      rafId = requestAnimationFrame(animate)
+    }
+
+    rafId = requestAnimationFrame(animate)
+
+    return () => {
+      if (rafId) {
+        cancelAnimationFrame(rafId)
+      }
+    }
+  }, [
+    active,
+    processing,
+    sensitivity,
+    updateRate,
+    historySize,
+    barWidth,
+    baseBarHeight,
+    barGap,
+    barRadius,
+    fadeEdges,
+    fadeWidth,
+    mode
+  ])
+
+  return (
+    <div
+      ref={containerRef}
+      aria-label={
+        active
+          ? 'Live audio waveform'
+          : processing
+            ? 'Preparing audio preview'
+            : 'Audio waveform idle'
+      }
+      className={cn('relative w-full', className)}
+      role="img"
+      style={{ height: heightStyle }}
+      {...props}
+    >
+      {!active && !processing ? (
+        <div className="absolute top-1/2 right-0 left-0 -translate-y-1/2 border-t-2 border-dotted border-muted-foreground/20" />
+      ) : null}
+      <canvas ref={canvasRef} aria-hidden="true" className="block h-full w-full" />
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/hooks/use-document-visible.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-document-visible.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Tracks document visibility so always-on visuals (mic meters, visualizers)
+ * can release their streams and rAF loops while the window is hidden or
+ * minimized — the idle-CPU discipline the native preview's frame-polling
+ * suppression follows.
+ */
+export function useDocumentVisible(): boolean {
+  const [visible, setVisible] = useState(() => document.visibilityState !== 'hidden')
+
+  useEffect(() => {
+    const update = (): void => {
+      setVisible(document.visibilityState !== 'hidden')
+    }
+    document.addEventListener('visibilitychange', update)
+    return () => document.removeEventListener('visibilitychange', update)
+  }, [])
+
+  return visible
+}

--- a/apps/desktop/src/renderer/src/hooks/use-mic-level-meter.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-mic-level-meter.ts
@@ -5,7 +5,6 @@ import {
   advanceMeterBallistics,
   amplitudeToDb,
   dbToMeterLevel,
-  matchMicrophoneDeviceId,
   samplesRmsAndPeak,
   type MeterBallisticsState
 } from '@/lib/mic-meter'
@@ -17,30 +16,30 @@ export type MicLevelMeter = {
   fillRef: (element: HTMLSpanElement | null) => void
   /** Attach the peak-hold marker element; its left offset is driven imperatively. */
   peakRef: (element: HTMLSpanElement | null) => void
-  /** True while the WebAudio analyser is metering the selected device. */
+  /** True while the WebAudio analyser is metering the stream. */
   active: boolean
   /** Peak dBFS for the text label, throttled to ~4Hz of React state. */
   peakDb: number | null
 }
 
 /**
- * Real-time mic meter (2026-07-10 report: the mixer bar moved once a second
- * and barely at all). The VISUAL runs on a renderer-side WebAudio analyser at
- * display rate, writing element styles directly — React state, the 1 Hz
- * telemetry commit throttle, and the backend diagnostics tick are all
- * bypassed. The backend's `micLiveLevel` stays the capture/health authority
- * and the mixer's fallback when the analyser cannot run (permission denied,
- * exclusive-mode device): shared-mode capture means this analyser coexists
- * with the backend's CoreAudio/dshow session capture.
+ * Real-time mic meter ballistics (2026-07-10 report: the mixer bar moved once
+ * a second and barely at all). The VISUAL runs on a renderer-side WebAudio
+ * analyser at display rate, writing element styles directly — React state,
+ * the 1 Hz telemetry commit throttle, and the backend diagnostics tick are
+ * all bypassed. Since the Studio audio rework (plan S2) the stream itself
+ * comes from use-mic-stream — one shared acquisition point for every mic
+ * visual — and this hook only analyses it. The backend's `micLiveLevel`
+ * stays the capture/health authority and the mixer's fallback whenever the
+ * stream cannot open (permission denied, exclusive-mode device).
  */
 export function useMicLevelMeter(input: {
-  /** Backend name of the selected microphone; matched to WebAudio by label. */
-  deviceName: string | undefined
-  enabled: boolean
+  /** Shared visual-only stream from use-mic-stream; null renders inactive. */
+  stream: MediaStream | null
   /** Backend mute is applied at capture gain; the analyser sees pre-mute signal. */
   muted: boolean
 }): MicLevelMeter {
-  const { deviceName, enabled, muted } = input
+  const { stream, muted } = input
   const [active, setActive] = useState(false)
   const [peakDb, setPeakDb] = useState<number | null>(null)
   const fillElementRef = useRef<HTMLSpanElement | null>(null)
@@ -56,7 +55,7 @@ export function useMicLevelMeter(input: {
   }, [])
 
   useEffect(() => {
-    if (!enabled) {
+    if (!stream) {
       setActive(false)
       setPeakDb(null)
       return
@@ -64,89 +63,57 @@ export function useMicLevelMeter(input: {
 
     let disposed = false
     let frame = 0
-    let stream: MediaStream | null = null
-    let context: AudioContext | null = null
+    const context = new AudioContext()
+    const analyser = context.createAnalyser()
+    // 2048 samples ≈ 43 ms at 48 kHz: a meaningful RMS window that still
+    // refreshes completely between display frames.
+    analyser.fftSize = 2048
+    const source = context.createMediaStreamSource(stream)
+    source.connect(analyser)
+    const samples = new Float32Array(analyser.fftSize)
+    let ballistics: MeterBallisticsState = INITIAL_METER_BALLISTICS
+    let lastFrameAt = performance.now()
+    let lastLabelAt = 0
+    setActive(true)
 
-    const stopStream = (): void => {
-      stream?.getTracks().forEach((track) => track.stop())
-      stream = null
-    }
-
-    const start = async (): Promise<void> => {
-      const media = navigator.mediaDevices
-      if (!media?.getUserMedia) {
-        return
-      }
-      const inputs = (await media.enumerateDevices().catch(() => []))
-        .filter((device) => device.kind === 'audioinput')
-        .map((device) => ({ deviceId: device.deviceId, label: device.label }))
-      const deviceId = matchMicrophoneDeviceId(deviceName, inputs)
-      stream = await media.getUserMedia({
-        audio: deviceId ? { deviceId: { exact: deviceId } } : true,
-        video: false
-      })
+    const tick = (): void => {
       if (disposed) {
-        stopStream()
         return
       }
-      context = new AudioContext()
-      const analyser = context.createAnalyser()
-      // 2048 samples ≈ 43 ms at 48 kHz: a meaningful RMS window that still
-      // refreshes completely between display frames.
-      analyser.fftSize = 2048
-      context.createMediaStreamSource(stream).connect(analyser)
-      const samples = new Float32Array(analyser.fftSize)
-      let ballistics: MeterBallisticsState = INITIAL_METER_BALLISTICS
-      let lastFrameAt = performance.now()
-      let lastLabelAt = 0
-      setActive(true)
-
-      const tick = (): void => {
-        if (disposed) {
-          return
-        }
-        const now = performance.now()
-        const elapsedMs = Math.min(100, now - lastFrameAt)
-        lastFrameAt = now
-        analyser.getFloatTimeDomainData(samples)
-        const { rms, peak } = samplesRmsAndPeak(samples)
-        const target = mutedRef.current ? 0 : dbToMeterLevel(amplitudeToDb(rms))
-        ballistics = advanceMeterBallistics(ballistics, target, elapsedMs, now)
-        const fill = fillElementRef.current
-        if (fill) {
-          fill.style.width = `${(ballistics.level * 100).toFixed(1)}%`
-        }
-        const marker = peakElementRef.current
-        if (marker) {
-          marker.style.left = `calc(${(ballistics.peakLevel * 100).toFixed(1)}% - 2px)`
-          marker.style.opacity = mutedRef.current || ballistics.peakLevel <= 0.001 ? '0' : '1'
-        }
-        if (now - lastLabelAt >= PEAK_DB_LABEL_INTERVAL_MS) {
-          lastLabelAt = now
-          setPeakDb(mutedRef.current ? null : amplitudeToDb(peak))
-        }
-        frame = requestAnimationFrame(tick)
+      const now = performance.now()
+      const elapsedMs = Math.min(100, now - lastFrameAt)
+      lastFrameAt = now
+      analyser.getFloatTimeDomainData(samples)
+      const { rms, peak } = samplesRmsAndPeak(samples)
+      const target = mutedRef.current ? 0 : dbToMeterLevel(amplitudeToDb(rms))
+      ballistics = advanceMeterBallistics(ballistics, target, elapsedMs, now)
+      const fill = fillElementRef.current
+      if (fill) {
+        fill.style.width = `${(ballistics.level * 100).toFixed(1)}%`
+      }
+      const marker = peakElementRef.current
+      if (marker) {
+        marker.style.left = `calc(${(ballistics.peakLevel * 100).toFixed(1)}% - 2px)`
+        marker.style.opacity = mutedRef.current || ballistics.peakLevel <= 0.001 ? '0' : '1'
+      }
+      if (now - lastLabelAt >= PEAK_DB_LABEL_INTERVAL_MS) {
+        lastLabelAt = now
+        setPeakDb(mutedRef.current ? null : amplitudeToDb(peak))
       }
       frame = requestAnimationFrame(tick)
     }
-
-    void start().catch(() => {
-      // Permission denied or the device is exclusively held: the mixer falls
-      // back to the backend-sampled meter. A passive meter must never toast.
-      if (!disposed) {
-        setActive(false)
-      }
-    })
+    frame = requestAnimationFrame(tick)
 
     return () => {
+      // The stream belongs to use-mic-stream — only the analyser is ours.
       disposed = true
       cancelAnimationFrame(frame)
-      stopStream()
-      void context?.close().catch(() => undefined)
+      source.disconnect()
+      void context.close().catch(() => undefined)
       setActive(false)
       setPeakDb(null)
     }
-  }, [deviceName, enabled])
+  }, [stream])
 
   return { fillRef, peakRef, active, peakDb }
 }

--- a/apps/desktop/src/renderer/src/hooks/use-mic-stream.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-mic-stream.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react'
+
+import { createMicStreamController } from '@/lib/mic-stream'
+
+export type MicStreamStatus = 'idle' | 'acquiring' | 'active' | 'unavailable'
+
+export type MicStream = {
+  /** The open visual-only stream, or null while unavailable/acquiring. */
+  stream: MediaStream | null
+  /** True while a stream is open. */
+  active: boolean
+  /** Honest lifecycle state — 'unavailable' means permission/in-use, not an error. */
+  status: MicStreamStatus
+}
+
+/**
+ * One shared acquisition point for every mic visual (mixer meter, bar
+ * visualizer, picker preview): opens the backend-named device through
+ * createMicStreamController and guarantees teardown on disable/unmount.
+ * Failures resolve to an inactive meter, never a toast — the backend's 1 Hz
+ * micLiveLevel remains the fallback authority for callers.
+ */
+export function useMicStream(input: {
+  /** Backend name of the selected microphone; matched to WebAudio by label. */
+  deviceName: string | undefined
+  enabled: boolean
+}): MicStream {
+  const { deviceName, enabled } = input
+  const [stream, setStream] = useState<MediaStream | null>(null)
+  const [status, setStatus] = useState<MicStreamStatus>('idle')
+
+  useEffect(() => {
+    if (!enabled) {
+      setStream(null)
+      setStatus('idle')
+      return
+    }
+    let disposed = false
+    setStatus('acquiring')
+    const controller = createMicStreamController<MediaStream>(navigator.mediaDevices)
+    void controller.open(deviceName).then((opened) => {
+      if (disposed) {
+        return
+      }
+      setStream(opened)
+      setStatus(opened ? 'active' : 'unavailable')
+    })
+    return () => {
+      disposed = true
+      controller.close()
+      setStream(null)
+    }
+  }, [deviceName, enabled])
+
+  return { stream, active: stream !== null, status }
+}

--- a/apps/desktop/src/renderer/src/lib/mic-meter.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-meter.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_METER_BALLISTICS,
   INITIAL_METER_BALLISTICS,
+  MIC_CLIP_HOLD_MS,
+  MIC_CLIP_THRESHOLD_DB,
   MIC_METER_FLOOR_DB,
+  advanceClipHoldDeadline,
   advanceMeterBallistics,
   amplitudeToDb,
   dbToMeterLevel,
+  fallbackBandLevels,
   matchMicrophoneDeviceId,
   samplesRmsAndPeak
 } from './mic-meter'
@@ -66,5 +70,35 @@ describe('mic meter math', () => {
     expect(matchMicrophoneDeviceId('Pro Microphone', [inputs[2]])).toBe('b')
     expect(matchMicrophoneDeviceId('Elgato Wave:3', inputs)).toBeUndefined()
     expect(matchMicrophoneDeviceId(undefined, inputs)).toBeUndefined()
+  })
+})
+
+describe('clip hold deadline', () => {
+  it('arms and extends the deadline while peaks are at or above the threshold', () => {
+    expect(advanceClipHoldDeadline(0, MIC_CLIP_THRESHOLD_DB, 1000)).toBe(1000 + MIC_CLIP_HOLD_MS)
+    expect(advanceClipHoldDeadline(0, 0, 1000)).toBe(1000 + MIC_CLIP_HOLD_MS)
+    expect(advanceClipHoldDeadline(2000, 0, 1500)).toBe(1500 + MIC_CLIP_HOLD_MS)
+  })
+
+  it('leaves the running deadline untouched for quiet or missing peaks', () => {
+    expect(advanceClipHoldDeadline(2500, -12, 1000)).toBe(2500)
+    expect(advanceClipHoldDeadline(2500, null, 1000)).toBe(2500)
+  })
+})
+
+describe('fallback band levels', () => {
+  it('renders a center-weighted hump whose center equals the level', () => {
+    const bands = fallbackBandLevels(0.8, 5)
+    expect(bands).toHaveLength(5)
+    expect(bands[2]).toBeCloseTo(0.8, 5)
+    expect(bands[0]).toBeCloseTo(0.8 * 0.4, 5)
+    expect(bands[0]).toBeCloseTo(bands[4], 5)
+    expect(bands[1]).toBeGreaterThan(bands[0])
+  })
+
+  it('clamps levels and handles degenerate band counts', () => {
+    expect(fallbackBandLevels(2, 1)).toEqual([1])
+    expect(fallbackBandLevels(-1, 3)).toEqual([0, 0, 0])
+    expect(fallbackBandLevels(0.5, 0)).toEqual([])
   })
 })

--- a/apps/desktop/src/renderer/src/lib/mic-meter.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-meter.ts
@@ -128,3 +128,39 @@ export function matchMicrophoneDeviceId(
     return label.length > 0 && (label.includes(wanted) || wanted.includes(label))
   })?.deviceId
 }
+
+export const MIC_CLIP_THRESHOLD_DB = -1
+export const MIC_CLIP_HOLD_MS = 1500
+
+/**
+ * Clip-hold deadline: a peak at/above the clip threshold arms (or extends)
+ * the indicator for MIC_CLIP_HOLD_MS; quieter peaks leave the running
+ * deadline untouched so a brief hot transient stays visible.
+ */
+export function advanceClipHoldDeadline(
+  deadline: number,
+  peakDb: number | null,
+  now: number
+): number {
+  if (peakDb !== null && peakDb >= MIC_CLIP_THRESHOLD_DB) {
+    return now + MIC_CLIP_HOLD_MS
+  }
+  return deadline
+}
+
+/**
+ * Deterministic band heights for the coarse fallback meter paths (backend
+ * 1 Hz level, on-demand sample): a center-weighted hump scaled by the real
+ * level — never fake noise. The center band equals the level exactly.
+ */
+export function fallbackBandLevels(level: number, bands: number): number[] {
+  if (bands <= 0) {
+    return []
+  }
+  const clamped = Math.min(1, Math.max(0, level))
+  const center = (bands - 1) / 2
+  return Array.from({ length: bands }, (_, index) => {
+    const distance = center === 0 ? 0 : Math.abs(index - center) / center
+    return clamped * (1 - 0.6 * distance)
+  })
+}

--- a/apps/desktop/src/renderer/src/lib/mic-stream.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-stream.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMicStreamController, type MicStreamConstraints } from './mic-stream'
+
+function fakeStream(): { stopped: number[]; stream: { getTracks: () => { stop: () => void }[] } } {
+  const stopped: number[] = []
+  const tracks = [0, 1].map((index) => ({ stop: (): void => void stopped.push(index) }))
+  return { stopped, stream: { getTracks: () => tracks } }
+}
+
+describe('createMicStreamController', () => {
+  it('matches the backend device name and requests that exact deviceId', async () => {
+    const { stream } = fakeStream()
+    const requested: MicStreamConstraints[] = []
+    const controller = createMicStreamController({
+      enumerateDevices: async () => [
+        { kind: 'videoinput', deviceId: 'cam-1', label: 'FaceTime HD Camera' },
+        { kind: 'audioinput', deviceId: 'mic-1', label: 'MacBook Pro Microphone' },
+        { kind: 'audioinput', deviceId: 'mic-2', label: 'USB Interface' }
+      ],
+      getUserMedia: async (constraints) => {
+        requested.push(constraints)
+        return stream
+      }
+    })
+
+    await expect(controller.open('MacBook Pro Microphone')).resolves.toBe(stream)
+    expect(requested).toEqual([{ audio: { deviceId: { exact: 'mic-1' } }, video: false }])
+  })
+
+  it('falls back to the default input when the name cannot be matched', async () => {
+    const { stream } = fakeStream()
+    const requested: MicStreamConstraints[] = []
+    const controller = createMicStreamController({
+      enumerateDevices: async () => [],
+      getUserMedia: async (constraints) => {
+        requested.push(constraints)
+        return stream
+      }
+    })
+
+    await expect(controller.open('Ghost Device')).resolves.toBe(stream)
+    expect(requested).toEqual([{ audio: true, video: false }])
+  })
+
+  it('resolves null without throwing when acquisition fails or media is missing', async () => {
+    const denied = createMicStreamController({
+      enumerateDevices: async () => [],
+      getUserMedia: async () => {
+        throw new Error('Permission denied')
+      }
+    })
+    await expect(denied.open(undefined)).resolves.toBeNull()
+    await expect(createMicStreamController(undefined).open('Any')).resolves.toBeNull()
+    // enumerateDevices failures fall back to the default input, not an error.
+    const { stream } = fakeStream()
+    const flakyEnumerate = createMicStreamController({
+      enumerateDevices: async () => {
+        throw new Error('enumerate failed')
+      },
+      getUserMedia: async () => stream
+    })
+    await expect(flakyEnumerate.open('Any')).resolves.toBe(stream)
+  })
+
+  it('stops tracks on close, including a stream that resolves after close', async () => {
+    const first = fakeStream()
+    let resolveSecond: ((stream: (typeof first)['stream']) => void) | undefined
+    const controller = createMicStreamController({
+      getUserMedia: async () => first.stream
+    })
+    await controller.open(undefined)
+    controller.close()
+    expect(first.stopped).toEqual([0, 1])
+
+    // A close() racing an in-flight open(): the late stream must be stopped
+    // and never handed out.
+    const second = fakeStream()
+    const racing = createMicStreamController({
+      getUserMedia: () =>
+        new Promise<(typeof second)['stream']>((resolve) => {
+          resolveSecond = resolve
+        })
+    })
+    const pending = racing.open(undefined)
+    racing.close()
+    // Let open() progress past device enumeration to the getUserMedia call.
+    await Promise.resolve()
+    resolveSecond?.(second.stream)
+    await expect(pending).resolves.toBeNull()
+    expect(second.stopped).toEqual([0, 1])
+
+    // A closed controller refuses further opens.
+    await expect(racing.open(undefined)).resolves.toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/mic-stream.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-stream.ts
@@ -1,0 +1,77 @@
+// Shared microphone MediaStream acquisition (plan: Studio Audio ElevenLabs UI
+// rework, S2). Every renderer mic visual — mixer meter, bar visualizer, picker
+// preview — opens its stream through this controller, never raw getUserMedia:
+// one acquisition path keeps the backend-name → WebAudio-label matching, the
+// shared-mode coexistence with backend capture, and the never-throw fallback
+// ("a passive meter must never toast") in a single tested place. The backend
+// stays the capture/health authority; these streams are visual-only.
+
+import { matchMicrophoneDeviceId } from './mic-meter'
+
+type MicTrackLike = { stop: () => void }
+
+export type MicMediaStreamLike = { getTracks: () => MicTrackLike[] }
+
+export type MicStreamConstraints = {
+  audio: { deviceId: { exact: string } } | true
+  video: false
+}
+
+export type MicMediaDevicesLike<S extends MicMediaStreamLike> = {
+  enumerateDevices?: () => Promise<Array<{ kind: string; deviceId: string; label: string }>>
+  getUserMedia?: (constraints: MicStreamConstraints) => Promise<S>
+}
+
+export type MicStreamController<S extends MicMediaStreamLike> = {
+  /**
+   * Open a stream for the backend-named device (default input when the name
+   * cannot be matched). Resolves null — never rejects — when media devices
+   * are unavailable, permission is denied, or the controller closed while
+   * acquiring (the racing stream's tracks are stopped).
+   */
+  open: (deviceName: string | undefined) => Promise<S | null>
+  /** Stop every open track; the controller cannot be reused afterwards. */
+  close: () => void
+}
+
+export function createMicStreamController<S extends MicMediaStreamLike>(
+  media: MicMediaDevicesLike<S> | undefined
+): MicStreamController<S> {
+  let current: S | null = null
+  let closed = false
+
+  const stopTracks = (stream: S | null): void => {
+    stream?.getTracks().forEach((track) => track.stop())
+  }
+
+  return {
+    async open(deviceName) {
+      if (closed || !media?.getUserMedia) {
+        return null
+      }
+      try {
+        const inputs = ((await media.enumerateDevices?.().catch(() => [])) ?? [])
+          .filter((device) => device.kind === 'audioinput')
+          .map((device) => ({ deviceId: device.deviceId, label: device.label }))
+        const deviceId = matchMicrophoneDeviceId(deviceName, inputs)
+        const stream = await media.getUserMedia({
+          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+          video: false
+        })
+        if (closed) {
+          stopTracks(stream)
+          return null
+        }
+        current = stream
+        return stream
+      } catch {
+        return null
+      }
+    },
+    close() {
+      closed = true
+      stopTracks(current)
+      current = null
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Executes the full **Studio Audio ElevenLabs UI Rework** plan (vault: `2026-07-12 - Videorc Studio Audio ElevenLabs UI Rework Plan`, 5 slices): the Studio's microphone visuals move from a 2px meter line to the ElevenLabs UI audio components, restyled to the black-glass design language. The backend remains the device/capture/health authority everywhere — this is renderer glass only.

### S1 — Vendored ElevenLabs UI components (zero new dependencies)
- `components/ui/bar-visualizer.tsx` + `components/ui/live-waveform.tsx`, vendored from the ui.elevenlabs.io shadcn registry (registry items ship **no npm dependencies** — plain React + WebAudio + canvas; `package.json` untouched).
- Adaptations (documented at the top of each file): bars paint in `currentColor` so the parent's text token drives the tone (chrome live / muted-gray idle / warning silent); containers unstyled per glass-panel rules; `useBarAnimator` no longer runs a rAF loop for single-frame sequences; **LiveWaveform no longer acquires a microphone itself** — upstream called getUserMedia for the OS-default mic; here the caller passes the backend-selected device's stream; its idle canvas loop exits instead of spinning forever.
- BarVisualizer gains a `levels` prop: deterministic bar heights for coarse fallback readings (backend 1 Hz level) instead of upstream's fake `demo` data.

### S2 — One shared mic-stream acquisition path
- `lib/mic-stream.ts` (`createMicStreamController`, framework-free + tested): backend-name → WebAudio-label matching, shared-mode coexistence with backend capture, never-throws ("a passive meter must never toast"), stops tracks on close including a close/open race.
- `hooks/use-mic-stream.ts` wraps it with an honest `status` (`idle/acquiring/active/unavailable`); `hooks/use-mic-level-meter.ts` now consumes the shared stream and only runs the analyser + ballistics (peak-dB label unchanged).
- `hooks/use-document-visible.ts`: all mic visuals release streams + rAF while the window is hidden.

### S3 — Audio mixer hero
- The 2px `MeterBar` becomes a 28-band center-aligned BarVisualizer over the shared stream, with an explicit state map: live analyser → chrome bars; **muted → flat dim bars** (the analyser sees pre-mute signal — dancing bars under a mute would lie); backend fallback → deterministic center-weighted bands from the real coarse level + the existing "Check level" button; silent/no-frames/permission → warning tone + copy.
- New clip indicator: peak ≥ −1 dBFS lights a warning-amber "Clip" chip held 1.5 s (`advanceClipHoldDeadline`, tested); width reserved so the row never shifts.

### S4 — See-before-you-pick mic preview
- `components/studio/mic-picker-preview.tsx`: a scrolling LiveWaveform of the **selected** device under both mic pickers (Quick Settings popover — lazy-loaded, and the Sources "Microphone mixer" section). Device list stays backend `deviceList` (`microphonePickerDevices` / fallback-dedup untouched); ElevenLabs' browser-enumeration `useAudioDevices` was deliberately not vendored.
- Stream lifecycle: opens while mounted + document visible, hard-stops on popover close/panel leave; acquisition failure shows honest inline copy, never a fake wave.

### S5 — In-session mic confidence sliver
- `components/studio/session-mic-sliver.tsx`: a passive 5-bar mini visualizer beside the session status badge (one home — the status cluster renders in the Preview panel header or the docked control row). Visible only during a session with a mic selected; width reserved so mute toggles don't shift layout. Deviation from plan: no warning-amber silent tint — the backend's 1 Hz level flickers near zero on normal speech pauses, so flat bars tell the silence story without false alarms.

## Perf evidence (same probe, preview active at 60 fps, `smoke:preview-performance`)

| role | clean main | this PR |
|---|---:|---:|
| electron-renderer | 19.40% | **17.44%** |
| electron-gpu | 9.54% | **3.74%** |
| electron-main | 5.46% | 5.93% |

Two deliberate perf choices: no CSS height transition on bars (band updates arrive faster than a transition finishes — it would restart perpetually), and 48 ms band updates. The probe's memory gate fails with `electron-main process count 4 exceeded 1` — pre-existing, fails identically on clean main (known dead gate, task spawned 2026-07-08); its functional checks (frames/transport/teardown) pass.

## Renderer asset budget

The new eager code initially pushed initial eager JS to 1,908,646 bytes (budget 1,900,000). Fixed by lazy-loading `MicPickerPreview` (and LiveWaveform with it) on first popover open, app-shell-style: now **1,897,254** raw — below both the budget and the pre-existing baseline path for first paint of Studio.

## Gates

- `pnpm typecheck` / `pnpm lint` (0 errors; 1 pre-existing warning in `use-studio.tsx`) / `pnpm format:check`
- `pnpm --filter @videorc/desktop test` — **793/793** (8 new: mic-stream controller, clip hold, fallback bands)
- `pnpm build`, `pnpm check:renderer-assets`, `pnpm audit:js` (1 pre-existing moderate, gate level high, no new deps)
- `pnpm smoke:local-gates` — full bundle green (cargo test + clippy + 13 smokes incl. source-reconciliation, backend-resilience — the `data-videorc-session-status` hook it reads is preserved)
- `pnpm smoke:preview-performance` — functional checks pass; perf table above
- `ui-theme-screens.mjs studio` both-theme sweep run and eyeballed: the mixer visualizer renders live chrome bars in dark and ink bars in light (`currentColor` doing its job), with the peak-dB label and Live tag intact

## Notes for review / owner by-eye

- Mixer visualizer states worth eyeballing with a real mic: live speech, mute toggle (flat dim, no dancing), Clip chip on a loud clap, permission-denied fallback with "Check level".
- Quick Settings → Mic popover: waveform should start moving within ~300 ms and the OS mic indicator should clear when the popover closes.
- Record or stream briefly: the 5-bar sliver appears next to the status badge and freezes flat when muted.
- macOS on-box acceptance for Windows behavior is not claimed: the analyser path should work on Windows (shared WASAPI) but the coarse fallback remains first-class there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
