### PR TITLE
Release 0.9.30-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.30-beta.1.md
+++ b/changelog/0.9.30-beta.1.md
@@ -1,0 +1,44 @@
+---
+version: 0.9.30-beta.1
+date: 2026-07-12
+channel: beta
+title: See your mic working — live audio meters across the Studio
+summary: The Studio now shows your microphone as a live multi-band visualizer — in the mixer, when picking a mic, and right next to the session status while you record or stream — so "is my mic on?" is answered at a glance.
+highlights:
+  - The audio mixer replaces its thin meter line with a live multi-band visualizer you can read from across the room.
+  - Picking a microphone now shows a live waveform preview of that device, so you never go live on the wrong mic.
+  - While recording or streaming, a small live signal indicator pulses next to the session status.
+  - A clip warning lights up when your input runs hot enough to distort.
+  - The sticked-in preview now sits flush in the Studio — no more border and panel around it.
+---
+
+## A microphone you can see
+
+The number one live anxiety is "is my mic actually working?" — and a 2-pixel
+meter line doesn't answer it from a streaming distance. The audio mixer now
+renders your microphone as a live multi-band visualizer: chrome bars dancing
+with your voice, flat and dim when muted, with the peak level readout kept
+right beside it. If the input runs hot enough to distort, a clip warning
+lights up and holds long enough to notice.
+
+When the live meter can't run — no permission yet, or the device is held by
+another app — the mixer says so and falls back to the coarse level check,
+never a fake animation.
+
+## Pick the right mic, every time
+
+The microphone pickers (Quick Settings and Sources) now show a live scrolling
+waveform of the selected device. Speak, see it move, and you know you picked
+the right input before you start — no more discovering the wrong mic after
+the recording.
+
+## Confidence while you're live
+
+During a recording or stream, a small live signal sliver sits next to the
+session status. A glance confirms audio is flowing; if you mute, it goes
+flat so the state is never ambiguous.
+
+## A cleaner sticked-in preview
+
+When you stick the preview into the app, it now stands alone — the border
+and panel around it are gone, and the video's own frame runs edge to edge.


### PR DESCRIPTION
Version 0.9.29 → 0.9.30 and the user-facing changelog entry for 0.9.30-beta.1.

Ships to users: the Studio audio rework (#80 — live multi-band mic visualizer in the mixer, live waveform preview in both mic pickers, in-session signal sliver, clip warning) and the standalone sticked-in preview (#78).

`pnpm changelog:check`: 31 entries valid, latest 0.9.30-beta.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)