### PR TITLE
Changelog 0.9.30-beta.1: cover the Windows recording fixes (#79)

### DIFF
--- a/changelog/0.9.30-beta.1.md
+++ b/changelog/0.9.30-beta.1.md
@@ -42,3 +42,11 @@ flat so the state is never ambiguous.
 
 When you stick the preview into the app, it now stands alone — the border
 and panel around it are gone, and the video's own frame runs edge to edge.
+
+## Windows tester builds
+
+Recordings on Windows keep their true wall-clock length and A/V alignment
+even when the encoder is under pressure, 1080p capture no longer gets
+throttled by an internal retry delay, and the proof preview stays live
+while you record. Hardware encoding is now probed honestly, so the
+recorder picks an encoder that actually works on your machine.


### PR DESCRIPTION
Markdown-only: adds a Windows section to the 0.9.30-beta.1 changelog entry since #79 (Windows recording timing + recording-time preview) merged after the prep PR was cut and ships in this release. `pnpm changelog:check` green (31 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows recording reliability under high encoder load.
  - Preserved accurate recording duration and audio/video synchronization.
  - Removed unnecessary throttling during 1080p capture retries.
  - Kept the proof preview visible while recording.
  - Improved hardware encoder detection to select a compatible option.

- **Documentation**
  - Added release notes covering the Windows tester build improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->