### PR TITLE
Record the 0.9.30-beta.1 release (build, upload, feed, announce)

### DIFF
--- a/docs/releases/0.9.30.md
+++ b/docs/releases/0.9.30.md
@@ -1,0 +1,63 @@
+# Videorc 0.9.30 Beta 1
+
+Videorc 0.9.30 ships the Studio audio ElevenLabs UI rework, the
+standalone sticked-in preview, and the Windows recording timing +
+recording-time preview fixes.
+
+## Scope
+
+- **Studio audio ElevenLabs UI rework** (PR #80, plan: vault
+  `2026-07-12 - Videorc Studio Audio ElevenLabs UI Rework Plan`):
+  vendored bar-visualizer + live-waveform (ui.elevenlabs.io shadcn
+  registry, zero new npm deps, currentColor tokens), shared
+  `createMicStreamController`/`useMicStream` acquisition (never-toast,
+  tested), 28-band mixer visualizer with explicit state map + clip-hold
+  chip, lazy MicPickerPreview under both mic pickers, SessionMicSliver
+  beside the session status badge, document-visibility stream gating.
+  Perf verified vs clean main (renderer 19.4%→17.4%, gpu 9.5%→3.7%,
+  preview active) and renderer eager-JS budget held via lazy preview.
+- **Standalone sticked-in preview** (PR #78): docked preview renders
+  bare — no glass card, border, or panel header; session status badge
+  moved into the docked control row (smoke hook preserved).
+- **Windows recording timing + recording-time preview** (PR #79,
+  parallel session): wall-time/A-V preservation under encoder pressure,
+  raw-frame throttle removal, truthful MF hardware probing, live proof
+  preview during recording, packaged duration/A-V coverage.
+
+## Release status
+
+- [x] Feature PRs merged via protected `main` (#78, #79, #80); release
+      prep PR #81 + changelog amend PR #82 (covers #79).
+- [x] Built from this repo checkout detached at `origin/main`
+      (`f59fcd10`) post-merge.
+- [x] Signed + notarized; `release:validate:macos` PASS.
+- [x] Uploaded to R2; feed serves `version: 0.9.30` through the www
+      redirect; `/api/changelog` serves `0.9.30-beta.1`.
+- [x] Discord announced (dry-run previewed first).
+- [x] X post drafted for the owner (not posted).
+
+## Known CI caveats recorded during this release
+
+- PR #81/#82 hit hosted-runner flakes: macOS process-memory sentinel
+  ("host sleep or scheduling stall"), Windows
+  `timed_out_duration_probe_terminates_its_child`, and — post-#79 —
+  the packaged 1080p duration gate and preview-liveness analyzer both
+  failed on hosted `windows-latest` (software MFT + slow runner). The
+  Windows installer artifact job needs hosted-runner calibration
+  (task chip spawned); #82 (markdown-only) merged with that optional
+  job red and JS/Rust green.
+
+## Owner acceptance checklist (by-eye, macOS)
+
+- [ ] Update from 0.9.29 arrives and installs; What's new shows
+      0.9.30-beta.1.
+- [ ] Audio mixer: live bars respond to speech; mute → flat dim bars;
+      loud clap → Clip chip; permission-denied → honest fallback +
+      Check level.
+- [ ] Mic picker (Quick Settings + Sources): live waveform of the
+      selected mic; OS mic indicator clears when the popover closes.
+- [ ] Record + stream briefly: 5-bar sliver next to the session status,
+      flat when muted.
+- [ ] Stick the preview into the app: bare video strip, no border/panel,
+      status badge + Pop out/Close in the control row.
+- [ ] Light theme spot-check of the mixer and pickers.


### PR DESCRIPTION
Internal release record for 0.9.30-beta.1: built from f59fcd10, signed + notarized (app + DMG stapled), release:validate PASS, uploaded to R2, feed verified serving version 0.9.30 through the www redirect, /api/changelog serving 0.9.30-beta.1 (31 entries), Discord announced after dry-run. Includes the hosted-runner CI caveats observed during the release and the owner by-eye checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)