### PR TITLE
feat: ship the Vertical scene — true 9:16 short-form recording

### DIFF
--- a/apps/desktop/src/renderer/src/components/preview-stage.tsx
+++ b/apps/desktop/src/renderer/src/components/preview-stage.tsx
@@ -91,9 +91,20 @@ export function PreviewStage({
 }
 
 /** All three preview states occupy the same output-aspect rect so the Studio
- * layout never jumps when the preview opens, docks, or closes. */
+ * layout never jumps when the preview opens, docks, or closes. Portrait
+ * canvases (the vertical 9:16 profile) keep the LANDSCAPE footprint: a raw
+ * 9:16 slot would tower ~2.4× over the Studio column, so the strip stays 16:9
+ * and the native surface pillarboxes the portrait video inside it (the
+ * surface contain-fits within the slot; the detached window is truly
+ * portrait). */
 function previewAspectRatio(aspect: { width: number; height: number }): string {
-  return aspect.width > 0 && aspect.height > 0 ? `${aspect.width} / ${aspect.height}` : '16 / 9'
+  if (aspect.width <= 0 || aspect.height <= 0) {
+    return '16 / 9'
+  }
+  if (aspect.height > aspect.width) {
+    return '16 / 9'
+  }
+  return `${aspect.width} / ${aspect.height}`
 }
 
 // Docked ("stick") mode: the native preview surface floats glued over the slot

--- a/apps/desktop/src/renderer/src/components/scene/scene-stage.tsx
+++ b/apps/desktop/src/renderer/src/components/scene/scene-stage.tsx
@@ -12,7 +12,15 @@ import { cn } from '@/lib/utils'
 // It is deliberately a diagram, not pixels; "Open preview" is the ground truth.
 
 const STAGE_W = 160
-const STAGE_H = 90
+
+/** Stage height follows the OUTPUT canvas aspect — a portrait (9:16) canvas
+ * must not be drawn on a 16:9 stage or camera drag/snap positions lie
+ * (vertical scene plan S4). Display height is capped in CSS; the viewBox only
+ * carries the aspect. */
+function stageHeight(outputAspect: number): number {
+  const aspect = Number.isFinite(outputAspect) && outputAspect > 0 ? outputAspect : 16 / 9
+  return Math.round(STAGE_W / aspect)
+}
 
 export function SceneStage({
   scene,
@@ -22,6 +30,7 @@ export function SceneStage({
   cameraShape = 'rectangle',
   cameraCornerRadiusPct = 12,
   dragEnabled = false,
+  outputAspect = 16 / 9,
   onSelectSource,
   onTogglePreview,
   onCommitPosition,
@@ -37,12 +46,15 @@ export function SceneStage({
   cameraCornerRadiusPct?: number
   /** SC3: allow dragging the camera rect (disabled in split/full layouts + live sessions). */
   dragEnabled?: boolean
+  /** Output canvas aspect (width / height); drives the stage shape. */
+  outputAspect?: number
   onSelectSource: (sourceId: string) => void
   onTogglePreview: () => void
   onCommitPosition?: (sourceId: string, position: { x: number; y: number }) => void
   onSnapCorner?: (corner: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right') => void
 }): ReactElement {
   const sources = scene?.sources ?? []
+  const stageH = stageHeight(outputAspect)
   const svgRef = useRef<SVGSVGElement | null>(null)
   const dragRef = useRef<{
     sourceId: string
@@ -142,14 +154,14 @@ export function SceneStage({
       <svg
         ref={svgRef}
         aria-label="Scene composition diagram"
-        className="block w-full"
+        className="mx-auto block max-h-[420px] w-full"
         role="img"
-        viewBox={`0 0 ${STAGE_W} ${STAGE_H}`}
+        viewBox={`0 0 ${STAGE_W} ${stageH}`}
       >
         {/* Canvas */}
         <rect
           className={cn(hasBackground ? 'fill-primary/10' : 'fill-transparent')}
-          height={STAGE_H}
+          height={stageH}
           width={STAGE_W}
           x={0}
           y={0}
@@ -159,6 +171,7 @@ export function SceneStage({
             key={source.id}
             cameraCornerRadiusPct={cameraCornerRadiusPct}
             cameraShape={cameraShape}
+            stageH={stageH}
             draggable={dragEnabled && source.kind === 'camera' && source.transform.width < 1}
             dragPosition={dragPosition?.sourceId === source.id ? dragPosition : null}
             selected={source.id === selectedSourceId}
@@ -178,7 +191,7 @@ export function SceneStage({
             fontSize={5}
             textAnchor="middle"
             x={STAGE_W / 2}
-            y={STAGE_H / 2}
+            y={stageH / 2}
           >
             No sources in the scene yet
           </text>
@@ -228,6 +241,7 @@ export function SceneStage({
 
 function StageSourceRect({
   source,
+  stageH,
   selected,
   draggable = false,
   dragPosition,
@@ -239,6 +253,7 @@ function StageSourceRect({
   onPointerUp
 }: {
   source: SceneSource
+  stageH: number
   selected: boolean
   draggable?: boolean
   dragPosition: { x: number; y: number } | null
@@ -250,9 +265,9 @@ function StageSourceRect({
   onPointerUp?: (event: React.PointerEvent<SVGGElement>) => void
 }): ReactElement {
   const x = (dragPosition?.x ?? source.transform.x) * STAGE_W
-  const y = (dragPosition?.y ?? source.transform.y) * STAGE_H
+  const y = (dragPosition?.y ?? source.transform.y) * stageH
   const width = Math.max(2, source.transform.width * STAGE_W)
-  const height = Math.max(2, source.transform.height * STAGE_H)
+  const height = Math.max(2, source.transform.height * stageH)
   const camera = source.kind === 'camera'
   // Mirror the compositors' mask geometry in schematic form: circle = fully
   // rounded (its box is square by construction), rounded = pct% of the shorter

--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -49,7 +49,8 @@ const QUICK_PRESETS: { id: LayoutPreset; label: string }[] = [
   { id: 'screen-camera', label: 'Screen + Cam' },
   { id: 'screen-only', label: 'Screen' },
   { id: 'camera-only', label: 'Camera' },
-  { id: 'side-by-side', label: 'Side by side' }
+  { id: 'side-by-side', label: 'Side by side' },
+  { id: 'vertical', label: 'Vertical (9:16)' }
 ]
 
 function presetLabel(preset: LayoutPreset): string {
@@ -62,7 +63,8 @@ const RESOLUTIONS = [
   { label: '4K', detail: '3840 × 2160', width: 3840, height: 2160 },
   { label: '2K', detail: '2560 × 1440', width: 2560, height: 1440 },
   { label: '1080p', detail: '1920 × 1080', width: 1920, height: 1080 },
-  { label: '720p', detail: '1280 × 720', width: 1280, height: 720 }
+  { label: '720p', detail: '1280 × 720', width: 1280, height: 720 },
+  { label: 'Vertical', detail: '1080 × 1920', width: 1080, height: 1920 }
 ]
 
 function resolutionKey(width: number, height: number): string {

--- a/apps/desktop/src/renderer/src/components/studio/scenes-gallery.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/scenes-gallery.tsx
@@ -17,11 +17,12 @@ const SCENE_PRESETS: { id: LayoutPreset; label: string }[] = [
   { id: 'screen-camera', label: 'Screen + Cam' },
   { id: 'screen-only', label: 'Screen' },
   { id: 'camera-only', label: 'Camera' },
-  { id: 'side-by-side', label: 'Side by side' }
+  { id: 'side-by-side', label: 'Side by side' },
+  { id: 'vertical', label: 'Vertical' }
 ]
 
 export function ScenesGallery(): ReactElement {
-  const { captureConfig, applyCameraPreset, layoutSwitchPending } = useStudioCore()
+  const { captureConfig, applyCameraPreset, layoutSwitchPending, isSessionActive } = useStudioCore()
   const { openStudioPanel } = useWorkspaceNav()
   const hasCamera = Boolean(captureConfig.sources.cameraId)
   const hasScreen = Boolean(captureConfig.sources.screenId ?? captureConfig.sources.windowId)
@@ -39,9 +40,15 @@ export function ScenesGallery(): ReactElement {
     >
       <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(104px,1fr))]">
         {SCENE_PRESETS.map((preset) => {
+          // Vertical changes the canvas orientation and the encoder canvas is
+          // fixed at session start — switching INTO it mid-session is refused
+          // (backend enforces this too). Every other scene stays live-safe.
+          const verticalBlockedLive =
+            preset.id === 'vertical' && isSessionActive && activePreset !== 'vertical'
           const disabled =
             (layoutPresetNeedsCamera(preset.id) && !hasCamera) ||
-            (layoutPresetNeedsScreen(preset.id) && !hasScreen)
+            (layoutPresetNeedsScreen(preset.id) && !hasScreen) ||
+            verticalBlockedLive
           const active = activePreset === preset.id
           return (
             <button
@@ -53,6 +60,11 @@ export function ScenesGallery(): ReactElement {
                 disabled && 'cursor-not-allowed opacity-50'
               )}
               disabled={disabled}
+              title={
+                verticalBlockedLive
+                  ? 'Vertical changes the canvas orientation — stop the session to switch.'
+                  : undefined
+              }
               type="button"
               onClick={() => applyCameraPreset({ layoutPreset: preset.id })}
             >
@@ -90,6 +102,14 @@ function LayoutThumb({ preset }: { preset: LayoutPreset }): ReactElement {
           <div className="absolute inset-y-1.5 left-1.5 w-[44%] rounded-[3px] bg-foreground/10" />
           <div className="absolute inset-y-1.5 right-1.5 w-[44%] rounded-[3px] bg-foreground/25" />
         </>
+      ) : null}
+      {preset === 'vertical' ? (
+        // 9:16 mini-canvas centered in the 16:9 thumb: camera band on top,
+        // screen below — the short-form arrangement, honest about pillarbox.
+        <div className="absolute inset-y-1 left-1/2 aspect-[9/16] -translate-x-1/2 overflow-hidden rounded-[3px] border border-background/60 bg-background/40">
+          <div className="absolute inset-x-0.5 top-0.5 h-[38%] rounded-[2px] bg-foreground/30" />
+          <div className="absolute inset-x-0.5 bottom-0.5 h-[56%] rounded-[2px] bg-foreground/10" />
+        </div>
       ) : null}
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
@@ -39,7 +39,8 @@ const LAYOUT_PRESETS = [
   { id: 'screen-camera', label: 'Screen + camera', enabled: true },
   { id: 'screen-only', label: 'Screen only', enabled: true },
   { id: 'camera-only', label: 'Camera only', enabled: true },
-  { id: 'side-by-side', label: 'Side-by-side', enabled: true }
+  { id: 'side-by-side', label: 'Side-by-side', enabled: true },
+  { id: 'vertical', label: 'Vertical (9:16)', enabled: true }
 ] as const
 
 export function LayoutTab(): ReactElement {
@@ -77,6 +78,7 @@ export function LayoutTab(): ReactElement {
   const hasScreen = hasSelectedScreenSource(captureConfig.sources)
   const isCameraOnly = layout.layoutPreset === 'camera-only'
   const isSideBySide = layout.layoutPreset === 'side-by-side'
+  const isVertical = layout.layoutPreset === 'vertical'
   const showOverlayControls = layout.layoutPreset === 'screen-camera'
 
   return (
@@ -140,6 +142,7 @@ export function LayoutTab(): ReactElement {
             cameraShape={layout.cameraShape}
             dragEnabled={showOverlayControls && !isSessionActive}
             hasBackground={Boolean(scene?.background)}
+            outputAspect={captureConfig.video.width / Math.max(1, captureConfig.video.height)}
             previewOpen={previewWindow.open}
             scene={scene}
             selectedSourceId={selectedSceneSourceId}
@@ -213,6 +216,13 @@ export function LayoutTab(): ReactElement {
                 <p className="text-sm text-muted-foreground">
                   Camera only fills the frame as a rectangle. Corner, size, and shape do not apply —
                   use fit, mirror, zoom, and pan.
+                </p>
+              ) : null}
+
+              {isVertical ? (
+                <p className="text-sm text-muted-foreground">
+                  Vertical stacks the camera band on top of the screen for 9:16 short-form output.
+                  Corner, size, and shape do not apply — use fit, mirror, zoom, and pan.
                 </p>
               ) : null}
 

--- a/apps/desktop/src/renderer/src/components/tabs/recording-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/recording-tab.tsx
@@ -22,7 +22,8 @@ const RESOLUTION_PRESETS = [
   { label: '4K', detail: '3840 × 2160', width: 3840, height: 2160 },
   { label: '2K', detail: '2560 × 1440', width: 2560, height: 1440 },
   { label: '1080p', detail: '1920 × 1080', width: 1920, height: 1080 },
-  { label: '720p', detail: '1280 × 720', width: 1280, height: 720 }
+  { label: '720p', detail: '1280 × 720', width: 1280, height: 720 },
+  { label: 'Vertical', detail: '1080 × 1920', width: 1080, height: 1920 }
 ] as const
 
 export function RecordingTab(): ReactElement {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -54,6 +54,7 @@ import {
   STORAGE_KEYS,
   streamOutputVideosForTargets,
   streamOutputVideoSettings,
+  verticalOrientationVideoPatch,
   videoProfileCompatibility,
   videoPresets,
   type CaptureConfig,
@@ -4725,7 +4726,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   }, [client])
 
   const requestLayoutTransaction = useCallback(
-    (layout: LayoutSettings, options?: { pendingIndicator?: boolean }) => {
+    (
+      layout: LayoutSettings,
+      options?: { pendingIndicator?: boolean; videoOverride?: VideoSettings }
+    ) => {
       const sessionActive = isActiveRecordingState(recordingRef.current.state)
       if (!client || wsStatus !== 'connected') {
         toast.error('Backend socket is not connected — layout unchanged.')
@@ -4762,7 +4766,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             intentId,
             sources: requestedSources,
             layout,
-            video: requestedConfig.video,
+            // The vertical orientation coupling patches React state and the
+            // transaction in the same tick; the ref may not have caught up,
+            // so the caller passes the canvas it just applied.
+            video: options?.videoOverride ?? requestedConfig.video,
             background: activeSceneBackground,
             protectedOverlayWindowIds
           })
@@ -4909,14 +4916,42 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   const applyCameraPreset = useCallback(
     (patch: Partial<LayoutSettings>) => {
-      requestLayoutTransaction({
-        ...captureConfigRef.current.layout,
-        ...patch,
-        cameraTransformMode: 'preset',
-        cameraTransform: null
-      })
+      const current = captureConfigRef.current
+      const nextPreset = patch.layoutPreset ?? current.layout.layoutPreset
+
+      // Vertical scene ⇄ canvas orientation coupling, OFF-AIR ONLY: entering
+      // vertical flips the canvas to 1080×1920 and remembers the landscape
+      // profile; leaving restores it. Mid-session the canvas is fixed (the
+      // vertical card is disabled and the backend refuses the switch).
+      let videoOverride: VideoSettings | undefined
+      if (!isActiveRecordingState(recordingRef.current.state)) {
+        const coupling = verticalOrientationVideoPatch(
+          current.layout.layoutPreset,
+          nextPreset,
+          current.video,
+          current.verticalRestoreVideo
+        )
+        if (coupling) {
+          videoOverride = coupling.video
+          setCaptureConfig((config) => ({
+            ...config,
+            video: coupling.video,
+            verticalRestoreVideo: coupling.verticalRestoreVideo
+          }))
+        }
+      }
+
+      requestLayoutTransaction(
+        {
+          ...current.layout,
+          ...patch,
+          cameraTransformMode: 'preset',
+          cameraTransform: null
+        },
+        videoOverride ? { videoOverride } : undefined
+      )
     },
-    [requestLayoutTransaction]
+    [requestLayoutTransaction, setCaptureConfig]
   )
 
   const switchSourceDeviceLive = useCallback(

--- a/apps/desktop/src/renderer/src/lib/capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.test.ts
@@ -22,6 +22,7 @@ import {
   isScreenCaptureKitCaptureDevice,
   isSelectableCaptureDevice,
   layoutPresetNeedsCamera,
+  verticalOrientationVideoPatch,
   layoutPresetNeedsScreen,
   loadCaptureConfig,
   normalizeLayoutSettings,
@@ -1417,5 +1418,44 @@ describe('camera shape and aspect (2026-07-06)', () => {
 
     expect(layout.cameraShape).toBe('rectangle')
     expect(layout.cameraAspect).toBe('source')
+  })
+})
+
+describe('vertical orientation video coupling', () => {
+  const landscape = videoPresets['record-4k30']
+  const vertical = videoPresets['vertical-1080x1920']
+
+  it('entering vertical applies the portrait profile and remembers the landscape canvas', () => {
+    const patch = verticalOrientationVideoPatch('screen-camera', 'vertical', landscape, null)
+    expect(patch).toEqual({ video: vertical, verticalRestoreVideo: landscape })
+  })
+
+  it('entering vertical keeps a canvas the user already made portrait', () => {
+    const customPortrait = { ...landscape, preset: 'custom' as const, width: 1440, height: 2560 }
+    expect(
+      verticalOrientationVideoPatch('screen-only', 'vertical', customPortrait, null)
+    ).toBeNull()
+  })
+
+  it('leaving vertical restores exactly the remembered landscape canvas once', () => {
+    const patch = verticalOrientationVideoPatch('vertical', 'screen-camera', vertical, landscape)
+    expect(patch).toEqual({ video: landscape, verticalRestoreVideo: null })
+  })
+
+  it('leaving vertical falls back to the default landscape profile with nothing remembered', () => {
+    const patch = verticalOrientationVideoPatch('vertical', 'side-by-side', vertical, null)
+    expect(patch).toEqual({ video: defaultCaptureConfig.video, verticalRestoreVideo: null })
+  })
+
+  it('leaving vertical never clobbers a canvas the user already made landscape', () => {
+    const patch = verticalOrientationVideoPatch('vertical', 'screen-camera', landscape, vertical)
+    expect(patch).toEqual({ video: landscape, verticalRestoreVideo: null })
+  })
+
+  it('is inert for same-orientation transitions', () => {
+    expect(
+      verticalOrientationVideoPatch('screen-camera', 'side-by-side', landscape, null)
+    ).toBeNull()
+    expect(verticalOrientationVideoPatch('vertical', 'vertical', vertical, landscape)).toBeNull()
   })
 })

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -44,6 +44,12 @@ export type CaptureConfig = {
   layout: LayoutSettings
   audio: AudioSettings
   video: VideoSettings
+  /**
+   * Landscape canvas remembered while the Vertical scene holds the output in
+   * portrait — restored when the user switches back to a landscape scene
+   * (verticalOrientationVideoPatch). Null outside the vertical scene.
+   */
+  verticalRestoreVideo: VideoSettings | null
   recordEnabled: boolean
   streamEnabled: boolean
   rtmpPreset: RtmpPreset
@@ -78,6 +84,47 @@ export function layoutPresetNeedsScreen(preset: LayoutPreset): boolean {
 
 export function hasSelectedCameraSource(sources: SourceSelection): boolean {
   return Boolean(sources.cameraId)
+}
+
+export type VerticalOrientationVideoPatch = {
+  video: VideoSettings
+  verticalRestoreVideo: VideoSettings | null
+}
+
+/**
+ * Off-air orientation coupling for the Vertical scene: entering `vertical`
+ * flips the canvas to the vertical profile and remembers the landscape
+ * settings; leaving restores exactly what was there. Returns null when no
+ * video change is needed — same orientation class, a canvas the user already
+ * made portrait (entering), or a canvas the user already made landscape while
+ * in the vertical scene (leaving — their explicit choice wins). Callers MUST
+ * NOT apply this mid-session: the encoder canvas is fixed at session start
+ * (the backend refuses live switches into vertical as defense in depth).
+ */
+export function verticalOrientationVideoPatch(
+  fromPreset: LayoutPreset,
+  toPreset: LayoutPreset,
+  video: VideoSettings,
+  verticalRestoreVideo: VideoSettings | null
+): VerticalOrientationVideoPatch | null {
+  const fromVertical = fromPreset === 'vertical'
+  const toVertical = toPreset === 'vertical'
+  if (fromVertical === toVertical) {
+    return null
+  }
+  if (toVertical) {
+    if (video.height > video.width) {
+      return null
+    }
+    return { video: videoPresets['vertical-1080x1920'], verticalRestoreVideo: video }
+  }
+  if (video.height <= video.width) {
+    return { video, verticalRestoreVideo: null }
+  }
+  return {
+    video: verticalRestoreVideo ?? defaultCaptureConfig.video,
+    verticalRestoreVideo: null
+  }
 }
 
 export function hasSelectedScreenSource(sources: SourceSelection): boolean {
@@ -265,6 +312,15 @@ export const videoPresets: Record<VideoPreset, VideoSettings> = {
     fps: 60,
     bitrateKbps: 9000
   },
+  // True portrait canvas for short-form output (Shorts/Reels/TikTok): the
+  // Vertical scene applies this preset off-air (vertical scene plan S2/S4).
+  'vertical-1080x1920': {
+    preset: 'vertical-1080x1920',
+    width: 1080,
+    height: 1920,
+    fps: 30,
+    bitrateKbps: 9000
+  },
   custom: {
     preset: 'custom',
     width: 1920,
@@ -284,7 +340,8 @@ export const recordingVideoPresetOptions: VideoPresetOption[] = [
   { value: 'record-4k30', label: 'Record 4K30' },
   { value: 'record-4k60-experimental', label: 'Record 4K60 experimental', tone: 'warning' },
   { value: 'tutorial-1440p30', label: 'Tutorial 1440p30' },
-  { value: 'tutorial-1080p30', label: 'Tutorial 1080p30' }
+  { value: 'tutorial-1080p30', label: 'Tutorial 1080p30' },
+  { value: 'vertical-1080x1920', label: 'Vertical 1080×1920 (9:16)' }
 ]
 
 export const streamingVideoPresetOptions: VideoPresetOption[] = [
@@ -461,6 +518,7 @@ export function auxiliaryStreamOutputVideoSettings(
 
 export const defaultCaptureConfig: CaptureConfig = {
   sources: {},
+  verticalRestoreVideo: null,
   layout: {
     layoutPreset: 'screen-camera',
     cameraTransformMode: 'preset',
@@ -580,6 +638,10 @@ export function loadCaptureConfig(): CaptureConfig {
     layout: normalizeLayoutSettings(loaded.layout),
     audio: normalizeAudioSettings(loaded.audio),
     video: normalizeVideoSettings(loaded.video),
+    verticalRestoreVideo:
+      loaded.verticalRestoreVideo != null
+        ? normalizeVideoSettings(loaded.verticalRestoreVideo)
+        : null,
     recordEnabled:
       typeof loaded.recordEnabled === 'boolean'
         ? loaded.recordEnabled

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -533,6 +533,7 @@ export type VideoPreset =
   | 'stream-safe-1080p60'
   | 'stream-youtube-4k30'
   | 'stream-1080p60'
+  | 'vertical-1080x1920'
   | 'custom'
 
 export interface VideoSettings {

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -386,6 +386,27 @@ async fn apply_scene_transaction(
     let intent_id = begin_layout_intent(state, requested_intent_id, needs).await?;
     let session_active = state.recording.lock().await.is_some();
 
+    // Vertical implies a portrait canvas and the encoder canvas is fixed at
+    // session start — switching INTO vertical mid-session is refused honestly
+    // (the renderer disables the card too; this is defense in depth). Being
+    // live in vertical stays fully mutable: source switches, backgrounds, and
+    // scene commits within the running vertical session all pass.
+    if session_active && matches!(params.layout.layout_preset, LayoutPreset::Vertical) {
+        let already_vertical = {
+            let compositor = state.compositor.lock().await;
+            compositor
+                .status
+                .scene_layout
+                .as_ref()
+                .is_some_and(|layout| matches!(layout.layout_preset, LayoutPreset::Vertical))
+        };
+        if !already_vertical {
+            bail!(
+                "Vertical changes the canvas orientation — stop the session before switching to it."
+            );
+        }
+    }
+
     let live = source_liveness(state, target_sources).await;
     match plan_live_swap(mutation_kind, needs, live) {
         ApplyMode::Hot => {

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -7588,6 +7588,10 @@ fn video_filter(
         return side_by_side_video_filter(camera_input_index, params, preview);
     }
 
+    if matches!(params.layout.layout_preset, LayoutPreset::Vertical) {
+        return vertical_video_filter(camera_input_index, params, preview);
+    }
+
     let base_scale = if preview {
         "scale=w=960:h=-2".to_string()
     } else {
@@ -7663,6 +7667,52 @@ fn side_by_side_video_filter(
     };
     let final_scale = if preview { ",scale=w=960:h=-2" } else { "" };
     format!("{screen};{camera};[{left}][{right}]hstack=inputs=2{final_scale}[v]")
+}
+
+/// Camera band height for the Vertical preset's legacy FFmpeg path — mirrors
+/// scene.rs VERTICAL_CAMERA_BAND (0.4) and the compositor arrangement: camera
+/// band on top (covers), screen below (contains, never cropped). Heights are
+/// evened for yuv420p.
+fn vertical_band_heights(canvas_height: u32) -> (u32, u32) {
+    let camera = ((f64::from(canvas_height) * 0.4).round() as u32 / 2) * 2;
+    let camera = camera.clamp(2, canvas_height.saturating_sub(2));
+    (camera, canvas_height - camera)
+}
+
+fn vertical_video_filter(
+    camera_input_index: Option<usize>,
+    params: &StartSessionParams,
+    preview: bool,
+) -> String {
+    let video = &params.output.video;
+    let width = video.width;
+    let (camera_height, screen_height) = vertical_band_heights(video.height);
+    let fps = video.fps;
+
+    // Screen CONTAINS in its band (nothing on the user's screen may be cropped
+    // away) and pads with black; the camera band fills via the shared camera
+    // frame filter (fit/fill/zoom preserved).
+    let screen = format!(
+        "[0:v]setpts=PTS-STARTPTS,scale={width}:{screen_height}:force_original_aspect_ratio=decrease,pad={width}:{screen_height}:(ow-iw)/2:(oh-ih)/2:color=black,fps={fps},format=yuv420p[vt_screen]"
+    );
+    let camera = match camera_input_index {
+        Some(index) => {
+            let mirror = if params.layout.camera_mirror {
+                "hflip,"
+            } else {
+                ""
+            };
+            let frame = camera_frame_filter(width, camera_height, &params.layout);
+            format!(
+                "[{index}:v]setpts=PTS-STARTPTS,{mirror}{frame},fps={fps},format=yuv420p[vt_camera]"
+            )
+        }
+        None => {
+            format!("color=c=black:s={width}x{camera_height}:r={fps},format=yuv420p[vt_camera]")
+        }
+    };
+    let final_scale = if preview { ",scale=w=960:h=-2" } else { "" };
+    format!("{screen};{camera};[vt_camera][vt_screen]vstack=inputs=2{final_scale}[v]")
 }
 
 fn output_scale_filter(video: &VideoSettings) -> String {
@@ -11285,6 +11335,46 @@ mod tests {
         params.layout.side_by_side_camera_side = SideBySideCameraSide::Left;
         let left = video_filter(Some(1), &params, false);
         assert!(left.contains("[sbs_camera][sbs_screen]hstack=inputs=2"));
+    }
+
+    #[test]
+    fn vertical_band_heights_are_even_and_tile_the_canvas() {
+        let (camera, screen) = vertical_band_heights(1920);
+        assert_eq!(camera, 768);
+        assert_eq!(screen, 1152);
+        for height in [720, 1080, 1919, 1921] {
+            let (camera, screen) = vertical_band_heights(height);
+            assert_eq!(camera % 2, 0);
+            assert_eq!(camera + screen, height);
+            assert!(camera >= 2);
+        }
+    }
+
+    #[test]
+    fn vertical_filter_stacks_camera_band_over_padded_screen() {
+        let mut params = base_params(true, false);
+        params.layout.layout_preset = LayoutPreset::Vertical;
+        params.output.video.width = 1080;
+        params.output.video.height = 1920;
+
+        let filter = video_filter(Some(1), &params, false);
+        // Camera band on top, screen below; screen pads (contains), never crops.
+        assert!(
+            filter.contains("[vt_camera][vt_screen]vstack=inputs=2"),
+            "stacked filter: {filter}"
+        );
+        assert!(
+            filter.contains("pad=1080:1152"),
+            "screen contains: {filter}"
+        );
+        assert!(!filter.contains("overlay"));
+
+        // Without a camera input the band renders black instead of collapsing.
+        let no_camera = video_filter(None, &params, false);
+        assert!(
+            no_camera.contains("color=c=black:s=1080x768"),
+            "{no_camera}"
+        );
     }
 
     fn ffmpeg_inputs(args: &[String]) -> Vec<&str> {

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -71,6 +71,25 @@ pub fn validate_scene_background(scene: &Scene) -> Result<(), String> {
     Ok(())
 }
 
+/// Fit the preview output inside the preview budget box (1280x720) while
+/// PRESERVING the canvas aspect. The old independent `min()` clamps distorted
+/// any non-16:9 canvas — a portrait 1080x1920 became a 1080x720 (3:2) preview
+/// surface inside a correctly 9:16 CSS slot (vertical scene plan S2).
+/// Dimensions are rounded down to even values for the YUV conversion paths.
+fn preview_output_dimensions(output_width: u32, output_height: u32) -> (u32, u32) {
+    const MAX_WIDTH: u32 = 1280;
+    const MAX_HEIGHT: u32 = 720;
+    let even = |value: u32| (value.max(2) / 2) * 2;
+    if output_width <= MAX_WIDTH && output_height <= MAX_HEIGHT {
+        return (even(output_width), even(output_height));
+    }
+    let scale = (f64::from(MAX_WIDTH) / f64::from(output_width.max(1)))
+        .min(f64::from(MAX_HEIGHT) / f64::from(output_height.max(1)));
+    let width = (f64::from(output_width) * scale).round() as u32;
+    let height = (f64::from(output_height) * scale).round() as u32;
+    (even(width), even(height))
+}
+
 pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
     let (output_width, output_height, fps) = params
         .video
@@ -82,12 +101,16 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
         name: "Default Scene".to_string(),
         sources: Vec::new(),
         outputs: vec![
-            SceneOutput {
-                id: "output:preview".to_string(),
-                kind: SceneOutputKind::Preview,
-                width: output_width.min(1280),
-                height: output_height.min(720),
-                fps: fps.min(30),
+            {
+                let (preview_width, preview_height) =
+                    preview_output_dimensions(output_width, output_height);
+                SceneOutput {
+                    id: "output:preview".to_string(),
+                    kind: SceneOutputKind::Preview,
+                    width: preview_width,
+                    height: preview_height,
+                    fps: fps.min(30),
+                }
             },
             SceneOutput {
                 id: "output:recording".to_string(),
@@ -144,12 +167,31 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
                 scene.sources.push(camera);
             }
         }
-        // Explicit arms (no wildcard): a new preset must state its composition
+        LayoutPreset::Vertical => {
+            // Stacked portrait arrangement (9:16 short-form): camera band on
+            // top, screen below. Fractions are canvas-normalized so the
+            // arrangement stays sane even if applied to a landscape canvas.
+            // Like side-by-side regions, the camera band keeps no bubble mask
+            // and the screen band CONTAINS (nothing on the user's screen may
+            // be cropped away); the camera honors the user's Fit/Fill.
+            let mut base = base_source(&params.sources);
+            base.transform =
+                vertical_band_transform(VERTICAL_CAMERA_BAND, 1.0 - VERTICAL_CAMERA_BAND);
+            base.default_transform = base.transform.clone();
+            scene.sources.push(base);
+
+            if let Some(camera_id) = params.sources.camera_id.clone() {
+                let mut camera =
+                    camera_source(camera_id, &params.layout, output_width, output_height);
+                camera.transform = vertical_band_transform(0.0, VERTICAL_CAMERA_BAND);
+                camera.default_transform = camera.transform.clone();
+                scene.sources.push(camera);
+            }
+        }
+        // Explicit arm (no wildcard): a new preset must state its composition
         // here or fail to compile — the old `_ =>` silently composited unknown
         // presets as screen-camera.
-        LayoutPreset::ScreenCamera | LayoutPreset::Vertical => {
-            // Vertical's stacked portrait arrangement lands with the vertical
-            // layout slice; until then it composites like screen-camera.
+        LayoutPreset::ScreenCamera => {
             scene.sources.push(base_source(&params.sources));
             if let Some(camera_id) = params.sources.camera_id.clone() {
                 scene.sources.push(camera_source(
@@ -334,6 +376,23 @@ fn region_transform(x: f64, width: f64) -> SceneTransform {
     }
 }
 
+/// Camera band height for the Vertical (9:16) preset: face on top, content
+/// below — the short-form idiom. Owner taste review may tune this (0.35-0.45).
+const VERTICAL_CAMERA_BAND: f64 = 0.4;
+
+fn vertical_band_transform(y: f64, height: f64) -> SceneTransform {
+    SceneTransform {
+        x: 0.0,
+        y,
+        width: 1.0,
+        height,
+        crop_left: 0.0,
+        crop_top: 0.0,
+        crop_right: 0.0,
+        crop_bottom: 0.0,
+    }
+}
+
 fn apply_transform_patch(
     mut transform: SceneTransform,
     patch: SceneTransformPatch,
@@ -440,6 +499,58 @@ mod tests {
         CameraTransform, CameraTransformMode, EffectiveSceneBackground, LayoutPreset,
         LayoutSettings, SideBySideSplit, SourceSelection,
     };
+
+    #[test]
+    fn vertical_preset_stacks_camera_band_over_contained_screen() {
+        let mut params = base_params();
+        params.layout.layout_preset = LayoutPreset::Vertical;
+        let scene = scene_from_capture_config(params);
+
+        assert_eq!(scene.sources.len(), 2);
+        let screen = &scene.sources[0];
+        let camera = &scene.sources[1];
+
+        // Screen fills the lower band edge-to-edge.
+        assert_eq!(screen.transform.x, 0.0);
+        assert_eq!(screen.transform.y, VERTICAL_CAMERA_BAND);
+        assert_eq!(screen.transform.width, 1.0);
+        assert_eq!(screen.transform.height, 1.0 - VERTICAL_CAMERA_BAND);
+
+        // Camera band sits on top, full width.
+        assert_eq!(camera.transform.x, 0.0);
+        assert_eq!(camera.transform.y, 0.0);
+        assert_eq!(camera.transform.width, 1.0);
+        assert_eq!(camera.transform.height, VERTICAL_CAMERA_BAND);
+        assert_eq!(camera.default_transform, camera.transform);
+    }
+
+    #[test]
+    fn vertical_preset_without_camera_keeps_the_screen_band() {
+        // Transient state only — the selection blocker refuses vertical
+        // without a camera; the band stays consistent with side-by-side.
+        let mut params = base_params();
+        params.layout.layout_preset = LayoutPreset::Vertical;
+        params.sources.camera_id = None;
+        let scene = scene_from_capture_config(params);
+
+        assert_eq!(scene.sources.len(), 1);
+        assert_eq!(scene.sources[0].transform.y, VERTICAL_CAMERA_BAND);
+    }
+
+    #[test]
+    fn preview_output_preserves_canvas_aspect_inside_the_budget_box() {
+        // Standard landscape canvases keep their historical preview sizes.
+        assert_eq!(preview_output_dimensions(1920, 1080), (1280, 720));
+        assert_eq!(preview_output_dimensions(3840, 2160), (1280, 720));
+        assert_eq!(preview_output_dimensions(1280, 720), (1280, 720));
+        // Portrait no longer distorts: 1080x1920 fits height-bound at 9:16.
+        assert_eq!(preview_output_dimensions(1080, 1920), (404, 720));
+        // Non-16:9 landscape scales by the binding axis instead of squashing.
+        assert_eq!(preview_output_dimensions(1500, 1000), (1080, 720));
+        // Small canvases pass through (evened), never upscaled.
+        assert_eq!(preview_output_dimensions(640, 360), (640, 360));
+        assert_eq!(preview_output_dimensions(3, 3), (2, 2));
+    }
 
     // Camera shape/aspect feature (2026-07-06): the box aspect is decided HERE
     // once; every render path center-crops into it via Fill. Portrait = 3:4,

--- a/scripts/smoke-layout-source-loop-app.mjs
+++ b/scripts/smoke-layout-source-loop-app.mjs
@@ -22,6 +22,10 @@ const LAYOUTS = [
   {
     preset: 'screen-camera',
     expectedKinds: ['camera', 'test-pattern']
+  },
+  {
+    preset: 'vertical',
+    expectedKinds: ['camera', 'test-pattern']
   }
 ]
 

--- a/scripts/smoke-recording-session.mjs
+++ b/scripts/smoke-recording-session.mjs
@@ -21,7 +21,16 @@ export const LAYOUT_PRESET_SCENARIOS = [
   { preset: 'screen-camera', label: 'Screen + camera' },
   { preset: 'screen-only', label: 'Screen only' },
   { preset: 'camera-only', label: 'Camera only' },
-  { preset: 'side-by-side', label: 'Side-by-side' }
+  { preset: 'side-by-side', label: 'Side-by-side' },
+  // Vertical records a true PORTRAIT canvas and the artifact's probed
+  // dimensions are asserted below — a vertical scene that silently produced
+  // landscape pixels must fail here. 720x1280 is the smallest exact 9:16
+  // canvas inside the backend's resolution bounds (width >= 640).
+  {
+    preset: 'vertical',
+    label: 'Vertical 9:16',
+    video: { width: 720, height: 1280 }
+  }
 ]
 
 export async function runBackendRecordingSmoke({
@@ -205,7 +214,8 @@ async function recordScenario({
     sessionParams({
       outputDirectoryCapability,
       preset: scenario.preset,
-      background: scenario.background
+      background: scenario.background,
+      video: scenario.video
     })
   )
   if (!['recording', 'streaming'].includes(started.state)) {
@@ -249,6 +259,17 @@ async function recordScenario({
         `(report: ${reportPaths.mdPath})`
     )
   }
+  if (scenario.video) {
+    const probedWidth = quality.metrics.width
+    const probedHeight = quality.metrics.height
+    if (probedWidth !== scenario.video.width || probedHeight !== scenario.video.height) {
+      throw new Error(
+        `[${scenario.label}] Artifact dimensions ${probedWidth}x${probedHeight} do not match the ` +
+          `requested canvas ${scenario.video.width}x${scenario.video.height}.`
+      )
+    }
+  }
+
   const durationFailures = evaluateRecordingWallDuration({
     expectedDurationMs: recordingMs,
     actualDurationSeconds: quality.metrics.durationSeconds
@@ -422,7 +443,7 @@ export function request(ws, timeoutMs, method, params) {
   })
 }
 
-function sessionParams({ outputDirectoryCapability, preset = 'screen-camera', background }) {
+function sessionParams({ outputDirectoryCapability, preset = 'screen-camera', background, video }) {
   return {
     sources: {
       testPattern: true
@@ -449,8 +470,8 @@ function sessionParams({ outputDirectoryCapability, preset = 'screen-camera', ba
       ...(outputDirectoryCapability ? { outputDirectoryCapability } : {}),
       video: {
         preset: 'custom',
-        width: SMOKE_VIDEO_WIDTH,
-        height: SMOKE_VIDEO_HEIGHT,
+        width: video?.width ?? SMOKE_VIDEO_WIDTH,
+        height: video?.height ?? SMOKE_VIDEO_HEIGHT,
         fps: SMOKE_VIDEO_FPS,
         bitrateKbps: SMOKE_VIDEO_BITRATE_KBPS
       },


### PR DESCRIPTION
## What changed

Completes the **Vertical Scene (9:16)** plan (vault: `2026-07-12 - Videorc Vertical Scene 9x16 Short Format Plan`) on top of the S1 plumbing (#84). The Scenes gallery gains a fifth card — **Vertical** — that records/streams a true 1080×1920 portrait canvas with the short-form arrangement: camera band on top (40%, honoring the user's camera Fit/Fill), screen below (60%, contained — nothing on the user's screen is ever cropped away).

### The product behavior
- **Selecting Vertical off-air** flips the output canvas to the new `vertical-1080x1920` profile and remembers your landscape settings; switching to any landscape scene restores exactly what was there (transition table unit-tested, including "user manually changed the canvas while vertical" cases).
- **Mid-session, switching INTO Vertical is refused honestly** — the card is disabled with a reason and the backend `apply_scene_transaction` bails (the encoder canvas is fixed at session start). Being live IN a vertical session stays fully mutable: source switches, backgrounds, scene commits all pass.
- **Preview:** the preview surface clamp is now aspect-preserving (`1080×1920 → 404×720` instead of the distorted `1080×720` the independent min() produced — tested); the docked strip keeps its landscape footprint and pillarboxes portrait video so the Studio column doesn't grow ~2.4× taller; the detached window is truly portrait. The Scene tab stage now derives its shape from the canvas aspect (the hardcoded 16:9 stage would have misplaced camera drag/snap on portrait).
- **Legacy FFmpeg path** gets a real `vstack` vertical filter mirroring the compositor arrangement (tested) — no silent screen-camera fallback.

### End-to-end proof
The all-layout recording smoke gains a **Vertical 9:16 scenario**: it records a real 720×1280 portrait artifact through the full compositor + encoder pipeline and asserts the probed artifact dimensions. Passing locally: 59 frames, 0 ms A/V skew, dimension check green. (`smoke-layout-source-loop` also enumerates vertical; on this box that smoke is blocked before reaching any layout by the known dev-app camera TCC issue — pre-existing, unrelated.)

## Gates
- `pnpm typecheck` / `pnpm lint` (0 errors) / `pnpm format:check`
- Desktop tests **807/807** (6 new orientation-coupling tests), script tests **569/569**
- `cargo test` 1026 passed + new scene/filter/clamp tests; the pre-existing `concurrent_compositor_starts_serialize_the_full_worker_handoff` tokio-race flake fails under load and passes isolated (same as clean main); `clippy -D warnings` + `cargo fmt` clean
- `pnpm smoke:dev` (all-layout recording artifact smoke incl. the new vertical scenario) **PASS**

## Owner by-eye (after merge)
- Click Vertical off-air: canvas flips to 1080×1920, preview pillarboxes in the docked strip, detached window goes portrait; click Screen + Cam: your landscape profile returns.
- Record a short vertical clip and check the stacked arrangement + camera Fit/Fill taste (band height is a named constant, 0.4 — say the word to tune 0.35–0.45).
- Try switching to Vertical while recording: card disabled with the reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Vertical (9:16)** layout with camera-over-screen composition, including vertical-aware preview/scene sizing.
  * Added **Vertical 1080 × 1920 (9:16)** options to quick settings, layout selection, and recording resolution.
  * Updated layout guidance and thumbnails for vertical.
* **Bug Fixes**
  * Prevented switching to **Vertical** while a session is active (unless already using Vertical).
  * Improved portrait preview stability to prevent layout jumps and adjusted preview aspect handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->