### PR TITLE
Release 0.9.31-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.31-beta.1.md
+++ b/changelog/0.9.31-beta.1.md
@@ -1,0 +1,48 @@
+---
+version: 0.9.31-beta.1
+date: 2026-07-12
+channel: beta
+title: Vertical mode — record true 9:16 for Shorts, Reels, and TikTok
+summary: The Studio now has a vertical mode with its own set of 9:16 scenes — flip one switch and you're composing, previewing, and recording a true 1080×1920 portrait video; flip back and your landscape setup returns exactly as you left it.
+highlights:
+  - A new toggle in the Scenes panel switches the whole Studio between horizontal (16:9) and vertical (9:16) modes.
+  - Vertical mode brings five scenes built for short-form — camera on top, camera on the bottom, an even split, full-screen recording with a floating camera bubble, and screen only.
+  - Recordings in vertical mode are real 1080×1920 portrait files, not landscape videos with bars.
+  - Each mode remembers its last scene and your canvas settings, so switching back and forth never loses your setup.
+  - Switching scenes inside a mode stays live-safe while you record or stream.
+---
+
+## One switch, a whole vertical studio
+
+Short-form video isn't a landscape recording turned sideways — it's its own
+format with its own layouts. The Studio now treats it that way: a small
+toggle next to the Scenes gallery flips the entire Studio into vertical
+mode. The canvas becomes a true 1080×1920 portrait, the preview follows,
+and the scene gallery swaps to layouts designed for a phone screen.
+
+Flip back to horizontal and everything returns exactly as you left it —
+your landscape scene, your resolution, your setup.
+
+## Five scenes made for short-form
+
+Vertical mode doesn't reuse the landscape layouts; it has its own gallery:
+
+- **Camera top** — your face above, your screen below. The classic Shorts
+  arrangement.
+- **Camera bottom** — the mirror: content up top, you underneath.
+- **Split** — screen and camera share the frame evenly.
+- **Screen + Cam** — the recording fills the whole frame and your camera
+  floats as a bubble you can drag, resize, and shape, just like the
+  landscape scene.
+- **Screen** — the recording alone, edge to edge.
+
+Your screen content is never cropped in the stacked scenes — the screen
+band always fits your whole display, and the camera band fills with your
+chosen fit.
+
+## Honest rules while you're live
+
+The canvas can't change size mid-session, so the orientation toggle is
+disabled while you record or stream — with the reason spelled out, not
+grayed-out mystery. Everything else stays live: switch between vertical
+scenes, swap sources, change backgrounds, all without stopping.


### PR DESCRIPTION
Version 0.9.30 → 0.9.31 and the user-facing changelog entry for the vertical Studio mode release (#87 vertical scene foundation + #88 orientation-mode split). `pnpm changelog:check`: 32 entries valid, latest 0.9.31-beta.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)