### PR TITLE
Record the 0.9.31 release (build, upload, feed, announce)

### DIFF
--- a/docs/releases/0.9.31.md
+++ b/docs/releases/0.9.31.md
@@ -1,0 +1,52 @@
+# Videorc 0.9.31 Beta 1
+
+Videorc 0.9.31 ships the vertical Studio mode: horizontal and vertical
+are two separate modes with their own scene sets, an orientation toggle,
+and true 1080x1920 portrait recording for short-form output.
+
+## Scope
+
+- **Vertical scene foundation** (PR #87, plan: vault `2026-07-12 -
+  Videorc Vertical Scene 9x16 Short Format Plan`): the
+  `vertical-1080x1920` output profile, aspect-preserving preview clamp,
+  stacked compositor arrangement, aspect-derived scene stage, docked
+  preview pillarbox cap, orientation⇄canvas coupling, legacy FFmpeg
+  vstack path, portrait recording smoke.
+- **Studio orientation modes** (PR #88, plan: vault `2026-07-12 -
+  Videorc Studio Orientation Modes Plan`): the preset family
+  (`vertical-camera-top` — renamed from `vertical` with serde/load
+  aliases — plus camera-bottom, split, screen-camera inset,
+  screen-only), mode derived from the preset orientation class, per-mode
+  last-scene memory at the layout commit point, cross-orientation live
+  blocker in both directions, the segmented Horizontal|Vertical toggle
+  in the Scenes header, mode-scoped galleries with portrait thumbs, and
+  smoke coverage recording real stacked + inset portrait artifacts.
+  Found and fixed in passing: both wire contracts hardcoded the original
+  four presets, so the main process retired the present pump on vertical
+  scenes (pre-existing since #84); the preset value lists are now
+  canonical in `shared/backend.ts`. The renderer eager-JS budget was
+  recalibrated to 1,950,000 raw (~2.5% headroom) with a follow-up task
+  to re-split the Studio dashboard chunks.
+
+## Release status
+
+- [x] Feature PRs merged via protected `main` (#87, #88); release prep
+      PR #89.
+- [x] Signed + notarized arm64 build (dist:release, staple verified by
+      release:validate:macos).
+- [x] Uploaded to R2; feed verified end-to-end
+      (`https://www.videorc.com/api/updates/latest-mac.yml` →
+      `version: 0.9.31`, artifact hashes present) and
+      `/api/changelog` serves the 0.9.31-beta.1 entry.
+- [x] Discord announcement posted (release:notify:discord).
+- [ ] Owner acceptance: flip the Studio to vertical, run each of the
+      five scenes by eye (band heights, split orientation, inset bubble
+      default, portrait thumbs, toggle feel in both themes), record one
+      real vertical short and upload it somewhere vertical-native.
+- [ ] Owner: X post (draft provided in session; posted manually).
+
+## Rollback
+
+Standard: re-upload the previous release's artifacts/manifest
+(0.9.30) per `docs/releases/release-runbook.md`; the feed is
+version-compared, so restoring the older manifest reverts updates.


### PR DESCRIPTION
Internal release record for 0.9.31-beta.1 (vertical Studio mode): signed+notarized build shipped, feed verified serving 0.9.31, changelog live, Discord announced. Owner acceptance checklist inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)