### PR TITLE
fix: teach the backend the vertical-1080x1920 video preset (0.9.31 wire bug)

### DIFF
--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -795,6 +795,8 @@ pub enum VideoPreset {
     StreamYoutube4k30,
     #[serde(rename = "stream-1080p60")]
     Stream1080p60,
+    #[serde(rename = "vertical-1080x1920")]
+    Vertical1080x1920,
     Custom,
 }
 
@@ -3334,6 +3336,17 @@ mod tests {
         assert_eq!(
             serde_json::to_value(VideoPreset::StreamYoutube4k30).unwrap(),
             serde_json::json!("stream-youtube-4k30")
+        );
+        // The 0.9.31 wire bug: the renderer's 'vertical-1080x1920' had no Rust
+        // variant, so entering vertical mode failed to deserialize. Pin BOTH
+        // directions so a renderer-only preset can never ship again.
+        assert_eq!(
+            serde_json::to_value(VideoPreset::Vertical1080x1920).unwrap(),
+            serde_json::json!("vertical-1080x1920")
+        );
+        assert_eq!(
+            serde_json::from_value::<VideoPreset>(serde_json::json!("vertical-1080x1920")).unwrap(),
+            VideoPreset::Vertical1080x1920
         );
     }
 

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -8464,6 +8464,15 @@ fn video_preset_defaults(preset: VideoPreset) -> VideoSettings {
             fps: 60,
             bitrate_kbps: 9000,
         },
+        // Mirrors videoPresets['vertical-1080x1920'] in capture.ts — the
+        // portrait canvas the vertical Studio mode applies.
+        VideoPreset::Vertical1080x1920 => VideoSettings {
+            preset,
+            width: 1080,
+            height: 1920,
+            fps: 30,
+            bitrate_kbps: 9000,
+        },
         VideoPreset::Custom => VideoSettings {
             preset,
             width: 1920,


### PR DESCRIPTION
## What broke

Updating to 0.9.31 and switching the Studio to vertical mode fails with:

> unknown variant `vertical-1080x1920`, expected one of `tutorial-1080p30`, …, `custom`

The renderer's `VideoPreset` union gained `'vertical-1080x1920'` (the canvas the vertical mode applies), but the **Rust `VideoPreset` enum** (`protocol.rs`) was never extended — every scene transaction carrying the vertical profile failed to deserialize at the WS boundary. The vertical **layout** presets were fully mirrored; the **video** preset enum was the one missed mirror. No gate caught it because the recording smokes send `preset: 'custom'` with explicit dimensions, so the new string never crossed the wire in CI.

## The fix

- `Vertical1080x1920` variant with `#[serde(rename = "vertical-1080x1920")]`
- `video_preset_defaults` arm: 1080×1920@30, 9000 kbps (mirrors `videoPresets['vertical-1080x1920']` in capture.ts — the exhaustive match made the compiler find this one)
- Both-direction serde pin test, with a comment naming this bug, so a renderer-only preset string can never ship silently again

## Verification

- Live repro against a dev backend: `scene.layout.apply_preview` with `video.preset: 'vertical-1080x1920'` — failed with the exact user-reported error on 0.9.31 code, now **APPLY-OK** (and the camera-blocker variant returns its honest message, proving we reach real validation past deserialization)
- `cargo test -p videorc-backend`: 1216 + 48 + 1 all green (including the flake this run), `clippy -D warnings`, `cargo fmt --check`

Follow-up worth considering (not in this patch): a script-level contract test that diffs the TS `videoPresets` keys against the Rust enum's serde names so the two unions cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a vertical 1080×1920 video preset.
  * Vertical recordings use 30 fps and a 9000 kbps bitrate.
  * Added support for saving and loading the new preset correctly.

* **Tests**
  * Added coverage for vertical preset serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->