### PR TITLE
Release 0.9.32-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.32-beta.1.md
+++ b/changelog/0.9.32-beta.1.md
@@ -1,0 +1,21 @@
+---
+version: 0.9.32-beta.1
+date: 2026-07-12
+channel: beta
+title: Vertical mode fixed — switching to 9:16 works again
+summary: A patch for 0.9.31 — switching the Studio into vertical mode failed with a settings error for every updated user; the vertical canvas profile is now understood end to end.
+highlights:
+  - Switching to vertical mode no longer fails with an "unknown variant" settings error.
+  - The vertical 1080×1920 canvas profile is recognized everywhere, including saved settings.
+---
+
+## The fix
+
+0.9.31 introduced the vertical Studio mode, but switching into it failed
+with a settings error ("unknown variant `vertical-1080x1920`") — the app's
+recording engine didn't recognize the new vertical canvas profile the
+interface applies. That mismatch is fixed and now guarded by tests in both
+directions, so the vertical mode works as announced: flip to vertical,
+record your 9:16 short, flip back.
+
+If you hit the error on 0.9.31, just update — no settings changes needed.


### PR DESCRIPTION
Patch release: 0.9.31 → 0.9.32. Ships #91 — switching to vertical mode failed for every updated user with `unknown variant 'vertical-1080x1920'` (the Rust VideoPreset enum was missing the vertical canvas profile). `pnpm changelog:check`: 33 entries valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error when switching to vertical Studio mode.
  * Added support for the vertical 1080×1920 (9:16) canvas profile, including saved settings.
  * Improved switching between horizontal and vertical modes.

* **Documentation**
  * Added release notes for version 0.9.32-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->