### PR TITLE
Record the 0.9.32-beta.1 release (vertical wire fix)

### DIFF
--- a/docs/releases/0.9.32.md
+++ b/docs/releases/0.9.32.md
@@ -1,0 +1,36 @@
+# Videorc 0.9.32 Beta 1
+
+Patch release: the 0.9.31 vertical Studio mode failed for every updated
+user the moment they switched into it.
+
+## Scope
+
+- **Vertical video-preset wire fix** (PR #91): the renderer's
+  `'vertical-1080x1920'` VideoPreset had no Rust enum variant, so every
+  scene transaction carrying the vertical canvas failed to deserialize
+  with `unknown variant 'vertical-1080x1920'`. Added the variant, the
+  `video_preset_defaults` arm (1080×1920@30, 9000 kbps), and a
+  both-direction serde pin named after this bug.
+- Why no gate caught it: the recording smokes send `preset: 'custom'`
+  with explicit dimensions, so the preset string never crossed the wire
+  in CI. Follow-up worth doing: a script-level contract test diffing the
+  TS `videoPresets` keys against the Rust enum serde names.
+
+## Release status
+
+- [x] Fix merged via protected `main` (#91); prep PR #92 (one
+      hosted-runner rerun: `intermittent_pipe_pressure_...` timing flake).
+- [x] Built from `de76fca9` detached at origin/main; signed + notarized
+      (app + DMG), `release:validate:macos` PASS, uploaded to R2.
+- [x] Feed serves `version: 0.9.32` through the www redirect;
+      `/api/changelog` serves 0.9.32-beta.1 (33 entries).
+- [x] Discord announced (dry-run previewed first).
+- [x] Live-repro verified pre-ship: `scene.layout.apply_preview` with the
+      vertical profile fails on 0.9.31 code, APPLY-OK on the fix.
+
+## Owner acceptance checklist (by-eye, macOS)
+
+- [ ] Update from 0.9.31, switch the Studio to vertical mode: no error,
+      canvas flips to 1080×1920.
+- [ ] Record a short vertical clip; switch back to horizontal — the
+      landscape profile returns.


### PR DESCRIPTION
Internal release record for the 0.9.32 patch: built from de76fca9, signed + notarized, uploaded, feed verified serving 0.9.32, Discord announced. Documents the root cause (renderer-only VideoPreset string) and the CI gap (smokes use preset custom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent switching to vertical Studio mode.
  * Improved handling of the 1080×1920 video preset to avoid scene transaction errors.

* **Documentation**
  * Added release notes for Videorc 0.9.32 Beta 1, including fix details, release status, and acceptance checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->