### PR TITLE
Release 0.9.33-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.33-beta.1.md
+++ b/changelog/0.9.33-beta.1.md
@@ -1,0 +1,20 @@
+---
+version: 0.9.33-beta.1
+date: 2026-07-12
+channel: beta
+title: Vertical mode preview fixed — the docked preview is truly 9:16
+summary: A follow-up patch for vertical mode — the preview sticked into the Studio now shows a real 9:16 portrait picture instead of a stretched one.
+highlights:
+  - The docked preview in vertical mode is now a true 9:16 portrait picture, centered on its strip — no more stretching.
+  - Horizontal mode's docked preview is unchanged, pixel for pixel.
+---
+
+## The fix
+
+With 0.9.32's vertical mode working end to end, one visual bug remained:
+sticking the preview into the Studio while in vertical mode showed the
+portrait picture stretched across a widescreen strip. The docked preview
+now gives the portrait canvas a true 9:16 frame, centered on the black
+strip, so what you see is exactly what records — camera band and screen
+in their real proportions. Pop the preview out and the window is
+portrait, as before.


### PR DESCRIPTION
Patch: 0.9.32 → 0.9.33. Ships #94 — the docked preview in vertical mode now renders a true 9:16 slot instead of stretching across the landscape strip. `pnpm changelog:check`: 34 entries valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vertical-mode docked previews with a correctly proportioned 9:16 portrait canvas centered within the preview strip.
  - Prevented vertical previews from appearing stretched in widescreen format.
  - Horizontal-mode docked previews remain unchanged.

- **Release**
  - Updated the desktop app version to 0.9.33.
  - Added release notes for beta version 0.9.33-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->