### PR TITLE
Record the 0.9.33-beta.1 release (docked preview 9:16 slot)

### DIFF
--- a/docs/releases/0.9.33.md
+++ b/docs/releases/0.9.33.md
@@ -1,0 +1,32 @@
+# Videorc 0.9.33 Beta 1
+
+Patch release: the vertical mode's docked preview rendered stretched.
+
+## Scope
+
+- **Docked preview true 9:16 slot** (PR #94): the docked slot kept a
+  16:9 shape (the landscape-footprint cap) while the native surface
+  carried the portrait canvas, so gluing the 9:16 surface over the 16:9
+  slot stretched the picture. The strip and slot are now separate: the
+  charcoal strip keeps the landscape footprint (Studio column height
+  unchanged), the slot carries the real canvas aspect and centers
+  inside it. Landscape docked preview is pixel-identical.
+
+## Release status
+
+- [x] Fix merged via protected `main` (#94); prep PR #95 (CI clean,
+      no reruns needed).
+- [x] Built from `520f9c74` detached at origin/main; signed + notarized
+      (app + DMG), `release:validate:macos` PASS, uploaded to R2.
+- [x] Feed serves `version: 0.9.33` through the www redirect;
+      `/api/changelog` serves 0.9.33-beta.1 (34 entries).
+- [x] Discord announced (dry-run previewed first).
+- [x] `pnpm probe:preview-window` PASS against the new slot markup
+      before merge.
+
+## Owner acceptance checklist (by-eye, macOS)
+
+- [ ] Update to 0.9.33, switch to vertical mode, stick the preview:
+      a centered true-9:16 picture on the black strip, camera/screen
+      bands in real proportion.
+- [ ] Switch to horizontal, stick the preview: identical to 0.9.32.


### PR DESCRIPTION
Internal release record: built from 520f9c74, signed + notarized, uploaded, feed verified serving 0.9.33, Discord announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stretched content in the docked preview when using vertical mode.
  * Portrait previews now maintain their correct aspect ratio and remain centered.
  * Improved transitions between vertical and horizontal preview modes.

* **Release**
  * Added the Videorc 0.9.33 Beta 1 release notes and validation checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->