### PR TITLE
fix: vertical scenes fill their bands — cover-crop, never letterbox

### DIFF
--- a/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
@@ -410,18 +410,30 @@ export function LayoutTab(): ReactElement {
               ) : null}
 
               <span className="pt-2 text-[12.5px] leading-none font-medium text-subtle">Lens</span>
-              <Field>
-                <FieldLabel>Fit</FieldLabel>
-                <ToggleGroup
-                  type="single"
-                  value={layout.cameraFit}
-                  variant="outline"
-                  onValueChange={(value) => value && patchLayout({ cameraFit: value as CameraFit })}
-                >
-                  <ToggleGroupItem value="fill">Fill crop</ToggleGroupItem>
-                  <ToggleGroupItem value="fit">Fit frame</ToggleGroupItem>
-                </ToggleGroup>
-              </Field>
+              {/* Vertical bands ALWAYS fill and crop — a "Fit frame" band would
+                  letterbox the short-form frame (2026-07-13 fill-crop plan), so
+                  the toggle is hidden and honest copy replaces it. Zoom and pan
+                  below still frame the crop. */}
+              {isVerticalStack ? (
+                <p className="text-sm text-muted-foreground">
+                  The camera band always fills and crops. Use zoom and pan to frame yourself.
+                </p>
+              ) : (
+                <Field>
+                  <FieldLabel>Fit</FieldLabel>
+                  <ToggleGroup
+                    type="single"
+                    value={layout.cameraFit}
+                    variant="outline"
+                    onValueChange={(value) =>
+                      value && patchLayout({ cameraFit: value as CameraFit })
+                    }
+                  >
+                    <ToggleGroupItem value="fill">Fill crop</ToggleGroupItem>
+                    <ToggleGroupItem value="fit">Fit frame</ToggleGroupItem>
+                  </ToggleGroup>
+                </Field>
+              )}
 
               <Field orientation="horizontal">
                 <FieldContent>

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -30,7 +30,7 @@ use crate::preview_screen::{
     preview_screen_frame_source, try_preview_screen_frame_source,
 };
 use crate::protocol::{
-    BackgroundFit, CameraFit, CameraShape, CompositorBackend, CompositorFramePipelineStatus,
+    BackgroundFit, CameraShape, CompositorBackend, CompositorFramePipelineStatus,
     CompositorFrameReady, CompositorImageCacheStatus, CompositorSceneSourceFit,
     CompositorSceneSourceKind, CompositorSceneSourceStatus, CompositorSceneUpdateParams,
     CompositorSourceKind, CompositorSourceStatus, CompositorState, CompositorStatus,
@@ -2528,7 +2528,10 @@ fn try_gpu_compose(
                         frame.width,
                         frame.height,
                         rect,
-                        matches!(layout.camera_fit, CameraFit::Fit) && layout.camera_zoom <= 100,
+                        matches!(
+                            scene_source_fit(&SceneSourceKind::Camera, layout),
+                            SceneFit::Contain
+                        ),
                         source_crop,
                         inputs.width,
                         inputs.height,
@@ -2554,7 +2557,10 @@ fn try_gpu_compose(
                         placeholder.width as u32,
                         placeholder.height as u32,
                         rect,
-                        matches!(layout.camera_fit, CameraFit::Fit) && layout.camera_zoom <= 100,
+                        matches!(
+                            scene_source_fit(&SceneSourceKind::Camera, layout),
+                            SceneFit::Contain
+                        ),
                         source_crop,
                         inputs.width,
                         inputs.height,
@@ -3500,8 +3506,10 @@ fn render_compositor_yuv420p_scene(inputs: CompositorRenderInputs<'_>, bytes: &m
                     rect,
                     SourceRenderOptions {
                         crop: scene_crop_from_transform(&transform),
-                        contain: matches!(snapshot.layout.camera_fit, CameraFit::Fit)
-                            && snapshot.layout.camera_zoom <= 100,
+                        contain: matches!(
+                            scene_source_fit(&SceneSourceKind::Camera, &snapshot.layout),
+                            SceneFit::Contain
+                        ),
                         mirror_x: snapshot.layout.camera_mirror,
                         mask: camera_mask(&snapshot.layout),
                     },
@@ -7499,6 +7507,95 @@ mod tests {
         assert_eq!(y_at(&bytes, 100, 50, 50), blue_y);
         assert_eq!(y_at(&bytes, 100, 89, 89), blue_y);
         assert_eq!(y_at(&bytes, 100, 90, 90), red_y);
+    }
+
+    #[test]
+    fn vertical_bands_fill_without_letterbox() {
+        // The 2026-07-13 owner report: vertical bands rendered their landscape
+        // sources contain-fit — thin strips with black above and below. Bands
+        // must COVER: every row inside both bands carries source pixels, even
+        // with the user's camera Fit preference set (bands ignore it).
+        let mut layout = crate::protocol::default_layout_settings();
+        layout.layout_preset = LayoutPreset::VerticalCameraTop;
+        layout.camera_fit = crate::protocol::CameraFit::Fit;
+        let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            sources: crate::protocol::SourceSelection {
+                screen_id: Some("screen:screencapturekit:1".to_string()),
+                window_id: None,
+                camera_id: Some("camera:avfoundation:0".to_string()),
+                microphone_id: None,
+                test_pattern: false,
+            },
+            layout: layout.clone(),
+            video: Some(VideoSettings {
+                preset: VideoPreset::Custom,
+                width: 90,
+                height: 160,
+                fps: 30,
+                bitrate_kbps: 2000,
+            }),
+            background: None,
+            protected_overlay_window_ids: Vec::new(),
+        });
+        let snapshot = CompositorSceneSnapshot {
+            revision: 1,
+            scene: Some(scene),
+            layout,
+            active_screen: None,
+        };
+        // Landscape sources into portrait bands: red camera, blue screen (BGRA).
+        let camera_frame = Arc::new(crate::frame_store::StoredFrame {
+            sequence: 1,
+            width: 160,
+            height: 90,
+            pixel_format: PreviewCameraPixelFormat::Bgra8,
+            metadata: (),
+            bytes: [0, 0, 255, 255].repeat(160 * 90),
+            source_iosurface: None,
+            source_pixel_buffer: None,
+            recycle_pool: None,
+            captured_at: Instant::now(),
+        });
+        let screen_frame = Arc::new(crate::frame_store::StoredFrame {
+            sequence: 1,
+            width: 160,
+            height: 90,
+            pixel_format: PreviewScreenPixelFormat::Bgra8,
+            metadata: (),
+            bytes: [255, 0, 0, 255].repeat(160 * 90),
+            source_iosurface: None,
+            source_pixel_buffer: None,
+            recycle_pool: None,
+            captured_at: Instant::now(),
+        });
+        let mut bytes = vec![0; raw_yuv420p_len(90, 160)];
+
+        render_compositor_yuv420p_frame(
+            CompositorRenderInputs {
+                sequence: 1,
+                width: 90,
+                height: 160,
+                snapshot: Some(&snapshot),
+                active_image_source: None,
+                background_image_source: None,
+                camera_frame: Some(&camera_frame),
+                screen_frame: Some(&screen_frame),
+                caption_overlay: None,
+                highlight_overlay: None,
+            },
+            &mut bytes,
+        );
+
+        let (red_y, _, _) = rgb_to_yuv(255, 0, 0);
+        let (blue_y, _, _) = rgb_to_yuv(0, 0, 255);
+        // Camera band = rows 0..64 (40% of 160). Edge rows carry camera, not black.
+        assert_eq!(y_at(&bytes, 90, 45, 2), red_y, "camera band top edge");
+        assert_eq!(y_at(&bytes, 90, 45, 60), red_y, "camera band bottom edge");
+        assert_eq!(y_at(&bytes, 90, 2, 30), red_y, "camera band left edge");
+        // Screen band = rows 64..160. Edge rows carry screen, not black.
+        assert_eq!(y_at(&bytes, 90, 45, 68), blue_y, "screen band top edge");
+        assert_eq!(y_at(&bytes, 90, 45, 156), blue_y, "screen band bottom edge");
+        assert_eq!(y_at(&bytes, 90, 87, 120), blue_y, "screen band right edge");
     }
 
     #[test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -7602,8 +7602,16 @@ fn video_filter(
         return vertical_video_filter(camera_input_index, params, preview, &bands);
     }
 
+    // Full-frame vertical scenes cover the portrait canvas (fill + crop);
+    // horizontal full-frame scenes keep contain+pad so UI edges survive.
+    let vertical_full_frame = matches!(
+        params.layout.layout_preset,
+        LayoutPreset::VerticalScreenCamera | LayoutPreset::VerticalScreenOnly
+    );
     let base_scale = if preview {
         "scale=w=960:h=-2".to_string()
+    } else if vertical_full_frame {
+        cover_scale_filter(&params.output.video)
     } else {
         output_scale_filter(&params.output.video)
     };
@@ -7732,11 +7740,12 @@ fn vertical_video_filter(
     let (camera_height, screen_height) = vertical_band_heights(video.height, bands.camera_fraction);
     let fps = video.fps;
 
-    // Screen CONTAINS in its band (nothing on the user's screen may be cropped
-    // away) and pads with black; the camera band fills via the shared camera
-    // frame filter (fit/fill/zoom preserved).
+    // Short-form bands are FILLED (2026-07-13 fill-crop plan): the screen
+    // covers its band (scale to fill + center crop, mirroring the compositor's
+    // vertical fit) and the camera band always fills too — the user's Fit
+    // preference must not letterbox a band (zoom/pan still frame the crop).
     let screen = format!(
-        "[0:v]setpts=PTS-STARTPTS,scale={width}:{screen_height}:force_original_aspect_ratio=decrease,pad={width}:{screen_height}:(ow-iw)/2:(oh-ih)/2:color=black,fps={fps},format=yuv420p[vt_screen]"
+        "[0:v]setpts=PTS-STARTPTS,scale={width}:{screen_height}:force_original_aspect_ratio=increase,crop={width}:{screen_height},fps={fps},format=yuv420p[vt_screen]"
     );
     let camera = match camera_input_index {
         Some(index) => {
@@ -7745,7 +7754,9 @@ fn vertical_video_filter(
             } else {
                 ""
             };
-            let frame = camera_frame_filter(width, camera_height, &params.layout);
+            let mut band_layout = params.layout.clone();
+            band_layout.camera_fit = CameraFit::Fill;
+            let frame = camera_frame_filter(width, camera_height, &band_layout);
             format!(
                 "[{index}:v]setpts=PTS-STARTPTS,{mirror}{frame},fps={fps},format=yuv420p[vt_camera]"
             )
@@ -7766,6 +7777,15 @@ fn vertical_video_filter(
 fn output_scale_filter(video: &VideoSettings) -> String {
     format!(
         "scale=w={}:h={}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2",
+        video.width, video.height, video.width, video.height
+    )
+}
+
+/// Cover variant for full-frame vertical scenes: fill the portrait canvas and
+/// center-crop instead of padding — short-form output carries no letterbox.
+fn cover_scale_filter(video: &VideoSettings) -> String {
+    format!(
+        "scale=w={}:h={}:force_original_aspect_ratio=increase,crop={}:{}",
         video.width, video.height, video.width, video.height
     )
 }
@@ -11413,22 +11433,24 @@ mod tests {
     }
 
     #[test]
-    fn vertical_filter_stacks_camera_band_over_padded_screen() {
+    fn vertical_filter_stacks_camera_band_over_covered_screen() {
         let mut params = base_params(true, false);
         params.layout.layout_preset = LayoutPreset::VerticalCameraTop;
         params.output.video.width = 1080;
         params.output.video.height = 1920;
 
         let filter = video_filter(Some(1), &params, false);
-        // Camera band on top, screen below; screen pads (contains), never crops.
+        // Camera band on top, screen below; both bands COVER — fill + center
+        // crop, never letterboxed (2026-07-13 fill-crop plan).
         assert!(
             filter.contains("[vt_camera][vt_screen]vstack=inputs=2"),
             "stacked filter: {filter}"
         );
         assert!(
-            filter.contains("pad=1080:1152"),
-            "screen contains: {filter}"
+            filter.contains("scale=1080:1152:force_original_aspect_ratio=increase,crop=1080:1152"),
+            "screen covers: {filter}"
         );
+        assert!(!filter.contains("pad="), "no letterbox pad: {filter}");
         assert!(!filter.contains("overlay"));
 
         // Without a camera input the band renders black instead of collapsing.
@@ -11447,14 +11469,14 @@ mod tests {
         params.output.video.height = 1920;
 
         let filter = video_filter(Some(1), &params, false);
-        // Screen band on top, camera below — the mirrored stack.
+        // Screen band on top, camera below — the mirrored stack; bands cover.
         assert!(
             filter.contains("[vt_screen][vt_camera]vstack=inputs=2"),
             "stacked filter: {filter}"
         );
         assert!(
-            filter.contains("pad=1080:1152"),
-            "screen contains: {filter}"
+            filter.contains("scale=1080:1152:force_original_aspect_ratio=increase,crop=1080:1152"),
+            "screen covers: {filter}"
         );
         assert!(!filter.contains("overlay"));
     }
@@ -11467,12 +11489,15 @@ mod tests {
         params.output.video.height = 1920;
 
         let filter = video_filter(Some(1), &params, false);
-        // 50/50: screen contains in the top 960, camera fills the bottom 960.
+        // 50/50: both halves cover their 960 bands.
         assert!(
             filter.contains("[vt_screen][vt_camera]vstack=inputs=2"),
             "stacked filter: {filter}"
         );
-        assert!(filter.contains("pad=1080:960"), "screen contains: {filter}");
+        assert!(
+            filter.contains("scale=1080:960:force_original_aspect_ratio=increase,crop=1080:960"),
+            "screen covers: {filter}"
+        );
         let no_camera = video_filter(None, &params, false);
         assert!(
             no_camera.contains("color=c=black:s=1080x960"),
@@ -11482,8 +11507,9 @@ mod tests {
 
     #[test]
     fn vertical_screen_camera_filter_rides_the_overlay_path() {
-        // The inset scene composes exactly like screen-camera: full-canvas
-        // screen (contained) with the camera overlaid at the user's corner.
+        // The inset scene composes like screen-camera — full-canvas screen
+        // with the camera overlaid — but the portrait screen COVERS the
+        // canvas (fill + crop): short-form output carries no letterbox.
         let mut params = base_params(true, false);
         params.layout.layout_preset = LayoutPreset::VerticalScreenCamera;
         params.output.video.width = 1080;
@@ -11493,8 +11519,10 @@ mod tests {
         assert!(filter.contains("overlay=x="), "overlay path: {filter}");
         assert!(!filter.contains("vstack"), "no stacking: {filter}");
         assert!(
-            filter.contains("scale=w=1080:h=1920:force_original_aspect_ratio=decrease"),
-            "portrait contain: {filter}"
+            filter.contains(
+                "scale=w=1080:h=1920:force_original_aspect_ratio=increase,crop=1080:1920"
+            ),
+            "portrait cover: {filter}"
         );
     }
 
@@ -11511,8 +11539,10 @@ mod tests {
         assert!(!filter.contains("overlay"), "no overlay: {filter}");
         assert!(!filter.contains("vstack"), "no stacking: {filter}");
         assert!(
-            filter.contains("scale=w=1080:h=1920:force_original_aspect_ratio=decrease"),
-            "portrait contain: {filter}"
+            filter.contains(
+                "scale=w=1080:h=1920:force_original_aspect_ratio=increase,crop=1080:1920"
+            ),
+            "portrait cover: {filter}"
         );
     }
 

--- a/crates/videorc-backend/src/scene_geometry.rs
+++ b/crates/videorc-backend/src/scene_geometry.rs
@@ -163,12 +163,40 @@ pub fn scene_crop_from_transform(transform: &SceneTransform) -> SceneCrop {
     }
 }
 
+/// True for every vertical-mode preset: their regions are short-form bands
+/// that must be FILLED — internal letterboxing is the bug (owner report,
+/// 2026-07-13 fill-crop plan), not a fidelity feature.
+fn vertical_fill_preset(preset: &LayoutPreset) -> bool {
+    matches!(
+        preset,
+        LayoutPreset::VerticalCameraTop
+            | LayoutPreset::VerticalCameraBottom
+            | LayoutPreset::VerticalSplit
+            | LayoutPreset::VerticalScreenCamera
+            | LayoutPreset::VerticalScreenOnly
+    )
+}
+
 /// The shared fit policy for source status, FFmpeg filters, CPU blits, and
-/// Metal placement. Side-by-side intentionally covers its narrow screen region;
-/// all full-frame screen/window presets contain so UI edges are never cropped.
+/// Metal placement. Side-by-side and ALL vertical presets cover their regions
+/// (short-form bands are filled, center-cropped — never letterboxed); the
+/// horizontal full-frame screen/window presets contain so UI edges are never
+/// cropped. Vertical BAND cameras cover unconditionally — a contain camera
+/// band letterboxes exactly like the reported bug; zoom/pan still frame the
+/// crop. The vertical screen+camera inset bubble keeps the user's Fit choice
+/// like its horizontal twin.
 pub fn scene_source_fit(kind: &SceneSourceKind, layout: &LayoutSettings) -> SceneFit {
     match kind {
         SceneSourceKind::Camera => {
+            let band_camera = matches!(
+                layout.layout_preset,
+                LayoutPreset::VerticalCameraTop
+                    | LayoutPreset::VerticalCameraBottom
+                    | LayoutPreset::VerticalSplit
+            );
+            if band_camera {
+                return SceneFit::Cover;
+            }
             if matches!(layout.camera_fit, CameraFit::Fit) && layout.camera_zoom <= 100 {
                 SceneFit::Contain
             } else {
@@ -176,7 +204,9 @@ pub fn scene_source_fit(kind: &SceneSourceKind, layout: &LayoutSettings) -> Scen
             }
         }
         SceneSourceKind::Screen | SceneSourceKind::Window => {
-            if matches!(layout.layout_preset, LayoutPreset::SideBySide) {
+            if matches!(layout.layout_preset, LayoutPreset::SideBySide)
+                || vertical_fill_preset(&layout.layout_preset)
+            {
                 SceneFit::Cover
             } else {
                 SceneFit::Contain
@@ -436,44 +466,71 @@ mod tests {
 
     #[test]
     fn preset_fit_and_mask_policy_table_is_renderer_independent() {
+        // Columns: preset, screen fit, camera fit (with CameraFit::Fit set —
+        // band cameras must IGNORE it and cover), mask. Every vertical preset
+        // covers its regions: short-form bands are filled, never letterboxed
+        // (2026-07-13 fill-crop plan, owner report).
         let cases = [
             (
                 LayoutPreset::ScreenCamera,
                 SceneFit::Contain,
+                SceneFit::Contain,
                 SceneMask::Rounded { radius_pct: 12 },
             ),
-            (LayoutPreset::ScreenOnly, SceneFit::Contain, SceneMask::None),
-            (LayoutPreset::CameraOnly, SceneFit::Contain, SceneMask::None),
-            (LayoutPreset::SideBySide, SceneFit::Cover, SceneMask::None),
-            // Vertical family: the inset twin masks exactly like ScreenCamera;
-            // the banded scenes keep a rectangular camera and CONTAIN screens.
+            (
+                LayoutPreset::ScreenOnly,
+                SceneFit::Contain,
+                SceneFit::Contain,
+                SceneMask::None,
+            ),
+            (
+                LayoutPreset::CameraOnly,
+                SceneFit::Contain,
+                SceneFit::Contain,
+                SceneMask::None,
+            ),
+            (
+                LayoutPreset::SideBySide,
+                SceneFit::Cover,
+                SceneFit::Contain,
+                SceneMask::None,
+            ),
+            // The inset twin masks exactly like ScreenCamera and keeps the
+            // user's camera Fit for its bubble; its SCREEN covers the frame.
             (
                 LayoutPreset::VerticalScreenCamera,
+                SceneFit::Cover,
                 SceneFit::Contain,
                 SceneMask::Rounded { radius_pct: 12 },
             ),
             (
                 LayoutPreset::VerticalCameraTop,
-                SceneFit::Contain,
+                SceneFit::Cover,
+                SceneFit::Cover,
                 SceneMask::None,
             ),
             (
                 LayoutPreset::VerticalCameraBottom,
-                SceneFit::Contain,
+                SceneFit::Cover,
+                SceneFit::Cover,
                 SceneMask::None,
             ),
             (
                 LayoutPreset::VerticalSplit,
-                SceneFit::Contain,
+                SceneFit::Cover,
+                SceneFit::Cover,
                 SceneMask::None,
             ),
+            // Screen-only scenes never render a camera; the camera column
+            // just documents the fallthrough (user Fit honored, moot here).
             (
                 LayoutPreset::VerticalScreenOnly,
+                SceneFit::Cover,
                 SceneFit::Contain,
                 SceneMask::None,
             ),
         ];
-        for (preset, expected_screen_fit, expected_mask) in cases {
+        for (preset, expected_screen_fit, expected_camera_fit, expected_mask) in cases {
             let mut layout = layout();
             layout.layout_preset = preset.clone();
             layout.camera_shape = CameraShape::Rounded;
@@ -482,6 +539,11 @@ mod tests {
                 scene_source_fit(&SceneSourceKind::Screen, &layout),
                 expected_screen_fit,
                 "screen fit for {preset:?}"
+            );
+            assert_eq!(
+                scene_source_fit(&SceneSourceKind::Camera, &layout),
+                expected_camera_fit,
+                "camera fit for {preset:?}"
             );
             assert_eq!(camera_mask(&layout), expected_mask, "mask for {preset:?}");
         }


### PR DESCRIPTION
## What broke

Owner report with screenshot on 0.9.33: in vertical mode the camera and screen render as thin letterboxed strips inside their bands — black above and below — in the preview AND the recording. Both bands contain-fit their landscape sources; a 16:9 screen in the 1080×1152 band drew at 1080×608.

## The law this PR encodes

**Vertical bands are always filled** (cover: scale to fill + center crop). Horizontal scenes keep their "never crop the user's screen" contain rules untouched.

## Changes

- **`scene_geometry::scene_source_fit`** — the single fit authority (CPU + Metal + preview all flow through it): screens/windows cover in all five vertical presets; stacked-band cameras cover unconditionally (the Fit preference must not letterbox a band — zoom/pan still frame the crop); the vertical Screen + camera inset bubble keeps the user's Fit like its horizontal twin. Truth-table test covers every preset × source kind.
- **Compositor** — three direct `camera_fit` checks bypassed the central policy (a second letterbox gate the new pixel test caught); they now route through `scene_source_fit`. New **letterbox-detector pixel test**: VerticalCameraTop on a portrait canvas with landscape sources, asserting band-edge pixels carry source color — fails on the previous code.
- **Legacy FFmpeg path** — vertical stack screen legs `pad` → centered `crop`; camera band legs always fill; full-frame vertical scenes use a new `cover_scale_filter` instead of contain+pad. All five vertical filter tests flipped from `pad=` pins to cover pins.
- **Layout tab** — the camera Fit toggle is hidden for the stacked vertical scenes ("The camera band always fills and crops. Use zoom and pan to frame yourself."); horizontal + vertical inset keep it.

Note on the smoke letterbox check the plan floated: the recording smoke's synthetic source is kind `test-pattern`, which is always Cover — a frame check there could not detect this bug class, so the compositor pixel test with real Screen/Camera kinds is the detector (the plan's stated fallback).

## Gates

- Fit truth table + letterbox pixel test (fails pre-fix), cargo **1219+48+1** green, `clippy -D warnings`, `cargo fmt`
- `pnpm typecheck` / lint / format, desktop tests **1001/1001**
- `pnpm smoke:dev` — all-layout recording, **7/7 quality PASS** including the vertical 720×1280 portrait artifact

## Owner by-eye after merge

Vertical mode with a real camera: both bands edge-to-edge, no black inside the frame; preview matches the recording; Screen-only vertical shows the middle of your screen (cover crops the sides — the format's nature); horizontal scenes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated vertical camera layouts so camera bands always fill their regions and crop as needed.
  - Replaced the Fit control with guidance text for vertical stacked layouts.
  - Preserved the Fit control for other layouts.

- **Bug Fixes**
  - Removed unwanted black letterboxing in vertical camera and screen layouts.
  - Standardized fill-and-crop behavior across rendering and recording paths.
  - Improved consistency across vertical layout presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->