### PR TITLE
Release 0.9.34-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.33",
+  "version": "0.9.34",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.34-beta.1.md
+++ b/changelog/0.9.34-beta.1.md
@@ -1,0 +1,28 @@
+---
+version: 0.9.34-beta.1
+date: 2026-07-13
+channel: beta
+title: Vertical scenes now fill the frame — no more black bars
+summary: Vertical mode's camera and screen now fill their sections edge to edge, cropped like every short-form app — no black bars above or below, in the preview and in the recording.
+highlights:
+  - Camera and screen fill their sections of the vertical frame edge to edge — scaled and cropped, never letterboxed.
+  - The preview and the recording now show exactly the same framing.
+  - In the stacked vertical scenes, use camera zoom and pan to frame yourself inside the crop.
+---
+
+## Vertical frames, actually full
+
+Vertical mode drew your camera and screen as thin strips with black
+above and below — technically accurate, completely wrong for shorts.
+Every vertical scene now fills its sections the way short-form apps do:
+scaled to fill and center-cropped, edge to edge, with zero letterboxing.
+This applies to the whole pipeline, so the docked preview, the popped-out
+preview, and the recorded file all show the same framing.
+
+In the stacked scenes (Camera top, Camera bottom, Split) the camera band
+always fills — the Fit toggle no longer applies there; use zoom and pan
+to frame yourself inside the crop. The vertical Screen + camera scene
+keeps your camera Fit choice for its floating bubble, and its screen now
+fills the portrait canvas (which crops the sides of a widescreen display
+— that's the nature of the format; horizontal mode remains the
+see-everything view).


### PR DESCRIPTION
Patch: 0.9.33 → 0.9.34. Ships #97 — vertical scenes now cover-crop their bands (no letterboxing) in preview and recording. `pnpm changelog:check`: 35 entries valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Vertical mode framing with edge-to-edge camera and screen rendering.
  * Removed black bars by applying center-cropping across previews and recorded output.
  * Updated Vertical stacked scenes to fill the camera area; use zoom and pan for framing.
  * Preserved camera Fit settings for the floating “Screen + camera” bubble while cropping the screen to fill the portrait canvas.

* **Release**
  * Updated the desktop app to version 0.9.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->