### PR TITLE
Prepare YouTube OAuth for Google verification

### DIFF
--- a/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
@@ -25,6 +25,7 @@ import { PanelSection } from '@/components/panel-section'
 import { CaptionsControls } from '@/components/captions/captions-controls'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -75,6 +76,7 @@ import { streamingDestinationEnableGate, type EntitlementUiGate } from '@/lib/en
 import { entitlementDisabledReason } from '@/lib/entitlements'
 import { streamKeyPlatformMismatch, streamKeyTailHint } from '@/lib/stream-key-format'
 import { cn } from '@/lib/utils'
+import { VIDEORC_WEB_LINKS } from '@/lib/videorc-web-links'
 
 type BadgeTone = 'success' | 'warning' | 'destructive' | 'outline'
 
@@ -390,7 +392,9 @@ function DestinationCard({
   const ready = isStreamTargetReady(target)
   const fullUrl = target.urlMode === 'full-url'
   const nativeDestination = target.platform !== 'custom'
-  const oauthUnavailableMessage = oauthUnavailableReason(target.platform)
+  const oauthUnavailableMessage =
+    oauthUnavailableReason(target.platform) ??
+    (credentials?.ready === false ? credentials.message : null)
   const oauthMode = nativeDestination && target.authMode === 'oauth' && !oauthUnavailableMessage
   // While a session is live the runtime status (on air / stopped / skipped) takes
   // over the badge; otherwise it reflects the saved-credential readiness.
@@ -908,31 +912,113 @@ function OAuthAccountPanel({
   onSelectYouTubeChannel: (channelId: string, accountId?: string) => Promise<void>
   onUseManualRtmp: () => void
 }): ReactElement {
+  const [youtubeConsentOpen, setYoutubeConsentOpen] = useState(false)
+  const [youtubeConsentAccepted, setYoutubeConsentAccepted] = useState(false)
+
   if (!account) {
     const connectDisabled = disabled || credentials?.ready === false
     return (
-      <div className="flex flex-col gap-2 rounded-row border bg-muted/30 p-3">
-        <div className="flex items-center justify-between gap-3">
-          <span className="text-sm font-medium">No account connected</span>
-          <Button
-            disabled={connectDisabled}
-            size="sm"
-            variant="secondary"
-            onClick={() => onConnect(platform)}
-          >
-            <LinkSimple data-icon="inline-start" weight="bold" />
-            Connect
-          </Button>
+      <>
+        <div className="flex flex-col gap-2 rounded-row border bg-muted/30 p-3">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium">No account connected</span>
+            <Button
+              disabled={connectDisabled}
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                if (platform === 'youtube') {
+                  setYoutubeConsentAccepted(false)
+                  setYoutubeConsentOpen(true)
+                } else {
+                  onConnect(platform)
+                }
+              }}
+            >
+              <LinkSimple data-icon="inline-start" weight="bold" />
+              Connect
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {credentials?.message ?? 'Uses backend provider credentials.'}
+          </p>
+          {credentials ? (
+            <Badge className="w-fit" variant={credentials.ready ? 'outline' : 'warning'}>
+              {credentialSourceLabel(credentials)}
+            </Badge>
+          ) : null}
         </div>
-        <p className="text-xs text-muted-foreground">
-          {credentials?.message ?? 'Uses backend provider credentials.'}
-        </p>
-        {credentials ? (
-          <Badge className="w-fit" variant={credentials.ready ? 'outline' : 'warning'}>
-            {credentialSourceLabel(credentials)}
-          </Badge>
+
+        {platform === 'youtube' ? (
+          <Dialog open={youtubeConsentOpen} onOpenChange={setYoutubeConsentOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Connect YouTube to Videorc</DialogTitle>
+                <DialogDescription>
+                  Videorc uses YouTube API Services to identify your channel and manage your live
+                  broadcasts and chat. The requested YouTube permission is stored locally on this
+                  computer and can be revoked with Disconnect at any time.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-3 text-sm">
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => openExternalUrl(VIDEORC_WEB_LINKS.privacy)}
+                  >
+                    Privacy Policy
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => openExternalUrl(VIDEORC_WEB_LINKS.terms)}
+                  >
+                    Videorc Terms
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => openExternalUrl('https://www.youtube.com/t/terms')}
+                  >
+                    YouTube Terms
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => openExternalUrl('https://policies.google.com/privacy')}
+                  >
+                    Google Privacy
+                  </Button>
+                </div>
+                <label className="flex items-start gap-3 rounded-row border bg-muted/30 p-3">
+                  <Checkbox
+                    checked={youtubeConsentAccepted}
+                    onCheckedChange={(checked) => setYoutubeConsentAccepted(checked === true)}
+                  />
+                  <span>
+                    I agree to the Videorc and YouTube terms and want to connect my YouTube account.
+                  </span>
+                </label>
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setYoutubeConsentOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  disabled={!youtubeConsentAccepted}
+                  onClick={() => {
+                    setYoutubeConsentOpen(false)
+                    onConnect('youtube')
+                  }}
+                >
+                  Continue to Google
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         ) : null}
-      </div>
+      </>
     )
   }
 

--- a/apps/desktop/src/renderer/src/lib/account.test.ts
+++ b/apps/desktop/src/renderer/src/lib/account.test.ts
@@ -106,6 +106,8 @@ describe('videorc web links', () => {
       login: 'https://www.videorc.com/login',
       desktopAuthorize: 'https://www.videorc.com/desktop/authorize/v2',
       premium: 'https://www.videorc.com/premium',
+      privacy: 'https://www.videorc.com/privacy',
+      terms: 'https://www.videorc.com/terms',
       billing: 'https://www.videorc.com/account/billing',
       changelogApi: 'https://www.videorc.com/api/changelog',
       changelog: 'https://www.videorc.com/changelog'

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -272,11 +272,8 @@ const STREAM_PLATFORM_LABELS: Record<StreamPlatform, string> = {
   custom: 'Custom RTMP'
 }
 
-export const YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE =
-  'YouTube OAuth is temporarily unavailable while Videorc awaits Google approval. Use Manual RTMP for YouTube for now.'
-
 export function oauthUnavailableReason(platform: StreamPlatform): string | null {
-  return platform === 'youtube' ? YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE : null
+  return platform === 'custom' ? 'Custom RTMP does not support OAuth.' : null
 }
 
 export function isPlatformOAuthAvailable(platform: StreamPlatform): boolean {

--- a/apps/desktop/src/renderer/src/lib/videorc-web-links.ts
+++ b/apps/desktop/src/renderer/src/lib/videorc-web-links.ts
@@ -25,6 +25,8 @@ export const VIDEORC_WEB_LINKS = {
   // exchanges it server-to-server; browser and deep-link never carry a session.
   desktopAuthorize: `${VIDEORC_WEB_ORIGIN}/desktop/authorize/v2`,
   premium: `${VIDEORC_WEB_ORIGIN}/premium`,
+  privacy: `${VIDEORC_WEB_ORIGIN}/privacy`,
+  terms: `${VIDEORC_WEB_ORIGIN}/terms`,
   billing: `${VIDEORC_WEB_ORIGIN}/account/billing`,
   // Published changelog (compiled from videorc changelog/ on each release):
   // JSON for the in-app What's New, pages for humans.

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -5719,6 +5719,57 @@ async fn handle_text_message_with_role(
                         .oauth
                         .highest_pending_account_write_generation(params.platform)
                         .await;
+                    if params.platform == StreamPlatform::Youtube {
+                        let credentials = match state.database.list_platform_account_credentials() {
+                            Ok(accounts) => accounts.into_iter().find(|account| {
+                                account.account.platform == StreamPlatform::Youtube
+                            }),
+                            Err(error) => {
+                                return ServerResponse::error(
+                                    command.id,
+                                    "platform-account-revocation-failed",
+                                    format!(
+                                        "Could not load the saved YouTube authorization before revoking it: {error}"
+                                    ),
+                                );
+                            }
+                        };
+                        if let Some(credentials) = credentials {
+                            let token_ref = credentials
+                                .refresh_token_secret_ref
+                                .as_deref()
+                                .or(credentials.token_secret_ref.as_deref());
+                            if let Some(token_ref) = token_ref {
+                                match secrets::get_secret(token_ref) {
+                                    Ok(token) => {
+                                        if let Err(error) = oauth::revoke_youtube_token(
+                                            &token,
+                                            &oauth::provider_http_client(),
+                                        )
+                                        .await
+                                        {
+                                            return ServerResponse::error(
+                                                command.id,
+                                                "platform-account-revocation-failed",
+                                                format!(
+                                                    "Could not revoke YouTube access. Check your connection and try Disconnect again. {error}"
+                                                ),
+                                            );
+                                        }
+                                    }
+                                    Err(error) => {
+                                        return ServerResponse::error(
+                                            command.id,
+                                            "platform-account-revocation-failed",
+                                            format!(
+                                                "Could not read the saved YouTube authorization before revoking it: {error}"
+                                            ),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
                     match state.database.disconnect_platform_account_after_generation(
                         params.platform,
                         pending_generation,

--- a/crates/videorc-backend/src/oauth.rs
+++ b/crates/videorc-backend/src/oauth.rs
@@ -21,6 +21,7 @@ const OAUTH_STATE_TTL_MINUTES: i64 = 10;
 const OAUTH_PROVIDER_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 const OAUTH_PROVIDER_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const BUNDLED_TWITCH_CLIENT_ID: Option<&str> = option_env!("VIDEORC_BUNDLED_TWITCH_CLIENT_ID");
+const BUNDLED_YOUTUBE_CLIENT_ID: Option<&str> = option_env!("VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID");
 // The Videorc X OAuth app (public Native App client, PKCE — no secret involved).
 // Client IDs are public identifiers; build-time/runtime env still override.
 const BUNDLED_X_CLIENT_ID: Option<&str> = match option_env!("VIDEORC_BUNDLED_X_CLIENT_ID") {
@@ -31,9 +32,26 @@ pub const YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE: &str = "YouTube OAuth is temporaril
 
 pub fn provider_oauth_unavailable_message(platform: StreamPlatform) -> Option<&'static str> {
     match platform {
-        StreamPlatform::Youtube => Some(YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE),
+        StreamPlatform::Youtube if !youtube_oauth_enabled() => {
+            Some(YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE)
+        }
         StreamPlatform::Twitch | StreamPlatform::X | StreamPlatform::Custom => None,
+        StreamPlatform::Youtube => None,
     }
+}
+
+fn youtube_oauth_enabled() -> bool {
+    optional_env("VIDEORC_ENABLE_YOUTUBE_OAUTH")
+        .as_deref()
+        .is_some_and(env_flag_enabled)
+        || option_env!("VIDEORC_BUNDLED_YOUTUBE_OAUTH_ENABLED").is_some_and(env_flag_enabled)
+}
+
+fn env_flag_enabled(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes"
+    )
 }
 
 pub fn provider_http_client() -> reqwest::Client {
@@ -2302,7 +2320,15 @@ impl OAuthTokenResponse {
 
 fn provider_config(platform: StreamPlatform) -> Result<OAuthProviderConfig> {
     match platform {
-        StreamPlatform::Youtube => anyhow::bail!("{YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE}"),
+        StreamPlatform::Youtube => {
+            if let Some(message) = provider_oauth_unavailable_message(platform) {
+                anyhow::bail!("{message}");
+            }
+            Ok(youtube_provider_config(required_credential(
+                "VIDEORC_YOUTUBE_CLIENT_ID",
+                BUNDLED_YOUTUBE_CLIENT_ID,
+            )?))
+        }
         StreamPlatform::Twitch => Ok(OAuthProviderConfig {
             authorization_url: "https://id.twitch.tv/oauth2/authorize".to_string(),
             token_url: "https://id.twitch.tv/oauth2/token".to_string(),
@@ -2336,6 +2362,23 @@ fn provider_config(platform: StreamPlatform) -> Result<OAuthProviderConfig> {
             pkce: true,
         }),
         StreamPlatform::Custom => anyhow::bail!("Custom RTMP does not support OAuth."),
+    }
+}
+
+fn youtube_provider_config(client_id: String) -> OAuthProviderConfig {
+    OAuthProviderConfig {
+        authorization_url: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
+        token_url: "https://oauth2.googleapis.com/token".to_string(),
+        profile_url: "https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true"
+            .to_string(),
+        client_id,
+        client_secret: None,
+        scopes: vec!["https://www.googleapis.com/auth/youtube.force-ssl".to_string()],
+        extra_params: HashMap::from([
+            ("access_type".to_string(), "offline".to_string()),
+            ("prompt".to_string(), "consent".to_string()),
+        ]),
+        pkce: true,
     }
 }
 
@@ -2391,12 +2434,25 @@ pub fn provider_client_id(platform: StreamPlatform) -> Result<String> {
 }
 
 pub fn provider_credential_statuses() -> Vec<OAuthProviderCredentialStatus> {
-    vec![
+    let youtube = if youtube_oauth_enabled() {
+        provider_credential_status(
+            StreamPlatform::Youtube,
+            "VIDEORC_YOUTUBE_CLIENT_ID",
+            "VIDEORC_YOUTUBE_CLIENT_SECRET",
+            BUNDLED_YOUTUBE_CLIENT_ID,
+            None,
+            true,
+            true,
+        )
+    } else {
         disabled_provider_credential_status(
             StreamPlatform::Youtube,
             YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE,
             true,
-        ),
+        )
+    };
+    vec![
+        youtube,
         // Twitch ships as a PUBLIC client type (dev console setting): no
         // client secret exists, token exchange + refresh use the client id
         // alone. VIDEORC_TWITCH_CLIENT_SECRET stays honoured for confidential
@@ -2420,6 +2476,35 @@ pub fn provider_credential_statuses() -> Vec<OAuthProviderCredentialStatus> {
             false,
         ),
     ]
+}
+
+pub async fn revoke_youtube_token(token: &str, client: &reqwest::Client) -> Result<()> {
+    revoke_youtube_token_at(token, client, "https://oauth2.googleapis.com/revoke").await
+}
+
+async fn revoke_youtube_token_at(
+    token: &str,
+    client: &reqwest::Client,
+    revocation_url: &str,
+) -> Result<()> {
+    if token.trim().is_empty() {
+        anyhow::bail!("YouTube OAuth token is empty.");
+    }
+    let response = client
+        .post(revocation_url)
+        .form(&[("token", token)])
+        .send()
+        .await
+        .context("Could not contact Google to revoke YouTube access")?;
+    if response.status().is_success() {
+        return Ok(());
+    }
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if status == reqwest::StatusCode::BAD_REQUEST && body.contains("invalid_token") {
+        return Ok(());
+    }
+    anyhow::bail!("Google rejected YouTube access revocation with HTTP {status}.")
 }
 
 fn disabled_provider_credential_status(
@@ -4592,6 +4677,66 @@ mod tests {
                 .iter()
                 .all(|status| !status.message.contains("CLIENT_SECRET"))
         );
+    }
+
+    #[test]
+    fn youtube_verification_config_uses_pkce_and_the_minimum_scope() {
+        let config = youtube_provider_config("public-client-id".to_string());
+
+        assert!(config.pkce);
+        assert_eq!(config.client_secret, None);
+        assert_eq!(
+            config.scopes,
+            vec!["https://www.googleapis.com/auth/youtube.force-ssl"]
+        );
+        assert_eq!(
+            config.extra_params.get("access_type").map(String::as_str),
+            Some("offline")
+        );
+        assert_eq!(
+            config.extra_params.get("prompt").map(String::as_str),
+            Some("consent")
+        );
+        assert!(env_flag_enabled("TRUE"));
+        assert!(!env_flag_enabled("0"));
+    }
+
+    #[tokio::test]
+    async fn youtube_revocation_posts_the_token_without_exposing_it_in_errors() {
+        async fn revoke(Form(form): Form<HashMap<String, String>>) -> impl IntoResponse {
+            if form.get("token").map(String::as_str) == Some("refresh-token-value") {
+                StatusCode::OK
+            } else {
+                StatusCode::BAD_REQUEST
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, Router::new().route("/revoke", post(revoke)))
+                .await
+                .unwrap();
+        });
+
+        revoke_youtube_token_at(
+            "refresh-token-value",
+            &reqwest::Client::new(),
+            &format!("http://{address}/revoke"),
+        )
+        .await
+        .unwrap();
+
+        let error = revoke_youtube_token_at(
+            "wrong-secret-token",
+            &reqwest::Client::new(),
+            &format!("http://{address}/revoke"),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("HTTP 400"));
+        assert!(!error.contains("wrong-secret-token"));
     }
 
     #[test]

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -319,15 +319,18 @@ own feed/backend).
 
 Production builds should inject Videorc-owned OAuth client IDs at backend compile time. Development and self-hosted builds can override those IDs at runtime.
 
-YouTube OAuth is paused until Google approval completes. Keep YouTube available
-through Manual RTMP and do not require or bundle Google OAuth credentials for
-release candidates while this pause is active.
+YouTube OAuth is paused in public builds until Google approval completes. Keep
+YouTube available through Manual RTMP. Only reviewer candidates (or approved
+releases) should set the two guarded YouTube build variables below.
 
 Bundled production defaults:
 
 ```sh
 VIDEORC_BUNDLED_TWITCH_CLIENT_ID=...
 VIDEORC_BUNDLED_X_CLIENT_ID=...
+# Reviewer candidate or approved release only:
+VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID=...
+VIDEORC_BUNDLED_YOUTUBE_OAUTH_ENABLED=1
 pnpm package:backend
 ```
 
@@ -336,6 +339,9 @@ Runtime/self-host overrides:
 ```sh
 VIDEORC_TWITCH_CLIENT_ID=...
 VIDEORC_X_CLIENT_ID=...
+# Local Google verification only:
+VIDEORC_ENABLE_YOUTUBE_OAUTH=1
+VIDEORC_YOUTUBE_CLIENT_ID=...
 ```
 
 Runtime values take precedence over bundled defaults. Client secrets, when used for provider flows, remain runtime-only:
@@ -408,7 +414,7 @@ Twitch release blocker:
 - Verify the app requests the scopes used by the backend:
   `channel:manage:broadcast`, `channel:read:stream_key`, and `user:read:chat`.
 
-The backend exposes credential source status to the renderer as `environment`, `bundled`, or `missing`; it never exposes actual client ID or secret values. Before release, open the packaged app's Streaming tab and confirm YouTube shows Manual RTMP with the Google approval pause message, while Twitch and X OAuth rows report either `Bundled default` or the intended runtime override.
+The backend exposes credential source status to the renderer as `environment`, `bundled`, or `missing`; it never exposes actual client ID or secret values. Before a public pre-approval release, confirm YouTube shows Manual RTMP with the Google approval pause message. In reviewer candidates, confirm the YouTube row reports the intended credential source and opens the consent disclosure before Google OAuth.
 
 Before a release candidate, run the redacted provider readiness check:
 

--- a/docs/oauth-live-smoke.md
+++ b/docs/oauth-live-smoke.md
@@ -6,10 +6,10 @@ This runbook is the release acceptance path for first-class OAuth/native livestr
 
 ## Provider Assumptions Checked 2026-07-07
 
-- **YouTube:** OAuth/native Live Streaming API support is paused while Videorc
-  awaits Google app approval. The product must expose YouTube as Manual RTMP
-  only, block stale YouTube OAuth settings with the approval message, and defer
-  native broadcast/channel acceptance until Google approval completes.
+- **YouTube:** Public builds keep OAuth/native Live Streaming API support paused
+  until Google approves the app. A verification candidate can explicitly enable
+  the complete flow so reviewers can exercise consent, channel selection,
+  broadcast management, chat, and revocation before approval.
 - **Twitch:** The developer app must register the OAuth redirect URL(s), and
   broadcaster actions use user access tokens with scoped permissions. The
   existing Videorc scopes still map to the current docs:
@@ -122,9 +122,27 @@ without a user gesture and browsers block gestureless custom-scheme navigation,
 leaving x.com's consent page on an infinite spinner while the app never receives the
 callback.
 
-YouTube OAuth is intentionally disabled until Google approval completes. Do not
-set Google OAuth readiness flags for release acceptance. Use Manual RTMP with a
-YouTube stream key for YouTube smoke coverage.
+YouTube public releases remain paused until Google approval completes. To build
+or run a reviewer candidate, enable the guarded path and provide the public
+installed-app client ID (PKCE is used; no client secret is bundled):
+
+```sh
+VIDEORC_ENABLE_YOUTUBE_OAUTH=1
+VIDEORC_YOUTUBE_CLIENT_ID=...
+VIDEORC_SMOKE_YOUTUBE_CHANNEL_READY=1
+```
+
+For a packaged reviewer or approved release, compile with:
+
+```sh
+VIDEORC_BUNDLED_YOUTUBE_OAUTH_ENABLED=1
+VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID=...
+```
+
+The Google app must register the three `127.0.0.1` callback URLs above. The
+authorization requests only `youtube.force-ssl`, requests offline access with
+PKCE, and Disconnect revokes the Google token before deleting local account
+data. Leave both enable flags unset in public builds until approval.
 
 Twitch:
 

--- a/scripts/lib/provider-readiness.mjs
+++ b/scripts/lib/provider-readiness.mjs
@@ -19,6 +19,7 @@ export const PROVIDERS = [
     label: 'YouTube',
     paused: true,
     pauseReason: YOUTUBE_OAUTH_PAUSED_REASON,
+    enableVars: ['VIDEORC_ENABLE_YOUTUBE_OAUTH', 'VIDEORC_BUNDLED_YOUTUBE_OAUTH_ENABLED'],
     clientIdVars: ['VIDEORC_YOUTUBE_CLIENT_ID', 'VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID'],
     secretVars: ['VIDEORC_YOUTUBE_CLIENT_SECRET'],
     secretRequired: false,
@@ -258,7 +259,8 @@ export function detectRunContext(env = {}) {
 }
 
 function readinessForProvider(provider, env, callbackCoverage) {
-  if (provider.paused) {
+  const explicitlyEnabled = provider.enableVars?.some((name) => env[name] === '1') ?? false
+  if (provider.paused && !explicitlyEnabled) {
     return {
       label: provider.label,
       ready: true,

--- a/scripts/lib/provider-readiness.test.mjs
+++ b/scripts/lib/provider-readiness.test.mjs
@@ -11,6 +11,7 @@ import {
 
 function completeEnv(overrides = {}) {
   return {
+    VIDEORC_ENABLE_YOUTUBE_OAUTH: '1',
     VIDEORC_YOUTUBE_CLIENT_ID: 'youtube-client-secret-value',
     VIDEORC_SMOKE_YOUTUBE_CHANNEL_READY: '1',
     VIDEORC_BUNDLED_TWITCH_CLIENT_ID: 'twitch-bundled-client-value',
@@ -37,9 +38,9 @@ describe('provider readiness evidence', () => {
     assert.deepEqual(result.failures, [])
     assert.equal(
       result.providers.find((provider) => provider.label === 'YouTube').clientId.source,
-      'paused'
+      'environment'
     )
-    assert.equal(result.providers.find((provider) => provider.label === 'YouTube').paused, true)
+    assert.equal(result.providers.find((provider) => provider.label === 'YouTube').paused, false)
     assert.equal(
       result.providers.find((provider) => provider.label === 'Twitch').clientId.source,
       'bundled'


### PR DESCRIPTION
## What
- add an explicit reviewer/approved-build gate for YouTube OAuth while keeping public pre-approval builds paused
- restore the Google installed-app PKCE flow with only `youtube.force-ssl`, offline access, and no bundled client secret
- add a YouTube consent disclosure in the Streaming tab with Videorc, YouTube, and Google policy links
- revoke the Google token before deleting local YouTube credentials on Disconnect
- make provider readiness exercise the enabled verification path and document reviewer-build setup

## Why
The old approval pause created a circular blocker: Google requires an end-to-end OAuth demo to approve the app, but Videorc could not produce a reviewer build with OAuth enabled. The desktop also lacked the required pre-consent disclosure and did not revoke Google authorization when users disconnected.

## Impact
Public builds remain unchanged unless the explicit enable flag is set. Reviewer candidates can compile a complete, least-privilege YouTube OAuth flow using a public client ID and PKCE. Disconnect fails safely on transient revocation errors so the user can retry instead of losing the only token that can revoke access.

Depends on the public policy copy in TheOrcDev/videorc-web#5.

## Checks
- `pnpm test:scripts` — 609 passed
- `pnpm --filter @videorc/desktop test` — 1,001 passed, 1 skipped
- `cargo test -p videorc-backend` — 1,269 passed across backend/helper/wire tests, 8 ignored
- `cargo clippy -p videorc-backend -- -D warnings`
- `cargo fmt --check --all`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm smoke:oauth`
- strict provider-readiness smoke with the YouTube verification gate enabled

`pnpm smoke:oauth-guards` was attempted after the core OAuth smoke passed, but its app bootstrap wedged before OAuth assertions because `backgrounds:bundled-assets` could not obtain a backend admin connection. The deterministic OAuth guard tests are covered by the passing script, desktop, and backend suites above.
