### PR TITLE
Record the 0.9.34-beta.1 release (vertical fill-crop)

### DIFF
--- a/docs/releases/0.9.34.md
+++ b/docs/releases/0.9.34.md
@@ -1,0 +1,26 @@
+# Videorc 0.9.34 Beta 1
+
+Patch release: vertical scenes letterboxed their bands.
+
+## Scope
+
+- **Vertical fill-crop** (PR #97): all five vertical scenes now COVER
+  their regions (fill + center crop) in the compositor (CPU/Metal/
+  preview via the single scene_source_fit authority — three direct
+  camera_fit checks were routed through it) and the legacy FFmpeg path
+  (pad → crop, cover_scale_filter for full-frame vertical). New
+  letterbox-detector compositor pixel test fails on the old code.
+  Horizontal scenes keep their contain rules.
+
+## Release status
+
+- [x] Fix merged (#97); prep PR #98 (CI clean).
+- [x] Built from `4a54739b`, signed + notarized, validate PASS, uploaded.
+- [x] Feed serves `version: 0.9.34`; changelog 35 entries.
+- [x] Discord announced (dry-run previewed first).
+
+## Owner acceptance checklist (by-eye, macOS)
+
+- [ ] Vertical mode with a real camera: both bands edge-to-edge, no
+      black inside the frame; preview matches the recording.
+- [ ] Horizontal scenes unchanged (screen never cropped).


### PR DESCRIPTION
Internal release record: built from 4a54739b, signed + notarized, uploaded, feed verified serving 0.9.34, Discord announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)