### PR TITLE
fix: owner UI batch — nine polish fixes across Studio, sidebar, windows

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1872,7 +1872,10 @@ async function openNotesWindow(): Promise<NotesWindowState> {
     minWidth: 360,
     minHeight: 240,
     title: 'Videorc Notes',
-    ...(isMac ? { titleBarStyle: 'hiddenInset' as const } : {}),
+    // Center the traffic lights in the 34px drag bar so they align with the title.
+    ...(isMac
+      ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 14, y: 11 } }
+      : {}),
     backgroundColor: DARK_WINDOW_PALETTE.base,
     show: false,
     ...appWindowIconOptions(),
@@ -2375,7 +2378,10 @@ async function openCommentsWindow(): Promise<CommentsWindowState> {
     minWidth: 320,
     minHeight: 360,
     title: 'Videorc Comments',
-    ...(isMac ? { titleBarStyle: 'hiddenInset' as const } : {}),
+    // Center the traffic lights in the 40px header so they align with the title.
+    ...(isMac
+      ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 14, y: 14 } }
+      : {}),
     backgroundColor: DARK_WINDOW_PALETTE.base,
     show: false,
     ...appWindowIconOptions(),
@@ -2593,7 +2599,10 @@ async function openCaptionsWindow(): Promise<CaptionsWindowState> {
     minWidth: 360,
     minHeight: 200,
     title: 'Videorc Captions',
-    ...(isMac ? { titleBarStyle: 'hiddenInset' as const } : {}),
+    // Center the traffic lights in the 40px header so they align with the title.
+    ...(isMac
+      ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 14, y: 14 } }
+      : {}),
     backgroundColor: DARK_WINDOW_PALETTE.base,
     show: false,
     ...appWindowIconOptions(),
@@ -3015,8 +3024,10 @@ async function openPreviewWindow(): Promise<PreviewWindowState> {
     title: 'Videorc Preview',
     // hiddenInset is macOS-only; off macOS the standard frame keeps the
     // preview window draggable without renderer drag regions (Phase 4 owns
-    // the frameless Windows chrome).
-    ...(isMac ? { titleBarStyle: 'hiddenInset' as const } : {}),
+    // the frameless Windows chrome). Traffic lights center in the 28px bar.
+    ...(isMac
+      ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 14, y: 8 } }
+      : {}),
     backgroundColor: DARK_WINDOW_PALETTE.base,
     // A docked window stays hidden until the renderer answers the dock epoch
     // with a slot rect; showing it at the remembered FLOATING frame first would

--- a/apps/desktop/src/renderer/src/components/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar.tsx
@@ -152,7 +152,7 @@ export function Sidebar({
   const modKey = displayKeyGlyph('⌘', platform)
 
   return (
-    <aside className="flex w-56 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
+    <aside className="-mt-9 flex w-56 shrink-0 flex-col border-r bg-sidebar pt-9 text-sidebar-foreground backdrop-blur-2xl">
       <div className="flex select-none items-center gap-3 px-4 py-4">
         {/* The PNG bakes a ~4% transparent margin around the tile; the scaled
             overflow-hidden wrapper crops it so the hairline ring hugs the art. */}
@@ -263,7 +263,7 @@ export function Sidebar({
 
       <SidebarUpdateChip captureActive={live} onOpenSettings={() => onSelect('settings')} />
 
-      <div className="flex items-center justify-between gap-2 border-t px-3 py-2.5">
+      <div className="flex min-h-11 items-center justify-between gap-2 border-t px-3 py-1.5">
         {/* Videorc product-account control. Backend status is secondary (a small
             dot on the trigger + the Health row); Health stays reachable here. */}
         <AccountMenu

--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -361,7 +361,6 @@ export function QuickSettings(): ReactElement {
             }
           />
         </div>
-        <ManageLink onClick={() => openStudioPanel('captions')}>Manage captions</ManageLink>
       </QuickCard>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
@@ -1,5 +1,4 @@
 import {
-  Aperture,
   Broadcast,
   CaretRight,
   FrameCorners,
@@ -16,7 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Kbd } from '@/components/ui/kbd'
 import { useWorkspaceNav } from '@/components/workspace-nav'
 import { useStudioCore } from '@/hooks/use-studio'
-import { outputSummary, recordingQuality, streamingSummary } from '@/lib/studio-session-view'
+import { outputSummary, streamingSummary } from '@/lib/studio-session-view'
 
 // The session's primary actions rendered as a matched pair of glassy hero
 // controls: taller, translucent, specular-shined (videorc-design glass tokens).
@@ -68,12 +67,6 @@ export function SessionPanel({
   return (
     <PanelSection>
       <div className="flex flex-col gap-0.5">
-        <SessionRow
-          icon={Aperture}
-          label="Output profile"
-          value={recordingQuality(video)}
-          onNavigate={() => openStudioPanel('recording')}
-        />
         <SessionRow
           icon={Broadcast}
           label="Streaming"

--- a/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
@@ -162,7 +162,10 @@ export function LayoutTab(): ReactElement {
               stay in the detached preview window. */}
           <SceneStage
             cameraCornerRadiusPct={layout.cameraCornerRadiusPct}
-            cameraShape={layout.cameraShape}
+            // WYSIWYG: only the inset scenes mask the camera bubble (backend
+            // camera_mask policy) — side-by-side and the vertical bands render
+            // a plain rectangle, so the schematic must too.
+            cameraShape={showOverlayControls ? layout.cameraShape : 'rectangle'}
             dragEnabled={showOverlayControls && !isSessionActive}
             hasBackground={Boolean(scene?.background)}
             outputAspect={captureConfig.video.width / Math.max(1, captureConfig.video.height)}

--- a/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
@@ -22,12 +22,7 @@ import { Badge } from '@/components/ui/badge'
 import { PowerSlider } from '@/components/power-slider'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
-import {
-  useStudioAudio,
-  useStudioCore,
-  useStudioDiagnostics,
-  useStudioPreview
-} from '@/hooks/use-studio'
+import { useStudioCore, useStudioDiagnostics, useStudioPreview } from '@/hooks/use-studio'
 import { cameraFormatShortfall, cameraFormatShortfallMessage } from '@/lib/camera-format-shortfall'
 import {
   MICROPHONE_SYNC_OFFSET_MAX_MS,
@@ -45,8 +40,6 @@ import {
   type AudioSyncRecommendationReport
 } from '@/lib/capture'
 import type { SourceSelection } from '@/lib/backend'
-import { formatDb } from '@/lib/format'
-import { cn } from '@/lib/utils'
 
 // Live chip for a capture source (UI rewrite V3): what the preview pipeline says
 // about the source RIGHT NOW. A live source whose newest frame is old is reported
@@ -111,8 +104,6 @@ export function SourcesTab(): ReactElement {
     captureConfig,
     setCaptureConfig,
     refreshBackend,
-    sampleAudioMeter,
-    canSampleAudio,
     selectedMicrophone,
     isSessionActive,
     layoutSwitchPending,
@@ -125,7 +116,6 @@ export function SourcesTab(): ReactElement {
     wsStatus
   } = useStudioCore()
   const { previewCameraStatus, previewScreenStatus } = useStudioPreview()
-  const { audioMeter, audioMeterLoading, meterLevel } = useStudioAudio()
   const { diagnosticStats } = useStudioDiagnostics()
   // Q6 (plan 022): explicit select states while device discovery is pending.
   const discoveryPending = wsStatus !== 'connected'
@@ -153,14 +143,6 @@ export function SourcesTab(): ReactElement {
   const syncMeasurementInputRef = useRef<HTMLInputElement | null>(null)
   const syncCalibration = audioSyncCalibrationState(syncRecommendation, captureConfig.audio)
 
-  const meterTone =
-    audioMeter?.status === 'ready'
-      ? 'bg-success'
-      : audioMeter?.status === 'silent' ||
-          audioMeter?.status === 'no-frames' ||
-          audioMeter?.status === 'permission-required'
-        ? 'bg-warning'
-        : 'bg-muted-foreground/40'
   const selectedCaptureId = captureConfig.sources.screenId ?? captureConfig.sources.windowId
   const liveDeviceSwitchDisabled = Boolean(sourceDeviceSwitchPending || layoutSwitchPending)
 
@@ -410,43 +392,13 @@ export function SourcesTab(): ReactElement {
         {/* See-before-you-pick: live waveform of the selected mic (shared with
             the Quick Settings popover). */}
         <MicPickerPreview deviceName={selectedMicrophone?.name} />
-        <div className="flex items-center justify-between text-sm">
-          <span className="flex items-center gap-2 text-muted-foreground">
-            {captureConfig.audio.microphoneMuted ? (
-              <SpeakerSlash className="size-4" weight="duotone" />
-            ) : (
-              <SpeakerHigh className="size-4" weight="duotone" />
-            )}
-            {selectedMicrophone ? selectedMicrophone.name : 'No microphone selected'}
-            <RuntimeChip
-              chip={
-                audioMeter?.status === 'ready'
-                  ? { label: 'Live', tone: 'good' }
-                  : audioMeter?.status === 'silent'
-                    ? {
-                        label: 'Silent',
-                        tone: 'warn',
-                        hint: 'The mic delivered only silence on the last check.'
-                      }
-                    : audioMeter?.status === 'permission-required'
-                      ? { label: 'Permission needed', tone: 'warn' }
-                      : audioMeter?.status === 'no-frames'
-                        ? {
-                            label: 'No frames',
-                            tone: 'warn',
-                            hint: 'The mic opened but did not send audio frames.'
-                          }
-                        : audioMeter?.status === 'unavailable'
-                          ? {
-                              label: 'Meter unavailable',
-                              tone: 'neutral',
-                              hint: 'The live level meter is not available on this platform yet. Recording audio is unaffected.'
-                            }
-                          : null
-              }
-            />
-          </span>
-          <span className="font-semibold tabular-nums">{formatDb(audioMeter?.peakDb)}</span>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          {captureConfig.audio.microphoneMuted ? (
+            <SpeakerSlash className="size-4" weight="duotone" />
+          ) : (
+            <SpeakerHigh className="size-4" weight="duotone" />
+          )}
+          {selectedMicrophone ? selectedMicrophone.name : 'No microphone selected'}
         </div>
         <div className="grid gap-2 rounded-row border bg-muted/30 px-3 py-2">
           <div className="flex items-center justify-between gap-3">
@@ -570,31 +522,6 @@ export function SourcesTab(): ReactElement {
             </div>
           </div>
         </div>
-        <div
-          aria-label="Microphone input level"
-          aria-valuemax={100}
-          aria-valuemin={0}
-          aria-valuenow={Math.round(Math.min(100, Math.max(0, meterLevel)))}
-          className="h-2.5 w-full overflow-hidden rounded-full bg-muted"
-          role="meter"
-        >
-          <div
-            className={cn('h-full rounded-full transition-all', meterTone)}
-            style={{ width: `${Math.min(100, Math.max(0, meterLevel))}%` }}
-          />
-        </div>
-        <p className="text-xs text-muted-foreground">
-          {audioMeter?.message ?? 'Run a check to confirm the mic is live before recording.'}
-        </p>
-        <Button
-          className="self-start"
-          disabled={!canSampleAudio || audioMeterLoading}
-          size="sm"
-          variant="outline"
-          onClick={sampleAudioMeter}
-        >
-          {audioMeterLoading ? 'Checking...' : 'Check mic'}
-        </Button>
       </PanelSection>
     </ConfigGrid>
   )

--- a/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
@@ -22,7 +22,6 @@ import { useEffect, useMemo, useState, type ReactElement } from 'react'
 
 import { ListRow } from '@/components/list-row'
 import { PanelSection } from '@/components/panel-section'
-import { CaptionsControls } from '@/components/captions/captions-controls'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -265,7 +264,6 @@ export function StreamingTab(): ReactElement {
           streamVideo={streamVideo}
           targets={streaming.targets}
         />
-        <CaptionsControls />
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/takeover-screens-section.tsx
+++ b/apps/desktop/src/renderer/src/components/takeover-screens-section.tsx
@@ -1,13 +1,5 @@
-import {
-  ArrowDown,
-  ArrowUp,
-  FloppyDisk,
-  ImageBroken,
-  ImageSquare,
-  Trash,
-  UploadSimple
-} from '@phosphor-icons/react'
-import { useEffect, useState, type ReactElement } from 'react'
+import { FloppyDisk, ImageBroken, ImageSquare, Trash, UploadSimple } from '@phosphor-icons/react'
+import { useEffect, useState, type DragEvent, type ReactElement } from 'react'
 
 import { Gallery } from '@/components/page'
 import { PanelSection } from '@/components/panel-section'
@@ -18,18 +10,21 @@ import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useStudioCore } from '@/hooks/use-studio'
 import type { StreamScreen } from '@/lib/backend'
+import { cn } from '@/lib/utils'
 
 // Takeover-image manager (upload/rename/reorder/delete). Lives on the Assets
 // page: the active takeover is global session state, not scene content — it
 // replaces the output regardless of scene, so the old Scene-page home was wrong
-// on its own terms.
+// on its own terms. Ordering is drag-and-drop (owner request 2026-07-13): drag
+// a tile onto another to take its position — the backend applies the full
+// order atomically via screens.reorder.
 export function TakeoverScreensSection(): ReactElement {
   const {
     activeScreen,
     deleteScreen,
     importScreenImage,
     isSessionActive,
-    moveScreen,
+    reorderScreen,
     renameScreen,
     screenImportPending,
     screens,
@@ -37,6 +32,8 @@ export function TakeoverScreensSection(): ReactElement {
   } = useStudioCore()
   const managementDisabled = isSessionActive || wsStatus !== 'connected'
   const uploadDisabled = managementDisabled || screenImportPending
+  const [draggingId, setDraggingId] = useState<string | null>(null)
+  const [dropIndex, setDropIndex] = useState<number | null>(null)
 
   return (
     <PanelSection
@@ -46,7 +43,7 @@ export function TakeoverScreensSection(): ReactElement {
           {screenImportPending ? 'Importing' : 'Upload'}
         </Button>
       }
-      description="Full-frame images that cover the output — flip them on from the Studio session panel. Management is locked while a session is live."
+      description="Full-frame images that cover the output — flip them on from the Studio session panel. Drag tiles to reorder. Management is locked while a session is live."
       icon={ImageSquare}
       title="Takeover screens"
     >
@@ -68,12 +65,28 @@ export function TakeoverScreensSection(): ReactElement {
               <ScreenTile
                 active={activeScreen?.id === screen.id}
                 disabled={managementDisabled}
-                index={index}
+                dragging={draggingId === screen.id}
+                dropTarget={dropIndex === index && draggingId !== screen.id}
                 key={screen.id}
                 screen={screen}
-                total={screens.length}
                 onDelete={() => void deleteScreen(screen.id)}
-                onMove={(direction) => void moveScreen(screen.id, direction)}
+                onDragEnd={() => {
+                  setDraggingId(null)
+                  setDropIndex(null)
+                }}
+                onDragEnter={() => {
+                  if (draggingId && draggingId !== screen.id) {
+                    setDropIndex(index)
+                  }
+                }}
+                onDragStart={() => setDraggingId(screen.id)}
+                onDrop={() => {
+                  if (draggingId && draggingId !== screen.id) {
+                    void reorderScreen(draggingId, index)
+                  }
+                  setDraggingId(null)
+                  setDropIndex(null)
+                }}
                 onRename={(name) => void renameScreen(screen.id, name)}
               />
             ))}
@@ -88,19 +101,25 @@ function ScreenTile({
   screen,
   active,
   disabled,
-  index,
-  total,
+  dragging,
+  dropTarget,
   onDelete,
-  onMove,
+  onDragEnd,
+  onDragEnter,
+  onDragStart,
+  onDrop,
   onRename
 }: {
   screen: StreamScreen
   active: boolean
   disabled: boolean
-  index: number
-  total: number
+  dragging: boolean
+  dropTarget: boolean
   onDelete: () => void
-  onMove: (direction: -1 | 1) => void
+  onDragEnd: () => void
+  onDragEnter: () => void
+  onDragStart: () => void
+  onDrop: () => void
   onRename: (name: string) => void
 }): ReactElement {
   const [imageFailed, setImageFailed] = useState(false)
@@ -122,12 +141,35 @@ function ScreenTile({
   }
 
   return (
-    <div className="flex min-w-0 flex-col overflow-hidden rounded-row border bg-background">
+    <div
+      className={cn(
+        'flex min-w-0 flex-col overflow-hidden rounded-row border bg-background transition-opacity',
+        !disabled && 'cursor-grab active:cursor-grabbing',
+        dragging && 'opacity-40',
+        dropTarget && 'ring-2 ring-ring'
+      )}
+      draggable={!disabled}
+      onDragEnd={onDragEnd}
+      onDragEnter={onDragEnter}
+      onDragOver={(event: DragEvent<HTMLDivElement>) => {
+        // Allow this tile to be a drop target.
+        event.preventDefault()
+      }}
+      onDragStart={(event: DragEvent<HTMLDivElement>) => {
+        event.dataTransfer.effectAllowed = 'move'
+        onDragStart()
+      }}
+      onDrop={(event: DragEvent<HTMLDivElement>) => {
+        event.preventDefault()
+        onDrop()
+      }}
+    >
       <div className="relative aspect-[4/3] bg-muted">
         {!missing ? (
           <img
             alt=""
             className="size-full object-cover"
+            draggable={false}
             src={managedScreenAssetUrl(screen.imagePath)}
             onError={() => setImageFailed(true)}
           />
@@ -172,30 +214,9 @@ function ScreenTile({
         </div>
         <span className="truncate text-xs text-muted-foreground">{screen.imagePath}</span>
         {/* Activation lives in the Studio session panel (one home per control);
-            tiles are management only — the Active badge still reports state. */}
-        <div className="flex min-w-0 items-center gap-1.5">
-          <Button
-            aria-label="Move takeover up"
-            disabled={disabled || index === 0}
-            size="icon-sm"
-            title="Move takeover up"
-            type="button"
-            variant="outline"
-            onClick={() => onMove(-1)}
-          >
-            <ArrowUp />
-          </Button>
-          <Button
-            aria-label="Move takeover down"
-            disabled={disabled || index === total - 1}
-            size="icon-sm"
-            title="Move takeover down"
-            type="button"
-            variant="outline"
-            onClick={() => onMove(1)}
-          >
-            <ArrowDown />
-          </Button>
+            tiles are management only — the Active badge still reports state.
+            Ordering is drag-and-drop on the tile itself. */}
+        <div className="flex min-w-0 items-center">
           <Button
             aria-label="Delete takeover"
             className="ml-auto"

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -706,7 +706,7 @@ export type StudioContextValue = {
   importScreenImage: () => Promise<void>
   renameScreen: (screenId: string, name: string) => Promise<void>
   deleteScreen: (screenId: string) => Promise<void>
-  moveScreen: (screenId: string, direction: -1 | 1) => Promise<void>
+  reorderScreen: (screenId: string, targetIndex: number) => Promise<void>
   activateScreen: (screenId: string) => Promise<void>
   clearActiveScreen: () => Promise<void>
   refreshPreview: () => Promise<void>
@@ -6463,8 +6463,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     [client, isSessionActive, reportError]
   )
 
-  const moveScreen = useCallback(
-    async (screenId: string, direction: -1 | 1) => {
+  const reorderScreen = useCallback(
+    async (screenId: string, targetIndex: number) => {
       if (!client || isSessionActive) {
         toast.error(
           isSessionActive
@@ -6475,8 +6475,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       }
 
       const currentIndex = screens.findIndex((screen) => screen.id === screenId)
-      const nextIndex = currentIndex + direction
-      if (currentIndex === -1 || nextIndex < 0 || nextIndex >= screens.length) {
+      const nextIndex = Math.max(0, Math.min(screens.length - 1, targetIndex))
+      if (currentIndex === -1 || nextIndex === currentIndex) {
         return
       }
 
@@ -8689,7 +8689,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       importScreenImage,
       renameScreen,
       deleteScreen,
-      moveScreen,
+      reorderScreen,
       activateScreen,
       clearActiveScreen,
       refreshPreview,
@@ -8857,7 +8857,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       importScreenImage,
       renameScreen,
       deleteScreen,
-      moveScreen,
+      reorderScreen,
       activateScreen,
       clearActiveScreen,
       refreshPreview,

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -85,8 +85,9 @@
   --input: oklch(0 0 0 / 12%);
   --ring: oklch(0 0 0 / 25%);
 
-  /* Sidebar sits on the same glass; selection is the monochrome block. */
-  --sidebar: oklch(0 0 0 / 3%);
+  /* Sidebar is a frosted pane on the glass (backdrop-blur in the aside);
+     selection is the monochrome block. */
+  --sidebar: oklch(0 0 0 / 4%);
   --sidebar-foreground: oklch(0.17 0.004 286);
   --sidebar-primary: oklch(0.17 0.004 286);
   --sidebar-primary-foreground: oklch(0.985 0 0);
@@ -171,7 +172,7 @@
   --input: oklch(1 0 0 / 10%);
   --ring: oklch(1 0 0 / 28%);
 
-  --sidebar: oklch(1 0 0 / 3%);
+  --sidebar: oklch(1 0 0 / 5%);
   --sidebar-foreground: oklch(0.97 0.001 286);
   --sidebar-primary: oklch(0.97 0.001 286);
   --sidebar-primary-foreground: oklch(0.13 0.003 286);


### PR DESCRIPTION
Owner-reported batch (2026-07-13), one fix per item:

1. **Studio session panel** — "Output profile" and "Output" said the same thing twice; the profile row is gone, Output stays (still deep-links to the Output page).
2. **Sidebar footer height** — the account/theme strip now matches the app footer bar (`min-h-11`), so the two bottom edges read as one line.
3. **Glassier sidebar** — the sidebar now spans to the window top (it used to stop abruptly at the 36px drag strip — the "cut off" report), carries a `backdrop-blur` over the wallpaper underlay, and its glass tints get a touch more presence in both themes (tokens only).
4. **Window title alignment** — Notes (34px bar), Comments/Captions (40px headers), and Preview (28px bar) each pin `trafficLightPosition` to their own titlebar center, so close/minimize align with the title.
5. **Manage captions link removed** from the Studio quick captions card — the sidebar Captions page is the home.
6. **Sources "Check mic" removed** — sampled meter bar, status chips, dB label, and the button are gone; the live waveform preview (in the picker) and the Studio mixer visualizer carry mic confidence. Dead `sampleAudioMeter`/`meterLevel` plumbing pruned from the tab.
7. **Scene stage WYSIWYG** — the schematic rounded the camera by shape in every preset, but the real render only masks the inset scenes; the stage now mirrors the backend `camera_mask` policy (side-by-side and vertical bands draw rectangles).
8. **Takeover drag-and-drop** — arrows are gone; drag a tile onto another to take its position. `moveScreen(direction)` generalized to `reorderScreen(id, targetIndex)` over the existing atomic `screens.reorder` RPC (backend validates the full order). Images are `draggable={false}` so the tile drag wins; drop target shows a focus ring; disabled while live.
9. **Livestream tab captions removed** — `CaptionsControls` renders only on the Captions tab now (one home per control).

## Gates
- `pnpm typecheck` / `pnpm lint` / `pnpm format:check` — clean
- Desktop tests 1001/1001
- Both-theme Studio screenshot sweep eyeballed: sidebar glass + top continuation, footer alignment, single Output row, no Manage captions

## Owner by-eye
- Notes/Comments windows: titles now sit on the traffic-light line.
- Assets → Takeover screens: drag tiles to reorder (locked while live).
- Scene tab with Side-by-side: camera rect matches the recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)