### PR TITLE
Release 0.9.35-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.34",
+  "version": "0.9.35",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.35-beta.1.md
+++ b/changelog/0.9.35-beta.1.md
@@ -1,0 +1,46 @@
+---
+version: 0.9.35-beta.1
+date: 2026-07-13
+channel: beta
+title: A polish pass — cleaner sidebar, tidier Studio, drag-and-drop takeovers
+summary: Nine small fixes from daily use — a glassier sidebar that reaches the top of the window, aligned window titles, drag-and-drop takeover ordering, and a tidier Studio with duplicate and leftover controls removed.
+highlights:
+  - The sidebar is glassier, reaches the top of the window, and its footer lines up with the bottom bar.
+  - Takeover screens reorder by drag and drop — grab a tile and drop it where it belongs.
+  - Window titles in Notes, Comments, Captions, and Preview now sit level with the close buttons.
+  - The Scene diagram now shows the camera exactly as it records — no rounded corners where there are none.
+  - Duplicate and leftover controls removed across Studio, Sources, and Livestream.
+---
+
+## Sidebar and windows
+
+The sidebar now behaves like a proper macOS sidebar: it reaches the very
+top of the window instead of stopping below the title area, gets a
+frosted glass treatment, and its footer (account and theme) sits at the
+same height as the bottom action bar. The auxiliary windows — Notes,
+Comments, Captions, and the popped-out Preview — align their titles with
+the close/minimize buttons.
+
+## Studio tidy-up
+
+The session panel said "Output profile" and "Output" back to back;
+one Output row remains. The captions card lost its extra "Manage
+captions" link (the Captions page in the sidebar is the home). The old
+"Check mic" button and its one-shot meter left the Sources page — the
+live waveform in the mic picker and the audio mixer's visualizer show
+your levels continuously now. Live captions controls also left the
+Livestream page; they live on the Captions page.
+
+## What you see is what you get
+
+The Scene diagram drew the camera with rounded corners in every layout,
+but recordings only round the camera in the Screen + camera scenes. The
+diagram now matches the output exactly. And takeover screens in Assets
+reorder by dragging tiles instead of clicking arrows.
+
+## YouTube account safety
+
+Two smaller YouTube improvements ride along: the Livestream page now
+shows a clear disclosure of what connecting a YouTube account allows
+before you consent, and disconnecting YouTube now also revokes Videorc's
+access with Google — not just locally.


### PR DESCRIPTION
0.9.34 → 0.9.35. Ships #101 (nine-fix UI polish batch) and #99's user-facing parts (YouTube consent disclosure + revoke-on-disconnect). `pnpm changelog:check`: 36 entries valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar styling, window alignment, and footer positioning.
  * Removed redundant controls across Studio navigation and livestream settings.
  * Matched Scene diagram camera rounding with recorded output.
  * Improved YouTube consent messaging and account disconnection behavior.
* **New Features**
  * Added drag-and-drop reordering for Assets takeovers.
* **Chores**
  * Released desktop version 0.9.35-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->