### PR TITLE
Record the 0.9.35-beta.1 release (UI polish batch)

### DIFF
--- a/docs/releases/0.9.35.md
+++ b/docs/releases/0.9.35.md
@@ -1,0 +1,35 @@
+# Videorc 0.9.35 Beta 1
+
+Owner UI polish batch plus the YouTube OAuth verification prep's
+user-facing parts.
+
+## Scope
+
+- **Owner UI batch** (PR #101, nine fixes): session panel Output dedup;
+  sidebar footer height matches the footer bar; sidebar spans to the
+  window top + backdrop blur + stronger glass tints; aux-window traffic
+  lights centered per titlebar (Notes 34/Comments 40/Captions 40/
+  Preview 28); Manage captions link removed from the quick card;
+  Sources "Check mic" flow removed (live waveform + mixer visualizer
+  own mic confidence); Scene stage camera rounding follows the backend
+  camera_mask policy (WYSIWYG); takeover reorder = drag-and-drop over
+  atomic screens.reorder (arrows removed); Livestream tab captions
+  panel removed (Captions tab is the home).
+- **YouTube OAuth verification prep** (PR #99, parallel session):
+  user-facing = Streaming-tab consent disclosure + revoke-on-disconnect;
+  reviewer-build OAuth gate stays off in public builds.
+
+## Release status
+
+- [x] PRs #99 + #101 merged; prep PR #102 (CI clean).
+- [x] Built from `538ea465`, signed + notarized, validate PASS, uploaded.
+- [x] Feed serves `version: 0.9.35`; changelog 36 entries.
+- [x] Discord announced (dry-run previewed first).
+
+## Owner acceptance checklist (by-eye, macOS)
+
+- [ ] Sidebar: glassy, reaches window top, footer aligns with bottom bar.
+- [ ] Notes/Comments windows: titles level with traffic lights.
+- [ ] Assets → Takeover: drag tiles to reorder (locked while live).
+- [ ] Side-by-side Scene stage: rectangular camera.
+- [ ] Sources: no Check mic; Livestream: no captions panel.


### PR DESCRIPTION
Internal release record: built from 538ea465, signed + notarized, uploaded, feed verified serving 0.9.35, Discord announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Videorc 0.9.35 Beta 1.
  * Documented release status, build and validation checkpoints, version details, and announcement readiness.
  * Added an acceptance checklist covering Owner interface polish, layout alignment, drag-and-drop behavior, camera framing, and Sources/Livestream updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->