### PR TITLE
fix: short-format mode always fills the whole 9:16 canvas

### DIFF
--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -36,7 +36,8 @@ import {
   microphonePickerDevices,
   layoutPresetNeedsCamera,
   layoutPresetNeedsScreen,
-  layoutPresetOrientation
+  layoutPresetOrientation,
+  resolutionOptionsForOrientation
 } from '@/lib/capture'
 
 // Lazy like the tab chunks (app-shell): the preview (and the live-waveform it
@@ -70,16 +71,6 @@ function presetLabel(preset: LayoutPreset): string {
       ?.label ?? preset
   )
 }
-
-// Resolution options mirroring the Output tab (recording-tab.tsx); picking one
-// patches width/height (the preset becomes Custom), exactly like that tab.
-const RESOLUTIONS = [
-  { label: '4K', detail: '3840 × 2160', width: 3840, height: 2160 },
-  { label: '2K', detail: '2560 × 1440', width: 2560, height: 1440 },
-  { label: '1080p', detail: '1920 × 1080', width: 1920, height: 1080 },
-  { label: '720p', detail: '1280 × 720', width: 1280, height: 720 },
-  { label: 'Vertical', detail: '1080 × 1920', width: 1080, height: 1920 }
-]
 
 function resolutionKey(width: number, height: number): string {
   return `${width}x${height}`
@@ -155,8 +146,14 @@ export function QuickSettings(): ReactElement {
   const hasScreen = Boolean(selectedCaptureId)
   const muted = captureConfig.audio.microphoneMuted
   const MuteIcon = muted ? SpeakerSlash : SpeakerHigh
+  // Resolution options mirror the Output tab (recording-tab.tsx) and follow
+  // the Studio mode — vertical mode offers only portrait canvases (the mode
+  // toggle is the one home for orientation).
+  const resolutions = resolutionOptionsForOrientation(
+    layoutPresetOrientation(captureConfig.layout.layoutPreset)
+  )
   const currentResolution = resolutionKey(captureConfig.video.width, captureConfig.video.height)
-  const knownResolution = RESOLUTIONS.some(
+  const knownResolution = resolutions.some(
     (resolution) => resolutionKey(resolution.width, resolution.height) === currentResolution
   )
 
@@ -311,7 +308,7 @@ export function QuickSettings(): ReactElement {
           disabled={isSessionActive}
           value={knownResolution ? currentResolution : ''}
           onValueChange={(value) => {
-            const match = RESOLUTIONS.find(
+            const match = resolutions.find(
               (resolution) => resolutionKey(resolution.width, resolution.height) === value
             )
             if (match) {
@@ -325,7 +322,7 @@ export function QuickSettings(): ReactElement {
             <SelectValue placeholder="Custom">{recordingQuality(captureConfig.video)}</SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {RESOLUTIONS.map((resolution) => (
+            {resolutions.map((resolution) => (
               <SelectItem
                 key={resolution.label}
                 value={resolutionKey(resolution.width, resolution.height)}

--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -62,7 +62,8 @@ const VERTICAL_QUICK_PRESETS: { id: LayoutPreset; label: string }[] = [
   { id: 'vertical-camera-bottom', label: 'Camera bottom' },
   { id: 'vertical-split', label: 'Split' },
   { id: 'vertical-screen-camera', label: 'Screen + Cam' },
-  { id: 'vertical-screen-only', label: 'Screen' }
+  { id: 'vertical-screen-only', label: 'Screen' },
+  { id: 'vertical-camera-only', label: 'Camera' }
 ]
 
 function presetLabel(preset: LayoutPreset): string {

--- a/apps/desktop/src/renderer/src/components/studio/scenes-gallery.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/scenes-gallery.tsx
@@ -35,7 +35,8 @@ const VERTICAL_SCENES: { id: LayoutPreset; label: string }[] = [
   { id: 'vertical-camera-bottom', label: 'Camera bottom' },
   { id: 'vertical-split', label: 'Split' },
   { id: 'vertical-screen-camera', label: 'Screen + Cam' },
-  { id: 'vertical-screen-only', label: 'Screen' }
+  { id: 'vertical-screen-only', label: 'Screen' },
+  { id: 'vertical-camera-only', label: 'Camera' }
 ]
 
 export function ScenesGallery(): ReactElement {
@@ -184,6 +185,9 @@ function LayoutThumb({ preset }: { preset: LayoutPreset }): ReactElement {
         ) : null}
         {preset === 'vertical-screen-only' ? (
           <div className="absolute inset-1 rounded-[2px] bg-foreground/10" />
+        ) : null}
+        {preset === 'vertical-camera-only' ? (
+          <div className="absolute inset-1 rounded-[2px] bg-foreground/30" />
         ) : null}
       </div>
     )

--- a/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
@@ -50,7 +50,8 @@ const VERTICAL_LAYOUT_TAB_PRESETS = [
   { id: 'vertical-camera-bottom', label: 'Camera bottom', enabled: true },
   { id: 'vertical-split', label: 'Split', enabled: true },
   { id: 'vertical-screen-camera', label: 'Screen + camera', enabled: true },
-  { id: 'vertical-screen-only', label: 'Screen only', enabled: true }
+  { id: 'vertical-screen-only', label: 'Screen only', enabled: true },
+  { id: 'vertical-camera-only', label: 'Camera only', enabled: true }
 ] as const
 
 export function LayoutTab(): ReactElement {
@@ -87,6 +88,7 @@ export function LayoutTab(): ReactElement {
   const hasCamera = hasSelectedCameraSource(captureConfig.sources)
   const hasScreen = hasSelectedScreenSource(captureConfig.sources)
   const isCameraOnly = layout.layoutPreset === 'camera-only'
+  const isVerticalCameraOnly = layout.layoutPreset === 'vertical-camera-only'
   const isSideBySide = layout.layoutPreset === 'side-by-side'
   // The stacked vertical scenes have fixed bands — no corner/size/shape; the
   // vertical Screen + camera is a true inset scene and keeps every overlay
@@ -245,10 +247,17 @@ export function LayoutTab(): ReactElement {
                 </p>
               ) : null}
 
+              {isVerticalCameraOnly ? (
+                <p className="text-sm text-muted-foreground">
+                  The camera fills the whole 9:16 canvas and crops to fit. Corner, size, and shape
+                  do not apply — use mirror, zoom, and pan to frame yourself.
+                </p>
+              ) : null}
+
               {isVerticalStack ? (
                 <p className="text-sm text-muted-foreground">
                   The stacked vertical scenes give the camera and the screen fixed bands of the 9:16
-                  canvas. Corner, size, and shape do not apply — use fit, mirror, zoom, and pan.
+                  canvas. Corner, size, and shape do not apply — use mirror, zoom, and pan.
                 </p>
               ) : null}
 
@@ -413,13 +422,16 @@ export function LayoutTab(): ReactElement {
               ) : null}
 
               <span className="pt-2 text-[12.5px] leading-none font-medium text-subtle">Lens</span>
-              {/* Vertical bands ALWAYS fill and crop — a "Fit frame" band would
-                  letterbox the short-form frame (2026-07-13 fill-crop plan), so
-                  the toggle is hidden and honest copy replaces it. Zoom and pan
-                  below still frame the crop. */}
-              {isVerticalStack ? (
+              {/* Vertical bands and the full-canvas vertical camera ALWAYS
+                  fill and crop — a "Fit frame" option would letterbox the
+                  short-form frame (2026-07-13 fill-crop plan), so the toggle
+                  is hidden and honest copy replaces it. Zoom and pan below
+                  still frame the crop. */}
+              {isVerticalStack || isVerticalCameraOnly ? (
                 <p className="text-sm text-muted-foreground">
-                  The camera band always fills and crops. Use zoom and pan to frame yourself.
+                  {isVerticalCameraOnly
+                    ? 'The camera always fills the 9:16 canvas and crops. Use zoom and pan to frame yourself.'
+                    : 'The camera band always fills and crops. Use zoom and pan to frame yourself.'}
                 </p>
               ) : (
                 <Field>

--- a/apps/desktop/src/renderer/src/components/tabs/recording-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/recording-tab.tsx
@@ -11,20 +11,13 @@ import { Switch } from '@/components/ui/switch'
 import { VideoPresetSelectItems } from '@/components/video-preset-select-items'
 import { useStudioCore } from '@/hooks/use-studio'
 import type { VideoPreset } from '@/lib/backend'
-import { videoProfileCompatibility } from '@/lib/capture'
+import {
+  layoutPresetOrientation,
+  resolutionOptionsForOrientation,
+  videoProfileCompatibility
+} from '@/lib/capture'
 import { videoProfileEntitlementGate } from '@/lib/entitlement-ui'
 import { VIDEORC_PREMIUM_URL } from '@/lib/premium-upgrade'
-
-// One-click resolutions so nobody has to remember pixel counts; picking one patches
-// width/height (switching the preset to Custom), and the number fields below stay
-// available for anything else.
-const RESOLUTION_PRESETS = [
-  { label: '4K', detail: '3840 × 2160', width: 3840, height: 2160 },
-  { label: '2K', detail: '2560 × 1440', width: 2560, height: 1440 },
-  { label: '1080p', detail: '1920 × 1080', width: 1920, height: 1080 },
-  { label: '720p', detail: '1280 × 720', width: 1280, height: 720 },
-  { label: 'Vertical', detail: '1080 × 1920', width: 1080, height: 1920 }
-] as const
 
 export function RecordingTab(): ReactElement {
   const {
@@ -36,6 +29,12 @@ export function RecordingTab(): ReactElement {
     entitlements
   } = useStudioCore()
   const { video } = captureConfig
+  // One-click resolutions so nobody has to remember pixel counts; picking one
+  // patches width/height (switching the preset to Custom). The list follows
+  // the Studio mode — vertical mode offers only portrait canvases, so the
+  // canvas can never contradict the scene's orientation.
+  const orientation = layoutPresetOrientation(captureConfig.layout.layoutPreset)
+  const resolutionPresets = resolutionOptionsForOrientation(orientation)
   const compatibility = videoProfileCompatibility(captureConfig)
   const compatibilityMessage = compatibility.blockingReason ?? compatibility.warning
   const profileGate = videoProfileEntitlementGate({ entitlements, kind: 'recording', video })
@@ -77,7 +76,11 @@ export function RecordingTab(): ReactElement {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <VideoPresetSelectItems entitlements={entitlements} kind="recording" />
+                <VideoPresetSelectItems
+                  entitlements={entitlements}
+                  kind="recording"
+                  orientation={orientation}
+                />
               </SelectContent>
             </Select>
             <FieldDescription>
@@ -111,7 +114,7 @@ export function RecordingTab(): ReactElement {
           <Field>
             <FieldLabel>Resolution</FieldLabel>
             <div className="flex flex-wrap gap-2">
-              {RESOLUTION_PRESETS.map((preset) => (
+              {resolutionPresets.map((preset) => (
                 <button
                   aria-pressed={video.width === preset.width && video.height === preset.height}
                   className="cursor-pointer rounded-row border border-border px-3 py-2 text-left text-sm font-medium transition-colors duration-100 hover:bg-accent aria-pressed:border-ring aria-pressed:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
@@ -128,18 +131,21 @@ export function RecordingTab(): ReactElement {
           </Field>
 
           <div className="grid grid-cols-2 gap-4">
+            {/* Bounds are orientation-symmetric (a portrait canvas is the
+                transposed landscape one); patchVideo transposes any entry
+                that would contradict the Studio mode's orientation. */}
             <NumberField
               disabled={isSessionActive}
               label="Width"
               max={3840}
-              min={640}
+              min={360}
               value={video.width}
               onChange={(width) => patchVideo({ width })}
             />
             <NumberField
               disabled={isSessionActive}
               label="Height"
-              max={2160}
+              max={3840}
               min={360}
               value={video.height}
               onChange={(height) => patchVideo({ height })}

--- a/apps/desktop/src/renderer/src/components/video-preset-select-items.tsx
+++ b/apps/desktop/src/renderer/src/components/video-preset-select-items.tsx
@@ -1,5 +1,6 @@
 import { LockKey } from '@phosphor-icons/react'
 import type { ReactElement } from 'react'
+import { Fragment } from 'react'
 
 import { SelectGroup, SelectItem, SelectLabel, SelectSeparator } from '@/components/ui/select'
 import type { EntitlementsSnapshot } from '@/lib/backend'
@@ -9,49 +10,57 @@ import {
   recordingVideoPresetOptions,
   streamingVideoPresetOptions,
   videoPresets,
+  type LayoutOrientation,
   type VideoPresetOption
 } from '@/lib/capture'
 import { videoProfileEntitlementGate } from '@/lib/entitlement-ui'
 
+// When the select edits the CANVAS, the Studio mode owns the orientation —
+// only same-orientation presets are offered (Custom always stays). Stream-leg
+// profile selects pass no orientation and keep the full list.
+function matchesOrientation(option: VideoPresetOption, orientation: LayoutOrientation): boolean {
+  const video = videoPresets[option.value]
+  return orientation === 'vertical' ? video.height > video.width : video.width >= video.height
+}
+
 export function VideoPresetSelectItems({
   entitlements,
-  kind
+  kind,
+  orientation
 }: {
   entitlements: EntitlementsSnapshot | null
   kind: 'recording' | 'streaming'
+  orientation?: LayoutOrientation
 }): ReactElement {
+  const groups: { label: string; options: VideoPresetOption[] }[] = [
+    { label: 'Recording', options: recordingVideoPresetOptions },
+    { label: 'Streaming', options: streamingVideoPresetOptions },
+    { label: 'Legacy', options: legacyVideoPresetOptions }
+  ]
+    .map((group) => ({
+      ...group,
+      options: orientation
+        ? group.options.filter((option) => matchesOrientation(option, orientation))
+        : group.options
+    }))
+    .filter((group) => group.options.length > 0)
+
   return (
     <SelectGroup>
-      <SelectLabel>Recording</SelectLabel>
-      {recordingVideoPresetOptions.map((option) => (
-        <VideoPresetSelectItem
-          entitlements={entitlements}
-          key={option.value}
-          kind={kind}
-          option={option}
-        />
+      {groups.map((group) => (
+        <Fragment key={group.label}>
+          <SelectLabel>{group.label}</SelectLabel>
+          {group.options.map((option) => (
+            <VideoPresetSelectItem
+              entitlements={entitlements}
+              key={option.value}
+              kind={kind}
+              option={option}
+            />
+          ))}
+          <SelectSeparator />
+        </Fragment>
       ))}
-      <SelectSeparator />
-      <SelectLabel>Streaming</SelectLabel>
-      {streamingVideoPresetOptions.map((option) => (
-        <VideoPresetSelectItem
-          entitlements={entitlements}
-          key={option.value}
-          kind={kind}
-          option={option}
-        />
-      ))}
-      <SelectSeparator />
-      <SelectLabel>Legacy</SelectLabel>
-      {legacyVideoPresetOptions.map((option) => (
-        <VideoPresetSelectItem
-          entitlements={entitlements}
-          key={option.value}
-          kind={kind}
-          option={option}
-        />
-      ))}
-      <SelectSeparator />
       <SelectItem value={customVideoPresetOption.value}>{customVideoPresetOption.label}</SelectItem>
     </SelectGroup>
   )

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -8212,10 +8212,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
       setCaptureConfig((current) => ({
         ...current,
-        video: coerceVideoToOrientation(
-          video,
-          layoutPresetOrientation(current.layout.layoutPreset)
-        )
+        video: coerceVideoToOrientation(video, layoutPresetOrientation(current.layout.layoutPreset))
       }))
     },
     [entitlements]

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -29,6 +29,7 @@ import {
   bridgeStreamingToLegacy,
   buildCameraSources,
   areEnabledStreamTargetsStartReady,
+  coerceVideoToOrientation,
   defaultSettings,
   isPlatformOAuthAvailable,
   legacyStreamKeyMigrationCandidates,
@@ -52,6 +53,7 @@ import {
   smokePreviewCompositorCaptureConfig,
   sourceSelectionChangeEvents,
   layoutPresetMemoryPatch,
+  layoutPresetOrientation,
   STORAGE_KEYS,
   streamOutputVideosForTargets,
   streamOutputVideoSettings,
@@ -8183,7 +8185,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const patchVideo = useCallback((patch: Partial<VideoSettings>) => {
     setCaptureConfig((current) => ({
       ...current,
-      video: { ...current.video, ...patch, preset: 'custom' }
+      // The Studio mode owns the canvas orientation — a patch that would
+      // contradict the active scene's orientation transposes width/height.
+      video: coerceVideoToOrientation(
+        { ...current.video, ...patch, preset: 'custom' },
+        layoutPresetOrientation(current.layout.layoutPreset)
+      )
     }))
   }, [])
 
@@ -8203,7 +8210,13 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         return
       }
 
-      setCaptureConfig((current) => ({ ...current, video }))
+      setCaptureConfig((current) => ({
+        ...current,
+        video: coerceVideoToOrientation(
+          video,
+          layoutPresetOrientation(current.layout.layoutPreset)
+        )
+      }))
     },
     [entitlements]
   )

--- a/apps/desktop/src/renderer/src/lib/capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.test.ts
@@ -734,6 +734,9 @@ describe('layout preset source requirements', () => {
     expect(layoutPresetNeedsScreen('vertical-screen-camera')).toBe(true)
     expect(layoutPresetNeedsScreen('vertical-screen-only')).toBe(true)
     expect(layoutPresetNeedsScreen('camera-only')).toBe(false)
+    // The camera-only scenes are what makes each mode usable without a
+    // screen — a camera-only creator must never see zero enabled scenes.
+    expect(layoutPresetNeedsScreen('vertical-camera-only')).toBe(false)
   })
 
   it('matches the backend blockers for camera-required presets', () => {
@@ -744,6 +747,7 @@ describe('layout preset source requirements', () => {
     expect(layoutPresetNeedsCamera('vertical-camera-bottom')).toBe(true)
     expect(layoutPresetNeedsCamera('vertical-split')).toBe(true)
     expect(layoutPresetNeedsCamera('vertical-screen-camera')).toBe(true)
+    expect(layoutPresetNeedsCamera('vertical-camera-only')).toBe(true)
     expect(layoutPresetNeedsCamera('screen-only')).toBe(false)
     expect(layoutPresetNeedsCamera('vertical-screen-only')).toBe(false)
   })

--- a/apps/desktop/src/renderer/src/lib/capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.test.ts
@@ -23,6 +23,8 @@ import {
   isSelectableCaptureDevice,
   HORIZONTAL_LAYOUT_PRESETS,
   VERTICAL_LAYOUT_PRESETS,
+  coerceVideoToOrientation,
+  resolutionOptionsForOrientation,
   layoutPresetMemoryPatch,
   layoutPresetNeedsCamera,
   layoutPresetOrientation,
@@ -1579,5 +1581,95 @@ describe('vertical orientation video coupling', () => {
         landscape
       )
     ).toBeNull()
+  })
+})
+
+describe('canvas orientation lock (the Studio mode owns the orientation)', () => {
+  const landscape2k = { ...videoPresets['tutorial-1440p30'] }
+
+  it('transposes a landscape canvas entering a vertical scene and marks it Custom', () => {
+    expect(coerceVideoToOrientation(landscape2k, 'vertical')).toEqual({
+      ...landscape2k,
+      preset: 'custom',
+      width: 1440,
+      height: 2560
+    })
+  })
+
+  it('transposes a portrait canvas under a horizontal scene', () => {
+    const portrait = { ...videoPresets['vertical-1080x1920'] }
+    expect(coerceVideoToOrientation(portrait, 'horizontal')).toEqual({
+      ...portrait,
+      preset: 'custom',
+      width: 1920,
+      height: 1080
+    })
+  })
+
+  it('keeps a matching canvas untouched, preset included', () => {
+    expect(coerceVideoToOrientation(landscape2k, 'horizontal')).toBe(landscape2k)
+    const portrait = videoPresets['vertical-1080x1920']
+    expect(coerceVideoToOrientation(portrait, 'vertical')).toBe(portrait)
+    // Square canvases belong to neither orientation — never touched.
+    const square = { ...landscape2k, preset: 'custom' as const, width: 1080, height: 1080 }
+    expect(coerceVideoToOrientation(square, 'vertical')).toBe(square)
+    expect(coerceVideoToOrientation(square, 'horizontal')).toBe(square)
+  })
+
+  it('offers only same-orientation one-click resolutions per mode', () => {
+    for (const option of resolutionOptionsForOrientation('vertical')) {
+      expect(option.height).toBeGreaterThan(option.width)
+    }
+    for (const option of resolutionOptionsForOrientation('horizontal')) {
+      expect(option.width).toBeGreaterThan(option.height)
+    }
+    // The vertical list is the transposed twin of the landscape list, so the
+    // quality ladder is identical in both modes.
+    expect(
+      resolutionOptionsForOrientation('vertical').map(({ width, height }) => [height, width])
+    ).toEqual(
+      resolutionOptionsForOrientation('horizontal').map(({ width, height }) => [width, height])
+    )
+  })
+
+  it('normalizes a persisted landscape canvas under a vertical scene on load', () => {
+    // A pre-lock build could persist exactly the owner-screenshot state:
+    // vertical-split scene with a landscape 2K canvas.
+    vi.stubGlobal('localStorage', {
+      getItem: () =>
+        JSON.stringify({
+          layout: { layoutPreset: 'vertical-split' },
+          video: { preset: 'custom', width: 2560, height: 1440, fps: 30, bitrateKbps: 8000 }
+        }),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    })
+    expect(loadCaptureConfig().video).toMatchObject({
+      preset: 'custom',
+      width: 1440,
+      height: 2560
+    })
+
+    // And the remembered landscape profile can never be portrait.
+    vi.stubGlobal('localStorage', {
+      getItem: () =>
+        JSON.stringify({
+          layout: { layoutPreset: 'vertical-split' },
+          video: { preset: 'custom', width: 1080, height: 1920, fps: 30, bitrateKbps: 9000 },
+          verticalRestoreVideo: {
+            preset: 'custom',
+            width: 1080,
+            height: 1920,
+            fps: 30,
+            bitrateKbps: 9000
+          }
+        }),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    })
+    expect(loadCaptureConfig().verticalRestoreVideo).toMatchObject({
+      width: 1920,
+      height: 1080
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -101,7 +101,8 @@ export function layoutPresetNeedsCamera(preset: LayoutPreset): boolean {
     preset === 'vertical-camera-top' ||
     preset === 'vertical-camera-bottom' ||
     preset === 'vertical-split' ||
-    preset === 'vertical-screen-camera'
+    preset === 'vertical-screen-camera' ||
+    preset === 'vertical-camera-only'
   )
 }
 

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -763,7 +763,10 @@ export function loadCaptureConfig(): CaptureConfig {
     ),
     verticalRestoreVideo:
       loaded.verticalRestoreVideo != null
-        ? coerceVideoToOrientation(normalizeVideoSettings(loaded.verticalRestoreVideo), 'horizontal')
+        ? coerceVideoToOrientation(
+            normalizeVideoSettings(loaded.verticalRestoreVideo),
+            'horizontal'
+          )
         : null,
     lastHorizontalPreset: normalizeRememberedPreset(loaded.lastHorizontalPreset, 'horizontal'),
     lastVerticalPreset: normalizeRememberedPreset(loaded.lastVerticalPreset, 'vertical'),

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -128,6 +128,57 @@ export type VerticalOrientationVideoPatch = {
 }
 
 /**
+ * The Studio mode owns the canvas orientation: vertical mode records a
+ * portrait canvas, horizontal a landscape one. Any video change that would
+ * contradict the active scene's orientation transposes width/height — the
+ * quality choice survives, the preset honestly becomes Custom. Every canvas
+ * write flows through this (patchVideo, applyVideoPreset, config load), and
+ * the backend refuses a mismatched session start as defense in depth.
+ */
+export function coerceVideoToOrientation(
+  video: VideoSettings,
+  orientation: LayoutOrientation
+): VideoSettings {
+  const transpose =
+    orientation === 'vertical' ? video.width > video.height : video.height > video.width
+  if (!transpose) {
+    return video
+  }
+  return { ...video, preset: 'custom', width: video.height, height: video.width }
+}
+
+export type ResolutionOption = {
+  label: string
+  detail: string
+  width: number
+  height: number
+}
+
+// One-click canvas sizes offered by Quick Settings and the Output tab. Each
+// Studio mode gets its own list — the vertical options are the transposed
+// twins of the landscape ones, so orientation can never contradict the mode
+// (the mode toggle is the one home for orientation).
+const HORIZONTAL_RESOLUTION_OPTIONS: ResolutionOption[] = [
+  { label: '4K', detail: '3840 × 2160', width: 3840, height: 2160 },
+  { label: '2K', detail: '2560 × 1440', width: 2560, height: 1440 },
+  { label: '1080p', detail: '1920 × 1080', width: 1920, height: 1080 },
+  { label: '720p', detail: '1280 × 720', width: 1280, height: 720 }
+]
+
+const VERTICAL_RESOLUTION_OPTIONS: ResolutionOption[] = [
+  { label: '4K', detail: '2160 × 3840', width: 2160, height: 3840 },
+  { label: '2K', detail: '1440 × 2560', width: 1440, height: 2560 },
+  { label: '1080p', detail: '1080 × 1920', width: 1080, height: 1920 },
+  { label: '720p', detail: '720 × 1280', width: 720, height: 1280 }
+]
+
+export function resolutionOptionsForOrientation(
+  orientation: LayoutOrientation
+): ResolutionOption[] {
+  return orientation === 'vertical' ? VERTICAL_RESOLUTION_OPTIONS : HORIZONTAL_RESOLUTION_OPTIONS
+}
+
+/**
  * Off-air orientation coupling for the Studio modes: entering a vertical
  * scene flips the canvas to the portrait profile and remembers the landscape
  * settings; leaving restores exactly what was there. Returns null when no
@@ -694,17 +745,24 @@ export function loadCaptureConfig(): CaptureConfig {
     defaultCaptureConfig
   ) as Partial<CaptureConfig>
   const { testPattern: _loadedTestPattern, ...loadedSources } = loaded.sources ?? {}
+  const layout = normalizeLayoutSettings(loaded.layout)
 
   return {
     ...defaultCaptureConfig,
     ...loaded,
     sources: { ...defaultCaptureConfig.sources, ...loadedSources, testPattern: false },
-    layout: normalizeLayoutSettings(loaded.layout),
+    layout,
     audio: normalizeAudioSettings(loaded.audio),
-    video: normalizeVideoSettings(loaded.video),
+    // A persisted canvas that contradicts the persisted scene's orientation
+    // (e.g. a landscape 2K under a vertical scene, saved by a pre-lock build)
+    // normalizes to the mode's orientation on load.
+    video: coerceVideoToOrientation(
+      normalizeVideoSettings(loaded.video),
+      layoutPresetOrientation(layout.layoutPreset)
+    ),
     verticalRestoreVideo:
       loaded.verticalRestoreVideo != null
-        ? normalizeVideoSettings(loaded.verticalRestoreVideo)
+        ? coerceVideoToOrientation(normalizeVideoSettings(loaded.verticalRestoreVideo), 'horizontal')
         : null,
     lastHorizontalPreset: normalizeRememberedPreset(loaded.lastHorizontalPreset, 'horizontal'),
     lastVerticalPreset: normalizeRememberedPreset(loaded.lastVerticalPreset, 'vertical'),

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -296,6 +296,7 @@ export type LayoutPreset =
   | 'vertical-split'
   | 'vertical-screen-camera'
   | 'vertical-screen-only'
+  | 'vertical-camera-only'
 
 /**
  * The Studio scene vocabularies by orientation mode, in gallery order. The
@@ -315,7 +316,8 @@ export const VERTICAL_LAYOUT_PRESETS = [
   'vertical-camera-bottom',
   'vertical-split',
   'vertical-screen-camera',
-  'vertical-screen-only'
+  'vertical-screen-only',
+  'vertical-camera-only'
 ] as const satisfies readonly LayoutPreset[]
 
 export const LAYOUT_PRESET_VALUES = [

--- a/apps/desktop/src/shared/native-preview-proof-geometry.test.ts
+++ b/apps/desktop/src/shared/native-preview-proof-geometry.test.ts
@@ -47,13 +47,39 @@ describe('Windows proof-surface geometry', () => {
     expect(previewProofLayerFit(camera, layout({ cameraFit: 'fill' }))).toBe('cover')
   })
 
-  it('covers only side-by-side screen regions', () => {
-    expect(previewProofLayerFit(screen, layout({ layoutPreset: 'screen-only' }))).toBe('contain')
-    expect(previewProofLayerFit(screen, layout({ layoutPreset: 'side-by-side' }))).toBe('cover')
-    // Vertical screen bands CONTAIN — nothing on the user's screen is cropped.
-    expect(previewProofLayerFit(screen, layout({ layoutPreset: 'vertical-camera-top' }))).toBe(
+  it('ignores camera Fit for band and full-canvas vertical cameras like Rust', () => {
+    // Vertical filled cameras COVER even with Fit set — a contained camera
+    // letterboxes its region (the vertical fill law). The inset bubble keeps
+    // the user's Fit like its horizontal twin.
+    for (const layoutPreset of [
+      'vertical-camera-top',
+      'vertical-camera-bottom',
+      'vertical-split',
+      'vertical-camera-only'
+    ] as const) {
+      expect(previewProofLayerFit(camera, layout({ layoutPreset }))).toBe('cover')
+    }
+    expect(previewProofLayerFit(camera, layout({ layoutPreset: 'vertical-screen-camera' }))).toBe(
       'contain'
     )
+  })
+
+  it('covers side-by-side and every vertical screen region', () => {
+    expect(previewProofLayerFit(screen, layout({ layoutPreset: 'screen-only' }))).toBe('contain')
+    expect(previewProofLayerFit(screen, layout({ layoutPreset: 'side-by-side' }))).toBe('cover')
+    // Vertical regions are always FILLED (cover) — the fill-crop law shipped
+    // in #97; a containing proof layer would flash letterboxed before the
+    // compositor publishes its authoritative fit.
+    for (const layoutPreset of [
+      'vertical-camera-top',
+      'vertical-camera-bottom',
+      'vertical-split',
+      'vertical-screen-camera',
+      'vertical-screen-only',
+      'vertical-camera-only'
+    ] as const) {
+      expect(previewProofLayerFit(screen, layout({ layoutPreset }))).toBe('cover')
+    }
   })
 
   it('preserves rounded and circle masks only for the inset scene overlays', () => {

--- a/apps/desktop/src/shared/native-preview-proof-geometry.ts
+++ b/apps/desktop/src/shared/native-preview-proof-geometry.ts
@@ -1,4 +1,10 @@
-import type { CameraShape, EffectiveSceneBackground, LayoutSettings, SceneSource } from './backend'
+import type {
+  CameraShape,
+  EffectiveSceneBackground,
+  LayoutPreset,
+  LayoutSettings,
+  SceneSource
+} from './backend'
 
 /** Keep the proof surface's background stage identical to Rust scene geometry. */
 export function previewProofBackgroundStageMargin(
@@ -7,6 +13,28 @@ export function previewProofBackgroundStageMargin(
   if (!background) return 0
   return Math.min(0.2, Math.max(0, background.visibilityPercent / 200))
 }
+
+// Mirrors Rust `scene_geometry::vertical_fill_preset`: every vertical scene's
+// regions are short-form bands that are always FILLED (cover), never
+// letterboxed.
+const VERTICAL_FILL_PRESETS: readonly LayoutPreset[] = [
+  'vertical-camera-top',
+  'vertical-camera-bottom',
+  'vertical-split',
+  'vertical-screen-camera',
+  'vertical-screen-only',
+  'vertical-camera-only'
+]
+
+// Band cameras and the full-canvas vertical camera ignore the user's Fit —
+// a contained camera letterboxes its region. Only the vertical screen+camera
+// inset bubble keeps the Fit choice (like its horizontal twin).
+const VERTICAL_FILLED_CAMERA_PRESETS: readonly LayoutPreset[] = [
+  'vertical-camera-top',
+  'vertical-camera-bottom',
+  'vertical-split',
+  'vertical-camera-only'
+]
 
 /**
  * Geometry policy used before the backend compositor has published its
@@ -18,9 +46,15 @@ export function previewProofLayerFit(
   layout: LayoutSettings
 ): 'contain' | 'cover' {
   if (source.kind === 'camera') {
+    if (VERTICAL_FILLED_CAMERA_PRESETS.includes(layout.layoutPreset)) {
+      return 'cover'
+    }
     return layout.cameraFit === 'fit' && layout.cameraZoom <= 100 ? 'contain' : 'cover'
   }
-  return layout.layoutPreset === 'side-by-side' ? 'cover' : 'contain'
+  return layout.layoutPreset === 'side-by-side' ||
+    VERTICAL_FILL_PRESETS.includes(layout.layoutPreset)
+    ? 'cover'
+    : 'contain'
 }
 
 export function previewProofLayerShape(

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -469,6 +469,7 @@ pub enum LayoutPreset {
     VerticalSplit,
     VerticalScreenCamera,
     VerticalScreenOnly,
+    VerticalCameraOnly,
 }
 
 impl LayoutPreset {
@@ -483,6 +484,7 @@ impl LayoutPreset {
                 | LayoutPreset::VerticalSplit
                 | LayoutPreset::VerticalScreenCamera
                 | LayoutPreset::VerticalScreenOnly
+                | LayoutPreset::VerticalCameraOnly
         )
     }
 }
@@ -3214,6 +3216,18 @@ mod tests {
             serde_json::to_value(LayoutPreset::VerticalScreenOnly).unwrap(),
             serde_json::json!("vertical-screen-only")
         );
+        // Explicit wire pin: smokes ride preset custom, so this test is the
+        // only CI coverage that the TS list and the Rust enum agree (the
+        // 0.9.32 lesson — a preset name missing on one side broke the wire).
+        assert_eq!(
+            serde_json::to_value(LayoutPreset::VerticalCameraOnly).unwrap(),
+            serde_json::json!("vertical-camera-only")
+        );
+        assert_eq!(
+            serde_json::from_value::<LayoutPreset>(serde_json::json!("vertical-camera-only"))
+                .unwrap(),
+            LayoutPreset::VerticalCameraOnly
+        );
     }
 
     #[test]
@@ -3229,6 +3243,7 @@ mod tests {
         assert!(LayoutPreset::VerticalSplit.is_vertical());
         assert!(LayoutPreset::VerticalScreenCamera.is_vertical());
         assert!(LayoutPreset::VerticalScreenOnly.is_vertical());
+        assert!(LayoutPreset::VerticalCameraOnly.is_vertical());
     }
 
     #[test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -7594,7 +7594,10 @@ fn video_filter(
         return camera_only_video_filter(params, preview);
     }
 
-    if matches!(params.layout.layout_preset, LayoutPreset::VerticalCameraOnly) {
+    if matches!(
+        params.layout.layout_preset,
+        LayoutPreset::VerticalCameraOnly
+    ) {
         // Same full-frame camera as CameraOnly, but the portrait canvas is
         // always FILLED (vertical fill law) — the user's Fit choice must not
         // letterbox the canvas; zoom/pan still frame the crop.

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -7594,6 +7594,15 @@ fn video_filter(
         return camera_only_video_filter(params, preview);
     }
 
+    if matches!(params.layout.layout_preset, LayoutPreset::VerticalCameraOnly) {
+        // Same full-frame camera as CameraOnly, but the portrait canvas is
+        // always FILLED (vertical fill law) — the user's Fit choice must not
+        // letterbox the canvas; zoom/pan still frame the crop.
+        let mut cover_params = params.clone();
+        cover_params.layout.camera_fit = CameraFit::Fill;
+        return camera_only_video_filter(&cover_params, preview);
+    }
+
     if matches!(params.layout.layout_preset, LayoutPreset::SideBySide) {
         return side_by_side_video_filter(camera_input_index, params, preview);
     }
@@ -7717,7 +7726,8 @@ fn vertical_stack_filter_bands(preset: &LayoutPreset) -> Option<VerticalStackFil
         | LayoutPreset::CameraOnly
         | LayoutPreset::SideBySide
         | LayoutPreset::VerticalScreenCamera
-        | LayoutPreset::VerticalScreenOnly => None,
+        | LayoutPreset::VerticalScreenOnly
+        | LayoutPreset::VerticalCameraOnly => None,
     }
 }
 
@@ -11559,6 +11569,26 @@ mod tests {
                 "scale=w=1080:h=1920:force_original_aspect_ratio=increase,crop=1080:1920"
             ),
             "portrait cover: {filter}"
+        );
+    }
+
+    #[test]
+    fn vertical_camera_only_filter_covers_the_portrait_canvas() {
+        let mut params = base_params(true, false);
+        params.layout.layout_preset = LayoutPreset::VerticalCameraOnly;
+        params.layout.camera_fit = CameraFit::Fit;
+        params.output.video.width = 1080;
+        params.output.video.height = 1920;
+
+        // The camera rides the camera-only path (input 0), but the portrait
+        // canvas is always FILLED — Fit must not pad the frame.
+        let filter = video_filter(None, &params, false);
+        assert!(!filter.contains("overlay"), "no overlay: {filter}");
+        assert!(!filter.contains("vstack"), "no stacking: {filter}");
+        assert!(!filter.contains("pad="), "no letterbox pad: {filter}");
+        assert!(
+            filter.contains("crop=w=1080:h=1920"),
+            "camera covers the portrait canvas: {filter}"
         );
     }
 

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -7737,8 +7737,19 @@ fn vertical_video_filter(
 ) -> String {
     let video = &params.output.video;
     let width = video.width;
-    let (camera_height, screen_height) = vertical_band_heights(video.height, bands.camera_fraction);
     let fps = video.fps;
+    let final_scale = if preview { ",scale=w=960:h=-2" } else { "" };
+
+    // One active source covers the WHOLE canvas (full-canvas fill plan,
+    // 2026-07-13): without a camera the bands collapse — a black camera band
+    // is never lawful short-form output. (The no-screen collapse rides the
+    // scene path; app sessions always attach a scene.)
+    let Some(camera_index) = camera_input_index else {
+        let base_scale = cover_scale_filter(video);
+        return format!("[0:v]setpts=PTS-STARTPTS,{base_scale},fps={fps}{final_scale}[v]");
+    };
+
+    let (camera_height, screen_height) = vertical_band_heights(video.height, bands.camera_fraction);
 
     // Short-form bands are FILLED (2026-07-13 fill-crop plan): the screen
     // covers its band (scale to fill + center crop, mirroring the compositor's
@@ -7747,25 +7758,17 @@ fn vertical_video_filter(
     let screen = format!(
         "[0:v]setpts=PTS-STARTPTS,scale={width}:{screen_height}:force_original_aspect_ratio=increase,crop={width}:{screen_height},fps={fps},format=yuv420p[vt_screen]"
     );
-    let camera = match camera_input_index {
-        Some(index) => {
-            let mirror = if params.layout.camera_mirror {
-                "hflip,"
-            } else {
-                ""
-            };
-            let mut band_layout = params.layout.clone();
-            band_layout.camera_fit = CameraFit::Fill;
-            let frame = camera_frame_filter(width, camera_height, &band_layout);
-            format!(
-                "[{index}:v]setpts=PTS-STARTPTS,{mirror}{frame},fps={fps},format=yuv420p[vt_camera]"
-            )
-        }
-        None => {
-            format!("color=c=black:s={width}x{camera_height}:r={fps},format=yuv420p[vt_camera]")
-        }
+    let mirror = if params.layout.camera_mirror {
+        "hflip,"
+    } else {
+        ""
     };
-    let final_scale = if preview { ",scale=w=960:h=-2" } else { "" };
+    let mut band_layout = params.layout.clone();
+    band_layout.camera_fit = CameraFit::Fill;
+    let frame = camera_frame_filter(width, camera_height, &band_layout);
+    let camera = format!(
+        "[{camera_index}:v]setpts=PTS-STARTPTS,{mirror}{frame},fps={fps},format=yuv420p[vt_camera]"
+    );
     let stack_order = if bands.camera_on_top {
         "[vt_camera][vt_screen]"
     } else {
@@ -11477,11 +11480,16 @@ mod tests {
         assert!(!filter.contains("pad="), "no letterbox pad: {filter}");
         assert!(!filter.contains("overlay"));
 
-        // Without a camera input the band renders black instead of collapsing.
+        // Without a camera input the bands collapse: the screen covers the
+        // whole canvas — never a black camera band (full-canvas fill plan).
         let no_camera = video_filter(None, &params, false);
+        assert!(!no_camera.contains("color=c=black"), "{no_camera}");
+        assert!(!no_camera.contains("vstack"), "{no_camera}");
         assert!(
-            no_camera.contains("color=c=black:s=1080x768"),
-            "{no_camera}"
+            no_camera.contains(
+                "scale=w=1080:h=1920:force_original_aspect_ratio=increase,crop=1080:1920"
+            ),
+            "screen covers the full canvas: {no_camera}"
         );
     }
 
@@ -11522,10 +11530,14 @@ mod tests {
             filter.contains("scale=1080:960:force_original_aspect_ratio=increase,crop=1080:960"),
             "screen covers: {filter}"
         );
+        // Camera-less split collapses to a full-canvas covered screen.
         let no_camera = video_filter(None, &params, false);
+        assert!(!no_camera.contains("vstack"), "{no_camera}");
         assert!(
-            no_camera.contains("color=c=black:s=1080x960"),
-            "{no_camera}"
+            no_camera.contains(
+                "scale=w=1080:h=1920:force_original_aspect_ratio=increase,crop=1080:1920"
+            ),
+            "screen covers the full canvas: {no_camera}"
         );
     }
 

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -7956,8 +7956,26 @@ fn validate_outputs(params: &StartSessionParams) -> Result<()> {
     }
 
     validate_video_settings(&params.output.video)?;
+    validate_canvas_orientation(params)?;
     validate_caption_output_policy(params)?;
     validate_video_profile_policy(params)?;
+
+    Ok(())
+}
+
+/// The Studio mode owns the canvas orientation: vertical scenes compose a
+/// portrait canvas. The renderer transposes every canvas write to match the
+/// active scene (capture.ts::coerceVideoToOrientation); this refusal is the
+/// defense in depth so a mismatched config can never record vertical bands
+/// tiled across a landscape canvas (owner screenshot, 2026-07-13).
+fn validate_canvas_orientation(params: &StartSessionParams) -> Result<()> {
+    if params.layout.layout_preset.is_vertical()
+        && params.output.video.width > params.output.video.height
+    {
+        bail!(
+            "Vertical scenes record a portrait canvas — pick a portrait resolution or switch to horizontal mode."
+        );
+    }
 
     Ok(())
 }
@@ -8007,8 +8025,12 @@ fn validate_caption_output_policy(params: &StartSessionParams) -> Result<()> {
 }
 
 fn validate_video_settings(video: &VideoSettings) -> Result<()> {
-    if !(640..=3840).contains(&video.width) || !(360..=2160).contains(&video.height) {
-        bail!("Video resolution must be between 640x360 and 3840x2160");
+    // Bounds are orientation-symmetric: a portrait canvas is the transposed
+    // landscape one (vertical Studio mode records 1080×1920 up to 2160×3840).
+    let long_side = video.width.max(video.height);
+    let short_side = video.width.min(video.height);
+    if !(640..=3840).contains(&long_side) || !(360..=2160).contains(&short_side) {
+        bail!("Video resolution must be between 640x360 and 3840x2160 in either orientation");
     }
 
     if !(24..=60).contains(&video.fps) {
@@ -8540,7 +8562,9 @@ fn require_video_profile(
 }
 
 fn is_4k_video(video: &VideoSettings) -> bool {
-    video.width >= 3840 || video.height >= 2160
+    // Orientation-symmetric: a portrait 2160×3840 canvas is 4K, but the
+    // portrait 2K twin (1440×2560) is not just because its height crosses 2160.
+    video.width.max(video.height) >= 3840 || video.width.min(video.height) >= 2160
 }
 
 fn build_stream_url(settings: &RtmpSettings) -> Result<StreamTarget> {
@@ -14528,6 +14552,60 @@ mod tests {
         let mut params = base_params(true, false);
         params.output.video.fps = 120;
 
+        assert!(validate_outputs(&params).is_err());
+    }
+
+    #[test]
+    fn vertical_scene_requires_portrait_canvas() {
+        // The owner-screenshot state (2026-07-13): a vertical scene over a
+        // landscape 2K canvas records band stacks letterboxed on a phone.
+        let mut params = base_params(true, false);
+        params.layout.layout_preset = LayoutPreset::VerticalSplit;
+        params.output.video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 2560,
+            height: 1440,
+            fps: 30,
+            bitrate_kbps: 8000,
+        };
+        let error = validate_outputs(&params).unwrap_err().to_string();
+        assert!(error.contains("portrait canvas"), "{error}");
+
+        params.output.video.width = 1440;
+        params.output.video.height = 2560;
+        validate_outputs(&params).unwrap();
+    }
+
+    #[test]
+    fn canvas_bounds_are_orientation_symmetric() {
+        let mut params = base_params(true, false);
+        params.layout.layout_preset = LayoutPreset::VerticalCameraTop;
+
+        // Portrait 4K is a legal canvas (the transposed landscape twin)…
+        params.output.video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 2160,
+            height: 3840,
+            fps: 30,
+            bitrate_kbps: 30_000,
+        };
+        validate_outputs(&params).unwrap();
+
+        // …and the portrait 2K twin is NOT classified 4K just because its
+        // height crosses 2160 (it may run above 30 fps like landscape 2K).
+        params.output.video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1440,
+            height: 2560,
+            fps: 60,
+            bitrate_kbps: 8000,
+        };
+        validate_outputs(&params).unwrap();
+
+        // The short-side cap still holds in every orientation.
+        params.output.video.width = 2560;
+        params.output.video.height = 2560;
+        params.output.video.fps = 30;
         assert!(validate_outputs(&params).is_err());
     }
 

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -124,8 +124,10 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
     };
 
     match params.layout.layout_preset {
-        LayoutPreset::CameraOnly => {
+        LayoutPreset::CameraOnly | LayoutPreset::VerticalCameraOnly => {
             // The camera is the full-frame source: no screen base, no overlay.
+            // The vertical variant is the identical arrangement on the
+            // portrait canvas (covering, per the vertical fill law).
             if let Some(camera_id) = params.sources.camera_id.clone() {
                 let mut camera =
                     camera_source(camera_id, &params.layout, output_width, output_height);
@@ -687,6 +689,17 @@ mod tests {
         let scene = scene_from_capture_config(params);
 
         assert_eq!(scene.sources.len(), 1);
+        assert_eq!(scene.sources[0].transform, full_frame_transform());
+    }
+
+    #[test]
+    fn vertical_camera_only_composes_exactly_like_camera_only() {
+        let mut params = base_params();
+        params.layout.layout_preset = LayoutPreset::VerticalCameraOnly;
+        let scene = scene_from_capture_config(params);
+
+        assert_eq!(scene.sources.len(), 1);
+        assert_eq!(scene.sources[0].kind, SceneSourceKind::Camera);
         assert_eq!(scene.sources[0].transform, full_frame_transform());
     }
 

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -194,17 +194,34 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
         // Explicit arm (no wildcard): a new preset must state its composition
         // here or fail to compile — the old `_ =>` silently composited unknown
         // presets as screen-camera. The vertical variant is the identical
-        // arrangement on the portrait canvas: screen full-frame contain,
-        // camera as the user's corner/size/shape inset bubble.
+        // arrangement on the portrait canvas: screen full-frame (covering, per
+        // the vertical fill law), camera as the user's corner/size/shape inset
+        // bubble. Vertical only: with no screen-side source the camera covers
+        // the whole canvas instead of floating over a dead placeholder (the
+        // horizontal twin keeps the placeholder — landscape mode has no fill
+        // law and Camera is the camera-only home there).
         LayoutPreset::ScreenCamera | LayoutPreset::VerticalScreenCamera => {
-            scene.sources.push(base_source(&params.sources));
-            if let Some(camera_id) = params.sources.camera_id.clone() {
-                scene.sources.push(camera_source(
-                    camera_id,
-                    &params.layout,
-                    output_width,
-                    output_height,
-                ));
+            if matches!(
+                params.layout.layout_preset,
+                LayoutPreset::VerticalScreenCamera
+            ) && !has_screen_source(&params.sources)
+                && let Some(camera_id) = params.sources.camera_id.clone()
+            {
+                let mut camera =
+                    camera_source(camera_id, &params.layout, output_width, output_height);
+                camera.transform = full_frame_transform();
+                camera.default_transform = full_frame_transform();
+                scene.sources.push(camera);
+            } else {
+                scene.sources.push(base_source(&params.sources));
+                if let Some(camera_id) = params.sources.camera_id.clone() {
+                    scene.sources.push(camera_source(
+                        camera_id,
+                        &params.layout,
+                        output_width,
+                        output_height,
+                    ));
+                }
             }
         }
     }
@@ -395,9 +412,12 @@ struct VerticalStackBands {
 }
 
 /// Push the stacked vertical arrangement: camera band at the given geometry,
-/// screen in the complementary band. Like side-by-side regions, the camera
-/// band keeps no bubble mask and the screen band CONTAINS (nothing on the
-/// user's screen may be cropped away); the camera honors the user's Fit/Fill.
+/// screen in the complementary band. Both bands COVER their regions (scale to
+/// fill + center crop — scene_geometry's vertical fill law), and like
+/// side-by-side regions the camera band keeps no bubble mask. With exactly
+/// one active source the bands collapse: the present source covers the WHOLE
+/// canvas — a black band where the other source would sit is never lawful
+/// short-form output (full-canvas fill plan, 2026-07-13).
 fn push_vertical_stack(
     scene: &mut Scene,
     params: &SceneConfigParams,
@@ -405,6 +425,13 @@ fn push_vertical_stack(
     output_height: u32,
     bands: VerticalStackBands,
 ) {
+    if let Some(source) =
+        collapsed_vertical_single_source(params, output_width, output_height)
+    {
+        scene.sources.push(source);
+        return;
+    }
+
     let (screen_y, screen_height) = if bands.camera_y == 0.0 {
         (bands.camera_height, 1.0 - bands.camera_height)
     } else {
@@ -421,6 +448,36 @@ fn push_vertical_stack(
         camera.transform = vertical_band_transform(bands.camera_y, bands.camera_height);
         camera.default_transform = camera.transform.clone();
         scene.sources.push(camera);
+    }
+}
+
+/// A screen-side source is selected: a window, a screen, or the test pattern
+/// (the same precedence base_source composites).
+fn has_screen_source(sources: &SourceSelection) -> bool {
+    sources.window_id.is_some() || sources.screen_id.is_some() || sources.test_pattern
+}
+
+/// The single full-canvas source a two-role vertical preset collapses to when
+/// only one source is active, or None when both roles are filled and the
+/// preset's own arrangement applies. With neither source active this yields
+/// the full-frame placeholder base (never a dead band).
+fn collapsed_vertical_single_source(
+    params: &SceneConfigParams,
+    output_width: u32,
+    output_height: u32,
+) -> Option<SceneSource> {
+    let has_screen = has_screen_source(&params.sources);
+    let camera_id = params.sources.camera_id.clone();
+    match (has_screen, camera_id) {
+        (true, Some(_)) => None,
+        (false, Some(camera_id)) => {
+            let mut camera =
+                camera_source(camera_id, &params.layout, output_width, output_height);
+            camera.transform = full_frame_transform();
+            camera.default_transform = full_frame_transform();
+            Some(camera)
+        }
+        (_, None) => Some(base_source(&params.sources)),
     }
 }
 
@@ -634,16 +691,55 @@ mod tests {
     }
 
     #[test]
-    fn vertical_stack_without_camera_keeps_the_screen_band() {
-        // Transient state only — the selection blocker refuses these presets
-        // without a camera; the band stays consistent with side-by-side.
+    fn vertical_stack_without_camera_expands_the_screen_full_canvas() {
+        // One active source covers the whole canvas — a black band where the
+        // camera would sit is never lawful short-form output.
         let mut params = base_params();
         params.layout.layout_preset = LayoutPreset::VerticalCameraTop;
         params.sources.camera_id = None;
         let scene = scene_from_capture_config(params);
 
         assert_eq!(scene.sources.len(), 1);
-        assert_eq!(scene.sources[0].transform.y, VERTICAL_CAMERA_BAND);
+        assert_eq!(scene.sources[0].transform, full_frame_transform());
+    }
+
+    #[test]
+    fn vertical_stack_without_screen_expands_the_camera_full_canvas() {
+        let mut params = base_params();
+        params.layout.layout_preset = LayoutPreset::VerticalSplit;
+        params.sources.screen_id = None;
+        params.sources.window_id = None;
+        params.sources.test_pattern = false;
+        let scene = scene_from_capture_config(params);
+
+        assert_eq!(scene.sources.len(), 1);
+        assert_eq!(scene.sources[0].kind, SceneSourceKind::Camera);
+        assert_eq!(scene.sources[0].transform, full_frame_transform());
+    }
+
+    #[test]
+    fn vertical_screen_camera_without_screen_expands_the_camera_full_canvas() {
+        // Vertical only: the bubble collapses to a full-canvas camera instead
+        // of floating over a dead placeholder. The horizontal twin keeps the
+        // placeholder (landscape mode has no fill law).
+        let mut params = base_params();
+        params.layout.layout_preset = LayoutPreset::VerticalScreenCamera;
+        params.sources.screen_id = None;
+        params.sources.window_id = None;
+        params.sources.test_pattern = false;
+        let scene = scene_from_capture_config(params);
+
+        assert_eq!(scene.sources.len(), 1);
+        assert_eq!(scene.sources[0].kind, SceneSourceKind::Camera);
+        assert_eq!(scene.sources[0].transform, full_frame_transform());
+
+        let mut horizontal = base_params();
+        horizontal.layout.layout_preset = LayoutPreset::ScreenCamera;
+        horizontal.sources.screen_id = None;
+        horizontal.sources.window_id = None;
+        horizontal.sources.test_pattern = false;
+        let horizontal_scene = scene_from_capture_config(horizontal);
+        assert_eq!(horizontal_scene.sources.len(), 2);
     }
 
     #[test]

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -140,7 +140,8 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
         }
         LayoutPreset::ScreenOnly | LayoutPreset::VerticalScreenOnly => {
             // Screen-only never composites the camera; the vertical variant is
-            // the same full-frame contain on the portrait canvas.
+            // the same full-frame arrangement on the portrait canvas (covering,
+            // per the vertical fill law — horizontal keeps contain).
             scene.sources.push(base_source(&params.sources));
         }
         LayoutPreset::SideBySide => {
@@ -604,7 +605,7 @@ mod tests {
     };
 
     #[test]
-    fn vertical_camera_top_stacks_camera_band_over_contained_screen() {
+    fn vertical_camera_top_stacks_camera_band_over_covered_screen() {
         let mut params = base_params();
         params.layout.layout_preset = LayoutPreset::VerticalCameraTop;
         let scene = scene_from_capture_config(params);

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -428,9 +428,7 @@ fn push_vertical_stack(
     output_height: u32,
     bands: VerticalStackBands,
 ) {
-    if let Some(source) =
-        collapsed_vertical_single_source(params, output_width, output_height)
-    {
+    if let Some(source) = collapsed_vertical_single_source(params, output_width, output_height) {
         scene.sources.push(source);
         return;
     }
@@ -474,8 +472,7 @@ fn collapsed_vertical_single_source(
     match (has_screen, camera_id) {
         (true, Some(_)) => None,
         (false, Some(camera_id)) => {
-            let mut camera =
-                camera_source(camera_id, &params.layout, output_width, output_height);
+            let mut camera = camera_source(camera_id, &params.layout, output_width, output_height);
             camera.transform = full_frame_transform();
             camera.default_transform = full_frame_transform();
             Some(camera)

--- a/crates/videorc-backend/src/scene_geometry.rs
+++ b/crates/videorc-backend/src/scene_geometry.rs
@@ -174,6 +174,7 @@ fn vertical_fill_preset(preset: &LayoutPreset) -> bool {
             | LayoutPreset::VerticalSplit
             | LayoutPreset::VerticalScreenCamera
             | LayoutPreset::VerticalScreenOnly
+            | LayoutPreset::VerticalCameraOnly
     )
 }
 
@@ -188,13 +189,18 @@ fn vertical_fill_preset(preset: &LayoutPreset) -> bool {
 pub fn scene_source_fit(kind: &SceneSourceKind, layout: &LayoutSettings) -> SceneFit {
     match kind {
         SceneSourceKind::Camera => {
-            let band_camera = matches!(
+            // Band cameras and the full-canvas vertical camera always cover:
+            // a contained camera letterboxes its region, which is exactly the
+            // vertical fill law's bug. Only the vertical screen+camera inset
+            // bubble keeps the user's Fit choice (like its horizontal twin).
+            let vertical_filled_camera = matches!(
                 layout.layout_preset,
                 LayoutPreset::VerticalCameraTop
                     | LayoutPreset::VerticalCameraBottom
                     | LayoutPreset::VerticalSplit
+                    | LayoutPreset::VerticalCameraOnly
             );
-            if band_camera {
+            if vertical_filled_camera {
                 return SceneFit::Cover;
             }
             if matches!(layout.camera_fit, CameraFit::Fit) && layout.camera_zoom <= 100 {
@@ -527,6 +533,14 @@ mod tests {
                 LayoutPreset::VerticalScreenOnly,
                 SceneFit::Cover,
                 SceneFit::Contain,
+                SceneMask::None,
+            ),
+            // The full-canvas vertical camera ignores Fit like the bands do
+            // (the portrait canvas is always filled) and stays maskless.
+            (
+                LayoutPreset::VerticalCameraOnly,
+                SceneFit::Cover,
+                SceneFit::Cover,
                 SceneMask::None,
             ),
         ];

--- a/crates/videorc-backend/src/storage.rs
+++ b/crates/videorc-backend/src/storage.rs
@@ -4635,6 +4635,7 @@ pub fn session_scene_label(
             crate::protocol::LayoutPreset::VerticalSplit => "Vertical · Split",
             crate::protocol::LayoutPreset::VerticalScreenCamera => "Vertical · Screen + Camera",
             crate::protocol::LayoutPreset::VerticalScreenOnly => "Vertical · Screen only",
+            crate::protocol::LayoutPreset::VerticalCameraOnly => "Vertical · Camera only",
         }
         .to_string(),
     )

--- a/scripts/smoke-layout-source-loop-app.mjs
+++ b/scripts/smoke-layout-source-loop-app.mjs
@@ -42,6 +42,10 @@ const LAYOUTS = [
   {
     preset: 'vertical-screen-only',
     expectedKinds: ['test-pattern']
+  },
+  {
+    preset: 'vertical-camera-only',
+    expectedKinds: ['camera']
   }
 ]
 

--- a/scripts/smoke-recording-session.mjs
+++ b/scripts/smoke-recording-session.mjs
@@ -25,9 +25,9 @@ export const LAYOUT_PRESET_SCENARIOS = [
   // The vertical scenes record a true PORTRAIT canvas and the artifact's
   // probed dimensions are asserted below — a vertical scene that silently
   // produced landscape pixels must fail here. 720x1280 is the smallest exact
-  // 9:16 canvas inside the backend's resolution bounds (width >= 640). One
-  // stacked and one inset scenario record real artifacts; the remaining
-  // vertical arrangements (camera-bottom, split, screen-only) are covered at
+  // 9:16 canvas inside the backend's resolution bounds. One stacked and one
+  // inset scenario record real artifacts; the remaining vertical arrangements
+  // (camera-bottom, split, screen-only, camera-only) are covered at
   // scene-fixture and FFmpeg-filter level plus the layout-source-loop smoke.
   {
     preset: 'vertical-camera-top',


### PR DESCRIPTION
## Short format fills the whole 9:16 canvas — always

Owner report (phone screenshot on 0.9.34-beta.1): a vertical-mode recording played back as a 16:9 band stack floating in the middle of the phone screen, black above and below.

**Root cause:** the band cover-crop fix (#97) works — but nothing forced the canvas itself to be portrait. The resolution one-clicks in Quick Settings and the Output tab (plus the free-form width/height fields) are orientation-blind; the owner's screenshot even shows "2K 2560×1440" selected with the 9:16 toggle on. Vertical bands then tile a landscape canvas, and the phone letterboxes the result. Full diagnosis in the vault plan (`2026-07-13 - Videorc Short Format Full Canvas Fill Plan`).

**The law this PR ships:** in short-format mode the canvas is always 9:16 portrait and every pixel is content — one active source covers the full canvas center-cropped; two sources tile bands (unchanged); no black bars, ever.

### S1 — The Studio mode owns the canvas orientation
- Per-mode resolution one-clicks: vertical mode offers the transposed portrait twins (720/1080p/2K/4K); the "Vertical" entry leaves the horizontal list (the mode toggle is the one home for orientation).
- `coerceVideoToOrientation` at every canvas write (`patchVideo`, `applyVideoPreset`, config load): a contradicting canvas transposes width/height and honestly becomes Custom.
- The Output tab's named-preset select filters to same-orientation presets.
- Backend defense in depth: session start refuses a vertical scene on a landscape canvas with an actionable error.
- `validate_video_settings` / `is_4k_video` are orientation-symmetric, so portrait 2K/4K canvases are legal and portrait 2K is not misread as 4K.

### S2 — One-source vertical scenes collapse to full canvas
- No camera → the screen covers the whole canvas (was: black camera band, pinned by tests now flipped).
- No screen → the camera covers the whole canvas (was: dead placeholder band); `vertical-screen-camera` collapses too (vertical only — the horizontal twin keeps its semantics).
- Legacy FFmpeg fallback drops the `color=black` band for the camera-less stack.

### S3 — New scene: vertical "Camera"
Vertical mode had no camera-only scene — all five scenes required a screen, so a camera-only creator saw **zero enabled scenes**. `vertical-camera-only` composes the camera across the whole portrait canvas (always Cover, maskless; zoom/pan frame the crop). Wire pinned on both sides (the 0.9.32 lesson).

### S4 — Stale mirrors
`previewProofLayerFit` still contained vertical screens (pre-#97 policy) — the preview could flash letterboxed before the compositor published its fit. Now mirrors `scene_geometry` exactly. Stale comments/copy fixed.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm format:check` — green
- `pnpm --filter @videorc/desktop test` — 1007 passed
- `pnpm test:scripts` — 609 passed
- `cargo fmt --check --all`, `cargo test -p videorc-backend` (all suites), `cargo clippy -- -D warnings` — green
- `pnpm smoke:recording-studio` steps 1–11 — PASS, including the **dev-app all-layout recording artifact smoke** (ffprobe-inspected artifacts; the vertical scenarios assert true portrait dimensions) and the real-launch first-frame contract; steps 13, 14, 16, 17, 20, 21 (live layout-switch recording, comment-highlight stream, pump diagnostics, click-focus, preview-window probe, surface reattach) — PASS individually.
- **Blocked in this environment, not by this change:** steps 12/15/18 fail at `select-camera-device` ("No camera device available to select") because the run happened from an isolated git worktree whose dev binaries have no TCC camera grant (grants are per binary path) — the identical failure reproduces on clean `origin/main` in the same worktree. Steps 22/23 (real ScreenCaptureKit smokes) need the same grants and were not attempted. Step 19 `probe:preview-lifecycle`: functional PASS (100 toggle cycles) but exit 2 on the memory-budget gate — the known pre-existing failure on clean main (2026-07-08 note). Recommend one `pnpm smoke:recording-studio` from the granted `~/projects/videorc` checkout after merge.

Owner by-eye after merge: vertical recording on a phone fills edge-to-edge in all three source configurations (both / camera-only / screen-only); horizontal mode unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
