### PR TITLE
Release 0.9.36-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.36-beta.1.md
+++ b/changelog/0.9.36-beta.1.md
@@ -1,0 +1,37 @@
+---
+version: 0.9.36-beta.1
+date: 2026-07-13
+channel: beta
+title: Short-format mode always fills the whole 9:16 frame
+summary: Vertical recordings can no longer come out letterboxed — the canvas is always true 9:16, single-source scenes fill the whole frame, and a new full-screen Camera scene joins vertical mode.
+highlights:
+  - Vertical mode always records a true portrait canvas — picking a resolution can no longer flip your short-form recording to landscape.
+  - Portrait resolutions got a proper ladder — 720, 1080p, 2K, and 4K, matching the landscape options.
+  - A vertical scene with only one source now fills the whole frame with it, instead of leaving a black band.
+  - New vertical scene, Camera — your camera full screen in 9:16, cropped to fit, with zoom and pan to frame yourself.
+---
+
+## The canvas can no longer contradict the mode
+
+Short-format mode is for phones, and phones want 9:16. Until now the
+resolution picker could quietly hand a vertical scene a landscape canvas
+— the recording then played back on a phone as a thin strip with black
+above and below. That combination is gone: in vertical mode every
+resolution option is portrait (720 × 1280 up to a full 2160 × 3840), the
+width and height fields swap themselves if a value would flip the
+orientation, and a mismatched older setting heals itself on launch.
+
+## One source, whole frame
+
+A vertical scene with just a screen or just a camera used to keep the
+other source's band — as a black stripe. Now the source you have fills
+the entire frame, center-cropped, exactly like short-form video should
+look. Add the second source and the familiar bands come right back.
+
+## New scene: Camera
+
+Vertical mode now has a full-screen Camera scene. Your camera covers the
+whole 9:16 frame — cropped to fit, never letterboxed — and zoom and pan
+let you frame yourself. It is also the first vertical scene that works
+without a screen selected, so camera-only creators are no longer locked
+out of vertical mode.


### PR DESCRIPTION
Version bump to 0.9.36 + user-facing changelog entry for the short-format full-canvas release (#104).

- `apps/desktop/package.json` → 0.9.36 (the updater feed key)
- `changelog/0.9.36-beta.1.md` — `pnpm changelog:check`: 37 entries valid, latest 0.9.36-beta.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen Camera scene for vertical video, which works without selecting a screen.
  * Improved one-source vertical scenes to fill the frame with center-cropping instead of black bands.

* **Bug Fixes**
  * Vertical mode now consistently uses a 9:16 portrait canvas, preventing landscape resolutions from being selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->