### PR TITLE
feat: add premium on-device noise cleanup

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -9152,13 +9152,39 @@ function smokeRendererScript(command: string, params: Record<string, unknown>): 
       if (${JSON.stringify(command)} === 'select-layout-preset') {
         const preset = String(params.preset ?? 'screen-only');
         await openTab('layout', '[data-videorc-layout-preset]');
-        const deadline = Date.now() + 5000;
         let button = null;
+        let deadline = Date.now() + 5000;
         while (Date.now() < deadline) {
           button = Array.from(document.querySelectorAll('[data-videorc-layout-preset]'))
             .find((candidate) => candidate.getAttribute('data-videorc-layout-preset') === preset);
           if (button && !button.disabled) break;
           await sleep(50);
+        }
+        // Layout controls are mode-scoped: landscape and portrait presets are
+        // intentionally never mounted together. The QA command owns the mode
+        // transition so maintained smokes can exercise both vocabularies.
+        if (!button) {
+          await openTab('studio', '[aria-label="Studio orientation"]');
+          const orientationLabel = preset.startsWith('vertical-')
+            ? 'Vertical studio (9:16)'
+            : 'Horizontal studio (16:9)';
+          const orientationButton = document.querySelector(
+            'button[aria-label="' + orientationLabel + '"]'
+          );
+          if (!orientationButton || orientationButton.disabled) {
+            throw new Error('Could not switch Studio orientation for layout preset ' + preset);
+          }
+          if (orientationButton.getAttribute('aria-pressed') !== 'true') {
+            orientationButton.click();
+          }
+          await openTab('layout', '[data-videorc-layout-preset]');
+          deadline = Date.now() + 5000;
+          while (Date.now() < deadline) {
+            button = Array.from(document.querySelectorAll('[data-videorc-layout-preset]'))
+              .find((candidate) => candidate.getAttribute('data-videorc-layout-preset') === preset);
+            if (button && !button.disabled) break;
+            await sleep(50);
+          }
         }
         if (!button) {
           throw new Error('Could not find layout preset ' + preset);

--- a/apps/desktop/src/renderer/src/components/tabs/library-noise-cleanup.test.ts
+++ b/apps/desktop/src/renderer/src/components/tabs/library-noise-cleanup.test.ts
@@ -1,0 +1,151 @@
+import { readFileSync } from 'node:fs'
+
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { NoiseCleanupDirectAction } from './library-tab'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { NoiseCleanupView } from '@/lib/noise-cleanup-view'
+
+function view(overrides: Partial<NoiseCleanupView> = {}): NoiseCleanupView {
+  return {
+    directAction: 'start',
+    menuAction: 'start',
+    directLabel: 'Clean noise',
+    menuLabel: 'Clean noise',
+    disabledReason: null,
+    detail: null,
+    statusAnnouncement: null,
+    busy: false,
+    conflictsWithFileActions: false,
+    premiumLocked: false,
+    derivative: false,
+    ...overrides
+  }
+}
+
+function renderAction(
+  title: string,
+  actionView: NoiseCleanupView,
+  sessionId = 'session-1'
+): string {
+  return renderToStaticMarkup(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(NoiseCleanupDirectAction, {
+        sessionId,
+        title,
+        view: actionView,
+        onAction: vi.fn()
+      })
+    )
+  )
+}
+
+describe('Library Noise Cleanup direct action', () => {
+  it('keeps the locked direct-action order: Play, Cleanup, Publish', () => {
+    const source = readFileSync(new URL('./library-tab.tsx', import.meta.url), 'utf8')
+    const rowActions = source.slice(source.indexOf('function RowActions'))
+    const play = rowActions.indexOf('aria-label="Play recording"')
+    const cleanup = rowActions.indexOf('<NoiseCleanupDirectAction')
+    const publish = rowActions.indexOf('aria-label="Open in Publish"')
+
+    expect(play).toBeGreaterThan(-1)
+    expect(cleanup).toBeGreaterThan(play)
+    expect(publish).toBeGreaterThan(cleanup)
+  })
+
+  it('uses a native accessible button for one-click cleanup', () => {
+    const markup = renderAction('Weekly update', view())
+
+    expect(markup).toContain('<button')
+    expect(markup).toContain('aria-label="Clean up noise in Weekly update"')
+    expect(markup).toContain('Clean noise')
+    expect(markup).not.toContain('disabled=""')
+    expect(markup).toContain('min-[1280px]:inline')
+  })
+
+  it('keeps Premium cleanup actionable and presents lock metadata', () => {
+    const markup = renderAction(
+      'Launch demo',
+      view({
+        directAction: 'upgrade',
+        menuAction: 'upgrade',
+        detail: 'Noise Cleanup requires Videorc Premium.',
+        premiumLocked: true
+      })
+    )
+
+    expect(markup).toContain('aria-label="Clean up noise in Launch demo"')
+    expect(markup).toContain('data-icon="inline-start"')
+    expect(markup).not.toContain('disabled=""')
+  })
+
+  it('uses session identity for unique descriptions when titles match', () => {
+    const locked = view({
+      directAction: 'upgrade',
+      menuAction: 'upgrade',
+      detail: 'Noise Cleanup requires Videorc Premium.',
+      premiumLocked: true
+    })
+    const first = renderAction('Same title', locked, 'session-one')
+    const second = renderAction('Same title', locked, 'session-two')
+
+    expect(first).toContain('noise-cleanup-session-one-description')
+    expect(second).toContain('noise-cleanup-session-two-description')
+    expect(second).not.toContain('noise-cleanup-session-one-description')
+  })
+
+  it('makes a disabled progress control focusable with coarse live status', () => {
+    const markup = renderAction(
+      'Launch demo',
+      view({
+        directAction: null,
+        menuAction: 'cancel',
+        directLabel: 'Cleaning 42%',
+        menuLabel: 'Cancel cleanup — 42%',
+        detail: 'Cleaning noise: 42% complete.',
+        statusAnnouncement: 'Cleaning noise, 40 percent.',
+        busy: true,
+        conflictsWithFileActions: true
+      })
+    )
+
+    expect(markup).toContain('tabindex="0"')
+    expect(markup).toContain('disabled=""')
+    expect(markup).toContain('aria-busy="true"')
+    expect(markup).toContain('aria-live="polite"')
+    expect(markup).toContain('Cleaning noise, 40 percent.')
+  })
+
+  it('keeps a reconnect-disabled action focusable with a described reason', () => {
+    const markup = renderAction(
+      'Launch demo',
+      view({
+        directAction: null,
+        disabledReason: 'Videorc is reconnecting. Try again in a moment.'
+      })
+    )
+
+    expect(markup).toContain('tabindex="0"')
+    expect(markup).toContain('disabled=""')
+    expect(markup).toContain('aria-describedby="noise-cleanup-session-1-description"')
+  })
+
+  it('does not render a second cleanup control on a cleaned derivative', () => {
+    const markup = renderAction(
+      'Weekly update — Noise cleaned',
+      view({
+        directAction: null,
+        menuAction: 'show-source',
+        directLabel: null,
+        menuLabel: 'Show source recording',
+        derivative: true
+      })
+    )
+
+    expect(markup).toBe('')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tabs/library-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/library-tab.tsx
@@ -11,13 +11,15 @@ import {
   DotsThree,
   FileVideo,
   FolderOpen,
+  LockSimple,
   MagnifyingGlass,
   Play,
   Sparkle,
   VideoCamera,
+  WaveformSlash,
   Wrench
 } from '@phosphor-icons/react'
-import { useEffect, useMemo, useState, type ReactElement } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import { toast } from 'sonner'
 
 import { PageHeader } from '@/components/page'
@@ -28,10 +30,12 @@ import { Checkbox } from '@/components/ui/checkbox'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   Dialog,
   DialogContent,
@@ -45,6 +49,7 @@ import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue
@@ -67,7 +72,17 @@ import {
   type LibraryFilter,
   type LibrarySort
 } from '@/lib/library-view'
+import {
+  activeNoiseCleanupSourceIds,
+  deriveNoiseCleanupView,
+  latestNoiseCleanupJobForSession,
+  noiseCleanupCancellationNotice,
+  withNoiseCleanupConnectionState,
+  type NoiseCleanupAction,
+  type NoiseCleanupView
+} from '@/lib/noise-cleanup-view'
 import { cn } from '@/lib/utils'
+import { openVideorcWebLink, VIDEORC_WEB_LINKS } from '@/lib/videorc-web-links'
 
 // The Library as a recordings manager (Library rewrite L4): a table of every
 // session — poster, name, scene, quality, duration, size, format, actions —
@@ -84,7 +99,8 @@ export function LibraryTab({
     settings,
     importRecording,
     deleteSessions,
-    renameSession
+    renameSession,
+    noiseCleanupJobs
   } = useStudioCore()
   const { recording } = useStudioRecordingState()
   const captureProtected = isActiveRecordingState(recording.state)
@@ -99,6 +115,15 @@ export function LibraryTab({
   const [renameDraft, setRenameDraft] = useState('')
   const [deleting, setDeleting] = useState<SessionSummary[]>([])
   const [deletePending, setDeletePending] = useState(false)
+  const [recentlyCreatedSessionId, setRecentlyCreatedSessionId] = useState<string | null>(null)
+  const rowElementsRef = useRef(new Map<string, HTMLDivElement>())
+  const previousCleanupStatusesRef = useRef(new Map<string, string>())
+
+  const focusLibrarySession = useCallback((sessionId: string): void => {
+    setFilter('all')
+    setQuery('')
+    setRecentlyCreatedSessionId(sessionId)
+  }, [])
 
   const runImport = async (): Promise<void> => {
     setImporting(true)
@@ -146,9 +171,49 @@ export function LibraryTab({
     () => sortLibrarySessions(filterLibrarySessions(sessions, filter, query), sort),
     [sessions, filter, query, sort]
   )
-  const visibleIds = useMemo(() => visible.map((session) => session.id), [visible])
+  const activeCleanupSourceIds = useMemo(
+    () => activeNoiseCleanupSourceIds(noiseCleanupJobs),
+    [noiseCleanupJobs]
+  )
+  const visibleIds = useMemo(
+    () =>
+      visible
+        .filter((session) => !activeCleanupSourceIds.has(session.id))
+        .map((session) => session.id),
+    [activeCleanupSourceIds, visible]
+  )
   const allVisibleSelected =
     visibleIds.length > 0 && visibleIds.every((id) => selected.includes(id))
+  const selectedCleanupActive = selected.some((id) => activeCleanupSourceIds.has(id))
+
+  useEffect(() => {
+    for (const job of noiseCleanupJobs) {
+      const previous = previousCleanupStatusesRef.current.get(job.id)
+      previousCleanupStatusesRef.current.set(job.id, job.status)
+      if (
+        previous &&
+        previous !== 'completed' &&
+        job.status === 'completed' &&
+        job.outputSessionId
+      ) {
+        focusLibrarySession(job.outputSessionId)
+      }
+    }
+  }, [focusLibrarySession, noiseCleanupJobs])
+
+  useEffect(() => {
+    if (!recentlyCreatedSessionId) {
+      return
+    }
+    const row = rowElementsRef.current.get(recentlyCreatedSessionId)
+    if (!row) {
+      return
+    }
+    row.scrollIntoView({ block: 'nearest' })
+    row.focus({ preventScroll: true })
+    const timer = window.setTimeout(() => setRecentlyCreatedSessionId(null), 3000)
+    return () => window.clearTimeout(timer)
+  }, [recentlyCreatedSessionId, visible])
 
   // Free space is an Electron-side directory fact (same source as Settings).
   useEffect(() => {
@@ -191,11 +256,13 @@ export function LibraryTab({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {LIBRARY_FILTERS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
+            <SelectGroup>
+              {LIBRARY_FILTERS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
           </SelectContent>
         </Select>
         <Button
@@ -232,7 +299,7 @@ export function LibraryTab({
         <div className="flex items-center gap-3 rounded-row border bg-muted/20 px-3 py-1.5 text-sm">
           <span className="text-muted-foreground">{selected.length} selected</span>
           <Button
-            disabled={captureProtected}
+            disabled={captureProtected || selectedCleanupActive}
             size="sm"
             variant="destructive"
             onClick={() => setDeleting(sessions.filter((session) => selected.includes(session.id)))}
@@ -243,6 +310,11 @@ export function LibraryTab({
           <Button size="sm" variant="ghost" onClick={() => setSelected([])}>
             Clear selection
           </Button>
+          {selectedCleanupActive ? (
+            <span className="text-xs text-muted-foreground">
+              Cancel or finish Noise Cleanup before deleting its source.
+            </span>
+          ) : null}
         </div>
       ) : null}
 
@@ -259,11 +331,11 @@ export function LibraryTab({
       ) : (
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-panel border">
           {/* Header row */}
-          <div className="grid grid-cols-[2rem_minmax(0,1fr)_8rem_5.5rem_5.5rem_4.5rem_8rem] items-center gap-2 border-b px-3 py-2 text-[12.5px] font-medium text-subtle">
+          <div className="grid grid-cols-[2rem_minmax(0,1fr)_8rem_5.5rem_5.5rem_4.5rem_8rem] items-center gap-2 border-b px-3 py-2 text-[12.5px] font-medium text-subtle min-[1280px]:grid-cols-[2rem_minmax(0,1fr)_8rem_5.5rem_5.5rem_4.5rem_13rem]">
             <Checkbox
-              aria-label="Select all visible recordings"
+              aria-label="Select all available visible recordings"
               checked={allVisibleSelected}
-              disabled={captureProtected}
+              disabled={captureProtected || visibleIds.length === 0}
               onCheckedChange={() =>
                 setSelected((current) => toggleAllLibrarySelection(current, visibleIds))
               }
@@ -285,10 +357,20 @@ export function LibraryTab({
                 <LibraryRow
                   key={session.id}
                   selected={selected.includes(session.id)}
-                  selectionDisabled={captureProtected || isLiveSession(session, recording)}
+                  selectionDisabled={
+                    captureProtected ||
+                    isLiveSession(session, recording) ||
+                    activeCleanupSourceIds.has(session.id)
+                  }
                   session={session}
+                  recentlyCreated={recentlyCreatedSessionId === session.id}
+                  registerRow={(element) => {
+                    if (element) rowElementsRef.current.set(session.id, element)
+                    else rowElementsRef.current.delete(session.id)
+                  }}
                   onDelete={() => setDeleting([session])}
                   onOpenInAi={() => onOpenInAi(session.id)}
+                  onRevealSession={focusLibrarySession}
                   onRename={() => {
                     setRenaming(session)
                     setRenameDraft(session.title)
@@ -391,17 +473,23 @@ export function LibraryTab({
 function LibraryRow({
   session,
   selected,
+  recentlyCreated,
   selectionDisabled,
+  registerRow,
   onToggleSelected,
   onOpenInAi,
+  onRevealSession,
   onRename,
   onDelete
 }: {
   session: SessionSummary
   selected: boolean
+  recentlyCreated: boolean
   selectionDisabled: boolean
+  registerRow: (element: HTMLDivElement | null) => void
   onToggleSelected: () => void
   onOpenInAi: () => void
+  onRevealSession: (sessionId: string) => void
   onRename: () => void
   onDelete: () => void
 }): ReactElement {
@@ -413,11 +501,16 @@ function LibraryRow({
   const live = isLiveSession(session, recording)
   return (
     <div
+      ref={registerRow}
+      aria-label={`${session.title || 'Untitled session'} recording row`}
       className={cn(
-        'grid grid-cols-[2rem_minmax(0,1fr)_8rem_5.5rem_5.5rem_4.5rem_8rem] items-center gap-2 border-b border-border/60 px-3 py-2 transition-colors last:border-b-0 hover:bg-accent/50',
-        selected && 'bg-accent/60'
+        'grid grid-cols-[2rem_minmax(0,1fr)_8rem_5.5rem_5.5rem_4.5rem_8rem] items-center gap-2 border-b border-border/60 px-3 py-2 transition-colors last:border-b-0 hover:bg-accent/50 min-[1280px]:grid-cols-[2rem_minmax(0,1fr)_8rem_5.5rem_5.5rem_4.5rem_13rem]',
+        selected && 'bg-accent/60',
+        recentlyCreated && 'bg-accent/60 ring-1 ring-ring/40'
       )}
       data-videorc-library-row={session.id}
+      role="group"
+      tabIndex={-1}
     >
       <Checkbox
         aria-label={`Select ${session.title || 'session'}`}
@@ -432,11 +525,16 @@ function LibraryRow({
           <p className="truncate text-xs text-muted-foreground">
             {dayLabel(session.startedAt)}
             {!filePath && !live ? ' · no local file' : ''}
+            {session.processingKind === 'noise-cleanup' && session.sourceTitle
+              ? ` · cleaned from ${session.sourceTitle}`
+              : ''}
           </p>
         </div>
       </div>
       <div className="min-w-0">
-        {session.sceneLabel ? (
+        {session.processingKind === 'noise-cleanup' ? (
+          <Badge variant="outline">Noise cleaned</Badge>
+        ) : session.sceneLabel ? (
           <Badge className="max-w-full" variant="outline">
             <span className="truncate">{session.sceneLabel}</span>
           </Badge>
@@ -464,6 +562,7 @@ function LibraryRow({
         session={session}
         onDelete={onDelete}
         onOpenInAi={onOpenInAi}
+        onRevealSession={onRevealSession}
         onRename={onRename}
       />
     </div>
@@ -534,12 +633,14 @@ function RowActions({
   filePath,
   session,
   onOpenInAi,
+  onRevealSession,
   onRename,
   onDelete
 }: {
   filePath: string | null
   session: SessionSummary
   onOpenInAi: () => void
+  onRevealSession: (sessionId: string) => void
   onRename: () => void
   onDelete: () => void
 }): ReactElement {
@@ -550,7 +651,11 @@ function RowActions({
     wsStatus,
     remuxSession,
     openSessionCommentsWindow,
-    duplicateSession
+    duplicateSession,
+    entitlements,
+    noiseCleanupJobs,
+    startNoiseCleanup,
+    cancelNoiseCleanup
   } = useStudioCore()
   const { recording } = useStudioRecordingState()
   const [duplicating, setDuplicating] = useState(false)
@@ -582,6 +687,18 @@ function RowActions({
     session.status === 'completed' && session.outputPath?.endsWith('.mkv') && !session.mp4Path
   )
   const canOpenComments = session.commentCount > 0
+  const cleanupJob = latestNoiseCleanupJobForSession(noiseCleanupJobs, session.id)
+  const cleanupView = withNoiseCleanupConnectionState(
+    deriveNoiseCleanupView({
+      session,
+      entitlements,
+      job: cleanupJob,
+      captureActive: captureProtected
+    }),
+    wsStatus === 'connected'
+  )
+  const fileActionsBusy = busy || cleanupView.conflictsWithFileActions
+  const cleanupMenuAction = cleanupView.menuAction
 
   const playFile = async (): Promise<void> => {
     if (!filePath || !window.videorc?.openSession) {
@@ -663,120 +780,281 @@ function RowActions({
     }
   }
 
+  const runNoiseCleanupAction = async (action: NoiseCleanupAction): Promise<void> => {
+    if (action === 'upgrade') {
+      openVideorcWebLink(VIDEORC_WEB_LINKS.premium)
+      return
+    }
+    if (action === 'open-output') {
+      if (cleanupJob?.outputSessionId) {
+        onRevealSession(cleanupJob.outputSessionId)
+      }
+      return
+    }
+    if (action === 'show-source') {
+      if (session.derivedFromSessionId) {
+        onRevealSession(session.derivedFromSessionId)
+      }
+      return
+    }
+
+    try {
+      if (action === 'cancel') {
+        if (!cleanupJob) return
+        const nextJob = await cancelNoiseCleanup(cleanupJob.id)
+        const notice = noiseCleanupCancellationNotice(nextJob)
+        toast.info(notice.title, { description: notice.description })
+        return
+      }
+      await startNoiseCleanup(session.id)
+      toast.success('Noise cleanup queued.', {
+        description: 'Videorc will create a separate cleaned copy on this device.'
+      })
+    } catch (error) {
+      toast.error(action === 'cancel' ? 'Could not cancel cleanup.' : 'Noise cleanup failed.', {
+        description: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
   return (
     <div className="flex items-center justify-end gap-0.5">
       <Button
         aria-label="Play recording"
-        className="size-8"
         disabled={!filePath || live}
-        size="icon"
+        size="icon-sm"
         title={live ? 'Available when the session ends' : 'Play in the default player'}
         variant="ghost"
         onClick={() => void playFile()}
       >
-        <Play className="size-4" weight="fill" />
+        <Play weight="fill" />
       </Button>
+      <NoiseCleanupDirectAction
+        sessionId={session.id}
+        title={session.title || 'Untitled session'}
+        view={cleanupView}
+        onAction={(action) => void runNoiseCleanupAction(action)}
+      />
       <Button
         aria-label="Open in Publish"
-        className="size-8"
-        size="icon"
+        size="icon-sm"
         title="Open in Publish (AI)"
         variant="ghost"
         onClick={onOpenInAi}
       >
-        <Sparkle className="size-4" weight="fill" />
+        <Sparkle weight="fill" />
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             aria-label="Session actions"
-            className="size-8"
             disabled={disconnected}
-            size="icon"
+            size="icon-sm"
             variant="ghost"
           >
-            {busy ? (
-              <CircleNotch className="size-4 animate-spin" />
+            {busy || cleanupView.busy ? (
+              <CircleNotch className="animate-spin" />
             ) : (
-              <DotsThree className="size-4" weight="bold" />
+              <DotsThree weight="bold" />
             )}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem disabled={!filePath || live} onClick={() => void playFile()}>
-            <Play />
-            Play
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={onOpenInAi}>
-            <Sparkle />
-            Open in Publish
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={!filePath}
-            onClick={() => filePath && void window.videorc?.revealSession?.(session.id)}
-          >
-            <FolderOpen />
-            Show in Finder
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={!canExportMp4 || busy}
-            onClick={() => void remuxSession(session.id)}
-          >
-            <FileVideo />
-            Export MP4
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={!canOpenComments || busy || disconnected}
-            onClick={() =>
-              void openSessionCommentsWindow(session.id, session.title, session.startedAt)
-            }
-          >
-            <ChatCircle />
-            Open Comments
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem disabled={busy} onClick={onRename}>
-            <PencilSimple />
-            Rename
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={!filePath || busy || duplicating || live}
-            onClick={() => void runDuplicate()}
-          >
-            <Copy />
-            {duplicating ? 'Duplicating…' : 'Duplicate'}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            disabled={!filePath || busy || captureProtected}
-            onClick={() => void runCheck()}
-          >
-            <CheckCircle />
-            {phase === 'checking' ? 'Checking…' : 'Check quality'}
-          </DropdownMenuItem>
-          {canRepair ? (
-            <DropdownMenuItem disabled={busy || captureProtected} onClick={() => void runRepair()}>
-              <Wrench />
-              {phase === 'repairing' ? 'Repairing…' : 'Repair & fix'}
+          <DropdownMenuGroup>
+            <DropdownMenuItem disabled={!filePath || live} onClick={() => void playFile()}>
+              <Play />
+              Play
             </DropdownMenuItem>
-          ) : null}
-          {hasBackup || persistedRepaired ? (
-            <DropdownMenuItem disabled={busy || captureProtected} onClick={() => void runRestore()}>
-              <ArrowCounterClockwise />
-              Restore original
+            <DropdownMenuItem onClick={onOpenInAi}>
+              <Sparkle />
+              Open in Publish
             </DropdownMenuItem>
-          ) : null}
+            <DropdownMenuItem
+              disabled={!filePath}
+              onClick={() => filePath && void window.videorc?.revealSession?.(session.id)}
+            >
+              <FolderOpen />
+              Show in Finder
+            </DropdownMenuItem>
+            {cleanupView.menuLabel ? (
+              <DropdownMenuItem
+                disabled={!cleanupMenuAction}
+                onClick={() => cleanupMenuAction && void runNoiseCleanupAction(cleanupMenuAction)}
+              >
+                {cleanupView.premiumLocked ? <LockSimple /> : <WaveformSlash />}
+                {cleanupView.menuLabel}
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuItem
+              disabled={!canExportMp4 || fileActionsBusy}
+              onClick={() => void remuxSession(session.id)}
+            >
+              <FileVideo />
+              Export MP4
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!canOpenComments || busy || disconnected}
+              onClick={() =>
+                void openSessionCommentsWindow(session.id, session.title, session.startedAt)
+              }
+            >
+              <ChatCircle />
+              Open Comments
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            disabled={busy || captureProtected}
-            variant="destructive"
-            onClick={onDelete}
-          >
-            <Trash />
-            Delete
-          </DropdownMenuItem>
+          <DropdownMenuGroup>
+            <DropdownMenuItem disabled={busy} onClick={onRename}>
+              <PencilSimple />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!filePath || fileActionsBusy || duplicating || live}
+              onClick={() => void runDuplicate()}
+            >
+              <Copy />
+              {duplicating ? 'Duplicating…' : 'Duplicate'}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              disabled={!filePath || fileActionsBusy || captureProtected}
+              onClick={() => void runCheck()}
+            >
+              <CheckCircle />
+              {phase === 'checking' ? 'Checking…' : 'Check quality'}
+            </DropdownMenuItem>
+            {canRepair ? (
+              <DropdownMenuItem
+                disabled={fileActionsBusy || captureProtected}
+                onClick={() => void runRepair()}
+              >
+                <Wrench />
+                {phase === 'repairing' ? 'Repairing…' : 'Repair & fix'}
+              </DropdownMenuItem>
+            ) : null}
+            {hasBackup || persistedRepaired ? (
+              <DropdownMenuItem
+                disabled={fileActionsBusy || captureProtected}
+                onClick={() => void runRestore()}
+              >
+                <ArrowCounterClockwise />
+                Restore original
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              disabled={fileActionsBusy || captureProtected}
+              variant="destructive"
+              onClick={onDelete}
+            >
+              <Trash />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
+  )
+}
+
+export function NoiseCleanupDirectAction({
+  sessionId,
+  title,
+  view,
+  onAction
+}: {
+  sessionId: string
+  title: string
+  view: NoiseCleanupView
+  onAction: (action: NoiseCleanupAction) => void
+}): ReactElement | null {
+  if (!view.directLabel) {
+    return null
+  }
+
+  const help = view.disabledReason ?? view.detail
+  const descriptionId = `noise-cleanup-${safeDomId(sessionId)}-description`
+  const ariaLabel =
+    view.directAction === 'open-output'
+      ? `Open cleaned copy for ${title}`
+      : `Clean up noise in ${title}`
+  const button = (
+    <Button
+      aria-busy={view.busy || undefined}
+      aria-describedby={help ? descriptionId : undefined}
+      aria-label={ariaLabel}
+      className="min-[1280px]:w-auto min-[1280px]:px-2"
+      disabled={!view.directAction}
+      size="icon-sm"
+      variant="ghost"
+      onClick={() => view.directAction && onAction(view.directAction)}
+    >
+      {view.premiumLocked ? (
+        <LockSimple data-icon="inline-start" />
+      ) : view.busy ? (
+        <CircleNotch className="animate-spin" data-icon="inline-start" />
+      ) : (
+        <WaveformSlash data-icon="inline-start" />
+      )}
+      <span className="hidden min-[1280px]:inline">{view.directLabel}</span>
+    </Button>
+  )
+  const status = view.statusAnnouncement ? (
+    <span aria-live="polite" className="sr-only">
+      {view.statusAnnouncement}
+    </span>
+  ) : null
+
+  if (!help) {
+    return (
+      <>
+        {button}
+        {status}
+      </>
+    )
+  }
+
+  if (view.directAction) {
+    return (
+      <>
+        <Tooltip>
+          <TooltipTrigger asChild>{button}</TooltipTrigger>
+          <TooltipContent id={descriptionId}>{help}</TooltipContent>
+        </Tooltip>
+        {status}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            aria-describedby={descriptionId}
+            aria-label={ariaLabel}
+            className="inline-flex rounded-md outline-none focus-visible:ring-3 focus-visible:ring-ring/30"
+            tabIndex={0}
+          >
+            {button}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent id={descriptionId}>{help}</TooltipContent>
+      </Tooltip>
+      {status}
+    </>
+  )
+}
+
+function safeDomId(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '') || 'recording'
   )
 }

--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -2,15 +2,26 @@ import { act, createElement, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const toastSpies = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn()
+}))
+vi.mock('sonner', () => ({ toast: toastSpies }))
+
 import type {
   AccountCallbackEnvelope,
   CompositorStatus,
   LayoutSettings,
+  NoiseCleanupJob,
   OAuthCallbackEnvelope,
   PreviewSurfaceBounds,
   PreviewSurfaceStatus,
   PreviewWindowState,
   Scene,
+  SessionSummary,
   VideorcApi
 } from '../../../shared/backend'
 import { BackgroundAssetsProvider } from './use-background-assets'
@@ -23,6 +34,7 @@ import {
 } from './use-studio'
 import { DEFAULT_BASIC_ENTITLEMENTS } from '../lib/entitlements'
 import { defaultCaptureConfig } from '../lib/capture'
+import { deriveNoiseCleanupView } from '../lib/noise-cleanup-view'
 
 type BackendCommand = { id: string; method: string; params?: unknown }
 
@@ -32,6 +44,30 @@ const signedInAccount = {
   username: 'provider-test',
   displayName: 'Provider Test',
   email: 'provider@example.test'
+}
+
+const premiumEntitlements = {
+  ...DEFAULT_BASIC_ENTITLEMENTS,
+  tier: 'premium' as const,
+  source: 'creem' as const,
+  capabilities: DEFAULT_BASIC_ENTITLEMENTS.capabilities.map((capability) => ({
+    ...capability,
+    state: 'enabled' as const,
+    reason: undefined
+  }))
+}
+
+function cleanupJob(overrides: Partial<NoiseCleanupJob> = {}): NoiseCleanupJob {
+  return {
+    id: 'cleanup-1',
+    sourceSessionId: 'session-1',
+    status: 'queued',
+    progressPercent: 0,
+    preset: 'speech-v1',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides
+  }
 }
 
 const callbackEnvelope: AccountCallbackEnvelope = {
@@ -200,6 +236,27 @@ class StudioBackend {
   oauthTransportFailuresRemaining = 1
   oauthRetryFailuresRemaining = 1
   oauthCompletedStates = new Set<string>()
+  entitlements = DEFAULT_BASIC_ENTITLEMENTS
+  noiseCleanupJobs: NoiseCleanupJob[] = []
+  sourceMutationRevision = 4
+
+  invalidateCompletedNoiseCleanup(message: string): void {
+    this.sourceMutationRevision += 1
+    this.noiseCleanupJobs = this.noiseCleanupJobs.map((job) =>
+      job.status === 'completed'
+        ? cleanupJob({
+            ...job,
+            status: 'failed',
+            progressPercent: 0,
+            outputSessionId: undefined,
+            outputPath: undefined,
+            errorCode: 'source-changed',
+            errorMessage: message,
+            updatedAt: `2026-07-12T00:00:${this.sourceMutationRevision.toString().padStart(2, '0')}.000Z`
+          })
+        : job
+    )
+  }
 
   response(command: BackendCommand): unknown {
     this.commands.push(command)
@@ -215,7 +272,8 @@ class StudioBackend {
           secretStoreBackend: 'test'
         }
       case 'entitlements.get':
-        return DEFAULT_BASIC_ENTITLEMENTS
+      case 'entitlements.refresh':
+        return this.entitlements
       case 'account.get':
         return { status: 'signed-out' }
       case 'account.complete_sign_in':
@@ -360,10 +418,60 @@ class StudioBackend {
         return { valid: true, issues: [] }
       case 'sessions.list':
         return []
+      case 'sessions.delete': {
+        const deletedSessionIds = new Set(params.sessionIds as string[])
+        this.noiseCleanupJobs = this.noiseCleanupJobs.map((job) =>
+          job.status === 'completed' &&
+          job.outputSessionId &&
+          deletedSessionIds.has(job.outputSessionId)
+            ? cleanupJob({
+                ...job,
+                status: 'failed',
+                progressPercent: 0,
+                outputSessionId: undefined,
+                outputPath: undefined,
+                errorCode: 'file-missing',
+                errorMessage: 'The cleaned recording was deleted.',
+                updatedAt: '2026-07-12T00:00:04.000Z'
+              })
+            : job
+        )
+        return []
+      }
       case 'sessions.delete.pending':
         return []
       case 'sessions.storage':
         return { count: 0, totalBytes: 0 }
+      case 'session.remux_mp4':
+        this.invalidateCompletedNoiseCleanup('The source recording changed after remux.')
+        return null
+      case 'repair.repair_file':
+        this.invalidateCompletedNoiseCleanup('The source recording changed after repair.')
+        return {
+          status: 'repaired',
+          path: 'C:\\recordings\\session-1.mkv',
+          interpolated: false
+        }
+      case 'repair.restore_file':
+        this.invalidateCompletedNoiseCleanup('The source recording changed after restore.')
+        return { restored: true }
+      case 'noiseCleanup.list':
+        return this.noiseCleanupJobs
+      case 'noiseCleanup.start': {
+        const job = cleanupJob({ sourceSessionId: String(params.sessionId) })
+        this.noiseCleanupJobs = [job]
+        return job
+      }
+      case 'noiseCleanup.cancel': {
+        const current = this.noiseCleanupJobs.find((job) => job.id === params.jobId) ?? cleanupJob()
+        const job = cleanupJob({
+          ...current,
+          status: 'cancelled',
+          updatedAt: '2026-07-12T00:00:01.000Z'
+        })
+        this.noiseCleanupJobs = [job]
+        return job
+      }
       case 'platformAccounts.list':
       case 'platformAccounts.validate':
       case 'platformAccounts.oauth.providerCredentials':
@@ -522,6 +630,7 @@ describe('real StudioProvider lifecycle', () => {
     restoreEnvironment?.()
     restoreEnvironment = undefined
     vi.unstubAllGlobals()
+    vi.clearAllMocks()
     vi.useRealTimers()
   })
 
@@ -652,6 +761,255 @@ describe('real StudioProvider lifecycle', () => {
       sessionId: 'session-1',
       durationMs: 1_000
     })
+  })
+
+  it('refreshes entitlements on focus and keeps cleanup jobs durable across row lifetimes', async () => {
+    const backend = new StudioBackend()
+    backend.noiseCleanupJobs = [cleanupJob()]
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+    const openedSessions: string[] = []
+    const revealedSessions: string[] = []
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      openSession: async (sessionId) => {
+        openedSessions.push(sessionId)
+        return ''
+      },
+      revealSession: async (sessionId) => {
+        revealedSessions.push(sessionId)
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(() => observations.at(-1)?.core.noiseCleanupJobs.length === 1)
+    expect(observations.at(-1)?.core.noiseCleanupJobs[0]?.status).toBe('queued')
+    await act(async () => {
+      await observations.at(-1)?.core.startNoiseCleanup('session-1')
+    })
+    expect(backend.commands.at(-1)).toMatchObject({
+      method: 'noiseCleanup.start',
+      params: { sessionId: 'session-1' }
+    })
+
+    const initialRefreshes = backend.commands.filter(
+      (command) => command.method === 'entitlements.refresh'
+    ).length
+    backend.entitlements = premiumEntitlements
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    await waitForObservation(() => observations.at(-1)?.core.entitlements?.tier === 'premium')
+    expect(
+      backend.commands.filter((command) => command.method === 'entitlements.refresh').length
+    ).toBeGreaterThan(initialRefreshes)
+
+    const processing = cleanupJob({
+      status: 'processing',
+      progressPercent: 42,
+      updatedAt: '2026-07-12T00:00:02.000Z'
+    })
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({ event: 'noiseCleanup.status', payload: processing })
+      })
+    })
+    await waitForObservation(
+      () => observations.at(-1)?.core.noiseCleanupJobs[0]?.status === 'processing'
+    )
+    expect(observations.at(-1)?.core.noiseCleanupJobs[0]?.progressPercent).toBe(42)
+
+    const completed = cleanupJob({
+      status: 'completed',
+      progressPercent: 100,
+      outputSessionId: 'cleaned-session',
+      outputPath: 'C:\\recordings\\cleaned-session.mkv',
+      updatedAt: '2026-07-12T00:00:03.000Z'
+    })
+    await act(async () => {
+      for (let duplicate = 0; duplicate < 2; duplicate += 1) {
+        backend.sockets[0]?.onmessage?.({
+          data: JSON.stringify({ event: 'noiseCleanup.status', payload: completed })
+        })
+      }
+    })
+    await waitForObservation(
+      () => observations.at(-1)?.core.noiseCleanupJobs[0]?.status === 'completed'
+    )
+    const completionToasts = toastSpies.success.mock.calls.filter(
+      ([message]) => message === 'Noise cleanup complete'
+    )
+    expect(completionToasts).toHaveLength(1)
+    const completionToast = completionToasts[0]?.[1] as
+      | {
+          action?: { label: string; onClick: () => void }
+          cancel?: { label: string; onClick: () => void }
+        }
+      | undefined
+    expect(completionToast?.action?.label).toBe('Play')
+    expect(completionToast?.cancel?.label).toBe('Show in Finder')
+    completionToast?.action?.onClick()
+    completionToast?.cancel?.onClick()
+    await act(async () => Promise.resolve())
+    expect(openedSessions).toEqual(['cleaned-session'])
+    expect(revealedSessions).toEqual(['cleaned-session'])
+
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'entitlements.updated',
+          payload: DEFAULT_BASIC_ENTITLEMENTS
+        })
+      })
+    })
+    await waitForObservation(() => observations.at(-1)?.core.entitlements?.tier === 'basic')
+  })
+
+  it('reconciles completed jobs after deletion, remux, and repair mutations', async () => {
+    const backend = new StudioBackend()
+    backend.entitlements = premiumEntitlements
+    backend.noiseCleanupJobs = [
+      cleanupJob({
+        status: 'completed',
+        progressPercent: 100,
+        outputSessionId: 'cleaned-session',
+        outputPath: 'C:\\recordings\\cleaned-session.mkv'
+      })
+    ]
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => []
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () => observations.at(-1)?.core.noiseCleanupJobs[0]?.status === 'completed'
+    )
+
+    expect(
+      toastSpies.success.mock.calls.filter(([message]) => message === 'Noise cleanup complete')
+    ).toEqual([])
+
+    await act(async () => {
+      await observations.at(-1)?.core.deleteSessions([{ id: 'cleaned-session' } as SessionSummary])
+    })
+    await waitForObservation(
+      () => observations.at(-1)?.core.noiseCleanupJobs[0]?.status === 'failed'
+    )
+    const nextCore = observations.at(-1)?.core
+    const failedJob = nextCore?.noiseCleanupJobs[0] ?? null
+    expect(failedJob).toMatchObject({
+      status: 'failed',
+      errorCode: 'file-missing',
+      errorMessage: 'The cleaned recording was deleted.'
+    })
+    expect(
+      deriveNoiseCleanupView({
+        session: {
+          id: 'session-1',
+          status: 'completed',
+          mode: 'record',
+          outputPath: 'C:\\recordings\\session-1.mkv'
+        },
+        entitlements: nextCore?.entitlements ?? null,
+        job: failedJob,
+        captureActive: false
+      }).directLabel
+    ).toBe('Retry cleanup')
+
+    for (const mutation of ['remux', 'repair'] as const) {
+      const completed = cleanupJob({
+        id: `cleanup-${mutation}`,
+        status: 'completed',
+        progressPercent: 100,
+        outputSessionId: `cleaned-${mutation}`,
+        outputPath: `C:\\recordings\\cleaned-${mutation}.mkv`,
+        updatedAt: `2026-07-12T00:00:${mutation === 'remux' ? '10' : '20'}.000Z`
+      })
+      backend.noiseCleanupJobs = [completed]
+      await act(async () => {
+        backend.sockets[0]?.onmessage?.({
+          data: JSON.stringify({ event: 'noiseCleanup.status', payload: completed })
+        })
+      })
+      await waitForObservation(
+        () =>
+          observations
+            .at(-1)
+            ?.core.noiseCleanupJobs.some(
+              (job) => job.id === completed.id && job.status === 'completed'
+            ) === true
+      )
+
+      if (mutation === 'remux') {
+        await act(async () => {
+          await observations.at(-1)?.core.remuxSession('session-1')
+        })
+      } else {
+        await act(async () => {
+          await observations.at(-1)?.core.repairRecording('session-1')
+        })
+      }
+      await waitForObservation(
+        () => observations.at(-1)?.core.noiseCleanupJobs[0]?.status === 'failed'
+      )
+      expect(observations.at(-1)?.core.noiseCleanupJobs[0]).toMatchObject({
+        status: 'failed',
+        errorCode: 'source-changed',
+        errorMessage: `The source recording changed after ${mutation}.`
+      })
+    }
+
+    expect(
+      backend.commands.filter((command) => command.method === 'noiseCleanup.list').length
+    ).toBeGreaterThanOrEqual(4)
   })
 
   it('recovers in cooldown on the same healthy websocket and ACKs exactly once', async () => {
@@ -1024,6 +1382,8 @@ function createVideorcApi(options: {
   acknowledge: (id: string) => Promise<boolean>
   pendingProvider: () => Promise<OAuthCallbackEnvelope[]>
   acknowledgeProvider: (id: string) => Promise<boolean>
+  openSession?: (sessionId: string) => Promise<string>
+  revealSession?: (sessionId: string) => Promise<void>
   nativePreview?: {
     getWindowState: () => PreviewWindowState
     drainHostCommands: (generation?: number) => Promise<PreviewSurfaceStatus>
@@ -1103,6 +1463,8 @@ function createVideorcApi(options: {
       getCaptionSnapshot: async () => null,
       getCaptionLines: async () => null,
       getGlassWallpaper: async () => null,
+      openSession: options.openSession ?? (async () => ''),
+      revealSession: options.revealSession ?? (async () => {}),
       getUpdateStatus: async () => ({ phase: 'unsupported' }),
       onBackendConnection: (callback: (value: unknown) => void) =>
         subscribe('backend:connection', callback),

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -120,6 +120,7 @@ import type {
   Device,
   DeviceList,
   EntitlementsSnapshot,
+  NoiseCleanupJob,
   MediaAccessSnapshot,
   ExportPublishPackResult,
   FileAssessment,
@@ -223,6 +224,7 @@ import {
 } from '@/lib/captions-preflight'
 import { goLiveEntitlementGate, videoProfileEntitlementGate } from '@/lib/entitlement-ui'
 import { entitlementDisabledReason } from '@/lib/entitlements'
+import { upsertNoiseCleanupJob } from '@/lib/noise-cleanup-view'
 import {
   applyLiveChatMessages,
   applyLiveChatProviderStatus,
@@ -345,6 +347,7 @@ function openLibraryFromQualityToast(sessionId?: string): void {
 // cadence that alone kept the renderer permanently busy. State-machine flips
 // still commit immediately via the significant-change fast path.
 const TELEMETRY_UI_COMMIT_INTERVAL_MS = 1000
+const SIGNED_IN_ENTITLEMENT_REFRESH_INTERVAL_MS = 5 * 60_000
 const LIVE_CHAT_RECOVERY_RETRY_DELAY_MS = 250
 
 async function requestLiveChatSendOperations(
@@ -559,6 +562,7 @@ export type StudioContextValue = {
   wsStatus: WsStatus
   health: BackendHealth | null
   entitlements: EntitlementsSnapshot | null
+  noiseCleanupJobs: NoiseCleanupJob[]
   account: VideorcAccountSnapshot | null
   aiCapabilities: AiCapabilities | null
   aiQuota: AiQuotaStatus | null
@@ -690,6 +694,7 @@ export type StudioContextValue = {
   runtimeInfo: RuntimeInfo | null
   // actions
   refreshBackend: () => Promise<void>
+  refreshEntitlements: () => Promise<void>
   refreshPlatformAccounts: () => Promise<void>
   validatePlatformAccounts: () => Promise<PlatformAccountValidation[]>
   connectPlatformAccount: (platform: PlatformAccount['platform']) => Promise<void>
@@ -745,6 +750,8 @@ export type StudioContextValue = {
   deleteSessions: (targets: SessionSummary[]) => Promise<void>
   duplicateSession: (sessionId: string) => Promise<void>
   importRecording: () => Promise<void>
+  startNoiseCleanup: (sessionId: string) => Promise<NoiseCleanupJob>
+  cancelNoiseCleanup: (jobId: string) => Promise<NoiseCleanupJob>
   sessionStorageTotals: SessionStorageTotals | null
   runAiWorkflow: (
     sessionId: string,
@@ -1312,6 +1319,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   wsStatusRef.current = wsStatus
   const [health, setHealth] = useState<BackendHealth | null>(null)
   const [entitlements, setEntitlements] = useState<EntitlementsSnapshot | null>(null)
+  const [noiseCleanupJobs, setNoiseCleanupJobs] = useState<NoiseCleanupJob[]>([])
+  const announcedNoiseCleanupCompletionsRef = useRef(new Set<string>())
+  const entitlementRefreshInFlightRef = useRef<Promise<EntitlementsSnapshot> | null>(null)
   const [account, setAccount] = useState<VideorcAccountSnapshot | null>(null)
   const [aiCapabilities, setAiCapabilities] = useState<AiCapabilities | null>(null)
   const [aiQuota, setAiQuota] = useState<AiQuotaStatus | null>(null)
@@ -1351,6 +1361,32 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const [twitchCategorySearchPending, setTwitchCategorySearchPending] = useState(false)
   const [xNativeCapability, setXNativeCapability] = useState<XNativeLiveCapability | null>(null)
   const [xNativeCapabilityLoading, setXNativeCapabilityLoading] = useState(false)
+  const refreshEntitlementsForClient = useCallback(
+    async (activeClient: BackendClient): Promise<EntitlementsSnapshot> => {
+      if (entitlementRefreshInFlightRef.current) {
+        return entitlementRefreshInFlightRef.current
+      }
+      const refresh = activeClient
+        .requestTyped('entitlements.refresh', undefined)
+        .then((snapshot) => {
+          // The backend returns the current fail-closed snapshot even when its
+          // server revalidation fails. Never merge it with stale local state.
+          if (clientRef.current === activeClient) {
+            setEntitlements(snapshot)
+          }
+          return snapshot
+        })
+      entitlementRefreshInFlightRef.current = refresh
+      try {
+        return await refresh
+      } finally {
+        if (entitlementRefreshInFlightRef.current === refresh) {
+          entitlementRefreshInFlightRef.current = null
+        }
+      }
+    },
+    []
+  )
   // Read-only live chat store: persisted by the backend when available, live-updated by
   // liveChat.* websocket events, and mirrored to the detached Comments window cache.
   const [liveChatSnapshot, setLiveChatSnapshot] = useState<LiveChatSnapshot>(() =>
@@ -2836,6 +2872,16 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     [resumePendingSessionDeletions]
   )
 
+  const refreshNoiseCleanupJobs = useCallback(async (activeClient: BackendClient | null) => {
+    if (!activeClient) {
+      return
+    }
+    const nextJobs = await activeClient.requestTyped('noiseCleanup.list', undefined)
+    // Source mutations can invalidate completed derivatives without emitting a
+    // cleanup status event. This list replaces local state authoritatively.
+    setNoiseCleanupJobs(nextJobs)
+  }, [])
+
   const refreshScreensForClient = useCallback(async (activeClient: BackendClient | null) => {
     if (!activeClient) {
       return
@@ -3534,6 +3580,39 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         bootstrapGuard.mark('devices')
         setDeviceList(payload as DeviceList)
       }),
+      nextClient.on('entitlements.updated', (payload) => {
+        setEntitlements(payload)
+      }),
+      nextClient.on('noiseCleanup.status', (payload) => {
+        const job = payload
+        setNoiseCleanupJobs((current) => upsertNoiseCleanupJob(current, job))
+        if (job.status === 'completed') {
+          void refreshSessions(nextClient)
+          const outputSessionId = job.outputSessionId
+          if (outputSessionId && !announcedNoiseCleanupCompletionsRef.current.has(job.id)) {
+            announcedNoiseCleanupCompletionsRef.current.add(job.id)
+            toast.success('Noise cleanup complete', {
+              id: `noise-cleanup-completed-${job.id}`,
+              description: 'A separate cleaned copy is ready. The original was not changed.',
+              duration: 15_000,
+              action: {
+                label: 'Play',
+                onClick: () => {
+                  const openSession = window.videorc?.openSession
+                  if (!openSession) return
+                  void openSession(outputSessionId).then((problem) => {
+                    if (problem) toast.error(problem)
+                  })
+                }
+              },
+              cancel: {
+                label: 'Show in Finder',
+                onClick: () => void window.videorc?.revealSession?.(outputSessionId)
+              }
+            })
+          }
+        }
+      }),
       nextClient.on('recording.status', (payload) => {
         bootstrapGuard.mark('recording')
         bootstrapGuard.mark('sessions')
@@ -3960,10 +4039,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           nextActiveScreen,
           nextStreamMetadataDraft,
           nextSessions,
-          nextSessionStorage
+          nextSessionStorage,
+          nextNoiseCleanupJobs
         ] = await Promise.all([
           bootstrapRequest<BackendHealth>('health.ping'),
-          bootstrapRequest<EntitlementsSnapshot>('entitlements.get'),
+          bootstrapRequest<EntitlementsSnapshot>('entitlements.refresh'),
           bootstrapRequest<VideorcAccountSnapshot>('account.get'),
           bootstrapRequest<DeviceList>('devices.list'),
           bootstrapRequest<RecordingStatus>('recording.status'),
@@ -3980,7 +4060,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           bootstrapRequest<StreamScreen | null>('screens.active'),
           bootstrapRequest<StreamMetadataDraft>('streamTargets.metadata.get'),
           bootstrapRequest<SessionSummary[]>('sessions.list', { limit: 200 }),
-          bootstrapRequest<SessionStorageTotals>('sessions.storage')
+          bootstrapRequest<SessionStorageTotals>('sessions.storage'),
+          bootstrapRequest<NoiseCleanupJob[]>('noiseCleanup.list')
         ])
         if (!generationIsCurrent()) {
           return
@@ -4032,6 +4113,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         } else {
           void refreshSessions(nextClient)
         }
+        setNoiseCleanupJobs((current) =>
+          nextNoiseCleanupJobs.reduce((jobs, job) => upsertNoiseCleanupJob(jobs, job), current)
+        )
         if (bootstrapGuard.isCurrent(bootstrapSnapshot, 'scene') && nextScene.sources.length) {
           applyScene(nextScene)
         }
@@ -4202,6 +4286,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       nextClient.close()
       setClient(null)
       setEntitlements(null)
+      setNoiseCleanupJobs([])
+      entitlementRefreshInFlightRef.current = null
       setAccount(null)
       setAiCapabilities(null)
       setAiQuota(null)
@@ -4319,10 +4405,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         nextPlatformAccounts,
         nextOauthProviderCredentials,
         nextPlatformAccountValidations,
-        nextStreamMetadataDraft
+        nextStreamMetadataDraft,
+        nextNoiseCleanupJobs
       ] = await Promise.all([
         client.request<BackendHealth>('health.ping'),
-        client.request<EntitlementsSnapshot>('entitlements.get'),
+        refreshEntitlementsForClient(client),
         client.request<VideorcAccountSnapshot>('account.get'),
         client.request<DeviceList>('devices.list'),
         client.request<SessionSummary[]>('sessions.list', { limit: 200 }),
@@ -4335,7 +4422,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           'platformAccounts.oauth.providerCredentials'
         ),
         client.request<PlatformAccountValidation[]>('platformAccounts.validate'),
-        client.request<StreamMetadataDraft>('streamTargets.metadata.get')
+        client.request<StreamMetadataDraft>('streamTargets.metadata.get'),
+        client.requestTyped('noiseCleanup.list', undefined)
       ])
       setAccount(nextAccount)
       await refreshAiReadinessForClient(client, nextAccount)
@@ -4356,10 +4444,44 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       setPlatformAccountValidations(nextPlatformAccountValidations)
       setStreamMetadataDraft(nextStreamMetadataDraft)
       setStreamMetadataValidation(nextStreamMetadataValidation)
+      setNoiseCleanupJobs((current) =>
+        nextNoiseCleanupJobs.reduce((jobs, job) => upsertNoiseCleanupJob(jobs, job), current)
+      )
     } catch (error) {
       reportError(error)
     }
-  }, [client, refreshAiReadinessForClient, reportError])
+  }, [client, refreshAiReadinessForClient, refreshEntitlementsForClient, reportError])
+
+  const refreshEntitlements = useCallback(async (): Promise<void> => {
+    if (!client || wsStatusRef.current !== 'connected') {
+      return
+    }
+    await refreshEntitlementsForClient(client)
+  }, [client, refreshEntitlementsForClient])
+
+  // Purchases and token expiry must not remain stale. Focus covers return from
+  // the Premium browser; the bounded signed-in timer covers an app left open.
+  useEffect(() => {
+    if (!client || wsStatus !== 'connected') {
+      return
+    }
+    const refreshOnFocus = (): void => {
+      void refreshEntitlementsForClient(client).catch(() => {
+        // Preserve the current fail-closed snapshot on transport failure.
+      })
+    }
+    window.addEventListener('focus', refreshOnFocus)
+    const timer =
+      account?.status === 'signed-in'
+        ? window.setInterval(refreshOnFocus, SIGNED_IN_ENTITLEMENT_REFRESH_INTERVAL_MS)
+        : null
+    return () => {
+      window.removeEventListener('focus', refreshOnFocus)
+      if (timer !== null) {
+        window.clearInterval(timer)
+      }
+    }
+  }, [account?.status, client, refreshEntitlementsForClient, wsStatus])
 
   // Real OS camera/mic access status (Electron getMediaAccessStatus, over IPC —
   // independent of the backend socket). Refresh on mount and whenever the window
@@ -6615,12 +6737,15 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       const nextAccount = await signOut()
       setAccount(nextAccount)
       if (client && wsStatus === 'connected') {
-        await refreshAiReadinessForClient(client, nextAccount)
+        await Promise.all([
+          refreshAiReadinessForClient(client, nextAccount),
+          refreshEntitlementsForClient(client)
+        ])
       }
     } catch (error) {
       reportError(error)
     }
-  }, [client, refreshAiReadinessForClient, reportError, wsStatus])
+  }, [client, refreshAiReadinessForClient, refreshEntitlementsForClient, reportError, wsStatus])
 
   const completeAccountSignIn = useCallback(
     async (envelope: AccountCallbackEnvelope): Promise<'complete' | 'retry'> => {
@@ -6668,13 +6793,16 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       accountCallbacksCompletedRef.current.add(envelope.id)
       setAccount(nextAccount)
       try {
-        await refreshAiReadinessForClient(client, nextAccount)
+        await Promise.all([
+          refreshAiReadinessForClient(client, nextAccount),
+          refreshEntitlementsForClient(client)
+        ])
       } catch (error) {
         reportError(error)
       }
       return 'complete'
     },
-    [client, refreshAiReadinessForClient, reportError, wsStatus]
+    [client, refreshAiReadinessForClient, refreshEntitlementsForClient, reportError, wsStatus]
   )
 
   useEffect(() => {
@@ -7935,14 +8063,14 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         const result = await window.videorc?.trashSessionDeletion?.(operation.operationId)
         failedCount += result?.failedCount ?? operation.pathCount + operation.blockedPathCount
       }
-      await refreshSessions(client)
+      await Promise.all([refreshSessions(client), refreshNoiseCleanupJobs(client)])
       if (failedCount > 0) {
         throw new Error(
           `${failedCount} file(s) could not be moved to Trash; their sessions were kept.`
         )
       }
     },
-    [client, refreshSessions]
+    [client, refreshNoiseCleanupJobs, refreshSessions]
   )
 
   const duplicateSession = useCallback(
@@ -7979,6 +8107,30 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     await refreshSessions(client)
   }, [client, refreshSessions, settings.outputDirectoryHandle])
 
+  const startNoiseCleanup = useCallback(
+    async (sessionId: string): Promise<NoiseCleanupJob> => {
+      if (!client) {
+        throw new Error('Backend is not connected.')
+      }
+      const job = await client.requestTyped('noiseCleanup.start', { sessionId })
+      setNoiseCleanupJobs((current) => upsertNoiseCleanupJob(current, job))
+      return job
+    },
+    [client]
+  )
+
+  const cancelNoiseCleanup = useCallback(
+    async (jobId: string): Promise<NoiseCleanupJob> => {
+      if (!client) {
+        throw new Error('Backend is not connected.')
+      }
+      const job = await client.requestTyped('noiseCleanup.cancel', { jobId })
+      setNoiseCleanupJobs((current) => upsertNoiseCleanupJob(current, job))
+      return job
+    },
+    [client]
+  )
+
   const ensureSessionPoster = useCallback(
     async (sessionId: string): Promise<boolean> => {
       if (!client) {
@@ -8007,13 +8159,13 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         await client.request('session.remux_mp4', {
           sessionId
         })
-        await refreshSessions(client)
+        await Promise.all([refreshSessions(client), refreshNoiseCleanupJobs(client)])
         toast.success('Remuxed recording to MP4.')
       } catch (error) {
         reportError(error)
       }
     },
-    [client, refreshSessions, reportError]
+    [client, refreshNoiseCleanupJobs, refreshSessions, reportError]
   )
 
   const runAiWorkflow = useCallback(
@@ -8166,9 +8318,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       if (!client) {
         throw new Error('Backend is not connected.')
       }
-      return client.requestTyped('repair.repair_file', { sessionId })
+      const result = await client.requestTyped('repair.repair_file', { sessionId })
+      await Promise.all([refreshSessions(client), refreshNoiseCleanupJobs(client)])
+      return result
     },
-    [client]
+    [client, refreshNoiseCleanupJobs, refreshSessions]
   )
 
   const restoreRecording = useCallback(
@@ -8177,9 +8331,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         throw new Error('Backend is not connected.')
       }
       const result = await client.requestTyped('repair.restore_file', { sessionId })
+      if (result.restored) {
+        await Promise.all([refreshSessions(client), refreshNoiseCleanupJobs(client)])
+      }
       return result.restored
     },
-    [client]
+    [client, refreshNoiseCleanupJobs, refreshSessions]
   )
 
   const patchVideo = useCallback((patch: Partial<VideoSettings>) => {
@@ -8586,6 +8743,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       wsStatus,
       health,
       entitlements,
+      noiseCleanupJobs,
       account,
       aiCapabilities,
       aiQuota,
@@ -8681,6 +8839,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       lastError,
       runtimeInfo,
       refreshBackend,
+      refreshEntitlements,
       refreshPlatformAccounts,
       validatePlatformAccounts,
       connectPlatformAccount,
@@ -8729,6 +8888,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       deleteSessions,
       duplicateSession,
       importRecording,
+      startNoiseCleanup,
+      cancelNoiseCleanup,
       sessionStorageTotals,
       runAiWorkflow,
       exportPublishPack,
@@ -8754,6 +8915,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       wsStatus,
       health,
       entitlements,
+      noiseCleanupJobs,
       account,
       aiCapabilities,
       aiQuota,
@@ -8849,6 +9011,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       lastError,
       runtimeInfo,
       refreshBackend,
+      refreshEntitlements,
       refreshPlatformAccounts,
       validatePlatformAccounts,
       connectPlatformAccount,
@@ -8897,6 +9060,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       deleteSessions,
       duplicateSession,
       importRecording,
+      startNoiseCleanup,
+      cancelNoiseCleanup,
       sessionStorageTotals,
       runAiWorkflow,
       exportPublishPack,

--- a/apps/desktop/src/renderer/src/lib/entitlement-ui.test.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlement-ui.test.ts
@@ -4,6 +4,7 @@ import type { EntitlementsSnapshot, VideoSettings } from './backend'
 import {
   cloudAiUploadGate,
   goLiveEntitlementGate,
+  noiseCleanupGate,
   streamingDestinationEnableGate,
   videoProfileEntitlementGate
 } from './entitlement-ui'
@@ -31,6 +32,10 @@ const premiumEntitlements: EntitlementsSnapshot = {
     },
     {
       featureId: 'cloud-ai',
+      state: 'enabled'
+    },
+    {
+      featureId: 'noise-cleanup',
       state: 'enabled'
     }
   ],
@@ -143,6 +148,7 @@ describe('entitlement UI gates', () => {
       allowed: true
     })
     expect(cloudAiUploadGate(developerEntitlements)).toEqual({ allowed: true })
+    expect(noiseCleanupGate(developerEntitlements)).toEqual({ allowed: true })
   })
 
   it('allows Basic Go Live with one destination and blocks over-limit configs before preflight', () => {
@@ -197,6 +203,17 @@ describe('entitlement UI gates', () => {
         video: youtube4k
       })
     ).toEqual({ allowed: true })
+  })
+
+  it('fails closed for Noise Cleanup and links Basic users to Premium', () => {
+    expect(noiseCleanupGate(null)).toEqual({
+      allowed: false,
+      featureId: 'noise-cleanup',
+      reason: 'Noise Cleanup requires Videorc Premium.',
+      upgradeUrl: VIDEORC_PREMIUM_URL
+    })
+    expect(noiseCleanupGate(basicEntitlements)).toEqual(noiseCleanupGate(null))
+    expect(noiseCleanupGate(premiumEntitlements)).toEqual({ allowed: true })
   })
 
   it('allows every recording preset on Basic — recording is not premium-gated', () => {
@@ -257,6 +274,7 @@ describe('entitlement UI gates', () => {
         streaming: { enabledTargetIds: ['youtube', 'twitch'] }
       }),
       cloudAiUploadGate(basicEntitlements),
+      noiseCleanupGate(basicEntitlements),
       videoProfileEntitlementGate({
         entitlements: basicEntitlements,
         kind: 'streaming',

--- a/apps/desktop/src/renderer/src/lib/entitlement-ui.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlement-ui.ts
@@ -84,6 +84,10 @@ export function cloudAiUploadGate(entitlements: EntitlementsSnapshot | null): En
   return featureGate(entitlements, 'cloud-ai')
 }
 
+export function noiseCleanupGate(entitlements: EntitlementsSnapshot | null): EntitlementUiGate {
+  return featureGate(entitlements, 'noise-cleanup')
+}
+
 export function videoProfileEntitlementGate({
   entitlements,
   kind,

--- a/apps/desktop/src/renderer/src/lib/entitlements.test.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlements.test.ts
@@ -31,6 +31,11 @@ const developerEntitlements: EntitlementsSnapshot = {
       featureId: 'cloud-ai',
       state: 'developer-override',
       reason: 'Enabled by Videorc debug/dev backend build.'
+    },
+    {
+      featureId: 'noise-cleanup',
+      state: 'developer-override',
+      reason: 'Enabled by Videorc debug/dev backend build.'
     }
   ],
   limits: {
@@ -62,6 +67,10 @@ describe('entitlements', () => {
     expect(entitlementDisabledReason(null, 'multistreaming')).toContain('Premium')
     expect(isFeatureEntitled(null, 'cloud-ai')).toBe(false)
     expect(entitlementDisabledReason(null, 'cloud-ai')).toContain('Premium')
+    expect(isFeatureEntitled(null, 'noise-cleanup')).toBe(false)
+    expect(entitlementDisabledReason(null, 'noise-cleanup')).toBe(
+      'Noise Cleanup requires Videorc Premium.'
+    )
     // Recording is free at full quality — the website promises free 4K
     // local recording; only streaming is tiered.
     expect(DEFAULT_BASIC_ENTITLEMENTS.limits.recording).toMatchObject({
@@ -82,6 +91,7 @@ describe('entitlements', () => {
     expect(isFeatureEntitled(developerEntitlements, 'livestreaming')).toBe(true)
     expect(isFeatureEntitled(developerEntitlements, 'multistreaming')).toBe(true)
     expect(isFeatureEntitled(developerEntitlements, 'cloud-ai')).toBe(true)
+    expect(isFeatureEntitled(developerEntitlements, 'noise-cleanup')).toBe(true)
     expect(entitlementDisabledReason(developerEntitlements, 'cloud-ai')).toBeNull()
   })
 

--- a/apps/desktop/src/renderer/src/lib/entitlements.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlements.ts
@@ -22,6 +22,11 @@ export const DEFAULT_BASIC_ENTITLEMENTS: EntitlementsSnapshot = {
       featureId: 'cloud-ai',
       state: 'disabled',
       reason: 'Cloud AI is a Videorc Premium feature.'
+    },
+    {
+      featureId: 'noise-cleanup',
+      state: 'disabled',
+      reason: 'Noise Cleanup requires Videorc Premium.'
     }
   ],
   limits: {

--- a/apps/desktop/src/renderer/src/lib/noise-cleanup-view.test.ts
+++ b/apps/desktop/src/renderer/src/lib/noise-cleanup-view.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest'
+
+import type { EntitlementsSnapshot, NoiseCleanupJob, SessionSummary } from './backend'
+import { DEFAULT_BASIC_ENTITLEMENTS } from './entitlements'
+import {
+  activeNoiseCleanupSourceIds,
+  deriveNoiseCleanupView,
+  latestNoiseCleanupJobForSession,
+  noiseCleanupCancellationNotice,
+  upsertNoiseCleanupJob,
+  withNoiseCleanupConnectionState
+} from './noise-cleanup-view'
+
+const premiumEntitlements: EntitlementsSnapshot = {
+  ...DEFAULT_BASIC_ENTITLEMENTS,
+  tier: 'premium',
+  source: 'creem',
+  capabilities: DEFAULT_BASIC_ENTITLEMENTS.capabilities.map((capability) => ({
+    ...capability,
+    state: 'enabled',
+    reason: undefined
+  }))
+}
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'session-1',
+    title: 'Weekly update',
+    startedAt: '2026-07-13T10:00:00.000Z',
+    status: 'completed',
+    mode: 'record',
+    outputPath: '/recordings/session-1.mkv',
+    layout: {} as SessionSummary['layout'],
+    sources: {},
+    healthEvents: [],
+    sessionLogs: [],
+    aiArtifacts: [],
+    commentCount: 0,
+    ...overrides
+  }
+}
+
+function job(overrides: Partial<NoiseCleanupJob> = {}): NoiseCleanupJob {
+  return {
+    id: 'cleanup-1',
+    sourceSessionId: 'session-1',
+    status: 'queued',
+    progressPercent: 0,
+    preset: 'speech-v1',
+    createdAt: '2026-07-13T10:00:00.000Z',
+    updatedAt: '2026-07-13T10:00:01.000Z',
+    ...overrides
+  }
+}
+
+function derive(
+  overrides: {
+    session?: SessionSummary
+    entitlements?: EntitlementsSnapshot | null
+    job?: NoiseCleanupJob | null
+    captureActive?: boolean
+  } = {}
+) {
+  return deriveNoiseCleanupView({
+    session: overrides.session ?? session(),
+    entitlements:
+      overrides.entitlements === undefined ? premiumEntitlements : overrides.entitlements,
+    job: overrides.job ?? null,
+    captureActive: overrides.captureActive ?? false
+  })
+}
+
+describe('Noise Cleanup Library view', () => {
+  it('keeps missing and Basic entitlements actionable as a Premium upgrade', () => {
+    for (const entitlements of [null, DEFAULT_BASIC_ENTITLEMENTS]) {
+      expect(derive({ entitlements })).toMatchObject({
+        directAction: 'upgrade',
+        menuAction: 'upgrade',
+        directLabel: 'Clean noise',
+        menuLabel: 'Clean noise — Premium',
+        premiumLocked: true,
+        detail: 'Noise Cleanup requires Videorc Premium.'
+      })
+    }
+  })
+
+  it('starts a supported finalized local recording with one click', () => {
+    expect(derive()).toMatchObject({
+      directAction: 'start',
+      menuAction: 'start',
+      directLabel: 'Clean noise',
+      busy: false
+    })
+  })
+
+  it('states truthful disabled reasons for live, imported, missing, and unfinished sessions', () => {
+    expect(derive({ captureActive: true }).disabledReason).toBe(
+      'Available after the live session ends.'
+    )
+    expect(derive({ session: session({ mode: 'imported' }) }).disabledReason).toContain('Imported')
+    expect(
+      derive({ session: session({ outputPath: undefined, mp4Path: undefined }) }).disabledReason
+    ).toBe('The local recording file is missing.')
+    expect(derive({ session: session({ status: 'failed' }) }).disabledReason).toBe(
+      'Noise Cleanup requires a finished recording.'
+    )
+  })
+
+  it('states intrinsic blockers before offering Premium', () => {
+    const cases = [
+      {
+        session: session(),
+        captureActive: true,
+        reason: 'Available after the live session ends.'
+      },
+      {
+        session: session({ status: 'running' }),
+        captureActive: false,
+        reason: 'Available after the live session ends.'
+      },
+      {
+        session: session({ mode: 'imported' }),
+        captureActive: false,
+        reason: 'Imported recordings are not supported by Noise Cleanup yet.'
+      },
+      {
+        session: session({ outputPath: undefined, mp4Path: undefined }),
+        captureActive: false,
+        reason: 'The local recording file is missing.'
+      },
+      {
+        session: session({ status: 'failed' }),
+        captureActive: false,
+        reason: 'Noise Cleanup requires a finished recording.'
+      }
+    ]
+
+    for (const entry of cases) {
+      expect(
+        derive({
+          session: entry.session,
+          captureActive: entry.captureActive,
+          entitlements: DEFAULT_BASIC_ENTITLEMENTS
+        })
+      ).toMatchObject({
+        directAction: null,
+        premiumLocked: false,
+        disabledReason: entry.reason
+      })
+    }
+  })
+
+  it('shows queued, processing, and validating status with menu cancellation', () => {
+    expect(derive({ job: job() })).toMatchObject({
+      directAction: null,
+      menuAction: 'cancel',
+      directLabel: 'Queued…',
+      busy: true,
+      conflictsWithFileActions: true
+    })
+    expect(derive({ job: job({ status: 'processing', progressPercent: 42.4 }) })).toMatchObject({
+      directLabel: 'Cleaning 42%',
+      menuLabel: 'Cancel cleanup — 42%',
+      statusAnnouncement: 'Cleaning noise, 40 percent.'
+    })
+    expect(derive({ job: job({ status: 'validating', progressPercent: 100 }) })).toMatchObject({
+      directLabel: 'Validating…',
+      menuAction: 'cancel',
+      conflictsWithFileActions: true
+    })
+  })
+
+  it('keeps an already-running local cleanup visible after entitlement loss', () => {
+    expect(
+      derive({
+        entitlements: DEFAULT_BASIC_ENTITLEMENTS,
+        job: job({ status: 'processing', progressPercent: 50 })
+      })
+    ).toMatchObject({ directLabel: 'Cleaning 50%', premiumLocked: false })
+  })
+
+  it('opens the managed cleaned copy only when completion has an output session', () => {
+    expect(
+      derive({
+        job: job({
+          status: 'completed',
+          progressPercent: 100,
+          outputSessionId: 'cleaned-session'
+        })
+      })
+    ).toMatchObject({
+      directAction: 'open-output',
+      menuAction: 'open-output',
+      directLabel: 'Open cleaned copy',
+      statusAnnouncement: 'Noise cleanup completed.'
+    })
+  })
+
+  it('marks cleaned derivatives and offers source reveal without another cleanup action', () => {
+    expect(
+      derive({
+        session: session({
+          id: 'cleaned-session',
+          derivedFromSessionId: 'session-1',
+          sourceTitle: 'Weekly update',
+          processingKind: 'noise-cleanup'
+        })
+      })
+    ).toMatchObject({
+      directAction: null,
+      menuAction: 'show-source',
+      menuLabel: 'Show source recording',
+      derivative: true
+    })
+  })
+
+  it('never offers cleanup again when a derivative source was deleted', () => {
+    expect(
+      derive({
+        session: session({
+          id: 'cleaned-session',
+          derivedFromSessionId: undefined,
+          sourceTitle: 'Deleted source',
+          processingKind: 'noise-cleanup'
+        })
+      })
+    ).toMatchObject({
+      directAction: null,
+      menuAction: null,
+      directLabel: null,
+      derivative: true,
+      detail: 'The source recording is no longer in Library.'
+    })
+  })
+
+  it('turns failed and cancelled jobs into retry with stable backend detail', () => {
+    expect(
+      derive({
+        job: job({
+          status: 'failed',
+          errorCode: 'noise-cleanup-no-audio',
+          errorMessage: 'This recording has no microphone audio.'
+        })
+      })
+    ).toMatchObject({
+      directAction: 'start',
+      directLabel: 'Retry cleanup',
+      detail: 'This recording has no microphone audio.'
+    })
+    expect(derive({ job: job({ status: 'cancelled' }) }).directLabel).toBe('Retry cleanup')
+  })
+
+  it('keeps durable job selection monotonic across row unmounts and stale events', () => {
+    const queued = job()
+    const processing = job({
+      status: 'processing',
+      progressPercent: 20,
+      updatedAt: '2026-07-13T10:00:02.000Z'
+    })
+    const stale = job({ updatedAt: '2026-07-13T10:00:00.500Z' })
+    const other = job({
+      id: 'cleanup-2',
+      sourceSessionId: 'session-2',
+      updatedAt: '2026-07-13T10:00:03.000Z'
+    })
+
+    const jobs = upsertNoiseCleanupJob(
+      upsertNoiseCleanupJob(upsertNoiseCleanupJob([queued], processing), stale),
+      other
+    )
+    expect(latestNoiseCleanupJobForSession(jobs, 'session-1')).toEqual(processing)
+    expect(latestNoiseCleanupJobForSession(jobs, 'session-2')).toEqual(other)
+  })
+
+  it('protects only sources with active cleanup jobs from bulk file actions', () => {
+    const activeSources = activeNoiseCleanupSourceIds([
+      job({ status: 'queued' }),
+      job({ id: 'cleanup-2', sourceSessionId: 'session-2', status: 'processing' }),
+      job({ id: 'cleanup-3', sourceSessionId: 'session-3', status: 'validating' }),
+      job({ id: 'cleanup-4', sourceSessionId: 'session-4', status: 'completed' }),
+      job({ id: 'cleanup-5', sourceSessionId: 'session-5', status: 'failed' }),
+      job({ id: 'cleanup-6', sourceSessionId: 'session-6', status: 'cancelled' })
+    ])
+
+    expect([...activeSources]).toEqual(['session-1', 'session-2', 'session-3'])
+  })
+
+  it('only confirms cancellation after the backend returns cancelled', () => {
+    expect(noiseCleanupCancellationNotice(job({ status: 'cancelled' }))).toEqual({
+      title: 'Noise cleanup cancelled',
+      description: 'The original recording was not changed.'
+    })
+    for (const status of ['queued', 'processing', 'validating'] as const) {
+      expect(noiseCleanupCancellationNotice(job({ status }))).toEqual({
+        title: 'Cancellation requested',
+        description:
+          'Noise cleanup is still stopping. Its status will update when cancellation finishes.'
+      })
+    }
+  })
+
+  it('disables backend start while reconnecting', () => {
+    const connectedView = derive()
+    expect(connectedView.directAction).toBe('start')
+
+    expect(withNoiseCleanupConnectionState(connectedView, false)).toMatchObject({
+      directAction: null,
+      menuAction: 'start',
+      directLabel: 'Clean noise',
+      disabledReason: 'Videorc is reconnecting. Try again in a moment.'
+    })
+    expect(withNoiseCleanupConnectionState(connectedView, true)).toBe(connectedView)
+  })
+
+  it('keeps browser upgrade and local cleaned-copy actions available while offline', () => {
+    const upgrade = derive({ entitlements: DEFAULT_BASIC_ENTITLEMENTS })
+    const completed = derive({
+      job: job({
+        status: 'completed',
+        progressPercent: 100,
+        outputSessionId: 'cleaned-session'
+      })
+    })
+
+    expect(upgrade.directAction).toBe('upgrade')
+    expect(withNoiseCleanupConnectionState(upgrade, false)).toBe(upgrade)
+    expect(completed.directAction).toBe('open-output')
+    expect(withNoiseCleanupConnectionState(completed, false)).toBe(completed)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/noise-cleanup-view.ts
+++ b/apps/desktop/src/renderer/src/lib/noise-cleanup-view.ts
@@ -1,0 +1,237 @@
+import type { EntitlementsSnapshot, NoiseCleanupJob, SessionSummary } from './backend'
+import { noiseCleanupGate } from './entitlement-ui'
+
+export type NoiseCleanupAction = 'upgrade' | 'start' | 'cancel' | 'open-output' | 'show-source'
+
+export interface NoiseCleanupView {
+  directAction: NoiseCleanupAction | null
+  menuAction: NoiseCleanupAction | null
+  directLabel: string | null
+  menuLabel: string | null
+  disabledReason: string | null
+  detail: string | null
+  statusAnnouncement: string | null
+  busy: boolean
+  conflictsWithFileActions: boolean
+  premiumLocked: boolean
+  derivative: boolean
+}
+
+export interface NoiseCleanupViewInput {
+  session: Pick<
+    SessionSummary,
+    'id' | 'status' | 'mode' | 'outputPath' | 'mp4Path' | 'derivedFromSessionId' | 'processingKind'
+  >
+  entitlements: EntitlementsSnapshot | null
+  job: NoiseCleanupJob | null
+  captureActive: boolean
+}
+
+export interface NoiseCleanupCancellationNotice {
+  title: string
+  description: string
+}
+
+export function deriveNoiseCleanupView({
+  session,
+  entitlements,
+  job,
+  captureActive
+}: NoiseCleanupViewInput): NoiseCleanupView {
+  if (session.processingKind === 'noise-cleanup') {
+    return view({
+      menuAction: session.derivedFromSessionId ? 'show-source' : null,
+      menuLabel: session.derivedFromSessionId ? 'Show source recording' : null,
+      detail: session.derivedFromSessionId ? null : 'The source recording is no longer in Library.',
+      derivative: true
+    })
+  }
+
+  if (job?.status === 'queued') {
+    return view({
+      menuAction: 'cancel',
+      directLabel: 'Queued…',
+      menuLabel: 'Cancel cleanup',
+      detail: 'Noise cleanup is queued and will start when media processing is available.',
+      statusAnnouncement: 'Noise cleanup queued.',
+      busy: true,
+      conflictsWithFileActions: true
+    })
+  }
+  if (job?.status === 'processing') {
+    const progress = clampProgress(job.progressPercent)
+    return view({
+      menuAction: 'cancel',
+      directLabel: `Cleaning ${Math.round(progress)}%`,
+      menuLabel: `Cancel cleanup — ${Math.round(progress)}%`,
+      detail: `Cleaning noise: ${Math.round(progress)}% complete.`,
+      statusAnnouncement: `Cleaning noise, ${coarseProgress(progress)} percent.`,
+      busy: true,
+      conflictsWithFileActions: true
+    })
+  }
+  if (job?.status === 'validating') {
+    return view({
+      menuAction: 'cancel',
+      directLabel: 'Validating…',
+      menuLabel: 'Cancel cleanup',
+      detail: 'Validating the cleaned copy before it appears in Library.',
+      statusAnnouncement: 'Validating cleaned copy.',
+      busy: true,
+      conflictsWithFileActions: true
+    })
+  }
+  if (job?.status === 'completed' && job.outputSessionId) {
+    return view({
+      directAction: 'open-output',
+      menuAction: 'open-output',
+      directLabel: 'Open cleaned copy',
+      menuLabel: 'Open cleaned copy',
+      detail: 'Noise cleanup completed. The original recording was not changed.',
+      statusAnnouncement: 'Noise cleanup completed.'
+    })
+  }
+
+  if (captureActive || session.status === 'running') {
+    const reason = 'Available after the live session ends.'
+    return view({ directLabel: 'Clean noise', menuLabel: 'Clean noise', disabledReason: reason })
+  }
+  if (session.mode === 'imported') {
+    const reason = 'Imported recordings are not supported by Noise Cleanup yet.'
+    return view({ directLabel: 'Clean noise', menuLabel: 'Clean noise', disabledReason: reason })
+  }
+  if (!session.mp4Path && !session.outputPath) {
+    const reason = 'The local recording file is missing.'
+    return view({ directLabel: 'Clean noise', menuLabel: 'Clean noise', disabledReason: reason })
+  }
+  if (session.status !== 'completed') {
+    const reason = 'Noise Cleanup requires a finished recording.'
+    return view({ directLabel: 'Clean noise', menuLabel: 'Clean noise', disabledReason: reason })
+  }
+
+  const gate = noiseCleanupGate(entitlements)
+  if (!gate.allowed) {
+    return view({
+      directAction: 'upgrade',
+      menuAction: 'upgrade',
+      directLabel: 'Clean noise',
+      menuLabel: 'Clean noise — Premium',
+      detail: gate.reason,
+      premiumLocked: true
+    })
+  }
+
+  const retry = job?.status === 'failed' || job?.status === 'cancelled'
+  return view({
+    directAction: 'start',
+    menuAction: 'start',
+    directLabel: retry ? 'Retry cleanup' : 'Clean noise',
+    menuLabel: retry ? 'Retry cleanup' : 'Clean noise',
+    detail: retry ? (job.errorMessage ?? 'The previous cleanup did not finish.') : null
+  })
+}
+
+export function latestNoiseCleanupJobForSession(
+  jobs: readonly NoiseCleanupJob[],
+  sessionId: string
+): NoiseCleanupJob | null {
+  let latest: NoiseCleanupJob | null = null
+  for (const job of jobs) {
+    if (
+      job.sourceSessionId === sessionId &&
+      (!latest || job.updatedAt.localeCompare(latest.updatedAt) > 0)
+    ) {
+      latest = job
+    }
+  }
+  return latest
+}
+
+export function activeNoiseCleanupSourceIds(jobs: readonly NoiseCleanupJob[]): ReadonlySet<string> {
+  return new Set(
+    jobs
+      .filter((job) => ['queued', 'processing', 'validating'].includes(job.status))
+      .map((job) => job.sourceSessionId)
+  )
+}
+
+export function noiseCleanupCancellationNotice(
+  job: NoiseCleanupJob
+): NoiseCleanupCancellationNotice {
+  if (job.status === 'cancelled') {
+    return {
+      title: 'Noise cleanup cancelled',
+      description: 'The original recording was not changed.'
+    }
+  }
+  if (['queued', 'processing', 'validating'].includes(job.status)) {
+    return {
+      title: 'Cancellation requested',
+      description:
+        'Noise cleanup is still stopping. Its status will update when cancellation finishes.'
+    }
+  }
+  if (job.status === 'completed') {
+    return {
+      title: 'Noise cleanup already completed',
+      description: 'The cleaned copy is ready in Library.'
+    }
+  }
+  return {
+    title: 'Noise cleanup stopped',
+    description: job.errorMessage ?? 'The cleanup job is no longer running.'
+  }
+}
+
+export function withNoiseCleanupConnectionState(
+  cleanupView: NoiseCleanupView,
+  connected: boolean
+): NoiseCleanupView {
+  if (connected || cleanupView.directAction !== 'start') {
+    return cleanupView
+  }
+  return {
+    ...cleanupView,
+    directAction: null,
+    disabledReason: 'Videorc is reconnecting. Try again in a moment.'
+  }
+}
+
+export function upsertNoiseCleanupJob(
+  jobs: readonly NoiseCleanupJob[],
+  next: NoiseCleanupJob
+): NoiseCleanupJob[] {
+  const index = jobs.findIndex((job) => job.id === next.id)
+  if (index < 0) {
+    return [...jobs, next]
+  }
+  if (jobs[index]?.updatedAt.localeCompare(next.updatedAt) > 0) {
+    return [...jobs]
+  }
+  return jobs.map((job, jobIndex) => (jobIndex === index ? next : job))
+}
+
+function view(overrides: Partial<NoiseCleanupView>): NoiseCleanupView {
+  return {
+    directAction: null,
+    menuAction: null,
+    directLabel: null,
+    menuLabel: null,
+    disabledReason: null,
+    detail: null,
+    statusAnnouncement: null,
+    busy: false,
+    conflictsWithFileActions: false,
+    premiumLocked: false,
+    derivative: false,
+    ...overrides
+  }
+}
+
+function clampProgress(progress: number): number {
+  return Math.min(100, Math.max(0, progress))
+}
+
+function coarseProgress(progress: number): number {
+  return Math.round(progress / 10) * 10
+}

--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest'
 import type {
   OAuthCallbackResult,
   OAuthCompleteParams,
+  NoiseCleanupJob,
   SessionCommentsPage,
   SessionDeletionOperation
 } from './backend'
@@ -18,6 +19,90 @@ import {
 } from './backend-rpc-contract'
 
 describe('backend RPC contract', () => {
+  it('types and strictly validates Noise Cleanup commands and status events', () => {
+    expectTypeOf<BackendRpcParams<'noiseCleanup.start'>>().toEqualTypeOf<{ sessionId: string }>()
+    expectTypeOf<BackendRpcParams<'noiseCleanup.cancel'>>().toEqualTypeOf<{ jobId: string }>()
+    expectTypeOf<BackendRpcResult<'noiseCleanup.list'>>().toEqualTypeOf<NoiseCleanupJob[]>()
+    expectTypeOf<BackendEventMap['noiseCleanup.status']>().toEqualTypeOf<NoiseCleanupJob>()
+
+    const job: NoiseCleanupJob = {
+      id: 'cleanup-1',
+      sourceSessionId: 'session-1',
+      status: 'processing',
+      progressPercent: 42,
+      preset: 'speech-v1',
+      createdAt: '2026-07-13T10:00:00.000Z',
+      updatedAt: '2026-07-13T10:00:01.000Z'
+    }
+
+    expect(validateBackendRpcParams('noiseCleanup.start', { sessionId: 'session-1' })).toEqual({
+      sessionId: 'session-1'
+    })
+    expect(validateBackendRpcResult('noiseCleanup.start', job)).toEqual(job)
+    expect(validateBackendRpcResult('noiseCleanup.list', [job])).toEqual([job])
+    expect(validateBackendEventPayload('noiseCleanup.status', job)).toEqual(job)
+
+    expect(() =>
+      validateBackendRpcParams('noiseCleanup.start', {
+        sessionId: 'session-1',
+        path: '/renderer-must-not-send-path.mp4'
+      })
+    ).toThrow('path must be a known field')
+    for (const malformed of [
+      { ...job, status: 'running' },
+      { ...job, progressPercent: 42.5 },
+      { ...job, progressPercent: 101 },
+      { ...job, preset: 'speech-v2' },
+      { ...job, status: 'completed', progressPercent: 100 },
+      { ...job, status: 'failed', errorCode: undefined, errorMessage: undefined },
+      { ...job, unexpected: true }
+    ]) {
+      expect(() => validateBackendEventPayload('noiseCleanup.status', malformed)).toThrow()
+    }
+  })
+
+  it('strictly validates entitlement refresh results and update events', () => {
+    const snapshot = {
+      schemaVersion: 1,
+      tier: 'premium',
+      source: 'creem',
+      capabilities: [
+        { featureId: 'noise-cleanup', state: 'enabled' },
+        { featureId: 'cloud-ai', state: 'enabled' }
+      ],
+      limits: {
+        recording: { maxWidth: 3840, maxHeight: 2160, maxFps: 60 },
+        streaming: {
+          maxWidth: 3840,
+          maxHeight: 2160,
+          maxFps: 30,
+          maxBitrateKbps: 30_000,
+          maxDestinations: 3
+        }
+      },
+      checkedAt: '2026-07-13T10:00:00.000Z'
+    }
+
+    expect(validateBackendRpcParams('entitlements.refresh', undefined)).toBeUndefined()
+    expect(validateBackendRpcResult('entitlements.refresh', snapshot)).toEqual(snapshot)
+    expect(validateBackendEventPayload('entitlements.updated', snapshot)).toEqual(snapshot)
+    expect(() =>
+      validateBackendEventPayload('entitlements.updated', {
+        ...snapshot,
+        capabilities: [{ featureId: 'noise-cleanup', state: 'maybe' }]
+      })
+    ).toThrow('state')
+    expect(() =>
+      validateBackendEventPayload('entitlements.updated', { ...snapshot, unexpected: true })
+    ).toThrow('unexpected must be a known field')
+    expect(() =>
+      validateBackendEventPayload('entitlements.updated', {
+        ...snapshot,
+        limits: { ...snapshot.limits, recording: { maxWidth: 3840 } }
+      })
+    ).toThrow('maxHeight')
+  })
+
   it('types and exactly validates provider OAuth callback completion', () => {
     expectTypeOf<
       BackendRpcParams<'platformAccounts.oauth.complete'>

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -8,6 +8,7 @@ import type {
   FileAssessment,
   GateStatus,
   LiveLayoutApplyStatus,
+  NoiseCleanupJob,
   OAuthCallbackResult,
   OAuthCompleteParams,
   PreviewCameraStatus,
@@ -66,6 +67,7 @@ type LayoutTransactionResult = LiveLayoutApplyStatus & {
 export interface BackendRpcMethodMap {
   'health.ping': BackendRpcDefinition<{ ffmpegPath?: string } | undefined, BackendHealth>
   'entitlements.get': BackendRpcDefinition<undefined, EntitlementsSnapshot>
+  'entitlements.refresh': BackendRpcDefinition<undefined, EntitlementsSnapshot>
   'account.get': BackendRpcDefinition<undefined, VideorcAccountSnapshot>
   'account.complete_sign_in': BackendRpcDefinition<
     { code: string; state: string; verifier: string; intentGeneration: number },
@@ -98,6 +100,9 @@ export interface BackendRpcMethodMap {
   'sessions.comments.list': BackendRpcDefinition<SessionCommentsListParams, SessionCommentsPage>
   'sessions.delete': BackendRpcDefinition<{ sessionIds: string[] }, SessionDeletionOperation[]>
   'sessions.delete.pending': BackendRpcDefinition<undefined, SessionDeletionOperation[]>
+  'noiseCleanup.start': BackendRpcDefinition<{ sessionId: string }, NoiseCleanupJob>
+  'noiseCleanup.cancel': BackendRpcDefinition<{ jobId: string }, NoiseCleanupJob>
+  'noiseCleanup.list': BackendRpcDefinition<undefined, NoiseCleanupJob[]>
   'repair.assess_file': BackendRpcDefinition<{ sessionId: string }, FileAssessment>
   'repair.repair_file': BackendRpcDefinition<
     { sessionId: string; expectAudio?: boolean; intendedFps?: number },
@@ -114,6 +119,8 @@ export type BackendRpcResult<TMethod extends BackendRpcMethod> =
 
 export interface BackendEventMap {
   'devices.changed': DeviceList
+  'entitlements.updated': EntitlementsSnapshot
+  'noiseCleanup.status': NoiseCleanupJob
   'platformAccounts.oauth.callback': OAuthCallbackResult
   'recording.status': RecordingStatus
   'scene.changed': Scene
@@ -194,7 +201,13 @@ const backendHealthSchema = objectSchema(
 
 const entitlementCapabilitySchema = objectSchema(
   {
-    featureId: enumSchema(['local-recording', 'livestreaming', 'multistreaming', 'cloud-ai']),
+    featureId: enumSchema([
+      'local-recording',
+      'livestreaming',
+      'multistreaming',
+      'cloud-ai',
+      'noise-cleanup'
+    ]),
     state: enumSchema(['enabled', 'disabled', 'developer-override']),
     reason: optionalText
   },
@@ -216,8 +229,25 @@ const entitlementsSchema = objectSchema(
     capabilities: arraySchema(entitlementCapabilitySchema, { maxLength: 32 }),
     limits: objectSchema(
       {
-        recording: boundedBackendPayloadSchema,
-        streaming: boundedBackendPayloadSchema
+        recording: objectSchema(
+          {
+            maxWidth: numberSchema({ integer: true, min: 1, max: 65_536 }),
+            maxHeight: numberSchema({ integer: true, min: 1, max: 65_536 }),
+            maxFps: numberSchema({ integer: true, min: 1, max: 1000 }),
+            maxBitrateKbps: optionalSchema(nonNegativeInteger)
+          },
+          { allowUnknown: false }
+        ),
+        streaming: objectSchema(
+          {
+            maxWidth: numberSchema({ integer: true, min: 1, max: 65_536 }),
+            maxHeight: numberSchema({ integer: true, min: 1, max: 65_536 }),
+            maxFps: numberSchema({ integer: true, min: 1, max: 1000 }),
+            maxBitrateKbps: nonNegativeInteger,
+            maxDestinations: numberSchema({ integer: true, min: 1, max: 1000 })
+          },
+          { allowUnknown: false }
+        )
       },
       { allowUnknown: false }
     ),
@@ -519,10 +549,43 @@ const sessionSummarySchema = boundedSemanticValue(
       startedAt: timestamp,
       status: boundedString,
       mode: boundedString,
-      commentCount: nonNegativeInteger
+      commentCount: nonNegativeInteger,
+      derivedFromSessionId: optionalSchema(boundedString),
+      sourceTitle: optionalSchema(stringSchema({ maxLength: 16_384 })),
+      processingKind: optionalSchema(literalSchema('noise-cleanup'))
     },
     { allowUnknown: true }
   )
+)
+
+const noiseCleanupJobFieldsSchema = objectSchema(
+  {
+    id: boundedString,
+    sourceSessionId: boundedString,
+    status: enumSchema(['queued', 'processing', 'validating', 'completed', 'failed', 'cancelled']),
+    progressPercent: numberSchema({ integer: true, min: 0, max: 100 }),
+    preset: literalSchema('speech-v1'),
+    outputSessionId: optionalSchema(boundedString),
+    outputPath: optionalSchema(boundedPath),
+    errorCode: optionalText,
+    errorMessage: optionalText,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  },
+  { allowUnknown: false }
+)
+const noiseCleanupJobSchema = runtimeSchema<NoiseCleanupJob>(
+  'a Noise Cleanup job',
+  (value, path) => {
+    const job = noiseCleanupJobFieldsSchema.parse(value, path) as NoiseCleanupJob
+    if (job.status === 'completed' && (!job.outputSessionId || !job.outputPath)) {
+      throw new Error(`${path} must identify the completed output session and path.`)
+    }
+    if (job.status === 'failed' && (!job.errorCode || !job.errorMessage)) {
+      throw new Error(`${path} must include a stable failure code and message.`)
+    }
+    return job
+  }
 )
 
 const fileAssessmentSchema = boundedSemanticValue(
@@ -639,6 +702,7 @@ const oauthCallbackResultSchema = runtimeSchema<OAuthCallbackResult>(
 const runtimeContracts = {
   'health.ping': { params: undefinedOrFfmpegPathSchema, result: backendHealthSchema },
   'entitlements.get': { params: undefinedSchema, result: entitlementsSchema },
+  'entitlements.refresh': { params: undefinedSchema, result: entitlementsSchema },
   'account.get': { params: undefinedSchema, result: accountSchema },
   'account.complete_sign_in': {
     params: objectSchema(
@@ -752,6 +816,18 @@ const runtimeContracts = {
       { maxLength: 500 }
     )
   },
+  'noiseCleanup.start': {
+    params: objectSchema({ sessionId: boundedString }, { allowUnknown: false }),
+    result: noiseCleanupJobSchema
+  },
+  'noiseCleanup.cancel': {
+    params: objectSchema({ jobId: boundedString }, { allowUnknown: false }),
+    result: noiseCleanupJobSchema
+  },
+  'noiseCleanup.list': {
+    params: undefinedSchema,
+    result: arraySchema(noiseCleanupJobSchema, { maxLength: 1000 })
+  },
   'repair.assess_file': {
     params: objectSchema({ sessionId: boundedString }, { allowUnknown: false }),
     result: fileAssessmentSchema
@@ -798,6 +874,8 @@ export const runtimeValidatedBackendRpcMethods = Object.freeze(
 
 const runtimeEventSchemas = {
   'devices.changed': deviceListSchema,
+  'entitlements.updated': entitlementsSchema,
+  'noiseCleanup.status': noiseCleanupJobSchema,
   'platformAccounts.oauth.callback': oauthCallbackResultSchema,
   'recording.status': recordingStatusSchema,
   'scene.changed': sceneSchema,

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -46,7 +46,12 @@ export interface SupportBundleExportParams {
   rendererDiagnostics?: RendererDiagnosticsSnapshot
 }
 
-export type FeatureId = 'local-recording' | 'livestreaming' | 'multistreaming' | 'cloud-ai'
+export type FeatureId =
+  | 'local-recording'
+  | 'livestreaming'
+  | 'multistreaming'
+  | 'cloud-ai'
+  | 'noise-cleanup'
 export type EntitlementState = 'enabled' | 'disabled' | 'developer-override'
 export type EntitlementTier = 'basic' | 'premium' | 'developer'
 export type EntitlementSource =
@@ -91,6 +96,31 @@ export interface EntitlementsSnapshot {
   limits: EntitlementLimits
   checkedAt?: string
   expiresAt?: string
+}
+
+export type NoiseCleanupJobStatus =
+  | 'queued'
+  | 'processing'
+  | 'validating'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+export type NoiseCleanupPreset = 'speech-v1'
+
+/** Durable backend-owned cleanup state. The renderer never infers completion
+ * from a local process or row lifetime. */
+export interface NoiseCleanupJob {
+  id: string
+  sourceSessionId: string
+  status: NoiseCleanupJobStatus
+  progressPercent: number
+  preset: NoiseCleanupPreset
+  outputSessionId?: string
+  outputPath?: string
+  errorCode?: string
+  errorMessage?: string
+  createdAt: string
+  updatedAt: string
 }
 
 export type VideorcAccountStatus = 'signed-out' | 'signed-in'
@@ -2361,6 +2391,10 @@ export interface SessionSummary {
   sessionLogs: SessionLogEntry[]
   aiArtifacts: AiArtifact[]
   commentCount: number
+  /** Present only for managed derivatives created from another Library session. */
+  derivedFromSessionId?: string
+  sourceTitle?: string
+  processingKind?: 'noise-cleanup'
 }
 
 export interface SessionStorageTotals {

--- a/crates/videorc-backend/src/entitlements.rs
+++ b/crates/videorc-backend/src/entitlements.rs
@@ -30,6 +30,7 @@ const MULTISTREAMING_DISABLED_REASON: &str =
     "Multistreaming requires Videorc Premium. Basic can stream to one destination at HD.";
 const CLOUD_AI_DISABLED_REASON: &str =
     "Cloud AI is a Videorc Premium feature. Sign in with a Premium account to enable it.";
+const NOISE_CLEANUP_DISABLED_REASON: &str = "Noise Cleanup requires Videorc Premium.";
 const DEV_BUILD_OVERRIDE_REASON: &str = "Enabled by Videorc debug/dev backend build.";
 
 // --- Account-hydrated entitlement (multistream premium gate) ------------------
@@ -203,6 +204,11 @@ pub fn basic_entitlements() -> EntitlementsSnapshot {
                 state: EntitlementState::Disabled,
                 reason: Some(CLOUD_AI_DISABLED_REASON.to_string()),
             },
+            EntitlementCapability {
+                feature_id: FeatureId::NoiseCleanup,
+                state: EntitlementState::Disabled,
+                reason: Some(NOISE_CLEANUP_DISABLED_REASON.to_string()),
+            },
         ],
         limits: basic_limits(),
         checked_at: None,
@@ -242,6 +248,7 @@ fn enabled_capabilities(
         FeatureId::Livestreaming,
         FeatureId::Multistreaming,
         FeatureId::CloudAi,
+        FeatureId::NoiseCleanup,
     ]
     .into_iter()
     .map(|feature_id| EntitlementCapability {
@@ -749,5 +756,31 @@ mod tests {
             .expect_err("cloud AI should be gated in Basic mode");
 
         assert!(error.to_string().contains("Premium"));
+    }
+
+    #[test]
+    fn noise_cleanup_is_explicitly_gated_by_tier() {
+        let basic = basic_entitlements();
+        let capability = capability(&basic, FeatureId::NoiseCleanup).expect("cleanup capability");
+        assert_eq!(capability.state, EntitlementState::Disabled);
+        assert_eq!(
+            capability.reason.as_deref(),
+            Some(NOISE_CLEANUP_DISABLED_REASON)
+        );
+        assert!(require_feature(&basic, FeatureId::NoiseCleanup).is_err());
+
+        for snapshot in [
+            premium_entitlements(EntitlementSource::Creem),
+            developer_test_entitlements(),
+        ] {
+            assert!(require_feature(&snapshot, FeatureId::NoiseCleanup).is_ok());
+        }
+    }
+
+    #[test]
+    fn release_env_cannot_unlock_noise_cleanup() {
+        let snapshot = current_entitlements_resolved(Some("noise-cleanup"), false, false);
+        assert_eq!(snapshot.tier, EntitlementTier::Basic);
+        assert!(require_feature(&snapshot, FeatureId::NoiseCleanup).is_err());
     }
 }

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -28,6 +28,7 @@ mod live_scene;
 mod metal_compositor;
 mod mpeg_ts;
 mod native_preview_host;
+mod noise_cleanup;
 mod oauth;
 mod pipeline;
 mod posters;
@@ -121,6 +122,8 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::timeout;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
+
+const ENTITLEMENT_REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
 
 use crate::backend_authority::{
     BackendBootstrap, BackendRole, authenticate_backend_token, authorize_backend_method,
@@ -328,6 +331,7 @@ async fn main() -> Result<()> {
     tokio::spawn(resume_pending_oauth_completions(state.clone()));
     // Resume interrupted repair jobs through the idle-only maintenance queue.
     tokio::spawn(resume_pending_repair_jobs(state.clone()));
+    noise_cleanup::resume_interrupted(&state);
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(state.clone()))
         .await?;
@@ -377,6 +381,7 @@ async fn shutdown_signal(state: AppState) {
         "Backend shutdown requested; stopping caption, capture, and artifact processes.",
     );
     captions::shutdown_caption_runtime(&state).await;
+    state.noise_cleanup.interrupt_all_for_shutdown();
     shutdown_capture_processes(state.clone()).await;
     captions::shutdown_caption_artifacts(&state).await;
 }
@@ -4321,6 +4326,10 @@ fn resolve_renderer_managed_backgrounds(
     Ok(())
 }
 
+fn rpc_params_are_empty(params: &serde_json::Value) -> bool {
+    params.is_null() || params.as_object().is_some_and(serde_json::Map::is_empty)
+}
+
 async fn handle_text_message_with_role(
     state: &AppState,
     text: &str,
@@ -4571,6 +4580,25 @@ async fn handle_text_message_with_role(
             ServerResponse::ok(command.id, resolved)
         }
         "entitlements.get" => ServerResponse::ok(command.id, entitlements::current_entitlements()),
+        "entitlements.refresh" => {
+            if !rpc_params_are_empty(&command.params) {
+                ServerResponse::error(
+                    command.id,
+                    "invalid-params",
+                    "entitlements.refresh does not accept parameters.",
+                )
+            } else {
+                // Revalidation is best-effort and fail-closed. The refresh helper
+                // retains only a still-valid verified snapshot on network failure;
+                // callers always receive the effective current snapshot.
+                let _ = tokio::time::timeout(
+                    ENTITLEMENT_REFRESH_TIMEOUT,
+                    refresh_account_entitlements(state),
+                )
+                .await;
+                ServerResponse::ok(command.id, entitlements::current_entitlements())
+            }
+        }
         "captions.start" => {
             let language = command
                 .params
@@ -5398,6 +5426,17 @@ async fn handle_text_message_with_role(
                     "session-delete-invalid",
                     "No sessions given.",
                 ),
+                Ok(params)
+                    if params.session_ids.iter().any(|session_id| {
+                        noise_cleanup::session_mutation_blocked(state, session_id).unwrap_or(true)
+                    }) =>
+                {
+                    ServerResponse::error(
+                        command.id,
+                        "noise-cleanup-mutation-blocked",
+                        "This recording cannot be deleted while Noise Cleanup is active.",
+                    )
+                }
                 Ok(params) => match state
                     .database
                     .prepare_session_deletions(&params.session_ids)
@@ -5501,6 +5540,13 @@ async fn handle_text_message_with_role(
                 .get("sessionId")
                 .and_then(|value| value.as_str())
                 .unwrap_or_default();
+            if noise_cleanup::session_mutation_blocked(state, session_id).unwrap_or(true) {
+                return ServerResponse::error(
+                    command.id,
+                    "noise-cleanup-mutation-blocked",
+                    "This recording cannot be duplicated while Noise Cleanup is active.",
+                );
+            }
             match session_ops::duplicate_session(state, session_id).await {
                 Ok(new_id) => {
                     ServerResponse::ok(command.id, serde_json::json!({ "sessionId": new_id }))
@@ -6278,6 +6324,16 @@ async fn handle_text_message_with_role(
         },
         "session.remux_mp4" => {
             match serde_json::from_value::<protocol::RemuxSessionParams>(command.params) {
+                Ok(params)
+                    if noise_cleanup::session_mutation_blocked(state, &params.session_id)
+                        .unwrap_or(true) =>
+                {
+                    ServerResponse::error(
+                        command.id,
+                        "noise-cleanup-mutation-blocked",
+                        "This recording cannot be remuxed while Noise Cleanup is active.",
+                    )
+                }
                 Ok(params) => match remux_session(state.clone(), params).await {
                     Ok(mp4_path) => {
                         ServerResponse::ok(command.id, serde_json::json!({ "mp4Path": mp4_path }))
@@ -6299,6 +6355,22 @@ async fn handle_text_message_with_role(
             Err(error) => ServerResponse::error(command.id, "invalid-params", error.to_string()),
         },
         "repair.repair_file" => match resolve_repair_file_params(state, command.params, role) {
+            Ok(params)
+                if state
+                    .database
+                    .session_id_for_media_path(&params.path)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|session_id| {
+                        noise_cleanup::session_mutation_blocked(state, &session_id).unwrap_or(true)
+                    }) =>
+            {
+                ServerResponse::error(
+                    command.id,
+                    "noise-cleanup-mutation-blocked",
+                    "This recording cannot be repaired while Noise Cleanup is active.",
+                )
+            }
             Ok(params) => match repair_service::repair_file(state.clone(), params).await {
                 Ok(status) => ServerResponse::ok(command.id, status),
                 Err(error) => ServerResponse::error(command.id, "repair-failed", error),
@@ -6306,6 +6378,22 @@ async fn handle_text_message_with_role(
             Err(error) => ServerResponse::error(command.id, "invalid-params", error.to_string()),
         },
         "repair.restore_file" => match resolve_repair_restore_params(state, command.params, role) {
+            Ok(params)
+                if state
+                    .database
+                    .session_id_for_media_path(&params.path)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|session_id| {
+                        noise_cleanup::session_mutation_blocked(state, &session_id).unwrap_or(true)
+                    }) =>
+            {
+                ServerResponse::error(
+                    command.id,
+                    "noise-cleanup-mutation-blocked",
+                    "This recording cannot be restored while Noise Cleanup is active.",
+                )
+            }
             Ok(params) => match repair_service::restore_file(params).await {
                 Ok(restored) => {
                     ServerResponse::ok(command.id, serde_json::json!({ "restored": restored }))
@@ -6314,6 +6402,56 @@ async fn handle_text_message_with_role(
             },
             Err(error) => ServerResponse::error(command.id, "invalid-params", error.to_string()),
         },
+        "noiseCleanup.start" => {
+            match serde_json::from_value::<protocol::NoiseCleanupStartParams>(command.params) {
+                Ok(params) => match noise_cleanup::start(state.clone(), params).await {
+                    Ok(job) => ServerResponse::ok(command.id, job),
+                    Err(error) => {
+                        let code = if error.contains("Premium") {
+                            "noise-cleanup-premium-required"
+                        } else if error.contains("live session") {
+                            "noise-cleanup-live"
+                        } else {
+                            "noise-cleanup-start-failed"
+                        };
+                        ServerResponse::error(command.id, code, error)
+                    }
+                },
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
+        "noiseCleanup.cancel" => {
+            match serde_json::from_value::<protocol::NoiseCleanupCancelParams>(command.params) {
+                Ok(params) => match noise_cleanup::cancel(state.clone(), params).await {
+                    Ok(job) => ServerResponse::ok(command.id, job),
+                    Err(error) => {
+                        ServerResponse::error(command.id, "noise-cleanup-cancel-failed", error)
+                    }
+                },
+                Err(error) => {
+                    ServerResponse::error(command.id, "invalid-params", error.to_string())
+                }
+            }
+        }
+        "noiseCleanup.list" => {
+            let valid = rpc_params_are_empty(&command.params);
+            if !valid {
+                ServerResponse::error(
+                    command.id,
+                    "invalid-params",
+                    "noiseCleanup.list does not accept parameters.",
+                )
+            } else {
+                match noise_cleanup::list(state).await {
+                    Ok(jobs) => ServerResponse::ok(command.id, jobs),
+                    Err(error) => {
+                        ServerResponse::error(command.id, "noise-cleanup-list-failed", error)
+                    }
+                }
+            }
+        }
         "ai.run_post_recording" => {
             match serde_json::from_value::<protocol::RunAiWorkflowParams>(command.params) {
                 Ok(params) => match ai::run_ai_workflow(state.clone(), params).await {
@@ -6658,6 +6796,20 @@ mod tests {
     use tokio::sync::broadcast;
 
     static CAPTION_LIFECYCLE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    #[test]
+    fn no_param_rpc_accepts_omitted_or_empty_params_only() {
+        assert!(rpc_params_are_empty(&serde_json::Value::Null));
+        assert!(rpc_params_are_empty(&json!({})));
+        assert!(!rpc_params_are_empty(&json!({ "unexpected": true })));
+        assert!(!rpc_params_are_empty(&json!([])));
+    }
+
+    #[test]
+    fn entitlement_refresh_is_bounded_below_the_rpc_deadline() {
+        assert_eq!(ENTITLEMENT_REFRESH_TIMEOUT, Duration::from_secs(10));
+        assert!(ENTITLEMENT_REFRESH_TIMEOUT < Duration::from_secs(30));
+    }
 
     async fn receive_tracked_json(
         receiver: &mut mpsc::Receiver<Message>,

--- a/crates/videorc-backend/src/noise_cleanup.rs
+++ b/crates/videorc-backend/src/noise_cleanup.rs
@@ -1,0 +1,3092 @@
+//! Durable, local, non-destructive Noise Cleanup processing.
+//!
+//! Renderer requests contain only a session id. This module resolves the current
+//! session-owned path, binds work to content and filesystem-object identities, and
+//! publishes through the existing no-replace Library file-operation journal.
+
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use tokio::sync::Notify;
+
+use crate::entitlements;
+use crate::ffmpeg::{default_ffmpeg_path, ffprobe_path_for};
+use crate::ffmpeg_work::MaintenanceCancelToken;
+use crate::process_job::{output_owned_std, spawn_owned_std};
+use crate::protocol::{
+    EntitlementsSnapshot, FeatureId, NoiseCleanupCancelParams, NoiseCleanupJob,
+    NoiseCleanupJobStatus, NoiseCleanupStartParams,
+};
+use crate::repair::{MediaProbe, STRICT_AV_SKEW_HARD_FAIL_MS, probe_media_cancellable};
+use crate::state::AppState;
+use crate::storage::{
+    NoiseCleanupSource, PersistedNoiseCleanupJob, SessionFileBoundIdentity, SessionFileOperation,
+    SessionMediaPathState, capture_session_file_bound_identity,
+    capture_session_file_content_identity_from_file,
+    capture_session_file_object_identity_from_file, session_file_bound_identity_matches,
+    session_media_path_state,
+};
+
+pub const NOISE_CLEANUP_PRESET: &str = "speech-v1";
+/// Locked by the deterministic engine probe: conservative stationary-noise
+/// reduction without normalization, compression, or any video processing.
+pub const SPEECH_V1_FILTER: &str = "afftdn=nr=18:nf=-34:tn=1";
+
+const ERROR_PREMIUM_REQUIRED: &str = "premium-required";
+const ERROR_NO_AUDIO: &str = "no-audio";
+const ERROR_MULTIPLE_AUDIO: &str = "multiple-audio-tracks";
+const ERROR_LIVE: &str = "recording-live";
+const ERROR_MISSING: &str = "file-missing";
+const ERROR_CHANGED: &str = "source-changed";
+const ERROR_IMPORTED: &str = "imported-unsupported";
+const ERROR_UNSUPPORTED: &str = "unsupported-recording";
+const ERROR_DISK_FULL: &str = "disk-full";
+const ERROR_FFMPEG: &str = "ffmpeg-feature-unavailable";
+const ERROR_DESTINATION: &str = "destination-not-writable";
+const ERROR_VALIDATION: &str = "validation-failed";
+const ERROR_PROCESSING: &str = "processing-failed";
+const MAX_FFMPEG_STDERR_BYTES: usize = 64 * 1024;
+
+#[derive(Debug)]
+struct JobControl {
+    user_cancelled: AtomicBool,
+    shutdown_interrupted: AtomicBool,
+    child_pid: AtomicU32,
+    cancelled: Notify,
+    finished: Notify,
+}
+
+impl JobControl {
+    fn new() -> Self {
+        Self {
+            user_cancelled: AtomicBool::new(false),
+            shutdown_interrupted: AtomicBool::new(false),
+            child_pid: AtomicU32::new(0),
+            cancelled: Notify::new(),
+            finished: Notify::new(),
+        }
+    }
+
+    fn request_cancel(&self) {
+        self.user_cancelled.store(true, Ordering::Release);
+        self.cancelled.notify_waiters();
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.user_cancelled.load(Ordering::Acquire)
+    }
+
+    fn is_shutdown_interrupted(&self) -> bool {
+        self.shutdown_interrupted.load(Ordering::Acquire)
+    }
+
+    fn should_interrupt(&self) -> bool {
+        self.is_cancelled() || self.is_shutdown_interrupted()
+    }
+
+    fn request_shutdown_interrupt(&self) {
+        self.shutdown_interrupted.store(true, Ordering::Release);
+        self.cancelled.notify_waiters();
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct NoiseCleanupRegistry {
+    jobs: Mutex<HashMap<String, Arc<JobControl>>>,
+}
+
+impl NoiseCleanupRegistry {
+    fn register(&self, job_id: &str) -> Arc<JobControl> {
+        let mut jobs = self.jobs.lock().expect("Noise Cleanup registry poisoned");
+        jobs.entry(job_id.to_string())
+            .or_insert_with(|| Arc::new(JobControl::new()))
+            .clone()
+    }
+
+    fn get(&self, job_id: &str) -> Option<Arc<JobControl>> {
+        self.jobs
+            .lock()
+            .expect("Noise Cleanup registry poisoned")
+            .get(job_id)
+            .cloned()
+    }
+
+    fn finish(&self, job_id: &str) {
+        if let Some(control) = self
+            .jobs
+            .lock()
+            .expect("Noise Cleanup registry poisoned")
+            .remove(job_id)
+        {
+            control.child_pid.store(0, Ordering::Release);
+            control.finished.notify_waiters();
+        }
+    }
+
+    pub fn interrupt_all_for_shutdown(&self) {
+        for control in self
+            .jobs
+            .lock()
+            .expect("Noise Cleanup registry poisoned")
+            .values()
+        {
+            control.request_shutdown_interrupt();
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CleanupFailure {
+    code: &'static str,
+    message: String,
+}
+
+impl CleanupFailure {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContainerPolicy {
+    Mp4,
+    Mkv,
+}
+
+impl ContainerPolicy {
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Mp4 => "mp4",
+            Self::Mkv => "mkv",
+        }
+    }
+
+    fn audio_codec(self) -> &'static str {
+        match self {
+            Self::Mp4 => "aac",
+            Self::Mkv => "pcm_s16le",
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ProcessOutcome {
+    Completed {
+        output_session_id: String,
+        output_path: String,
+    },
+    CapturePreempted,
+    UserCancelled,
+    ShutdownInterrupted,
+    Failed(CleanupFailure),
+}
+
+pub async fn start(
+    state: AppState,
+    params: NoiseCleanupStartParams,
+) -> Result<NoiseCleanupJob, String> {
+    start_with_entitlements(state, params, entitlements::current_entitlements()).await
+}
+
+async fn start_with_entitlements(
+    state: AppState,
+    params: NoiseCleanupStartParams,
+    snapshot: EntitlementsSnapshot,
+) -> Result<NoiseCleanupJob, String> {
+    // This is deliberately first: Basic cannot create a job row, staging file,
+    // destination probe, or any other media-processing side effect.
+    entitlements::require_feature(&snapshot, FeatureId::NoiseCleanup)
+        .map_err(|error| error.to_string())?;
+    let session_id = params.session_id.trim();
+    if session_id.is_empty() {
+        return Err("sessionId is required".to_string());
+    }
+
+    let source = resolve_source(&state, session_id).map_err(|error| error.message)?;
+    let work = state.ffmpeg_work.snapshot();
+    if work.capture_active || work.capture_waiting > 0 || work.finalizing_active {
+        return Err("Available after the live session ends.".to_string());
+    }
+    let path = PathBuf::from(
+        source
+            .media_path
+            .as_deref()
+            .ok_or_else(|| "The recording file is missing on disk.".to_string())?,
+    );
+    let identity_path = path.clone();
+    let source_identity = tokio::task::spawn_blocking(move || {
+        capture_session_file_bound_identity(&identity_path)?
+            .context("The recording file is missing on disk.")
+    })
+    .await
+    .map_err(|error| format!("Source identity task failed: {error}"))?
+    .map_err(|error| error.to_string())?;
+    let persisted = state
+        .database
+        .create_or_get_noise_cleanup_job(session_id, &source_identity, NOISE_CLEANUP_PRESET)
+        .map_err(|error| error.to_string())?;
+
+    if persisted.job.status.is_active() && state.noise_cleanup.get(&persisted.job.id).is_none() {
+        spawn_job(state.clone(), persisted.job.id.clone());
+    }
+    Ok(persisted.job)
+}
+
+pub async fn list(state: &AppState) -> Result<Vec<NoiseCleanupJob>, String> {
+    let database = state.database.clone();
+    tokio::task::spawn_blocking(move || database.list_noise_cleanup_jobs())
+        .await
+        .map_err(|error| format!("Noise Cleanup list task failed: {error}"))?
+        .map_err(|error| error.to_string())
+}
+
+pub async fn cancel(
+    state: AppState,
+    params: NoiseCleanupCancelParams,
+) -> Result<NoiseCleanupJob, String> {
+    let job_id = params.job_id.trim();
+    if job_id.is_empty() {
+        return Err("jobId is required".to_string());
+    }
+    let persisted = state
+        .database
+        .noise_cleanup_job(job_id)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "Noise Cleanup job was not found.".to_string())?;
+    if !persisted.job.status.is_active() {
+        return Ok(persisted.job);
+    }
+
+    if let Some(control) = state.noise_cleanup.get(job_id) {
+        control.request_cancel();
+        let finished = control.finished.notified();
+        if state.noise_cleanup.get(job_id).is_some() {
+            let _ = tokio::time::timeout(Duration::from_secs(10), finished).await;
+        }
+    } else {
+        let mut job = persisted.job;
+        terminal_job(&state, &mut job, NoiseCleanupJobStatus::Cancelled, None);
+    }
+    state
+        .database
+        .noise_cleanup_job(job_id)
+        .map_err(|error| error.to_string())?
+        .map(|job| job.job)
+        .ok_or_else(|| "Noise Cleanup job was not found.".to_string())
+}
+
+pub fn resume_interrupted(state: &AppState) {
+    match state.database.reconcile_interrupted_noise_cleanup_jobs() {
+        Ok(jobs) => {
+            for job in jobs {
+                state.emit_event("noiseCleanup.status", &job);
+                spawn_job(state.clone(), job.id);
+            }
+        }
+        Err(error) => state.emit_log(
+            "warn",
+            format!("Could not reconcile interrupted Noise Cleanup jobs: {error:#}"),
+        ),
+    }
+}
+
+pub fn session_mutation_blocked(state: &AppState, session_id: &str) -> Result<bool> {
+    Ok(state
+        .database
+        .active_noise_cleanup_job_for_source(session_id)?
+        .is_some())
+}
+
+fn spawn_job(state: AppState, job_id: String) {
+    let control = state.noise_cleanup.register(&job_id);
+    tokio::spawn(async move {
+        run_job(state.clone(), job_id.clone(), control).await;
+        state.noise_cleanup.finish(&job_id);
+    });
+}
+
+async fn run_job(state: AppState, job_id: String, control: Arc<JobControl>) {
+    loop {
+        let Some(mut persisted) = state.database.noise_cleanup_job(&job_id).ok().flatten() else {
+            return;
+        };
+        if !persisted.job.status.is_active() {
+            return;
+        }
+        if control.is_shutdown_interrupted() {
+            return;
+        }
+        if control.is_cancelled() {
+            terminal_job(
+                &state,
+                &mut persisted.job,
+                NoiseCleanupJobStatus::Cancelled,
+                None,
+            );
+            return;
+        }
+        if let Err(error) = entitlements::require_feature(
+            &entitlements::current_entitlements(),
+            FeatureId::NoiseCleanup,
+        ) {
+            fail_job(
+                &state,
+                &mut persisted.job,
+                CleanupFailure::new(ERROR_PREMIUM_REQUIRED, error.to_string()),
+            );
+            return;
+        }
+
+        set_job_state(&state, &mut persisted.job, NoiseCleanupJobStatus::Queued, 0);
+        let permit_future = state.ffmpeg_work.begin_maintenance_when_idle();
+        tokio::pin!(permit_future);
+        let permit = tokio::select! {
+            permit = &mut permit_future => permit,
+            _ = control.cancelled.notified() => {
+                if control.is_cancelled() {
+                    terminal_job(&state, &mut persisted.job, NoiseCleanupJobStatus::Cancelled, None);
+                    return;
+                }
+                if control.is_shutdown_interrupted() {
+                    return;
+                }
+                continue;
+            }
+        };
+        if control.is_shutdown_interrupted() {
+            drop(permit);
+            return;
+        }
+        if control.is_cancelled() {
+            drop(permit);
+            terminal_job(
+                &state,
+                &mut persisted.job,
+                NoiseCleanupJobStatus::Cancelled,
+                None,
+            );
+            return;
+        }
+        if let Err(error) = entitlements::require_feature(
+            &entitlements::current_entitlements(),
+            FeatureId::NoiseCleanup,
+        ) {
+            drop(permit);
+            fail_job(
+                &state,
+                &mut persisted.job,
+                CleanupFailure::new(ERROR_PREMIUM_REQUIRED, error.to_string()),
+            );
+            return;
+        }
+        let maintenance_cancel = permit.cancel_token();
+        if persisted.source_full_sha256 == "pending" {
+            match prepare_job_fingerprint(&state, &persisted, &control, &maintenance_cancel).await {
+                Ok(true) => {
+                    drop(permit);
+                    return;
+                }
+                Ok(false) => {
+                    let Some(refreshed) = state.database.noise_cleanup_job(&job_id).ok().flatten()
+                    else {
+                        drop(permit);
+                        return;
+                    };
+                    persisted = refreshed;
+                }
+                Err(_) if control.is_shutdown_interrupted() => {
+                    drop(permit);
+                    return;
+                }
+                Err(_) if control.is_cancelled() => {
+                    drop(permit);
+                    terminal_job(
+                        &state,
+                        &mut persisted.job,
+                        NoiseCleanupJobStatus::Cancelled,
+                        None,
+                    );
+                    return;
+                }
+                Err(_) if maintenance_cancel.is_cancelled() => {
+                    drop(permit);
+                    set_job_state(&state, &mut persisted.job, NoiseCleanupJobStatus::Queued, 0);
+                    continue;
+                }
+                Err(error) => {
+                    drop(permit);
+                    fail_job(&state, &mut persisted.job, error);
+                    return;
+                }
+            }
+        }
+        if let Err(error) = entitlements::require_feature(
+            &entitlements::current_entitlements(),
+            FeatureId::NoiseCleanup,
+        ) {
+            drop(permit);
+            fail_job(
+                &state,
+                &mut persisted.job,
+                CleanupFailure::new(ERROR_PREMIUM_REQUIRED, error.to_string()),
+            );
+            return;
+        }
+
+        set_job_state(
+            &state,
+            &mut persisted.job,
+            NoiseCleanupJobStatus::Processing,
+            1,
+        );
+        let process_state = state.clone();
+        let process_job = persisted.clone();
+        let process_control = control.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            process_job_blocking(
+                &process_state,
+                &process_job,
+                &process_control,
+                &maintenance_cancel,
+            )
+        })
+        .await;
+        drop(permit);
+
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => ProcessOutcome::Failed(CleanupFailure::new(
+                ERROR_PROCESSING,
+                format!("Noise Cleanup worker failed: {error}"),
+            )),
+        };
+        let Some(mut current) = state
+            .database
+            .noise_cleanup_job(&job_id)
+            .ok()
+            .flatten()
+            .map(|job| job.job)
+        else {
+            return;
+        };
+        match outcome {
+            ProcessOutcome::Completed {
+                output_session_id,
+                output_path,
+            } => {
+                current.output_session_id = Some(output_session_id);
+                current.output_path = Some(output_path);
+                terminal_job(&state, &mut current, NoiseCleanupJobStatus::Completed, None);
+                return;
+            }
+            ProcessOutcome::CapturePreempted => {
+                current.error_code = None;
+                current.error_message = None;
+                set_job_state(&state, &mut current, NoiseCleanupJobStatus::Queued, 0);
+                continue;
+            }
+            ProcessOutcome::UserCancelled => {
+                terminal_job(&state, &mut current, NoiseCleanupJobStatus::Cancelled, None);
+                return;
+            }
+            ProcessOutcome::ShutdownInterrupted => {
+                current.error_code = None;
+                current.error_message = None;
+                set_job_state(&state, &mut current, NoiseCleanupJobStatus::Queued, 0);
+                return;
+            }
+            ProcessOutcome::Failed(error) => {
+                fail_job(&state, &mut current, error);
+                return;
+            }
+        }
+    }
+}
+
+async fn prepare_job_fingerprint(
+    state: &AppState,
+    persisted: &PersistedNoiseCleanupJob,
+    control: &Arc<JobControl>,
+    maintenance_cancel: &MaintenanceCancelToken,
+) -> std::result::Result<bool, CleanupFailure> {
+    let source = resolve_source(state, &persisted.job.source_session_id)?;
+    let path = PathBuf::from(
+        source
+            .media_path
+            .as_deref()
+            .ok_or_else(|| CleanupFailure::new(ERROR_MISSING, "The recording file is missing."))?,
+    );
+    let expected = persisted.source_identity.clone();
+    let hash_path = path.clone();
+    let hash_control = control.clone();
+    let hash_maintenance_cancel = maintenance_cancel.clone();
+    let full_sha256 = tokio::task::spawn_blocking(move || {
+        let current = capture_session_file_bound_identity(&hash_path)?
+            .context("The recording file is missing on disk.")?;
+        if current != expected {
+            bail!("The source recording changed before Noise Cleanup started.");
+        }
+        let sha256 = full_file_sha256_cancellable(&hash_path, &|| {
+            hash_control.should_interrupt() || hash_maintenance_cancel.is_cancelled()
+        })?;
+        let after = capture_session_file_bound_identity(&hash_path)?
+            .context("The recording file disappeared while it was fingerprinted.")?;
+        if after != expected {
+            bail!("The source recording changed while Noise Cleanup fingerprinted it.");
+        }
+        Ok(sha256)
+    })
+    .await
+    .map_err(|error| {
+        CleanupFailure::new(
+            ERROR_PROCESSING,
+            format!("Source fingerprint task failed: {error}"),
+        )
+    })?
+    .map_err(|error| CleanupFailure::new(ERROR_CHANGED, error.to_string()))?;
+
+    let completed = state
+        .database
+        .bind_noise_cleanup_source_fingerprint(&persisted.job.id, &full_sha256)
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?;
+    let Some(mut completed) = completed else {
+        return Ok(false);
+    };
+    let output_registered = completed
+        .output_session_id
+        .as_deref()
+        .is_some_and(|session_id| {
+            state
+                .database
+                .noise_cleanup_source(session_id)
+                .ok()
+                .flatten()
+                .is_some()
+        });
+    let output_state = completed
+        .output_path
+        .as_deref()
+        .map(|path| session_media_path_state(Path::new(path)))
+        .unwrap_or(SessionMediaPathState::Missing);
+    if output_registered
+        && matches!(
+            output_state,
+            SessionMediaPathState::Present | SessionMediaPathState::Unavailable
+        )
+    {
+        let mut current = persisted.job.clone();
+        current.output_session_id = completed.output_session_id;
+        current.output_path = completed.output_path;
+        terminal_job(state, &mut current, NoiseCleanupJobStatus::Completed, None);
+        return Ok(true);
+    }
+
+    fail_job(
+        state,
+        &mut completed,
+        CleanupFailure::new(ERROR_MISSING, "The cleaned recording is missing on disk."),
+    );
+    Ok(false)
+}
+
+fn process_job_blocking(
+    state: &AppState,
+    persisted: &PersistedNoiseCleanupJob,
+    control: &JobControl,
+    maintenance_cancel: &MaintenanceCancelToken,
+) -> ProcessOutcome {
+    match process_job_inner(state, persisted, control, maintenance_cancel) {
+        Ok(completed) => completed,
+        Err(_) if control.is_cancelled() => ProcessOutcome::UserCancelled,
+        Err(_) if control.is_shutdown_interrupted() => ProcessOutcome::ShutdownInterrupted,
+        Err(_) if maintenance_cancel.is_cancelled() => ProcessOutcome::CapturePreempted,
+        Err(error) => ProcessOutcome::Failed(error),
+    }
+}
+
+fn process_job_inner(
+    state: &AppState,
+    persisted: &PersistedNoiseCleanupJob,
+    control: &JobControl,
+    maintenance_cancel: &MaintenanceCancelToken,
+) -> std::result::Result<ProcessOutcome, CleanupFailure> {
+    let cancelled = || control.should_interrupt() || maintenance_cancel.is_cancelled();
+    let source = resolve_source(state, &persisted.job.source_session_id)?;
+    let source_path = PathBuf::from(
+        source
+            .media_path
+            .as_deref()
+            .ok_or_else(|| CleanupFailure::new(ERROR_MISSING, "The recording file is missing."))?,
+    );
+    require_source_identity_cancellable(
+        &source_path,
+        &persisted.source_identity,
+        &persisted.source_full_sha256,
+        &cancelled,
+    )?;
+    let policy = container_policy(&source_path, source.container.as_deref())?;
+    let ffmpeg_path = default_ffmpeg_path();
+    let ffprobe_path = ffprobe_path_for(&ffmpeg_path);
+    let probe = preflight_media(
+        &ffmpeg_path,
+        &ffprobe_path,
+        &source_path,
+        policy,
+        &cancelled,
+    )?;
+    if cancelled() {
+        return Ok(cancelled_outcome(control));
+    }
+    let duration = media_duration(&probe).ok_or_else(|| {
+        CleanupFailure::new(
+            ERROR_UNSUPPORTED,
+            "The recording duration is missing or invalid.",
+        )
+    })?;
+    let destination = first_free_output_path_with(&source_path, |candidate| {
+        state
+            .database
+            .session_media_path_registered(&candidate.display().to_string())
+            .unwrap_or(true)
+    })?;
+    ensure_destination_ready(&destination, source_path.metadata().ok().map(|m| m.len()))?;
+    let output_session_id = uuid::Uuid::new_v4().to_string();
+    let staging = staging_path_for(&destination, &persisted.job.id);
+    let operation = state
+        .database
+        .begin_session_file_operation("noise-cleanup", &output_session_id, &staging, &destination)
+        .map_err(|error| CleanupFailure::new(ERROR_DESTINATION, error.to_string()))?;
+
+    let outcome = run_cleanup_ffmpeg(
+        state,
+        persisted,
+        &operation,
+        control,
+        maintenance_cancel,
+        &ffmpeg_path,
+        &source_path,
+        &staging,
+        policy,
+        duration,
+    );
+    let expected_output = match outcome {
+        Ok(identity) => identity,
+        Err(outcome) => {
+            bind_partial_and_cancel(state, &operation, &staging);
+            return Ok(outcome);
+        }
+    };
+
+    let mut validating_job = state
+        .database
+        .noise_cleanup_job(&persisted.job.id)
+        .ok()
+        .flatten()
+        .map(|job| job.job)
+        .unwrap_or_else(|| persisted.job.clone());
+    set_job_state(
+        state,
+        &mut validating_job,
+        NoiseCleanupJobStatus::Validating,
+        99,
+    );
+    if let Err(error) = validate_output(
+        &ffmpeg_path,
+        &ffprobe_path,
+        &source_path,
+        &staging,
+        &probe,
+        policy,
+        &cancelled,
+    ) {
+        bind_partial_and_cancel(state, &operation, &staging);
+        if cancelled() {
+            return Ok(cancelled_outcome(control));
+        }
+        return Err(error);
+    }
+    if let Err(error) = require_source_identity_cancellable(
+        &source_path,
+        &persisted.source_identity,
+        &persisted.source_full_sha256,
+        &cancelled,
+    ) {
+        bind_partial_and_cancel(state, &operation, &staging);
+        return Err(error);
+    }
+    if cancelled() {
+        bind_partial_and_cancel(state, &operation, &staging);
+        return Ok(cancelled_outcome(control));
+    }
+
+    if let Err(error) = publish_identity_bound_file(&staging, &destination, &expected_output) {
+        bind_partial_and_cancel(state, &operation, &staging);
+        return Err(CleanupFailure::new(ERROR_DESTINATION, error.to_string()));
+    }
+    let output_path = destination.display().to_string();
+    let output_title = format!("{} — Noise Cleaned", source.title.trim());
+    let duration_ms = Some((duration * 1000.0) as i64);
+    let size = match destination.metadata() {
+        Ok(metadata) => metadata.len() as i64,
+        Err(error) => {
+            let _ = state.database.cancel_session_file_operation(&operation);
+            return Err(CleanupFailure::new(ERROR_VALIDATION, error.to_string()));
+        }
+    };
+    let inserted = match state.database.complete_noise_cleanup_derivative(
+        &persisted.job.id,
+        &source.id,
+        &output_session_id,
+        &output_title,
+        &source.title,
+        &output_path,
+        policy.extension(),
+        duration_ms,
+        size,
+    ) {
+        Ok(inserted) => inserted,
+        Err(error) => {
+            let _ = state.database.cancel_session_file_operation(&operation);
+            return Err(CleanupFailure::new(ERROR_PROCESSING, error.to_string()));
+        }
+    };
+    if !inserted {
+        let _ = state.database.cancel_session_file_operation(&operation);
+        return Err(CleanupFailure::new(
+            ERROR_CHANGED,
+            "The source session disappeared before the cleaned copy was registered.",
+        ));
+    }
+    if let Err(error) = state.database.finish_session_file_operation(&operation.id) {
+        state.emit_log(
+            "warn",
+            format!(
+                "Noise Cleanup output was committed, but operation {} remains for startup reconciliation: {error:#}",
+                operation.id
+            ),
+        );
+    }
+    Ok(ProcessOutcome::Completed {
+        output_session_id,
+        output_path,
+    })
+}
+
+fn resolve_source(
+    state: &AppState,
+    session_id: &str,
+) -> std::result::Result<NoiseCleanupSource, CleanupFailure> {
+    let source = state
+        .database
+        .noise_cleanup_source(session_id)
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?
+        .ok_or_else(|| CleanupFailure::new(ERROR_MISSING, "Session not found."))?;
+    if source.status != "completed" {
+        return Err(CleanupFailure::new(
+            ERROR_LIVE,
+            "Noise Cleanup is available only after the recording finishes.",
+        ));
+    }
+    if source.mode == "imported" {
+        return Err(CleanupFailure::new(
+            ERROR_IMPORTED,
+            "Imported recordings are not supported by Noise Cleanup v1.",
+        ));
+    }
+    if source.processing_kind.as_deref() == Some("noise-cleanup")
+        || source.derived_from_session_id.is_some()
+    {
+        return Err(CleanupFailure::new(
+            ERROR_UNSUPPORTED,
+            "A Noise Cleaned recording cannot be cleaned again.",
+        ));
+    }
+    if !matches!(source.mode.as_str(), "record" | "record+stream") {
+        return Err(CleanupFailure::new(
+            ERROR_UNSUPPORTED,
+            "Only finalized Videorc recordings are supported.",
+        ));
+    }
+    if source.sources.test_pattern {
+        return Err(CleanupFailure::new(
+            ERROR_UNSUPPORTED,
+            "Test-tone recordings are not supported by Noise Cleanup.",
+        ));
+    }
+    if source.sources.microphone_id.is_none() {
+        return Err(CleanupFailure::new(
+            ERROR_NO_AUDIO,
+            "This recording has no selected microphone to clean.",
+        ));
+    }
+    let Some(path) = source.media_path.as_deref() else {
+        return Err(CleanupFailure::new(
+            ERROR_MISSING,
+            "The recording file is missing on disk.",
+        ));
+    };
+    if !Path::new(path).is_file() {
+        return Err(CleanupFailure::new(
+            ERROR_MISSING,
+            "The recording file is missing on disk.",
+        ));
+    }
+    Ok(source)
+}
+
+fn container_policy(
+    path: &Path,
+    declared_container: Option<&str>,
+) -> std::result::Result<ContainerPolicy, CleanupFailure> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase);
+    match extension.as_deref() {
+        Some("mp4") if declared_container.is_none_or(|value| value == "mp4" || value == "mkv") => {
+            // A Videorc MKV session may have a later managed MP4 remux; the visible
+            // MP4 path is authoritative and receives the exact MP4 codec policy.
+            Ok(ContainerPolicy::Mp4)
+        }
+        Some("mkv") if declared_container.is_none_or(|value| value == "mkv") => {
+            Ok(ContainerPolicy::Mkv)
+        }
+        _ => Err(CleanupFailure::new(
+            ERROR_UNSUPPORTED,
+            "Noise Cleanup v1 supports only finalized Videorc MP4 and MKV recordings.",
+        )),
+    }
+}
+
+fn preflight_media(
+    ffmpeg_path: &str,
+    ffprobe_path: &str,
+    source: &Path,
+    policy: ContainerPolicy,
+    is_cancelled: &dyn Fn() -> bool,
+) -> std::result::Result<MediaProbe, CleanupFailure> {
+    require_ffmpeg_capabilities(ffmpeg_path, policy)?;
+    let probe = probe_media_cancellable(ffprobe_path, &source.display().to_string(), is_cancelled)
+        .map_err(|error| CleanupFailure::new(ERROR_FFMPEG, error))?;
+    if probe.video.is_none() {
+        return Err(CleanupFailure::new(
+            ERROR_UNSUPPORTED,
+            "This recording does not contain a video stream.",
+        ));
+    }
+    match probe.audio.len() {
+        0 => Err(CleanupFailure::new(
+            ERROR_NO_AUDIO,
+            "This recording has no audio stream to clean.",
+        )),
+        1 => Ok(probe),
+        _ => Err(CleanupFailure::new(
+            ERROR_MULTIPLE_AUDIO,
+            "Recordings with multiple audio tracks are not supported by Noise Cleanup v1.",
+        )),
+    }
+}
+
+fn require_ffmpeg_capabilities(
+    ffmpeg_path: &str,
+    policy: ContainerPolicy,
+) -> std::result::Result<(), CleanupFailure> {
+    let mut filters_command = Command::new(ffmpeg_path);
+    filters_command
+        .args(["-hide_banner", "-filters"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let filters = output_owned_std(&mut filters_command)
+        .map_err(|error| CleanupFailure::new(ERROR_FFMPEG, error.to_string()))?;
+    let filters_text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&filters.stdout),
+        String::from_utf8_lossy(&filters.stderr)
+    );
+    if !filters.status.success() || !filters_text.lines().any(|line| line.contains(" afftdn ")) {
+        return Err(CleanupFailure::new(
+            ERROR_FFMPEG,
+            "The bundled FFmpeg does not provide the required afftdn filter.",
+        ));
+    }
+    let mut encoders_command = Command::new(ffmpeg_path);
+    encoders_command
+        .args(["-hide_banner", "-encoders"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let encoders = output_owned_std(&mut encoders_command)
+        .map_err(|error| CleanupFailure::new(ERROR_FFMPEG, error.to_string()))?;
+    let encoder_text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&encoders.stdout),
+        String::from_utf8_lossy(&encoders.stderr)
+    );
+    let needle = format!(" {} ", policy.audio_codec());
+    if !encoders.status.success() || !encoder_text.lines().any(|line| line.contains(&needle)) {
+        return Err(CleanupFailure::new(
+            ERROR_FFMPEG,
+            format!(
+                "The bundled FFmpeg does not provide the required {} audio encoder.",
+                policy.audio_codec()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+pub fn build_ffmpeg_args(
+    input: &Path,
+    output: &Path,
+    container: &str,
+) -> std::result::Result<Vec<String>, String> {
+    let policy = match container {
+        "mp4" => ContainerPolicy::Mp4,
+        "mkv" => ContainerPolicy::Mkv,
+        _ => return Err(format!("Unsupported Noise Cleanup container: {container}")),
+    };
+    let mut args = vec![
+        "-nostdin".to_string(),
+        "-hide_banner".to_string(),
+        "-loglevel".to_string(),
+        "error".to_string(),
+        "-n".to_string(),
+        "-i".to_string(),
+        input.display().to_string(),
+        "-map".to_string(),
+        "0".to_string(),
+        "-map_metadata".to_string(),
+        "0".to_string(),
+        "-c".to_string(),
+        "copy".to_string(),
+        "-c:a".to_string(),
+        policy.audio_codec().to_string(),
+    ];
+    if policy == ContainerPolicy::Mp4 {
+        args.extend(["-b:a".to_string(), "192k".to_string()]);
+    }
+    args.extend([
+        "-af".to_string(),
+        SPEECH_V1_FILTER.to_string(),
+        "-progress".to_string(),
+        "pipe:1".to_string(),
+        "-nostats".to_string(),
+        output.display().to_string(),
+    ]);
+    Ok(args)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_cleanup_ffmpeg(
+    state: &AppState,
+    persisted: &PersistedNoiseCleanupJob,
+    operation: &SessionFileOperation,
+    control: &JobControl,
+    maintenance_cancel: &MaintenanceCancelToken,
+    ffmpeg_path: &str,
+    source: &Path,
+    staging: &Path,
+    policy: ContainerPolicy,
+    duration_seconds: f64,
+) -> std::result::Result<SessionFileBoundIdentity, ProcessOutcome> {
+    let args = build_ffmpeg_args(source, staging, policy.extension()).map_err(|message| {
+        ProcessOutcome::Failed(CleanupFailure::new(ERROR_PROCESSING, message))
+    })?;
+    let mut command = Command::new(ffmpeg_path);
+    command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = spawn_owned_std(&mut command).map_err(|error| {
+        ProcessOutcome::Failed(CleanupFailure::new(ERROR_PROCESSING, error.to_string()))
+    })?;
+    control
+        .child_pid
+        .store(child.id(), std::sync::atomic::Ordering::Release);
+    let stdout = child.stdout.take().expect("piped Noise Cleanup stdout");
+    let stderr = child.stderr.take().expect("piped Noise Cleanup stderr");
+    let (progress_tx, progress_rx) = std::sync::mpsc::channel::<String>();
+    let stdout_reader = thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            let _ = progress_tx.send(line);
+        }
+    });
+    let stderr_reader = thread::spawn(move || read_bounded_tail(stderr, MAX_FFMPEG_STDERR_BYTES));
+    let mut last_emit = Instant::now() - Duration::from_secs(1);
+    let mut last_progress = 1_u8;
+    let status = loop {
+        if control.should_interrupt() || maintenance_cancel.is_cancelled() {
+            let _ = child.kill();
+            let status = child.wait().ok();
+            break status;
+        }
+        while let Ok(line) = progress_rx.try_recv() {
+            if let Some(progress) = parse_progress_line(&line, duration_seconds)
+                && progress > last_progress
+                && (last_emit.elapsed() >= Duration::from_millis(250) || progress >= 98)
+            {
+                last_progress = progress;
+                last_emit = Instant::now();
+                if let Some(mut job) = state
+                    .database
+                    .noise_cleanup_job(&persisted.job.id)
+                    .ok()
+                    .flatten()
+                    .map(|job| job.job)
+                {
+                    set_job_state(state, &mut job, NoiseCleanupJobStatus::Processing, progress);
+                }
+            }
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => thread::sleep(Duration::from_millis(40)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                control.child_pid.store(0, Ordering::Release);
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                return Err(ProcessOutcome::Failed(CleanupFailure::new(
+                    ERROR_PROCESSING,
+                    format!("Could not wait for FFmpeg: {error}"),
+                )));
+            }
+        }
+    };
+    control.child_pid.store(0, Ordering::Release);
+    let _ = stdout_reader.join();
+    let stderr = stderr_reader.join().unwrap_or_default();
+    if control.is_cancelled() {
+        return Err(ProcessOutcome::UserCancelled);
+    }
+    if control.is_shutdown_interrupted() {
+        return Err(ProcessOutcome::ShutdownInterrupted);
+    }
+    if maintenance_cancel.is_cancelled() {
+        return Err(ProcessOutcome::CapturePreempted);
+    }
+    if !status.is_some_and(|status| status.success()) {
+        return Err(ProcessOutcome::Failed(CleanupFailure::new(
+            ERROR_PROCESSING,
+            format!(
+                "FFmpeg could not clean this recording: {}",
+                String::from_utf8_lossy(&stderr).trim()
+            ),
+        )));
+    }
+
+    bind_completed_operation(state, operation, staging).map_err(ProcessOutcome::Failed)
+}
+
+fn read_bounded_tail(mut reader: impl Read, limit: usize) -> Vec<u8> {
+    let mut tail = Vec::with_capacity(limit.min(8 * 1024));
+    let mut chunk = [0_u8; 8 * 1024];
+    while let Ok(read) = reader.read(&mut chunk) {
+        if read == 0 {
+            break;
+        }
+        tail.extend_from_slice(&chunk[..read]);
+        if tail.len() > limit {
+            tail.drain(..tail.len() - limit);
+        }
+    }
+    tail
+}
+
+fn parse_progress_line(line: &str, duration_seconds: f64) -> Option<u8> {
+    let (key, value) = line.trim().split_once('=')?;
+    if !matches!(key, "out_time_us" | "out_time_ms") || duration_seconds <= 0.0 {
+        return None;
+    }
+    let micros = value.parse::<f64>().ok()?;
+    let percent = ((micros / 1_000_000.0) / duration_seconds * 100.0)
+        .floor()
+        .clamp(1.0, 98.0);
+    Some(percent as u8)
+}
+
+fn validate_output(
+    ffmpeg_path: &str,
+    ffprobe_path: &str,
+    source_path: &Path,
+    output_path: &Path,
+    source_probe: &MediaProbe,
+    policy: ContainerPolicy,
+    is_cancelled: &dyn Fn() -> bool,
+) -> std::result::Result<(), CleanupFailure> {
+    let output = probe_media_cancellable(
+        ffprobe_path,
+        &output_path.display().to_string(),
+        is_cancelled,
+    )
+    .map_err(|error| CleanupFailure::new(ERROR_VALIDATION, error))?;
+    let source_video = source_probe.video.as_ref().expect("preflight video");
+    let output_video = output.video.as_ref().ok_or_else(|| {
+        CleanupFailure::new(ERROR_VALIDATION, "Cleaned output has no video stream.")
+    })?;
+    if output.audio.len() != 1 {
+        return Err(CleanupFailure::new(
+            ERROR_VALIDATION,
+            "Cleaned output does not contain exactly one audio stream.",
+        ));
+    }
+    let output_audio = &output.audio[0];
+    if output_audio.codec != policy.audio_codec()
+        || output_audio.channels != source_probe.audio[0].channels
+        || output_audio.sample_rate != source_probe.audio[0].sample_rate
+    {
+        return Err(CleanupFailure::new(
+            ERROR_VALIDATION,
+            "Cleaned audio codec, channel count, or sample rate is incorrect.",
+        ));
+    }
+    if source_video.codec != output_video.codec
+        || source_video.width != output_video.width
+        || source_video.height != output_video.height
+        || source_video.nb_frames != output_video.nb_frames
+        || !nearly_equal(source_video.avg_fps, output_video.avg_fps, 0.001)
+    {
+        return Err(CleanupFailure::new(
+            ERROR_VALIDATION,
+            "The cleaned output did not preserve the source video stream shape.",
+        ));
+    }
+    let source_duration = media_duration(source_probe).unwrap_or_default();
+    let output_duration = media_duration(&output).unwrap_or_default();
+    if source_duration <= 0.0
+        || output_duration <= 0.0
+        || (source_duration - output_duration).abs() * 1000.0 > STRICT_AV_SKEW_HARD_FAIL_MS
+    {
+        return Err(CleanupFailure::new(
+            ERROR_VALIDATION,
+            "The cleaned output duration or A/V alignment changed beyond tolerance.",
+        ));
+    }
+    if output_av_skew_ms(&output).is_some_and(|skew| skew > STRICT_AV_SKEW_HARD_FAIL_MS) {
+        return Err(CleanupFailure::new(
+            ERROR_VALIDATION,
+            "The cleaned output A/V skew exceeds the recording analyzer tolerance.",
+        ));
+    }
+    let source_hash = video_stream_hash(ffmpeg_path, source_path, is_cancelled)?;
+    let output_hash = video_stream_hash(ffmpeg_path, output_path, is_cancelled)?;
+    if source_hash != output_hash {
+        return Err(CleanupFailure::new(
+            ERROR_VALIDATION,
+            "The cleaned output video packets differ from the source.",
+        ));
+    }
+    decode_audio(ffmpeg_path, output_path, is_cancelled)
+}
+
+fn video_stream_hash(
+    ffmpeg_path: &str,
+    path: &Path,
+    is_cancelled: &dyn Fn() -> bool,
+) -> std::result::Result<Vec<u8>, CleanupFailure> {
+    run_output_cancellable(
+        Command::new(ffmpeg_path).args([
+            "-v",
+            "error",
+            "-i",
+            &path.display().to_string(),
+            "-map",
+            "0:v",
+            "-c",
+            "copy",
+            "-f",
+            "streamhash",
+            "-hash",
+            "sha256",
+            "-",
+        ]),
+        is_cancelled,
+    )
+    .and_then(|output| {
+        output
+            .status
+            .success()
+            .then_some(output.stdout)
+            .ok_or_else(|| {
+                CleanupFailure::new(
+                    ERROR_VALIDATION,
+                    format!(
+                        "Could not hash video packets: {}",
+                        String::from_utf8_lossy(&output.stderr).trim()
+                    ),
+                )
+            })
+    })
+}
+
+fn decode_audio(
+    ffmpeg_path: &str,
+    path: &Path,
+    is_cancelled: &dyn Fn() -> bool,
+) -> std::result::Result<(), CleanupFailure> {
+    let output = run_output_cancellable(
+        Command::new(ffmpeg_path).args([
+            "-v",
+            "error",
+            "-i",
+            &path.display().to_string(),
+            "-map",
+            "0:a:0",
+            "-f",
+            "null",
+            "-",
+        ]),
+        is_cancelled,
+    )?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(CleanupFailure::new(
+            ERROR_VALIDATION,
+            format!(
+                "Cleaned audio could not be decoded: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        ))
+    }
+}
+
+fn run_output_cancellable(
+    command: &mut Command,
+    is_cancelled: &dyn Fn() -> bool,
+) -> std::result::Result<std::process::Output, CleanupFailure> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = spawn_owned_std(command)
+        .map_err(|error| CleanupFailure::new(ERROR_VALIDATION, error.to_string()))?;
+    loop {
+        if is_cancelled() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(CleanupFailure::new(
+                ERROR_PROCESSING,
+                "Noise Cleanup was cancelled.",
+            ));
+        }
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child
+                    .wait_with_output()
+                    .map_err(|error| CleanupFailure::new(ERROR_VALIDATION, error.to_string()));
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(40)),
+            Err(error) => {
+                let _ = child.kill();
+                return Err(CleanupFailure::new(ERROR_VALIDATION, error.to_string()));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn require_source_identity(
+    source: &Path,
+    expected: &SessionFileBoundIdentity,
+    expected_full_sha256: &str,
+) -> std::result::Result<(), CleanupFailure> {
+    require_source_identity_cancellable(source, expected, expected_full_sha256, &|| false)
+}
+
+fn require_source_identity_cancellable(
+    source: &Path,
+    expected: &SessionFileBoundIdentity,
+    expected_full_sha256: &str,
+    is_cancelled: &dyn Fn() -> bool,
+) -> std::result::Result<(), CleanupFailure> {
+    if is_cancelled() {
+        return Err(CleanupFailure::new(
+            ERROR_PROCESSING,
+            "Noise Cleanup identity validation was interrupted.",
+        ));
+    }
+    let current = capture_session_file_bound_identity(source)
+        .map_err(|error| CleanupFailure::new(ERROR_CHANGED, error.to_string()))?;
+    let bound_matches = current.as_ref().is_some_and(|current| {
+        session_file_bound_identity_matches(
+            current,
+            &expected.content_identity,
+            Some(&expected.object_identity),
+        )
+    });
+    let full_matches = bound_matches
+        && full_file_sha256_cancellable(source, is_cancelled)
+            .is_ok_and(|sha256| sha256 == expected_full_sha256);
+    if full_matches && !is_cancelled() {
+        Ok(())
+    } else {
+        Err(CleanupFailure::new(
+            ERROR_CHANGED,
+            "The source recording changed while Noise Cleanup was running.",
+        ))
+    }
+}
+
+#[cfg(test)]
+fn full_file_sha256(path: &Path) -> Result<String> {
+    full_file_sha256_cancellable(path, &|| false)
+}
+
+fn full_file_sha256_cancellable(path: &Path, is_cancelled: &dyn Fn() -> bool) -> Result<String> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("Could not open source recording {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        if is_cancelled() {
+            bail!("Source fingerprinting was interrupted.");
+        }
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("Could not fingerprint {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn bind_partial_and_cancel(state: &AppState, operation: &SessionFileOperation, staging: &Path) {
+    if let Ok(mut file) = OpenOptions::new().read(true).write(true).open(staging) {
+        if let Ok(object) = capture_session_file_object_identity_from_file(&file, staging) {
+            let _ = state
+                .database
+                .bind_session_file_operation_object_identity(&operation.id, &object);
+        }
+        if let Ok(content) = capture_session_file_content_identity_from_file(&mut file, staging) {
+            let _ = state
+                .database
+                .bind_session_file_operation_content_identity(&operation.id, &content);
+        }
+    }
+    if let Err(error) = state.database.cancel_session_file_operation(operation) {
+        state.emit_log(
+            "warn",
+            format!(
+                "Could not reconcile cancelled Noise Cleanup staging operation {}: {error:#}",
+                operation.id
+            ),
+        );
+    }
+}
+
+fn publish_identity_bound_file(
+    staging: &Path,
+    destination: &Path,
+    expected: &SessionFileBoundIdentity,
+) -> Result<()> {
+    crate::session_ops::rename_session_file_no_replace(staging, destination)?;
+    crate::session_ops::sync_session_file_parent(destination)?;
+    if capture_session_file_bound_identity(destination)?.is_some_and(|actual| {
+        session_file_bound_identity_matches(
+            &actual,
+            &expected.content_identity,
+            Some(&expected.object_identity),
+        )
+    }) {
+        return Ok(());
+    }
+    if crate::session_ops::rename_session_file_no_replace(destination, staging).is_ok() {
+        let _ = crate::session_ops::sync_session_file_parent(staging);
+    }
+    bail!("Noise Cleanup staging bytes changed during publication.")
+}
+
+fn bind_completed_operation(
+    state: &AppState,
+    operation: &SessionFileOperation,
+    staging: &Path,
+) -> std::result::Result<SessionFileBoundIdentity, CleanupFailure> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(staging)
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?;
+    file.sync_all()
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?;
+    let object_identity = capture_session_file_object_identity_from_file(&file, staging)
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?;
+    state
+        .database
+        .bind_session_file_operation_object_identity(&operation.id, &object_identity)
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?;
+    let content_identity = capture_session_file_content_identity_from_file(&mut file, staging)
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?;
+    state
+        .database
+        .bind_session_file_operation_content_identity(&operation.id, &content_identity)
+        .map_err(|error| CleanupFailure::new(ERROR_PROCESSING, error.to_string()))?;
+    Ok(SessionFileBoundIdentity {
+        content_identity,
+        object_identity,
+    })
+}
+
+#[cfg(test)]
+fn first_free_output_path(source: &Path) -> std::result::Result<PathBuf, CleanupFailure> {
+    first_free_output_path_with(source, |_| false)
+}
+
+fn first_free_output_path_with(
+    source: &Path,
+    mut is_registered: impl FnMut(&Path) -> bool,
+) -> std::result::Result<PathBuf, CleanupFailure> {
+    let stem = source
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("Recording");
+    let extension = source
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("mp4");
+    for attempt in 0..10_000 {
+        let suffix = if attempt == 0 {
+            " — Noise Cleaned".to_string()
+        } else {
+            format!(" — Noise Cleaned {}", attempt + 1)
+        };
+        let candidate = source.with_file_name(format!("{stem}{suffix}.{extension}"));
+        if !candidate.exists() && !is_registered(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(CleanupFailure::new(
+        ERROR_DESTINATION,
+        "Could not find a free Noise Cleaned filename.",
+    ))
+}
+
+fn staging_path_for(destination: &Path, job_id: &str) -> PathBuf {
+    let stem = destination
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("recording");
+    let extension = destination
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("mp4");
+    destination.with_file_name(format!(".{stem}.{job_id}.videorc-partial.{extension}"))
+}
+
+fn ensure_destination_ready(
+    destination: &Path,
+    source_size: Option<u64>,
+) -> std::result::Result<(), CleanupFailure> {
+    let parent = destination.parent().ok_or_else(|| {
+        CleanupFailure::new(ERROR_DESTINATION, "The destination folder is invalid.")
+    })?;
+    let probe = parent.join(format!(
+        ".videorc-noise-cleanup-write-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(&probe).map_err(|error| {
+        CleanupFailure::new(
+            ERROR_DESTINATION,
+            format!("The recording folder is not writable: {error}"),
+        )
+    })?;
+    let _ = file.sync_all();
+    drop(file);
+    let _ = std::fs::remove_file(&probe);
+
+    if let (Some(required), Some(available)) = (source_size, available_space(parent))
+        && !has_cleanup_space(required, available)
+    {
+        return Err(CleanupFailure::new(
+            ERROR_DISK_FULL,
+            "There is not enough free disk space to create a cleaned copy.",
+        ));
+    }
+    Ok(())
+}
+
+fn has_cleanup_space(source_size: u64, available: u64) -> bool {
+    let required = source_size
+        .saturating_add(source_size / 4)
+        .saturating_add(64 * 1024 * 1024);
+    available >= required
+}
+
+#[cfg(unix)]
+fn available_space(path: &Path) -> Option<u64> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let path = CString::new(path.as_os_str().as_bytes()).ok()?;
+    let mut stats = std::mem::MaybeUninit::<libc::statvfs>::zeroed();
+    if unsafe { libc::statvfs(path.as_ptr(), stats.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    let stats = unsafe { stats.assume_init() };
+    Some((stats.f_bavail as u64).saturating_mul(stats.f_frsize))
+}
+
+#[cfg(target_os = "windows")]
+fn available_space(path: &Path) -> Option<u64> {
+    use windows::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+    use windows::core::PCWSTR;
+
+    let path = crate::atomic_file::windows_verbatim_path(path).ok()?;
+    let mut available = 0_u64;
+    unsafe { GetDiskFreeSpaceExW(PCWSTR(path.as_ptr()), Some(&mut available), None, None) }.ok()?;
+    Some(available)
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+fn available_space(_path: &Path) -> Option<u64> {
+    None
+}
+
+fn media_duration(probe: &MediaProbe) -> Option<f64> {
+    probe
+        .format_duration
+        .or_else(|| probe.video.as_ref().and_then(|video| video.duration))
+        .filter(|duration| duration.is_finite() && *duration > 0.0)
+}
+
+fn output_av_skew_ms(probe: &MediaProbe) -> Option<f64> {
+    let video = probe.video.as_ref()?;
+    let audio = probe.audio.first()?;
+    let mut skew = match (video.start_time, audio.start_time) {
+        (Some(video), Some(audio)) => Some((video - audio).abs() * 1000.0),
+        _ => None,
+    };
+    if let (Some(video), Some(audio)) = (video.duration, audio.duration) {
+        let delayed_audio = (video - audio).max(0.0) * 1000.0;
+        skew = Some(skew.map_or(delayed_audio, |current| current.max(delayed_audio)));
+    }
+    skew
+}
+
+fn nearly_equal(left: Option<f64>, right: Option<f64>, tolerance: f64) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => (left - right).abs() <= tolerance,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn cancelled_outcome(control: &JobControl) -> ProcessOutcome {
+    if control.is_cancelled() {
+        ProcessOutcome::UserCancelled
+    } else if control.is_shutdown_interrupted() {
+        ProcessOutcome::ShutdownInterrupted
+    } else {
+        ProcessOutcome::CapturePreempted
+    }
+}
+
+fn set_job_state(
+    state: &AppState,
+    job: &mut NoiseCleanupJob,
+    status: NoiseCleanupJobStatus,
+    progress: u8,
+) {
+    job.status = status;
+    job.progress_percent = progress.min(100);
+    job.updated_at = Utc::now().to_rfc3339();
+    if let Err(error) = state.database.save_noise_cleanup_job(job) {
+        state.emit_log(
+            "error",
+            format!("Could not persist Noise Cleanup job {}: {error:#}", job.id),
+        );
+        return;
+    }
+    state.emit_event("noiseCleanup.status", &*job);
+}
+
+fn terminal_job(
+    state: &AppState,
+    job: &mut NoiseCleanupJob,
+    status: NoiseCleanupJobStatus,
+    failure: Option<CleanupFailure>,
+) {
+    if let Some(failure) = failure {
+        job.error_code = Some(failure.code.to_string());
+        job.error_message = Some(failure.message);
+    } else {
+        job.error_code = None;
+        job.error_message = None;
+    }
+    let progress = if status == NoiseCleanupJobStatus::Completed {
+        100
+    } else {
+        job.progress_percent
+    };
+    set_job_state(state, job, status, progress);
+}
+
+fn fail_job(state: &AppState, job: &mut NoiseCleanupJob, failure: CleanupFailure) {
+    terminal_job(state, job, NoiseCleanupJobStatus::Failed, Some(failure));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entitlements;
+    use crate::protocol::{
+        OutputSettings, RtmpPreset, RtmpSettings, SourceSelection, VideoPreset, VideoSettings,
+        default_layout_settings,
+    };
+    use crate::storage::{Database, NewSession};
+    use tokio::sync::broadcast;
+
+    #[test]
+    fn speech_v1_is_locked_to_the_probed_conservative_filter() {
+        assert_eq!(NOISE_CLEANUP_PRESET, "speech-v1");
+        assert_eq!(SPEECH_V1_FILTER, "afftdn=nr=18:nf=-34:tn=1");
+    }
+
+    #[test]
+    fn exact_container_args_copy_video_and_encode_only_audio() {
+        let mp4 = build_ffmpeg_args(Path::new("in.mp4"), Path::new("out.mp4"), "mp4").unwrap();
+        assert!(mp4.windows(2).any(|pair| pair == ["-c", "copy"]));
+        assert!(mp4.windows(2).any(|pair| pair == ["-loglevel", "error"]));
+        assert!(mp4.iter().any(|arg| arg == "-hide_banner"));
+        assert!(mp4.windows(2).any(|pair| pair == ["-c:a", "aac"]));
+        assert!(mp4.windows(2).any(|pair| pair == ["-b:a", "192k"]));
+        assert!(mp4.windows(2).any(|pair| pair == ["-af", SPEECH_V1_FILTER]));
+        assert!(mp4.windows(2).any(|pair| pair == ["-progress", "pipe:1"]));
+        assert!(
+            !mp4.iter()
+                .any(|arg| arg == "-vf" || arg == "-filter_complex")
+        );
+
+        let mkv = build_ffmpeg_args(Path::new("in.mkv"), Path::new("out.mkv"), "mkv").unwrap();
+        assert!(mkv.windows(2).any(|pair| pair == ["-c:a", "pcm_s16le"]));
+        assert!(!mkv.iter().any(|arg| arg == "192k"));
+        assert!(build_ffmpeg_args(Path::new("in.mov"), Path::new("out.mov"), "mov").is_err());
+        assert_eq!(
+            container_policy(Path::new("legacy.mkv"), None).unwrap(),
+            ContainerPolicy::Mkv
+        );
+    }
+
+    #[test]
+    fn progress_is_duration_based_and_capped_before_validation() {
+        assert_eq!(parse_progress_line("out_time_us=5000000", 10.0), Some(50));
+        assert_eq!(parse_progress_line("out_time_ms=20000000", 10.0), Some(98));
+        assert_eq!(parse_progress_line("progress=continue", 10.0), None);
+    }
+
+    #[test]
+    fn disk_space_policy_requires_source_plus_conservative_headroom() {
+        let source = 100 * 1024 * 1024;
+        let required = source + source / 4 + 64 * 1024 * 1024;
+        assert!(!has_cleanup_space(source, required - 1));
+        assert!(has_cleanup_space(source, required));
+    }
+
+    #[test]
+    fn ffmpeg_stderr_tail_is_strictly_bounded() {
+        let bytes = (0..100_000)
+            .map(|value| (value % 251) as u8)
+            .collect::<Vec<_>>();
+        let tail = read_bounded_tail(std::io::Cursor::new(&bytes), 64 * 1024);
+        assert_eq!(tail.len(), 64 * 1024);
+        assert_eq!(tail, bytes[bytes.len() - 64 * 1024..]);
+    }
+
+    #[test]
+    fn output_names_are_non_destructive_and_count_collisions() {
+        let base =
+            std::env::temp_dir().join(format!("videorc-cleanup-name-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let source = base.join("Recording.mp4");
+        std::fs::write(&source, b"source").unwrap();
+        let first = first_free_output_path(&source).unwrap();
+        assert_eq!(first.file_name().unwrap(), "Recording — Noise Cleaned.mp4");
+        std::fs::write(&first, b"existing").unwrap();
+        let second = first_free_output_path(&source).unwrap();
+        assert_eq!(
+            second.file_name().unwrap(),
+            "Recording — Noise Cleaned 2.mp4"
+        );
+        std::fs::remove_file(&first).unwrap();
+        let reserved =
+            first_free_output_path_with(&source, |candidate| candidate == first.as_path()).unwrap();
+        assert_eq!(
+            reserved, second,
+            "DB-owned missing paths must remain reserved"
+        );
+        assert_eq!(std::fs::read(&source).unwrap(), b"source");
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    fn test_state(database: Database) -> AppState {
+        let (events, _) = broadcast::channel(32);
+        AppState::new("test-token".to_string(), 0, events, database)
+    }
+
+    fn completed_recording(
+        id: &str,
+        path: &Path,
+        mode: &str,
+        microphone_id: Option<String>,
+    ) -> NewSession {
+        NewSession {
+            id: id.to_string(),
+            title: "Source title".to_string(),
+            started_at: Utc::now().to_rfc3339(),
+            mode: mode.to_string(),
+            output_path: None,
+            container: Some("mp4".to_string()),
+            stream_preset: None,
+            sources: SourceSelection {
+                screen_id: Some("screen:1".to_string()),
+                window_id: None,
+                camera_id: None,
+                microphone_id,
+                test_pattern: false,
+            },
+            layout: default_layout_settings(),
+            output: OutputSettings {
+                record_enabled: true,
+                stream_enabled: false,
+                output_directory: path.parent().map(|path| path.display().to_string()),
+                ffmpeg_path: None,
+                video: VideoSettings {
+                    preset: VideoPreset::Tutorial1080p30,
+                    width: 1920,
+                    height: 1080,
+                    fps: 30,
+                    bitrate_kbps: 6000,
+                },
+                rtmp: RtmpSettings {
+                    preset: RtmpPreset::Custom,
+                    server_url: String::new(),
+                    stream_key: String::new(),
+                },
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn basic_gate_rejects_before_creating_a_job() {
+        let state = test_state(Database::open_in_memory_for_tests());
+        let result = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "missing".to_string(),
+            },
+            entitlements::basic_entitlements(),
+        )
+        .await;
+        assert!(result.unwrap_err().contains("Premium"));
+        assert!(state.database.list_noise_cleanup_jobs().unwrap().is_empty());
+    }
+
+    #[test]
+    fn durable_jobs_are_idempotent_resume_queued_and_rollback_owned_publication() {
+        let base =
+            std::env::temp_dir().join(format!("videorc-cleanup-durable-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let source_path = base.join("source.mp4");
+        let source_bytes = vec![0x51; 160 * 1024];
+        std::fs::write(&source_path, &source_bytes).unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(source_bytes.len() as i64),
+            )
+            .unwrap();
+        let identity = capture_session_file_bound_identity(&source_path)
+            .unwrap()
+            .unwrap();
+        let full_sha256 = full_file_sha256(&source_path).unwrap();
+        let first = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        let second = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        assert_eq!(
+            first.job.id, second.job.id,
+            "duplicate start must be idempotent"
+        );
+
+        let mut interrupted = first.job.clone();
+        interrupted.status = NoiseCleanupJobStatus::Processing;
+        interrupted.progress_percent = 47;
+        interrupted.updated_at = Utc::now().to_rfc3339();
+        database.save_noise_cleanup_job(&interrupted).unwrap();
+        let resumed = database.reconcile_interrupted_noise_cleanup_jobs().unwrap();
+        assert_eq!(resumed.len(), 1);
+        assert_eq!(resumed[0].status, NoiseCleanupJobStatus::Queued);
+        assert_eq!(resumed[0].progress_percent, 0);
+        assert!(
+            database
+                .bind_noise_cleanup_source_fingerprint(&first.job.id, &full_sha256)
+                .unwrap()
+                .is_none()
+        );
+
+        let staging = base.join(".cleaned.partial.mp4");
+        let published = base.join("cleaned.mp4");
+        let operation = database
+            .begin_session_file_operation("noise-cleanup", "derivative", &staging, &published)
+            .unwrap();
+        std::fs::write(&staging, b"owned cleaned bytes").unwrap();
+        let state = test_state(database.clone());
+        let ownership = bind_completed_operation(&state, &operation, &staging).unwrap();
+        publish_identity_bound_file(&staging, &published, &ownership).unwrap();
+        assert!(published.exists());
+        database.cancel_session_file_operation(&operation).unwrap();
+        assert!(
+            !published.exists(),
+            "row-less exact owned final must roll back"
+        );
+        assert_eq!(std::fs::read(&source_path).unwrap(), source_bytes);
+
+        let committed_staging = base.join(".committed.partial.mp4");
+        let committed_operation = database
+            .begin_session_file_operation(
+                "noise-cleanup",
+                "derivative",
+                &committed_staging,
+                &published,
+            )
+            .unwrap();
+        std::fs::write(&committed_staging, b"validated derivative").unwrap();
+        let ownership =
+            bind_completed_operation(&state, &committed_operation, &committed_staging).unwrap();
+        publish_identity_bound_file(&committed_staging, &published, &ownership).unwrap();
+        assert!(
+            database
+                .complete_noise_cleanup_derivative(
+                    &first.job.id,
+                    "source",
+                    "derivative",
+                    "Source title — Noise Cleaned",
+                    "Source title",
+                    published.to_str().unwrap(),
+                    "mp4",
+                    Some(1000),
+                    20,
+                )
+                .unwrap()
+        );
+        // Simulate a crash after the atomic derivative/job commit but before
+        // the file-operation journal was retired. Completed work must not be
+        // requeued or produce a numbered duplicate; startup retains the exact
+        // row/file pair and removes only the redundant journal.
+        assert!(
+            database
+                .reconcile_interrupted_noise_cleanup_jobs()
+                .unwrap()
+                .is_empty()
+        );
+        let reconciliation = database.reconcile_session_file_operations().unwrap();
+        assert_eq!(reconciliation.published, 1);
+        assert!(
+            database
+                .pending_session_file_operations()
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            database
+                .noise_cleanup_job(&first.job.id)
+                .unwrap()
+                .unwrap()
+                .job
+                .status,
+            NoiseCleanupJobStatus::Completed
+        );
+        let derivative = database
+            .list_sessions(20)
+            .unwrap()
+            .into_iter()
+            .find(|session| session.id == "derivative")
+            .unwrap();
+        assert_eq!(
+            derivative.derived_from_session_id.as_deref(),
+            Some("source")
+        );
+        assert_eq!(derivative.source_title.as_deref(), Some("Source title"));
+        assert_eq!(derivative.processing_kind.as_deref(), Some("noise-cleanup"));
+        assert!(derivative.ai_artifacts.is_empty());
+        assert_eq!(derivative.comment_count, 0);
+        let duplicate_path = base.join("cleaned copy.mp4");
+        std::fs::write(&duplicate_path, b"duplicate derivative").unwrap();
+        assert!(
+            database
+                .clone_session_row(
+                    "derivative",
+                    "derivative-copy",
+                    "Source title — Noise Cleaned (copy)",
+                    None,
+                    Some(duplicate_path.to_str().unwrap()),
+                    &Utc::now().to_rfc3339(),
+                    Some(20),
+                )
+                .unwrap()
+        );
+        let derivative_copy = database
+            .list_sessions(20)
+            .unwrap()
+            .into_iter()
+            .find(|session| session.id == "derivative-copy")
+            .unwrap();
+        assert_eq!(
+            derivative_copy.derived_from_session_id.as_deref(),
+            Some("source")
+        );
+        assert_eq!(
+            derivative_copy.source_title.as_deref(),
+            Some("Source title")
+        );
+        assert_eq!(
+            derivative_copy.processing_kind.as_deref(),
+            Some("noise-cleanup")
+        );
+        let deletions = database
+            .prepare_session_deletions(&["source".to_string()])
+            .unwrap();
+        for path in &deletions[0].paths {
+            std::fs::remove_file(path).unwrap();
+        }
+        let completion = database
+            .complete_session_deletion(&deletions[0].operation_id, &[])
+            .unwrap();
+        assert!(completion.deleted);
+        let derivative = database
+            .list_sessions(20)
+            .unwrap()
+            .into_iter()
+            .find(|session| session.id == "derivative")
+            .unwrap();
+        assert_eq!(derivative.derived_from_session_id, None);
+        assert_eq!(derivative.source_title.as_deref(), Some("Source title"));
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[tokio::test]
+    async fn queued_cancel_is_terminal_and_does_not_touch_source() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-queued-cancel-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source_path = base.join("source.mp4");
+        std::fs::write(&source_path, b"source remains untouched").unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(24),
+            )
+            .unwrap();
+        let state = test_state(database);
+        let maintenance = state.ffmpeg_work.try_begin_maintenance().unwrap();
+        let job = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "source".to_string(),
+            },
+            entitlements::developer_test_entitlements(),
+        )
+        .await
+        .unwrap();
+        assert!(session_mutation_blocked(&state, "source").unwrap());
+        let cancelled = cancel(state.clone(), NoiseCleanupCancelParams { job_id: job.id })
+            .await
+            .unwrap();
+        assert!(!session_mutation_blocked(&state, "source").unwrap());
+        let retry = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "source".to_string(),
+            },
+            entitlements::developer_test_entitlements(),
+        )
+        .await
+        .unwrap();
+        assert_ne!(
+            retry.id, cancelled.id,
+            "cancelled jobs must never block Retry"
+        );
+        let retry = cancel(state.clone(), NoiseCleanupCancelParams { job_id: retry.id })
+            .await
+            .unwrap();
+        assert_eq!(retry.status, NoiseCleanupJobStatus::Cancelled);
+        drop(maintenance);
+        assert_eq!(cancelled.status, NoiseCleanupJobStatus::Cancelled);
+        assert_eq!(
+            std::fs::read(&source_path).unwrap(),
+            b"source remains untouched"
+        );
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[tokio::test]
+    async fn shutdown_interruption_keeps_queued_job_restart_resumable() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-shutdown-resume-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source_path = base.join("source.mp4");
+        std::fs::write(&source_path, b"durable queued source").unwrap();
+        let database_path = base.join("videorc.sqlite3");
+        let database = Database::open_file_for_tests(&database_path);
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(21),
+            )
+            .unwrap();
+        let state = test_state(database.clone());
+        let maintenance = state.ffmpeg_work.try_begin_maintenance().unwrap();
+        let job = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "source".to_string(),
+            },
+            entitlements::developer_test_entitlements(),
+        )
+        .await
+        .unwrap();
+        state.noise_cleanup.interrupt_all_for_shutdown();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while state.noise_cleanup.get(&job.id).is_some() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("queued worker did not stop for shutdown");
+        assert_eq!(
+            database
+                .noise_cleanup_job(&job.id)
+                .unwrap()
+                .unwrap()
+                .job
+                .status,
+            NoiseCleanupJobStatus::Queued
+        );
+        drop(maintenance);
+        drop(state);
+        drop(database);
+        let reopened = Database::open_file_for_tests(&database_path);
+        let resumable = reopened.reconcile_interrupted_noise_cleanup_jobs().unwrap();
+        assert_eq!(resumable.len(), 1);
+        assert_eq!(resumable[0].id, job.id);
+        assert_eq!(resumable[0].status, NoiseCleanupJobStatus::Queued);
+        assert_eq!(
+            std::fs::read(&source_path).unwrap(),
+            b"durable queued source"
+        );
+        drop(reopened);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn missing_mp4_remux_falls_back_to_existing_managed_mkv() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-media-fallback-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let mkv = base.join("source.mkv");
+        let missing_mp4 = base.join("missing.mp4");
+        std::fs::write(&mkv, b"existing authoritative mkv").unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        let mut session =
+            completed_recording("source", &mkv, "record", Some("microphone:1".to_string()));
+        session.output_path = Some(mkv.display().to_string());
+        session.container = Some("mkv".to_string());
+        database
+            .create_completed_session(
+                &session,
+                &now,
+                Some(missing_mp4.to_str().unwrap()),
+                Some(1000),
+                Some(26),
+            )
+            .unwrap();
+        let source = database.noise_cleanup_source("source").unwrap().unwrap();
+        assert_eq!(source.media_path.as_deref(), mkv.to_str());
+        assert_eq!(
+            container_policy(&mkv, source.container.as_deref()).unwrap(),
+            ContainerPolicy::Mkv
+        );
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn source_object_replacement_is_rejected_even_with_identical_bytes() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-source-identity-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source = base.join("source.mp4");
+        let old = base.join("old.mp4");
+        let bytes = vec![0x41; 160 * 1024];
+        std::fs::write(&source, &bytes).unwrap();
+        let identity = capture_session_file_bound_identity(&source)
+            .unwrap()
+            .unwrap();
+        let full_sha256 = full_file_sha256(&source).unwrap();
+        std::fs::rename(&source, &old).unwrap();
+        std::fs::write(&source, &bytes).unwrap();
+        let error = require_source_identity(&source, &identity, &full_sha256).unwrap_err();
+        assert_eq!(error.code, ERROR_CHANGED);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn same_inode_same_length_middle_edit_is_rejected_by_full_fingerprint() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-source-middle-edit-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source = base.join("source.mp4");
+        let bytes = vec![0x41; 192 * 1024];
+        std::fs::write(&source, &bytes).unwrap();
+        let identity = capture_session_file_bound_identity(&source)
+            .unwrap()
+            .unwrap();
+        let full_sha256 = full_file_sha256(&source).unwrap();
+        let mut changed = bytes;
+        changed[96 * 1024] = 0x42;
+        std::fs::write(&source, changed).unwrap();
+        let sampled = capture_session_file_bound_identity(&source)
+            .unwrap()
+            .unwrap();
+        assert!(
+            session_file_bound_identity_matches(
+                &sampled,
+                &identity.content_identity,
+                Some(&identity.object_identity),
+            ),
+            "the job-specific full fingerprint must close the sampled-middle gap"
+        );
+        let error = require_source_identity(&source, &identity, &full_sha256).unwrap_err();
+        assert_eq!(error.code, ERROR_CHANGED);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn deleting_derivative_invalidates_completed_job_and_allows_retry() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-delete-derivative-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source_path = base.join("source.mp4");
+        let output_path = base.join("source — Noise Cleaned.mp4");
+        std::fs::write(&source_path, b"source bytes").unwrap();
+        std::fs::write(&output_path, b"cleaned bytes").unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(12),
+            )
+            .unwrap();
+        let identity = capture_session_file_bound_identity(&source_path)
+            .unwrap()
+            .unwrap();
+        let full_sha256 = full_file_sha256(&source_path).unwrap();
+        let job = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        assert!(
+            database
+                .bind_noise_cleanup_source_fingerprint(&job.job.id, &full_sha256)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            database
+                .complete_noise_cleanup_derivative(
+                    &job.job.id,
+                    "source",
+                    "derivative",
+                    "Source title — Noise Cleaned",
+                    "Source title",
+                    output_path.to_str().unwrap(),
+                    "mp4",
+                    Some(1000),
+                    13,
+                )
+                .unwrap()
+        );
+        let old_source_path = base.join("old-source.mp4");
+        std::fs::rename(&source_path, &old_source_path).unwrap();
+        std::fs::write(&source_path, b"source bytes").unwrap();
+        let replacement_identity = capture_session_file_bound_identity(&source_path)
+            .unwrap()
+            .unwrap();
+        let replacement_full_sha256 = full_file_sha256(&source_path).unwrap();
+        let replacement_job = database
+            .create_or_get_noise_cleanup_job("source", &replacement_identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        assert!(
+            database
+                .bind_noise_cleanup_source_fingerprint(
+                    &replacement_job.job.id,
+                    &replacement_full_sha256,
+                )
+                .unwrap()
+                .is_none(),
+            "object mismatch must prevent completed-result reuse"
+        );
+        assert_ne!(
+            replacement_job.job.id, job.job.id,
+            "byte-identical filesystem-object replacement must not reuse completed output"
+        );
+        assert_eq!(replacement_job.job.status, NoiseCleanupJobStatus::Queued);
+        let deletion = database
+            .prepare_session_deletions(&["derivative".to_string()])
+            .unwrap();
+        for path in &deletion[0].paths {
+            std::fs::remove_file(path).unwrap();
+        }
+        assert!(
+            database
+                .complete_session_deletion(&deletion[0].operation_id, &[])
+                .unwrap()
+                .deleted
+        );
+        let invalidated = database
+            .noise_cleanup_job(&job.job.id)
+            .unwrap()
+            .unwrap()
+            .job;
+        assert_eq!(invalidated.status, NoiseCleanupJobStatus::Failed);
+        assert_eq!(invalidated.error_code.as_deref(), Some(ERROR_MISSING));
+        assert!(invalidated.output_session_id.is_none());
+        assert!(invalidated.output_path.is_none());
+        let retry = database
+            .create_or_get_noise_cleanup_job("source", &replacement_identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        assert_eq!(retry.job.id, replacement_job.job.id);
+        assert_eq!(retry.job.status, NoiseCleanupJobStatus::Queued);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn externally_missing_output_keeps_derivative_metadata_and_reserves_its_path() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-external-output-delete-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source_path = base.join("source.mp4");
+        let output_path = base.join("source — Noise Cleaned.mp4");
+        std::fs::write(&source_path, b"source bytes").unwrap();
+        std::fs::write(&output_path, b"first cleaned bytes").unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(12),
+            )
+            .unwrap();
+        let identity = capture_session_file_bound_identity(&source_path)
+            .unwrap()
+            .unwrap();
+        let full_sha256 = full_file_sha256(&source_path).unwrap();
+        let first = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        database
+            .bind_noise_cleanup_source_fingerprint(&first.job.id, &full_sha256)
+            .unwrap();
+        database
+            .complete_noise_cleanup_derivative(
+                &first.job.id,
+                "source",
+                "first-derivative",
+                "Source title — Noise Cleaned",
+                "Source title",
+                output_path.to_str().unwrap(),
+                "mp4",
+                Some(1000),
+                19,
+            )
+            .unwrap();
+        std::fs::remove_file(&output_path).unwrap();
+        let jobs = database.list_noise_cleanup_jobs().unwrap();
+        let invalidated = jobs.iter().find(|job| job.id == first.job.id).unwrap();
+        assert_eq!(invalidated.status, NoiseCleanupJobStatus::Failed);
+        assert_eq!(invalidated.error_code.as_deref(), Some(ERROR_MISSING));
+        assert!(database.list_sessions(20).unwrap().iter().any(|session| {
+            session.id == "first-derivative" && session.mp4_path.as_deref() == output_path.to_str()
+        }));
+
+        // A later remount or restore makes the original Library row usable
+        // again; reconciliation must never destroy that durable path metadata.
+        std::fs::write(&output_path, b"first cleaned bytes restored").unwrap();
+        assert!(output_path.is_file());
+
+        let retry = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        database
+            .bind_noise_cleanup_source_fingerprint(&retry.job.id, &full_sha256)
+            .unwrap();
+        let second_path = first_free_output_path_with(&source_path, |candidate| {
+            database
+                .session_media_path_registered(&candidate.display().to_string())
+                .unwrap()
+        })
+        .unwrap();
+        assert_eq!(
+            second_path.file_name().unwrap(),
+            "source — Noise Cleaned 2.mp4"
+        );
+        std::fs::write(&second_path, b"second cleaned bytes").unwrap();
+        database
+            .complete_noise_cleanup_derivative(
+                &retry.job.id,
+                "source",
+                "second-derivative",
+                "Source title — Noise Cleaned",
+                "Source title",
+                second_path.to_str().unwrap(),
+                "mp4",
+                Some(1000),
+                20,
+            )
+            .unwrap();
+        let derivatives = database
+            .list_sessions(20)
+            .unwrap()
+            .into_iter()
+            .filter(|session| session.processing_kind.as_deref() == Some("noise-cleanup"))
+            .collect::<Vec<_>>();
+        assert_eq!(derivatives.len(), 2);
+        assert!(
+            derivatives
+                .iter()
+                .any(|session| session.id == "first-derivative")
+        );
+        assert!(derivatives.iter().any(|session| {
+            session.id == "second-derivative" && session.mp4_path.as_deref() == second_path.to_str()
+        }));
+        let stale_reserved_path = base.join("source — Noise Cleaned 3.mp4");
+        database
+            .clone_session_row(
+                "second-derivative",
+                "older-stale-derivative",
+                "Older stale derivative",
+                None,
+                Some(stale_reserved_path.to_str().unwrap()),
+                &Utc::now().to_rfc3339(),
+                Some(20),
+            )
+            .unwrap();
+        assert!(!stale_reserved_path.exists());
+        let third_path = first_free_output_path_with(&source_path, |candidate| {
+            database
+                .session_media_path_registered(&candidate.display().to_string())
+                .unwrap()
+        })
+        .unwrap();
+        assert_eq!(
+            third_path.file_name().unwrap(),
+            "source — Noise Cleaned 4.mp4",
+            "missing paths owned by older derivative rows must remain reserved"
+        );
+
+        let old_source = base.join("old-source.mp4");
+        std::fs::rename(&source_path, &old_source).unwrap();
+        std::fs::write(&source_path, b"source bytes").unwrap();
+        let reconciled = database.list_noise_cleanup_jobs().unwrap();
+        let changed = reconciled
+            .iter()
+            .find(|job| job.id == retry.job.id)
+            .unwrap();
+        assert_eq!(changed.status, NoiseCleanupJobStatus::Failed);
+        assert_eq!(changed.error_code.as_deref(), Some(ERROR_CHANGED));
+        assert!(
+            database
+                .list_sessions(20)
+                .unwrap()
+                .iter()
+                .any(|session| session.id == "second-derivative")
+        );
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unavailable_output_does_not_mutate_completed_job_or_derivative_row() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-unavailable-output-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let mounted = base.join("mounted");
+        let displaced = base.join("displaced");
+        std::fs::create_dir_all(&mounted).unwrap();
+        let source_path = base.join("source.mp4");
+        let output_path = mounted.join("source — Noise Cleaned.mp4");
+        std::fs::write(&source_path, b"source bytes").unwrap();
+        std::fs::write(&output_path, b"cleaned bytes").unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(12),
+            )
+            .unwrap();
+        let identity = capture_session_file_bound_identity(&source_path)
+            .unwrap()
+            .unwrap();
+        let full_sha256 = full_file_sha256(&source_path).unwrap();
+        let job = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        database
+            .bind_noise_cleanup_source_fingerprint(&job.job.id, &full_sha256)
+            .unwrap();
+        database
+            .complete_noise_cleanup_derivative(
+                &job.job.id,
+                "source",
+                "derivative",
+                "Source title — Noise Cleaned",
+                "Source title",
+                output_path.to_str().unwrap(),
+                "mp4",
+                Some(1000),
+                13,
+            )
+            .unwrap();
+
+        // Simulate an unavailable mount point. Opening a child below a regular
+        // file fails with NotADirectory rather than a definitive NotFound.
+        std::fs::rename(&mounted, &displaced).unwrap();
+        std::fs::write(&mounted, b"temporarily unavailable mount").unwrap();
+        assert_eq!(
+            session_media_path_state(&output_path),
+            SessionMediaPathState::Unavailable
+        );
+        let listed = database.list_noise_cleanup_jobs().unwrap();
+        let completed = listed
+            .iter()
+            .find(|listed| listed.id == job.job.id)
+            .unwrap();
+        assert_eq!(completed.status, NoiseCleanupJobStatus::Completed);
+        assert_eq!(completed.output_session_id.as_deref(), Some("derivative"));
+        assert_eq!(completed.output_path.as_deref(), output_path.to_str());
+        let repeated = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        assert_eq!(repeated.job.id, job.job.id);
+        assert_eq!(repeated.job.status, NoiseCleanupJobStatus::Completed);
+
+        std::fs::remove_file(&mounted).unwrap();
+        std::fs::rename(&displaced, &mounted).unwrap();
+        assert!(output_path.is_file());
+        let restored = database
+            .list_sessions(20)
+            .unwrap()
+            .into_iter()
+            .find(|session| session.id == "derivative")
+            .unwrap();
+        assert_eq!(restored.mp4_path.as_deref(), output_path.to_str());
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn job_list_compacts_terminal_history_and_keeps_active_work() {
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-list-bound-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source_path = base.join("source.mp4");
+        std::fs::write(&source_path, b"source bytes").unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(12),
+            )
+            .unwrap();
+        let identity = capture_session_file_bound_identity(&source_path)
+            .unwrap()
+            .unwrap();
+        for index in 0..1_005 {
+            let mut job = database
+                .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+                .unwrap()
+                .job;
+            job.status = NoiseCleanupJobStatus::Failed;
+            job.error_code = Some("test-failure".to_string());
+            job.error_message = Some(format!("failure {index}"));
+            job.updated_at = Utc::now().to_rfc3339();
+            database.save_noise_cleanup_job(&job).unwrap();
+        }
+        let active = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap()
+            .job;
+        let listed = database.list_noise_cleanup_jobs().unwrap();
+        assert!(listed.len() <= 1_000);
+        assert_eq!(
+            listed
+                .iter()
+                .filter(|job| job.status == NoiseCleanupJobStatus::Failed)
+                .count(),
+            1,
+            "only the latest terminal state per source should reach bootstrap"
+        );
+        assert!(listed.iter().any(|job| job.id == active.id));
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    fn generate_test_fixture(ffmpeg: &str, path: &Path, audio_tracks: usize) -> bool {
+        let mut command = Command::new(ffmpeg);
+        command.args([
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x90:rate=30:duration=2",
+        ]);
+        for index in 0..audio_tracks {
+            let frequency = 440 + index * 110;
+            command.args([
+                "-f",
+                "lavfi",
+                "-i",
+                &format!("sine=frequency={frequency}:sample_rate=48000:duration=2"),
+            ]);
+        }
+        command.args(["-map", "0:v:0"]);
+        for index in 0..audio_tracks {
+            command.args(["-map", &format!("{}:a:0", index + 1)]);
+        }
+        command.args(["-c:v", "mpeg4", "-q:v", "5"]);
+        if audio_tracks == 0 {
+            command.arg("-an");
+        } else {
+            let audio_codec = if path.extension().and_then(|value| value.to_str()) == Some("mkv") {
+                "pcm_s16le"
+            } else {
+                "aac"
+            };
+            command.args(["-c:a", audio_codec]);
+            if audio_codec == "aac" {
+                command.args(["-b:a", "128k"]);
+            }
+            command.arg("-shortest");
+        }
+        command.arg(path);
+        output_owned_std(&mut command).is_ok_and(|output| output.status.success())
+    }
+
+    #[tokio::test]
+    async fn real_ffmpeg_engine_rejects_ambiguous_audio_and_publishes_a_valid_derivative() {
+        let ffmpeg = default_ffmpeg_path();
+        let mut version = Command::new(&ffmpeg);
+        version
+            .arg("-version")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if !output_owned_std(&mut version).is_ok_and(|output| output.status.success()) {
+            eprintln!("Skipping real Noise Cleanup engine test: ffmpeg is unavailable");
+            return;
+        }
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-real-engine-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let no_audio = base.join("no-audio.mp4");
+        let one_audio = base.join("one-audio.mp4");
+        let one_audio_mkv = base.join("one-audio.mkv");
+        let multi_audio = base.join("multi-audio.mp4");
+        assert!(generate_test_fixture(&ffmpeg, &no_audio, 0));
+        assert!(generate_test_fixture(&ffmpeg, &one_audio, 1));
+        assert!(generate_test_fixture(&ffmpeg, &one_audio_mkv, 1));
+        assert!(generate_test_fixture(&ffmpeg, &multi_audio, 2));
+        let ffprobe = ffprobe_path_for(&ffmpeg);
+        let never = || false;
+        assert_eq!(
+            preflight_media(&ffmpeg, &ffprobe, &no_audio, ContainerPolicy::Mp4, &never)
+                .unwrap_err()
+                .code,
+            ERROR_NO_AUDIO
+        );
+        assert_eq!(
+            preflight_media(
+                &ffmpeg,
+                &ffprobe,
+                &multi_audio,
+                ContainerPolicy::Mp4,
+                &never,
+            )
+            .unwrap_err()
+            .code,
+            ERROR_MULTIPLE_AUDIO
+        );
+
+        let source_before = capture_session_file_bound_identity(&one_audio)
+            .unwrap()
+            .unwrap();
+        let source_bytes = std::fs::read(&one_audio).unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &one_audio,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(one_audio.to_str().unwrap()),
+                Some(2000),
+                Some(source_bytes.len() as i64),
+            )
+            .unwrap();
+        let state = test_state(database.clone());
+        let started = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "source".to_string(),
+            },
+            entitlements::developer_test_entitlements(),
+        )
+        .await
+        .unwrap();
+        assert!(session_mutation_blocked(&state, "source").unwrap());
+        let fingerprint_capture = tokio::time::timeout(
+            Duration::from_secs(10),
+            state.ffmpeg_work.begin_capture_when_available(),
+        )
+        .await
+        .expect("capture did not preempt queued fingerprint work");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = database
+                    .noise_cleanup_job(&started.id)
+                    .unwrap()
+                    .unwrap()
+                    .job
+                    .status;
+                if status == NoiseCleanupJobStatus::Queued {
+                    break;
+                }
+                assert!(status.is_active(), "fingerprint preemption became terminal");
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("fingerprint preemption did not remain queued");
+        drop(fingerprint_capture);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = database
+                    .noise_cleanup_job(&started.id)
+                    .unwrap()
+                    .unwrap()
+                    .job
+                    .status;
+                if status == NoiseCleanupJobStatus::Processing {
+                    break;
+                }
+                assert!(status.is_active(), "cleanup terminated before preemption");
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("cleanup never entered processing");
+        let capture = tokio::time::timeout(
+            Duration::from_secs(10),
+            state.ffmpeg_work.begin_capture_when_available(),
+        )
+        .await
+        .expect("capture did not preempt Noise Cleanup");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = database
+                    .noise_cleanup_job(&started.id)
+                    .unwrap()
+                    .unwrap()
+                    .job
+                    .status;
+                if status == NoiseCleanupJobStatus::Queued {
+                    break;
+                }
+                assert!(status.is_active(), "preempted cleanup became terminal");
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("preempted cleanup did not return to queued");
+        drop(capture);
+        let completed = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let job = database
+                    .noise_cleanup_job(&started.id)
+                    .unwrap()
+                    .unwrap()
+                    .job;
+                if !job.status.is_active() {
+                    return job;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("Noise Cleanup engine timed out");
+        assert_eq!(
+            completed.status,
+            NoiseCleanupJobStatus::Completed,
+            "{:?}: {:?}",
+            completed.error_code,
+            completed.error_message
+        );
+        let output = PathBuf::from(completed.output_path.as_deref().unwrap());
+        assert!(output.is_file());
+        assert_eq!(std::fs::read(&one_audio).unwrap(), source_bytes);
+        let source_after = capture_session_file_bound_identity(&one_audio)
+            .unwrap()
+            .unwrap();
+        assert!(session_file_bound_identity_matches(
+            &source_after,
+            &source_before.content_identity,
+            Some(&source_before.object_identity),
+        ));
+        let repeated_start = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "source".to_string(),
+            },
+            entitlements::developer_test_entitlements(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            repeated_start.id, completed.id,
+            "exact unchanged source should return its completed job immediately"
+        );
+        let repeated = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let job = database
+                    .noise_cleanup_job(&repeated_start.id)
+                    .unwrap()
+                    .unwrap()
+                    .job;
+                if !job.status.is_active() {
+                    return job;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("completed-result lookup timed out");
+        assert_eq!(repeated.status, NoiseCleanupJobStatus::Completed);
+        assert_eq!(repeated.output_path, completed.output_path);
+        assert_eq!(
+            database
+                .list_noise_cleanup_jobs()
+                .unwrap()
+                .into_iter()
+                .filter(|job| job.source_session_id == "source")
+                .count(),
+            1
+        );
+        assert!(!session_mutation_blocked(&state, "source").unwrap());
+        let derivative = database
+            .list_sessions(20)
+            .unwrap()
+            .into_iter()
+            .find(|session| session.id == completed.output_session_id.clone().unwrap())
+            .unwrap();
+        assert_eq!(
+            derivative.derived_from_session_id.as_deref(),
+            Some("source")
+        );
+        assert_eq!(derivative.processing_kind.as_deref(), Some("noise-cleanup"));
+
+        let cancel_source = base.join("cancel-source.mp4");
+        std::fs::copy(&one_audio, &cancel_source).unwrap();
+        let cancel_bytes = std::fs::read(&cancel_source).unwrap();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "cancel-source",
+                    &cancel_source,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(cancel_source.to_str().unwrap()),
+                Some(2000),
+                Some(cancel_bytes.len() as i64),
+            )
+            .unwrap();
+        let cancelling = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "cancel-source".to_string(),
+            },
+            entitlements::developer_test_entitlements(),
+        )
+        .await
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = database
+                    .noise_cleanup_job(&cancelling.id)
+                    .unwrap()
+                    .unwrap()
+                    .job
+                    .status;
+                if status == NoiseCleanupJobStatus::Processing {
+                    break;
+                }
+                assert!(status.is_active(), "cleanup terminated before Cancel");
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("cleanup never became cancellable");
+        let cancelled = cancel(
+            state.clone(),
+            NoiseCleanupCancelParams {
+                job_id: cancelling.id,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(cancelled.status, NoiseCleanupJobStatus::Cancelled);
+        assert_eq!(std::fs::read(&cancel_source).unwrap(), cancel_bytes);
+
+        let mkv_bytes = std::fs::read(&one_audio_mkv).unwrap();
+        let mut mkv_session = completed_recording(
+            "mkv-source",
+            &one_audio_mkv,
+            "record",
+            Some("microphone:1".to_string()),
+        );
+        mkv_session.output_path = Some(one_audio_mkv.display().to_string());
+        mkv_session.container = Some("mkv".to_string());
+        database
+            .create_completed_session(
+                &mkv_session,
+                &now,
+                None,
+                Some(2000),
+                Some(mkv_bytes.len() as i64),
+            )
+            .unwrap();
+        let mkv_job = start_with_entitlements(
+            state.clone(),
+            NoiseCleanupStartParams {
+                session_id: "mkv-source".to_string(),
+            },
+            entitlements::developer_test_entitlements(),
+        )
+        .await
+        .unwrap();
+        let mkv_completed = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let job = database
+                    .noise_cleanup_job(&mkv_job.id)
+                    .unwrap()
+                    .unwrap()
+                    .job;
+                if !job.status.is_active() {
+                    return job;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("MKV Noise Cleanup engine timed out");
+        assert_eq!(
+            mkv_completed.status,
+            NoiseCleanupJobStatus::Completed,
+            "{:?}: {:?}",
+            mkv_completed.error_code,
+            mkv_completed.error_message
+        );
+        let mkv_output = PathBuf::from(mkv_completed.output_path.as_deref().unwrap());
+        assert_eq!(
+            mkv_output.extension().and_then(|value| value.to_str()),
+            Some("mkv")
+        );
+        let mkv_probe =
+            probe_media_cancellable(&ffprobe, &mkv_output.display().to_string(), &never).unwrap();
+        assert_eq!(mkv_probe.audio[0].codec, "pcm_s16le");
+        assert_eq!(std::fs::read(&one_audio_mkv).unwrap(), mkv_bytes);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn imported_no_mic_and_derived_sessions_are_rejected_before_media_work() {
+        let database = Database::open_in_memory_for_tests();
+        let state = test_state(database.clone());
+        let base =
+            std::env::temp_dir().join(format!("videorc-cleanup-source-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let file = base.join("recording.mp4");
+        std::fs::write(&file, b"not media").unwrap();
+        let now = Utc::now().to_rfc3339();
+        let make = |id: &str, mode: &str, microphone_id: Option<String>| NewSession {
+            id: id.to_string(),
+            title: id.to_string(),
+            started_at: now.clone(),
+            mode: mode.to_string(),
+            output_path: None,
+            container: Some("mp4".to_string()),
+            stream_preset: None,
+            sources: SourceSelection {
+                screen_id: Some("screen:1".to_string()),
+                window_id: None,
+                camera_id: None,
+                microphone_id,
+                test_pattern: false,
+            },
+            layout: default_layout_settings(),
+            output: OutputSettings {
+                record_enabled: true,
+                stream_enabled: false,
+                output_directory: None,
+                ffmpeg_path: None,
+                video: VideoSettings {
+                    preset: VideoPreset::Tutorial1080p30,
+                    width: 1920,
+                    height: 1080,
+                    fps: 30,
+                    bitrate_kbps: 6000,
+                },
+                rtmp: RtmpSettings {
+                    preset: RtmpPreset::Custom,
+                    server_url: String::new(),
+                    stream_key: String::new(),
+                },
+            },
+        };
+        database
+            .create_completed_session(
+                &make("imported", "imported", Some("mic".into())),
+                &now,
+                Some(file.to_str().unwrap()),
+                None,
+                Some(9),
+            )
+            .unwrap();
+        database
+            .create_completed_session(
+                &make("no-mic", "record", None),
+                &now,
+                Some(file.to_str().unwrap()),
+                None,
+                Some(9),
+            )
+            .unwrap();
+        assert_eq!(
+            resolve_source(&state, "imported").unwrap_err().code,
+            ERROR_IMPORTED
+        );
+        assert_eq!(
+            resolve_source(&state, "no-mic").unwrap_err().code,
+            ERROR_NO_AUDIO
+        );
+        let _ = std::fs::remove_dir_all(base);
+    }
+}

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -96,6 +96,7 @@ pub enum FeatureId {
     Livestreaming,
     Multistreaming,
     CloudAi,
+    NoiseCleanup,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -2420,6 +2421,88 @@ pub struct SessionSummary {
     pub session_logs: Vec<SessionLogEntry>,
     pub ai_artifacts: Vec<AiArtifact>,
     pub comment_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derived_from_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processing_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum NoiseCleanupJobStatus {
+    Queued,
+    Processing,
+    Validating,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl NoiseCleanupJobStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Processing => "processing",
+            Self::Validating => "validating",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Queued | Self::Processing | Self::Validating)
+    }
+}
+
+impl std::str::FromStr for NoiseCleanupJobStatus {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "processing" => Ok(Self::Processing),
+            "validating" => Ok(Self::Validating),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(format!("Unknown Noise Cleanup job status: {value}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NoiseCleanupJob {
+    pub id: String,
+    pub source_session_id: String,
+    pub status: NoiseCleanupJobStatus,
+    pub progress_percent: u8,
+    pub preset: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NoiseCleanupStartParams {
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NoiseCleanupCancelParams {
+    pub job_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/videorc-backend/src/state.rs
+++ b/crates/videorc-backend/src/state.rs
@@ -403,6 +403,7 @@ pub struct AppState {
     /// request token — OAuth 1.0a callbacks carry no `state` param).
     pub x_oauth1: Arc<crate::x_oauth1::XOauth1Sessions>,
     pub ffmpeg_work: Arc<FfmpegWorkCoordinator>,
+    pub noise_cleanup: Arc<crate::noise_cleanup::NoiseCleanupRegistry>,
     pub live_chat: LiveChatSlot,
     pub live_chat_persistence: LiveChatPersistence,
     /// In-memory product-account session override (deep-link sign-in / Sign out).
@@ -473,6 +474,7 @@ impl AppState {
             )),
             x_oauth1: Arc::new(crate::x_oauth1::XOauth1Sessions::default()),
             ffmpeg_work: Arc::new(FfmpegWorkCoordinator::new()),
+            noise_cleanup: Arc::new(crate::noise_cleanup::NoiseCleanupRegistry::default()),
             live_chat: Arc::new(tokio::sync::Mutex::new(LiveChatCoordinator::default())),
             account_session: Arc::new(tokio::sync::Mutex::new(
                 crate::account::restore_persisted_account(),

--- a/crates/videorc-backend/src/storage.rs
+++ b/crates/videorc-backend/src/storage.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -22,8 +22,8 @@ use crate::live_chat::{
 use crate::process_job::output_owned_std;
 use crate::protocol::{
     AiArtifact, AiArtifactKind, AiArtifactStatus, DiagnosticStats, HealthEvent, HealthLevel,
-    LayoutSettings, OutputSettings, SessionLogEntry, SessionStorageTotals, SessionSummary,
-    SourceSelection, StreamScreen, StreamScreenStatus,
+    LayoutSettings, NoiseCleanupJob, NoiseCleanupJobStatus, OutputSettings, SessionLogEntry,
+    SessionStorageTotals, SessionSummary, SourceSelection, StreamScreen, StreamScreenStatus,
 };
 use crate::repair::{GateStatus, RepairJob, RepairJobStatus};
 use crate::streaming::{
@@ -31,6 +31,8 @@ use crate::streaming::{
     UpsertPlatformAccount, default_stream_metadata_draft, stream_platform_from_id,
     stream_platform_id,
 };
+
+const MAX_NOISE_CLEANUP_JOB_LIST: usize = 1_000;
 
 #[derive(Clone)]
 pub struct Database {
@@ -57,6 +59,26 @@ pub struct NewSession {
     pub sources: SourceSelection,
     pub layout: LayoutSettings,
     pub output: OutputSettings,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NoiseCleanupSource {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub mode: String,
+    pub media_path: Option<String>,
+    pub container: Option<String>,
+    pub sources: SourceSelection,
+    pub derived_from_session_id: Option<String>,
+    pub processing_kind: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PersistedNoiseCleanupJob {
+    pub job: NoiseCleanupJob,
+    pub source_identity: SessionFileBoundIdentity,
+    pub source_full_sha256: String,
 }
 
 #[derive(Debug, Clone)]
@@ -385,6 +407,13 @@ pub(crate) struct SessionFileBoundIdentity {
     pub object_identity: SessionFileObjectIdentity,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionMediaPathState {
+    Present,
+    Missing,
+    Unavailable,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum DeletionPathState {
     Missing,
@@ -615,6 +644,47 @@ pub(crate) fn session_file_bound_identity_matches(
                     .same_sampled_bytes(expected_content_identity)
         }
         None => &actual.content_identity == expected_content_identity,
+    }
+}
+
+/// Cheap list/bootstrap staleness check: exact filesystem object plus length
+/// and modification time, without sampling media bytes. Full/sample hashing is
+/// reserved for the capture-aware background worker.
+pub(crate) fn session_file_quick_identity_matches(
+    path: &Path,
+    expected: &SessionFileBoundIdentity,
+) -> Result<bool> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    let metadata = file.metadata()?;
+    let modified_unix_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_nanos()).unwrap_or(i64::MAX));
+    let object_identity = capture_session_file_object_identity_from_file(&file, path)?;
+    Ok(object_identity == expected.object_identity
+        && metadata.len() == expected.content_identity.len
+        && modified_unix_nanos == expected.content_identity.modified_unix_nanos)
+}
+
+/// Classify a managed media path without treating every I/O error as deletion.
+/// In particular, permission failures and unavailable volumes must not cause
+/// Library metadata to be retired.
+pub(crate) fn session_media_path_state(path: &Path) -> SessionMediaPathState {
+    match File::open(path) {
+        Ok(file) => match file.metadata() {
+            Ok(metadata) if metadata.is_file() => SessionMediaPathState::Present,
+            Ok(_) => SessionMediaPathState::Missing,
+            Err(_) => SessionMediaPathState::Unavailable,
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            SessionMediaPathState::Missing
+        }
+        Err(_) => SessionMediaPathState::Unavailable,
     }
 }
 
@@ -2045,6 +2115,488 @@ impl Database {
         Ok(candidates)
     }
 
+    pub(crate) fn noise_cleanup_source(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<NoiseCleanupSource>> {
+        let conn = self.lock()?;
+        let row = conn
+            .query_row(
+                "SELECT id, title, status, mode, mp4_path, output_path, container,
+                    sources_json, derived_from_session_id, processing_kind
+             FROM sessions WHERE id = ?1 AND library_hidden = 0",
+                params![session_id],
+                |row| {
+                    let sources_json: String = row.get(7)?;
+                    let sources = serde_json::from_str(&sources_json).map_err(|error| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            7,
+                            rusqlite::types::Type::Text,
+                            Box::new(error),
+                        )
+                    })?;
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                        row.get::<_, Option<String>>(6)?,
+                        sources,
+                        row.get::<_, Option<String>>(8)?,
+                        row.get::<_, Option<String>>(9)?,
+                    ))
+                },
+            )
+            .optional()?;
+        Ok(row.map(
+            |(
+                id,
+                title,
+                status,
+                mode,
+                mp4_path,
+                output_path,
+                container,
+                sources,
+                derived_from_session_id,
+                processing_kind,
+            )| {
+                let media_path = [mp4_path, output_path]
+                    .into_iter()
+                    .flatten()
+                    .find(|path| Path::new(path).is_file());
+                NoiseCleanupSource {
+                    id,
+                    title,
+                    status,
+                    mode,
+                    media_path,
+                    container,
+                    sources,
+                    derived_from_session_id,
+                    processing_kind,
+                }
+            },
+        ))
+    }
+
+    /// Return active work or create a queued job immediately using only the fast
+    /// bound identity. The worker computes the full-file fingerprint off Tokio,
+    /// then resolves completed-result idempotency before FFmpeg starts.
+    pub(crate) fn create_or_get_noise_cleanup_job(
+        &self,
+        source_session_id: &str,
+        source_identity: &SessionFileBoundIdentity,
+        preset: &str,
+    ) -> Result<PersistedNoiseCleanupJob> {
+        let source_identity_json = serde_json::to_string(&source_identity.content_identity)?;
+        let source_object_identity_json = serde_json::to_string(&source_identity.object_identity)?;
+        let now = Utc::now().to_rfc3339();
+        let mut conn = self.lock()?;
+        let transaction = conn.transaction()?;
+        if let Some(existing) = query_one_noise_cleanup_job(
+            &transaction,
+            "WHERE source_session_id = ?1 AND status IN ('queued', 'processing', 'validating') ORDER BY created_at ASC LIMIT 1",
+            params![source_session_id],
+        )? {
+            transaction.commit()?;
+            return Ok(existing);
+        }
+        if let Some(completed) = query_one_noise_cleanup_job(
+            &transaction,
+            "WHERE source_session_id = ?1 AND source_identity_json = ?2
+                    AND source_object_identity_json = ?3 AND preset = ?4
+                    AND status = 'completed'
+             ORDER BY updated_at DESC, id DESC LIMIT 1",
+            params![
+                source_session_id,
+                source_identity_json,
+                source_object_identity_json,
+                preset
+            ],
+        )? {
+            let output_state = completed
+                .job
+                .output_path
+                .as_deref()
+                .map(|path| session_media_path_state(Path::new(path)))
+                .unwrap_or(SessionMediaPathState::Missing);
+            let session_exists =
+                completed
+                    .job
+                    .output_session_id
+                    .as_deref()
+                    .is_some_and(|session_id| {
+                        transaction
+                            .query_row(
+                                "SELECT 1 FROM sessions WHERE id = ?1",
+                                params![session_id],
+                                |_| Ok(()),
+                            )
+                            .optional()
+                            .ok()
+                            .flatten()
+                            .is_some()
+                    });
+            if session_exists
+                && matches!(
+                    output_state,
+                    SessionMediaPathState::Present | SessionMediaPathState::Unavailable
+                )
+            {
+                transaction.commit()?;
+                return Ok(completed);
+            }
+            transaction.execute(
+                "UPDATE noise_cleanup_jobs
+                 SET status = 'failed', progress_percent = 0, error_code = 'file-missing',
+                     error_message = 'The cleaned recording is missing or unregistered.',
+                     updated_at = ?2
+                 WHERE id = ?1",
+                params![completed.job.id, now],
+            )?;
+        }
+        let id = Uuid::new_v4().to_string();
+        transaction.execute(
+            "INSERT INTO noise_cleanup_jobs
+                (id, source_session_id, source_identity_json, source_object_identity_json,
+                 source_full_sha256, status, progress_percent, preset,
+                 created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 'pending', 'queued', 0, ?5, ?6, ?6)",
+            params![
+                id,
+                source_session_id,
+                source_identity_json,
+                source_object_identity_json,
+                preset,
+                now
+            ],
+        )?;
+        let job = query_one_noise_cleanup_job(&transaction, "WHERE id = ?1", params![id])?
+            .context("New Noise Cleanup job disappeared")?;
+        transaction.commit()?;
+        Ok(job)
+    }
+
+    /// Bind the slow full-file fingerprint, returning an existing validated
+    /// result for the exact content + filesystem object + preset when present.
+    pub(crate) fn bind_noise_cleanup_source_fingerprint(
+        &self,
+        job_id: &str,
+        source_full_sha256: &str,
+    ) -> Result<Option<NoiseCleanupJob>> {
+        let mut conn = self.lock()?;
+        let transaction = conn.transaction()?;
+        let updated = transaction.execute(
+            "UPDATE noise_cleanup_jobs SET source_full_sha256 = ?2, updated_at = ?3
+             WHERE id = ?1 AND status = 'queued'",
+            params![job_id, source_full_sha256, Utc::now().to_rfc3339()],
+        )?;
+        if updated != 1 {
+            bail!("Noise Cleanup job {job_id} was no longer queued for fingerprinting.");
+        }
+        let current = query_one_noise_cleanup_job(&transaction, "WHERE id = ?1", params![job_id])?
+            .context("Fingerprint-bound Noise Cleanup job disappeared")?;
+        let completed = query_one_noise_cleanup_job(
+            &transaction,
+            "WHERE id <> ?1 AND source_session_id = ?2 AND source_identity_json = ?3
+                    AND source_object_identity_json = ?4 AND source_full_sha256 = ?5
+                    AND preset = ?6 AND status = 'completed'
+             ORDER BY updated_at DESC LIMIT 1",
+            params![
+                job_id,
+                current.job.source_session_id,
+                serde_json::to_string(&current.source_identity.content_identity)?,
+                serde_json::to_string(&current.source_identity.object_identity)?,
+                source_full_sha256,
+                current.job.preset,
+            ],
+        )?
+        .map(|job| job.job);
+        transaction.commit()?;
+        Ok(completed)
+    }
+
+    pub(crate) fn noise_cleanup_job(
+        &self,
+        job_id: &str,
+    ) -> Result<Option<PersistedNoiseCleanupJob>> {
+        let conn = self.lock()?;
+        query_one_noise_cleanup_job(&conn, "WHERE id = ?1", params![job_id])
+    }
+
+    pub(crate) fn list_noise_cleanup_jobs(&self) -> Result<Vec<NoiseCleanupJob>> {
+        let conn = self.lock()?;
+        let mut jobs = query_noise_cleanup_jobs(
+            &conn,
+            "WHERE status IN ('queued', 'processing', 'validating')
+             ORDER BY updated_at DESC, id DESC LIMIT ?1",
+            params![MAX_NOISE_CLEANUP_JOB_LIST as i64],
+        )?;
+        let remaining = MAX_NOISE_CLEANUP_JOB_LIST.saturating_sub(jobs.len());
+        if remaining > 0 {
+            jobs.extend(query_noise_cleanup_jobs(
+                &conn,
+                "WHERE id IN (
+                    SELECT id FROM (
+                        SELECT id, ROW_NUMBER() OVER (
+                            PARTITION BY source_session_id
+                            ORDER BY updated_at DESC, id DESC
+                        ) AS source_rank
+                        FROM noise_cleanup_jobs
+                        WHERE status NOT IN ('queued', 'processing', 'validating')
+                    ) WHERE source_rank = 1
+                 ) ORDER BY updated_at DESC, id DESC LIMIT ?1",
+                params![remaining as i64],
+            )?);
+        }
+        let mut source_paths_cache: HashMap<String, Vec<String>> = HashMap::new();
+        for persisted in &jobs {
+            if persisted.job.status != NoiseCleanupJobStatus::Completed
+                || source_paths_cache.contains_key(&persisted.job.source_session_id)
+            {
+                continue;
+            }
+            let source_paths: Option<(Option<String>, Option<String>)> = conn
+                .query_row(
+                    "SELECT mp4_path, output_path FROM sessions WHERE id = ?1",
+                    params![persisted.job.source_session_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()?;
+            source_paths_cache.insert(
+                persisted.job.source_session_id.clone(),
+                source_paths
+                    .into_iter()
+                    .flat_map(|(mp4, output)| [mp4, output])
+                    .flatten()
+                    .collect(),
+            );
+        }
+        drop(conn);
+
+        let now = Utc::now().to_rfc3339();
+        for persisted in &mut jobs {
+            if persisted.job.status != NoiseCleanupJobStatus::Completed {
+                continue;
+            }
+            let output_state = persisted
+                .job
+                .output_path
+                .as_deref()
+                .map(|path| session_media_path_state(Path::new(path)))
+                .unwrap_or(SessionMediaPathState::Missing);
+            if output_state == SessionMediaPathState::Unavailable {
+                continue;
+            }
+            let output_missing = output_state == SessionMediaPathState::Missing;
+            // Metadata/object checks deliberately happen outside the DB mutex
+            // and never sample large media bodies during bootstrap.
+            let mut source_matches = false;
+            let mut source_unavailable = false;
+            if let Some(paths) = source_paths_cache.get(&persisted.job.source_session_id) {
+                for path in paths {
+                    match session_file_quick_identity_matches(
+                        Path::new(path),
+                        &persisted.source_identity,
+                    ) {
+                        Ok(true) => source_matches = true,
+                        Ok(false) => {}
+                        Err(_) => source_unavailable = true,
+                    }
+                }
+            }
+            if !output_missing && !source_matches && source_unavailable {
+                continue;
+            }
+            let source_changed = !source_matches;
+            if output_missing || source_changed {
+                let code = if output_missing {
+                    "file-missing"
+                } else {
+                    "source-changed"
+                };
+                let message = if output_missing {
+                    "The cleaned recording is missing on disk."
+                } else {
+                    "The source recording changed after this cleanup completed."
+                };
+                let mut conn = self.lock()?;
+                let transaction = conn.transaction()?;
+                transaction.execute(
+                    "UPDATE noise_cleanup_jobs
+                     SET status = 'failed', progress_percent = 0,
+                         error_code = ?2, error_message = ?3,
+                         updated_at = ?4
+                     WHERE id = ?1 AND status = 'completed'",
+                    params![persisted.job.id, code, message, now],
+                )?;
+                transaction.commit()?;
+                persisted.job.status = NoiseCleanupJobStatus::Failed;
+                persisted.job.progress_percent = 0;
+                persisted.job.error_code = Some(code.to_string());
+                persisted.job.error_message = Some(message.to_string());
+                persisted.job.updated_at = now.clone();
+            }
+        }
+        Ok(jobs.into_iter().map(|job| job.job).collect())
+    }
+
+    pub(crate) fn active_noise_cleanup_job_for_source(
+        &self,
+        source_session_id: &str,
+    ) -> Result<Option<NoiseCleanupJob>> {
+        let conn = self.lock()?;
+        Ok(query_one_noise_cleanup_job(
+            &conn,
+            "WHERE source_session_id = ?1 AND status IN ('queued', 'processing', 'validating') ORDER BY created_at ASC LIMIT 1",
+            params![source_session_id],
+        )?
+        .map(|job| job.job))
+    }
+
+    pub(crate) fn session_id_for_media_path(&self, path: &str) -> Result<Option<String>> {
+        let conn = self.lock()?;
+        conn.query_row(
+            "SELECT id FROM sessions WHERE output_path = ?1 OR mp4_path = ?1 LIMIT 1",
+            params![path],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    pub(crate) fn session_media_path_registered(&self, path: &str) -> Result<bool> {
+        let conn = self.lock()?;
+        Ok(conn
+            .query_row(
+                "SELECT 1 FROM sessions
+                 WHERE output_path = ?1 OR mp4_path = ?1
+                 LIMIT 1",
+                params![path],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some())
+    }
+
+    pub(crate) fn save_noise_cleanup_job(&self, job: &NoiseCleanupJob) -> Result<()> {
+        let conn = self.lock()?;
+        let updated = conn.execute(
+            "UPDATE noise_cleanup_jobs
+             SET status = ?2, progress_percent = ?3, output_session_id = ?4,
+                 output_path = ?5, error_code = ?6, error_message = ?7, updated_at = ?8
+             WHERE id = ?1",
+            params![
+                job.id,
+                job.status.as_str(),
+                i64::from(job.progress_percent.min(100)),
+                job.output_session_id,
+                job.output_path,
+                job.error_code,
+                job.error_message,
+                job.updated_at,
+            ],
+        )?;
+        if updated != 1 {
+            bail!("Noise Cleanup job {} was not found.", job.id);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn reconcile_interrupted_noise_cleanup_jobs(&self) -> Result<Vec<NoiseCleanupJob>> {
+        let now = Utc::now().to_rfc3339();
+        self.lock()?.execute(
+            "UPDATE noise_cleanup_jobs
+             SET status = 'queued', progress_percent = 0, output_session_id = NULL,
+                 output_path = NULL, error_code = NULL, error_message = NULL, updated_at = ?1
+             WHERE status IN ('processing', 'validating')",
+            params![now],
+        )?;
+        let conn = self.lock()?;
+        query_noise_cleanup_jobs(
+            &conn,
+            "WHERE status = 'queued' ORDER BY created_at ASC, id ASC",
+            [],
+        )
+        .map(|jobs| jobs.into_iter().map(|job| job.job).collect())
+    }
+
+    /// Commit the managed derivative row and its completed job state in one
+    /// SQLite transaction. The file-operation journal is intentionally removed
+    /// after this commit: a crash before commit rolls the exact owned file back;
+    /// a crash after commit retains the row/file pair and startup only retires
+    /// the still-present journal.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn complete_noise_cleanup_derivative(
+        &self,
+        job_id: &str,
+        source_session_id: &str,
+        output_session_id: &str,
+        title: &str,
+        source_title: &str,
+        output_path: &str,
+        container: &str,
+        duration_ms: Option<i64>,
+        file_size_bytes: i64,
+    ) -> Result<bool> {
+        let now = Utc::now().to_rfc3339();
+        let is_mp4 = container == "mp4";
+        let mut conn = self.lock()?;
+        let transaction = conn.transaction()?;
+        let inserted = transaction.execute(
+            "INSERT INTO sessions
+                (id, title, started_at, ended_at, status, mode, output_path, mp4_path,
+                 stream_preset, container, duration_ms, sources_json, layout_json, output_json,
+                 diagnostics_json, file_size_bytes, derived_from_session_id, source_title,
+                 processing_kind)
+             SELECT ?3, ?4, ?6, ?6, 'completed', mode,
+                    CASE WHEN ?9 = 0 THEN ?7 ELSE NULL END,
+                    CASE WHEN ?9 = 1 THEN ?7 ELSE NULL END,
+                    stream_preset, ?8, COALESCE(?10, duration_ms), sources_json, layout_json,
+                    output_json, NULL, ?11, ?2, ?5, 'noise-cleanup'
+             FROM sessions WHERE id = ?2",
+            params![
+                job_id,
+                source_session_id,
+                output_session_id,
+                title,
+                source_title,
+                now,
+                output_path,
+                container,
+                is_mp4 as i64,
+                duration_ms,
+                file_size_bytes,
+            ],
+        )?;
+        if inserted != 1 {
+            return Ok(false);
+        }
+        let completed = transaction.execute(
+            "UPDATE noise_cleanup_jobs
+             SET status = 'completed', progress_percent = 100, output_session_id = ?2,
+                 output_path = ?3, error_code = NULL, error_message = NULL, updated_at = ?4
+             WHERE id = ?1 AND source_session_id = ?5
+               AND source_full_sha256 <> 'pending'
+               AND status IN ('queued', 'processing', 'validating')",
+            params![
+                job_id,
+                output_session_id,
+                output_path,
+                now,
+                source_session_id
+            ],
+        )?;
+        if completed != 1 {
+            bail!("Noise Cleanup job {job_id} was no longer active at derivative commit.");
+        }
+        transaction.commit()?;
+        Ok(true)
+    }
+
     #[cfg(test)]
     pub fn save_live_chat_message(&self, message: &LiveChatMessage) -> Result<()> {
         self.save_live_chat_messages(std::slice::from_ref(message))
@@ -2415,7 +2967,8 @@ impl Database {
         let mut stmt = conn.prepare(
             "SELECT id, title, started_at, ended_at, status, mode, output_path, mp4_path,
                     stream_preset, container, duration_ms, sources_json, layout_json,
-                    diagnostics_json, file_size_bytes
+                    diagnostics_json, file_size_bytes, derived_from_session_id, source_title,
+                    processing_kind
              FROM sessions
              WHERE library_hidden = 0
              ORDER BY started_at DESC
@@ -2442,6 +2995,9 @@ impl Database {
                 layout_json,
                 diagnostics_json,
                 row.get::<_, Option<i64>>(14)?,
+                row.get::<_, Option<String>>(15)?,
+                row.get::<_, Option<String>>(16)?,
+                row.get::<_, Option<String>>(17)?,
             ))
         })?;
 
@@ -2463,6 +3019,9 @@ impl Database {
                 layout_json,
                 diagnostics_json,
                 stored_file_size,
+                derived_from_session_id,
+                source_title,
+                processing_kind,
             ) = row?;
 
             // Size truth (Library rewrite L1): stat the VISIBLE file live while
@@ -2491,6 +3050,9 @@ impl Database {
                 session_logs: self.session_logs_for_session_locked(&conn, &id)?,
                 ai_artifacts: self.ai_artifacts_for_session_locked(&conn, &id)?,
                 comment_count: self.live_chat_message_count_for_session_locked(&conn, &id)?,
+                derived_from_session_id,
+                source_title,
+                processing_kind,
                 quality_status: self.latest_quality_status_for_session_locked(
                     &conn,
                     output_path.as_deref(),
@@ -2538,7 +3100,7 @@ impl Database {
         staging_path: &Path,
         final_path: &Path,
     ) -> Result<SessionFileOperation> {
-        if !matches!(kind, "import" | "duplicate") {
+        if !matches!(kind, "import" | "duplicate" | "noise-cleanup") {
             bail!("Unsupported session file operation kind: {kind}");
         }
         if staging_path == final_path {
@@ -3170,9 +3732,11 @@ impl Database {
         let inserted = conn.execute(
             "INSERT INTO sessions (id, title, started_at, ended_at, status, mode, output_path,
                                    mp4_path, stream_preset, container, duration_ms, sources_json,
-                                   layout_json, output_json, diagnostics_json, file_size_bytes)
+                                   layout_json, output_json, diagnostics_json, file_size_bytes,
+                                   derived_from_session_id, source_title, processing_kind)
              SELECT ?2, ?3, ?6, ?6, 'completed', mode, ?4, ?5, stream_preset, container,
-                    duration_ms, sources_json, layout_json, output_json, NULL, ?7
+                    duration_ms, sources_json, layout_json, output_json, NULL, ?7,
+                    derived_from_session_id, source_title, processing_kind
              FROM sessions WHERE id = ?1",
             params![
                 source_id,
@@ -3992,7 +4556,10 @@ impl Database {
                 sources_json TEXT NOT NULL,
                 layout_json TEXT NOT NULL,
                 output_json TEXT NOT NULL,
-                diagnostics_json TEXT
+                diagnostics_json TEXT,
+                derived_from_session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+                source_title TEXT,
+                processing_kind TEXT
             );
 
             CREATE TABLE IF NOT EXISTS health_events (
@@ -4131,6 +4698,40 @@ impl Database {
                 published_identity_json TEXT
             );
 
+            CREATE TABLE IF NOT EXISTS noise_cleanup_jobs (
+                id TEXT PRIMARY KEY,
+                source_session_id TEXT NOT NULL,
+                source_identity_json TEXT NOT NULL,
+                source_object_identity_json TEXT NOT NULL,
+                source_full_sha256 TEXT NOT NULL,
+                status TEXT NOT NULL,
+                progress_percent INTEGER NOT NULL DEFAULT 0,
+                preset TEXT NOT NULL,
+                output_session_id TEXT,
+                output_path TEXT,
+                error_code TEXT,
+                error_message TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY(source_session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+                FOREIGN KEY(output_session_id) REFERENCES sessions(id) ON DELETE SET NULL
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_noise_cleanup_one_active_per_source
+                ON noise_cleanup_jobs(source_session_id)
+                WHERE status IN ('queued', 'processing', 'validating');
+            CREATE TRIGGER IF NOT EXISTS trg_noise_cleanup_derivative_deleted
+            BEFORE DELETE ON sessions
+            FOR EACH ROW
+            BEGIN
+                UPDATE noise_cleanup_jobs
+                SET status = 'failed', progress_percent = 0, output_session_id = NULL,
+                    output_path = NULL, error_code = 'file-missing',
+                    error_message = 'The cleaned recording was deleted.',
+                    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                WHERE output_session_id = OLD.id AND status = 'completed';
+            END;
+
             CREATE TABLE IF NOT EXISTS session_delete_operations (
                 id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL UNIQUE,
@@ -4179,6 +4780,47 @@ impl Database {
             "sessions",
             "library_hidden",
             "library_hidden INTEGER NOT NULL DEFAULT 0",
+        )?;
+        ensure_column(
+            &conn,
+            "sessions",
+            "derived_from_session_id",
+            "derived_from_session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL",
+        )?;
+        ensure_column(&conn, "sessions", "source_title", "source_title TEXT")?;
+        ensure_column(&conn, "sessions", "processing_kind", "processing_kind TEXT")?;
+        ensure_column(
+            &conn,
+            "noise_cleanup_jobs",
+            "source_object_identity_json",
+            "source_object_identity_json TEXT",
+        )?;
+        ensure_column(
+            &conn,
+            "noise_cleanup_jobs",
+            "source_full_sha256",
+            "source_full_sha256 TEXT",
+        )?;
+        conn.execute(
+            "UPDATE noise_cleanup_jobs
+             SET status = 'failed', progress_percent = 0,
+                 source_object_identity_json = COALESCE(
+                    source_object_identity_json, '{\"volumeId\":0,\"fileId\":0}'
+                 ),
+                 source_full_sha256 = COALESCE(source_full_sha256, 'legacy-unverified'),
+                 output_session_id = NULL, output_path = NULL,
+                 error_code = 'source-changed',
+                 error_message = 'Noise Cleanup must be retried after the safety upgrade.',
+                 updated_at = ?1
+             WHERE source_object_identity_json IS NULL OR source_full_sha256 IS NULL",
+            params![Utc::now().to_rfc3339()],
+        )?;
+        conn.execute_batch(
+            "DROP INDEX IF EXISTS idx_noise_cleanup_completed_identity_preset;
+             CREATE INDEX idx_noise_cleanup_completed_identity_preset
+                ON noise_cleanup_jobs(source_session_id, source_identity_json,
+                                      source_object_identity_json, source_full_sha256, preset)
+                WHERE status = 'completed';",
         )?;
         ensure_column(
             &conn,
@@ -4534,6 +5176,79 @@ fn chat_send_operation_from_row(
         created_at: row.get(5)?,
         updated_at: row.get(6)?,
     })
+}
+
+fn noise_cleanup_job_from_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<PersistedNoiseCleanupJob> {
+    let status_text: String = row.get(5)?;
+    let status = status_text.parse().map_err(|error: String| {
+        rusqlite::Error::FromSqlConversionFailure(
+            5,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
+        )
+    })?;
+    let progress: i64 = row.get(6)?;
+    let source_identity_json: String = row.get(2)?;
+    let source_content_identity = serde_json::from_str(&source_identity_json).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(error))
+    })?;
+    let source_object_identity_json: String = row.get(3)?;
+    let source_object_identity =
+        serde_json::from_str(&source_object_identity_json).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+    Ok(PersistedNoiseCleanupJob {
+        job: NoiseCleanupJob {
+            id: row.get(0)?,
+            source_session_id: row.get(1)?,
+            status,
+            progress_percent: u8::try_from(progress.clamp(0, 100)).unwrap_or(0),
+            preset: row.get(7)?,
+            output_session_id: row.get(8)?,
+            output_path: row.get(9)?,
+            error_code: row.get(10)?,
+            error_message: row.get(11)?,
+            created_at: row.get(12)?,
+            updated_at: row.get(13)?,
+        },
+        source_identity: SessionFileBoundIdentity {
+            content_identity: source_content_identity,
+            object_identity: source_object_identity,
+        },
+        source_full_sha256: row.get(4)?,
+    })
+}
+
+fn query_noise_cleanup_jobs<P: rusqlite::Params>(
+    conn: &Connection,
+    filter: &str,
+    params: P,
+) -> Result<Vec<PersistedNoiseCleanupJob>> {
+    let sql = format!(
+        "SELECT id, source_session_id, source_identity_json, source_object_identity_json,
+                source_full_sha256, status, progress_percent, preset,
+                output_session_id, output_path, error_code, error_message, created_at, updated_at
+         FROM noise_cleanup_jobs {filter}"
+    );
+    let mut statement = conn.prepare(&sql)?;
+    let rows = statement.query_map(params, noise_cleanup_job_from_row)?;
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn query_one_noise_cleanup_job<P: rusqlite::Params>(
+    conn: &Connection,
+    filter: &str,
+    params: P,
+) -> Result<Option<PersistedNoiseCleanupJob>> {
+    let mut jobs = query_noise_cleanup_jobs(conn, filter, params)?;
+    Ok(jobs.pop())
 }
 
 fn query_repair_jobs(conn: &Connection, filter: &str) -> Result<Vec<RepairJob>> {

--- a/crates/videorc-backend/src/support_bundle.rs
+++ b/crates/videorc-backend/src/support_bundle.rs
@@ -634,6 +634,9 @@ mod tests {
                 created_at: "2026-06-13T00:00:01Z".to_string(),
             }],
             comment_count: 0,
+            derived_from_session_id: None,
+            source_title: None,
+            processing_kind: None,
         };
 
         let (sessions, summary) = redact_sessions(vec![session]);

--- a/crates/videorc-backend/src/videorc_api.rs
+++ b/crates/videorc-backend/src/videorc_api.rs
@@ -17,6 +17,8 @@ use serde::de::DeserializeOwned;
 
 pub(crate) const CAPTION_CHUNK_UPLOAD_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(10);
+pub(crate) const AI_CAPABILITIES_REQUEST_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(8);
 const DESKTOP_AUTH_EXCHANGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 use crate::protocol::{
@@ -281,8 +283,28 @@ impl VideorcApiClient {
 
     /// Fetch safe client-facing AI capability metadata for the signed-in user.
     pub async fn get_ai_capabilities(&self, bearer_token: &str) -> Result<AiCapabilities> {
-        self.get_bearer_json("/api/ai/capabilities", bearer_token)
+        let path = "/api/ai/capabilities";
+        let response = self
+            .http
+            .get(self.endpoint(path))
+            .bearer_auth(bearer_token)
+            .timeout(AI_CAPABILITIES_REQUEST_TIMEOUT)
+            .send()
             .await
+            .with_context(|| format!("Could not reach Videorc API path {path}."))?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            bail!("Sign in to use cloud AI.");
+        }
+        if !response.status().is_success() {
+            let status = response.status();
+            let message = read_safe_error_message(response).await;
+            bail!("Videorc API request failed ({status}): {message}");
+        }
+        response
+            .json()
+            .await
+            .with_context(|| format!("Could not read Videorc API response for {path}."))
     }
 
     /// Fetch safe client-facing AI quota metadata for the signed-in user.
@@ -679,6 +701,12 @@ mod tests {
         );
         assert_eq!(resolve_api_base_url(true, Some("   ")), DEV_API_BASE_URL);
         assert_eq!(resolve_api_base_url(true, None), DEV_API_BASE_URL);
+    }
+
+    #[test]
+    fn entitlement_capability_request_finishes_before_the_rpc_deadline() {
+        assert!(!AI_CAPABILITIES_REQUEST_TIMEOUT.is_zero());
+        assert!(AI_CAPABILITIES_REQUEST_TIMEOUT < std::time::Duration::from_secs(10));
     }
 
     #[test]

--- a/docs/acceptance/2026-07-13-noise-cleanup.md
+++ b/docs/acceptance/2026-07-13-noise-cleanup.md
@@ -1,0 +1,84 @@
+# Noise Cleanup — acceptance, 2026-07-13
+
+Scope: the Premium Noise Cleanup implementation in the desktop/backend repository
+and the companion Premium-copy change in `videorcweb`, following the Obsidian plan
+`2026-07-13 - Videorc Noise Cleanup Premium Feature Plan`.
+
+This note records deterministic evidence separately from release-stage manual and
+platform evidence. It intentionally contains no secrets, recordings, generated
+media, usernames, or machine-local evidence paths.
+
+## Product and safety contract
+
+| Contract                    | Result | Evidence                                                                                                                                                                                                                                                                    |
+| --------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Premium gate                | PASS   | `noise-cleanup` is an explicit Rust/TypeScript capability. Basic and missing snapshots fail closed; Premium and Developer pass. Backend authorization runs before durable work is created, and the old environment override cannot unlock a release build.                  |
+| One-click Library action    | PASS   | The responsive direct action and matching kebab command cover upgrade, start, queued, processing, validating, cancel, retry, completed, derivative, reconnecting, and unsupported-session states. Intrinsic blockers resolve before the Premium upsell.                     |
+| Local-only processing       | PASS   | The backend resolves the managed session path and bundled FFmpeg locally. No upload, provider credential, cloud-consent, quota, Creem product, or entitlement-database change was added.                                                                                    |
+| Non-destructive derivative  | PASS   | Work stages beside a numbered destination, validates before publication, and inserts a managed `— Noise Cleaned` session with immutable source-title/provenance fields. The original is never overwritten.                                                                  |
+| Exact media policy          | PASS   | MP4 uses AAC 192 kbps; MKV uses `pcm_s16le`; video and non-audio streams are copied. Unsupported containers, imported sessions, missing/unfinished/live sessions, test-tone sources, no-audio input, and ambiguous multi-audio input fail clearly.                          |
+| Durable jobs                | PASS   | SQLite owns queued/processing/validating/completed/failed/cancelled state, active-job uniqueness, restart recovery, completed-result idempotency, bounded history, and missing/unavailable media reconciliation. Renderer navigation or row unmount does not own job truth. |
+| Capture precedence          | PASS   | Full-file identity reads, FFprobe/FFmpeg work, validation, and publication checks all observe app-owned cancellation/capture-preemption state. Capture returns cleanup to queued; user cancellation is terminal.                                                            |
+| Identity and path ownership | PASS   | Full SHA-256 plus sampled content and filesystem-object identity reject same-size and object replacements. Output naming reserves every Library-owned database path, including currently missing files, and unavailable volumes never cause derivative metadata deletion.   |
+| Entitlement freshness       | PASS   | Focus, bounded signed-in polling, explicit refresh, and backend events update the renderer. The capability HTTP request has an 8-second request timeout inside the 10-second RPC deadline.                                                                                  |
+| Marketing truth             | PASS   | Pricing, Premium, account, FAQ, CTA, metadata, and showcase copy promise one-click on-device cleanup with no upload or quota. Smart Zoom and Silence Removal remain experimental; free 4K recording and Basic single-destination streaming remain truthful.                 |
+
+## Media proof
+
+The versioned `speech-v1` preset is locked to
+`afftdn=nr=18:nf=-34:tn=1`. The bundled macOS FFmpeg passed capability and
+artifact preflight for `afftdn`, AAC, `pcm_s16le`, RTMP/TLS, and VideoToolbox.
+
+| Artifact | Noise reduction | SNR gain | Voice-band delta | Duration delta | Video                              |
+| -------- | --------------: | -------: | ---------------: | -------------: | ---------------------------------- |
+| MP4      |          3.4 dB |   2.0 dB |           0.1 dB |         0.0 ms | Packet hashes match; stream copied |
+| MKV      |          3.1 dB |   2.0 dB |           0.0 dB |         1.0 ms | Packet hashes match; stream copied |
+
+Both sources remained byte-for-byte unchanged. Both outputs decoded, retained
+audio, and passed the maintained final-artifact A/V analyzer. The smoke generates
+its deterministic fixtures at runtime and commits no media.
+
+Real backend integration also proves MP4 completion, MKV completion with
+`pcm_s16le`, ambiguous-audio rejection, queued and running cancellation,
+capture preemption/resume, restart recovery, changed-source rejection, and
+identity-owned rollback.
+
+## Gate record
+
+| Gate                                 | Result                | Notes                                                                                                                                                                                                                                                  |
+| ------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| TypeScript typecheck / lint / format | PASS                  | Node 24 and pnpm 11; no warnings.                                                                                                                                                                                                                      |
+| Desktop production build             | PASS                  | Main, preload, and renderer bundles built.                                                                                                                                                                                                             |
+| Desktop tests                        | PASS                  | 127 files; 1,034 passed and one existing OBS-import test skipped.                                                                                                                                                                                      |
+| Node script tests                    | PASS                  | 618/618 across 120 suites, including macOS/Windows FFmpeg capability and Noise Cleanup artifact assertions.                                                                                                                                            |
+| JS production advisory audit         | PASS                  | No known production vulnerabilities found.                                                                                                                                                                                                             |
+| Rust format / clippy                 | PASS                  | `cargo fmt --check --all`; clippy with warnings denied.                                                                                                                                                                                                |
+| Rust tests                           | PASS                  | 48 native-preview-helper + 1,251 backend + 1 wire test = 1,300 passed; 8 ignored, 0 failed.                                                                                                                                                            |
+| Bundled Noise Cleanup artifact smoke | PASS                  | MP4/MKV source immutability, objective metrics, stream-copy hashes, codec policy, duration, and A/V analysis passed.                                                                                                                                   |
+| macOS package preflight              | PASS                  | Release backend/helper and universal native-preview addon built; bundled FFmpeg capability and artifact proof passed.                                                                                                                                  |
+| Recording Studio aggregate           | PARTIAL / ENV BLOCKED | Steps 1–23 passed, including maintained Noise Cleanup, all-layout recording, imported-screen, captions, native preview lifecycle/window/surface, scene, focus, and stress gates. Step 24 stopped because this host exposes no ScreenCaptureKit source. |
+| Notes-window real-screen smoke       | ENV BLOCKED           | Rerun separately; the same missing ScreenCaptureKit source blocked before capture.                                                                                                                                                                     |
+| Companion web verification           | PASS                  | 305/305 tests, typecheck, build, and Vercel preview checks passed; lint has one unrelated existing contributors-image warning.                                                                                                                         |
+
+The focused aggregate desktop suite printed one non-failing `window is not
+defined` diagnostic from an upstream native-preview async callback after its
+test completed. The full desktop suite, typecheck, lint, production build, and
+the maintained native-preview smokes all passed; this is not attributed to
+Noise Cleanup and is not silently represented as a clean log.
+
+## Release-stage evidence still required
+
+| Evidence                                | State   | Required proof                                                                                                                                                                                                                        |
+| --------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Real-voice listening panel              | BLOCKED | An owner must compare clean, noisy, gentle, selected `speech-v1`, and strong samples by ear and reject pumping, metallic speech, or clipped consonants. Objective evidence alone does not satisfy this row.                           |
+| Windows native/package run              | BLOCKED | No Windows host or MSVC/Windows SDK is available here. A compile-only cross-check stopped in native dependencies because Windows C headers were absent; run the real Windows package preflight and MP4/MKV artifact smoke on Windows. |
+| Desktop dark/light/narrow/keyboard pass | BLOCKED | Automated semantics, SSR accessibility, responsive-state, focusable-disabled-tooltip, and keyboard-native Button coverage pass. A human Electron sweep at both themes and narrow/wide widths remains required.                        |
+| Real ScreenCaptureKit recording         | BLOCKED | The host has no discoverable native screen source. This does not block the local post-processing engine, but cross-feature recording acceptance remains explicit.                                                                     |
+
+## Review verdict
+
+The implementation is suitable for draft-PR review. Deterministic product,
+authorization, persistence, media, macOS package, web-copy, and regression proof
+is green. It is not yet a declaration of Windows parity, by-ear audio acceptance,
+or final desktop visual acceptance; those rows must be completed before changing
+the PR from draft or shipping the Premium promise to production.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -274,20 +274,22 @@ needed, failures, and final PASS/FAIL/BLOCKED verdict in a dated note under
 
 ## Open-Core Capability Boundary
 
-Videorc's product boundary is open core: the local recording studio remains a
-first-class free product, while distribution and cloud-assisted workflows are
-premium capabilities. This repository enforces the capability boundary; pricing
-and purchase flows belong to the product/website layer.
+Videorc's product boundary is open core: the local recording studio and its
+technical file-management tools remain a first-class free product, while
+distribution, cloud-assisted workflows, and optional local creative transforms
+are premium capabilities. This repository enforces the capability boundary;
+pricing and purchase flows belong to the product/website layer.
 
-| Capability                 | Free/core                                                                              | Premium                                                                                  |
-| -------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Local recording            | Included: local MKV/MP4 recording remains first-class.                                 | Included.                                                                                |
-| Native preview             | Included: production preview uses the detached CAMetalLayer path when available.       | Included.                                                                                |
-| Source and layout controls | Included: source selection, camera placement, presets, and local layout controls.      | Included.                                                                                |
-| Local library              | Included: session metadata, local files, remux, repair, and export helpers stay local. | Included.                                                                                |
-| Local audio extraction     | Included when no cloud upload is requested.                                            | Included.                                                                                |
-| Livestreaming destinations | Not included in free/core.                                                             | Included: manual RTMP, provider destinations, and multistreaming.                        |
-| Cloud AI workflow          | Not included in free/core.                                                             | Included when the user grants cloud AI consent and required API credentials are present. |
+| Capability                 | Free/core                                                                                        | Premium                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Local recording            | Included: local MKV/MP4 recording remains first-class.                                           | Included.                                                                                |
+| Native preview             | Included: production preview uses the detached CAMetalLayer path when available.                 | Included.                                                                                |
+| Source and layout controls | Included: source selection, camera placement, presets, and local layout controls.                | Included.                                                                                |
+| Local library              | Included: session metadata, local files, remux, repair, and export helpers stay local.           | Included.                                                                                |
+| Local audio extraction     | Included when no cloud upload is requested.                                                      | Included.                                                                                |
+| Local creative transforms  | Not included: optional content-enhancement transforms are separate from technical repair/export. | Included: one-click on-device Noise Cleanup for finished recordings.                     |
+| Livestreaming destinations | Included: one destination at the Basic HD limits.                                                | Included: higher streaming limits and multistreaming.                                    |
+| Cloud AI workflow          | Not included in free/core.                                                                       | Included when the user grants cloud AI consent and required API credentials are present. |
 
 How the boundary is enforced (since 2026-07-05 there is no runtime unlock):
 
@@ -310,10 +312,12 @@ How the boundary is enforced (since 2026-07-05 there is no runtime unlock):
   patched client cannot reach them.
 
 Local recording, native preview, source/layout controls, the library, local
-repair/remux, and local audio extraction without upload must not require
-premium entitlement. Anyone distributing a modified build must also follow
-[TRADEMARK.md](../TRADEMARK.md) (rebrand, own bundle id, own OAuth clients,
-own feed/backend).
+repair/remux/export, and local audio extraction without upload must not require
+premium entitlement. Optional creative transforms that change recording content,
+such as Noise Cleanup, may require Premium even when their media processing stays
+on-device. Anyone distributing a modified build must also follow
+[TRADEMARK.md](../TRADEMARK.md) (rebrand, own bundle id, own OAuth clients, own
+feed/backend).
 
 ## OAuth Client IDs
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "smoke:captions-live": "node scripts/smoke-captions-live-app.mjs",
     "captions:contact-sheet": "node scripts/caption-style-contact-sheet.mjs",
     "smoke:repair-encoder": "node scripts/smoke-repair-encoder.mjs",
+    "smoke:noise-cleanup": "node scripts/smoke-noise-cleanup.mjs",
+    "smoke:noise-cleanup:bundled": "node scripts/smoke-noise-cleanup.mjs --require-bundled",
     "smoke:obs-import": "node scripts/smoke-obs-import.mjs",
     "smoke:process-lifecycle": "node scripts/smoke-process-lifecycle.mjs",
     "smoke:process-memory": "node scripts/smoke-process-memory.mjs --gate",

--- a/scripts/lib/noise-cleanup-artifact.mjs
+++ b/scripts/lib/noise-cleanup-artifact.mjs
@@ -1,0 +1,326 @@
+import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export const NOISE_CLEANUP_PRESET = 'speech-v1'
+export const NOISE_CLEANUP_FILTER = 'afftdn=nr=18:nf=-34:tn=1'
+export const NOISE_CLEANUP_CANDIDATES = Object.freeze([
+  { name: 'gentle', filter: 'afftdn=nr=12:nf=-38:tn=1' },
+  { name: NOISE_CLEANUP_PRESET, filter: NOISE_CLEANUP_FILTER },
+  { name: 'strong', filter: 'afftdn=nr=24:nf=-30:tn=1' }
+])
+
+export function noiseCleanupArgs(inputPath, outputPath, filter = NOISE_CLEANUP_FILTER) {
+  const audioCodecArgs = outputPath.toLowerCase().endsWith('.mkv')
+    ? ['-c:a', 'pcm_s16le']
+    : ['-c:a', 'aac', '-b:a', '192k']
+  return [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-nostdin',
+    '-n',
+    '-i',
+    inputPath,
+    '-map',
+    '0',
+    '-map_metadata',
+    '0',
+    '-c',
+    'copy',
+    ...audioCodecArgs,
+    '-af',
+    filter,
+    '-progress',
+    'pipe:1',
+    outputPath
+  ]
+}
+
+export function noisySpeechFixtureArgs(outputPath) {
+  const audioCodecArgs = outputPath.toLowerCase().endsWith('.mkv')
+    ? ['-c:a', 'pcm_s16le']
+    : ['-c:a', 'aac', '-b:a', '192k']
+  return [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-nostdin',
+    '-y',
+    '-f',
+    'lavfi',
+    '-i',
+    'testsrc2=size=640x360:rate=30:duration=8',
+    '-f',
+    'lavfi',
+    '-i',
+    'aevalsrc=0.18*sin(2*PI*180*t)+0.12*sin(2*PI*360*t)+0.08*sin(2*PI*720*t):s=48000:d=8',
+    '-f',
+    'lavfi',
+    '-i',
+    'anoisesrc=color=pink:amplitude=0.05:sample_rate=48000:duration=8:seed=1337',
+    '-filter_complex',
+    "[1:a]volume='if(between(t,2,6),1,0)':eval=frame[voice];[voice][2:a]amix=inputs=2:normalize=0[a]",
+    '-map',
+    '0:v',
+    '-map',
+    '[a]',
+    '-c:v',
+    'mpeg4',
+    '-q:v',
+    '5',
+    '-pix_fmt',
+    'yuv420p',
+    ...audioCodecArgs,
+    '-shortest',
+    outputPath
+  ]
+}
+
+export function parseMeanVolume(stderr) {
+  const match = stderr.match(/mean_volume:\s*(-?\d+(?:\.\d+)?)\s*dB/)
+  if (!match) {
+    throw new Error(`volumedetect did not report mean_volume: ${stderr.slice(-500)}`)
+  }
+  return Number(match[1])
+}
+
+export function parseStreamHash(stdout) {
+  const match = stdout.match(/SHA256=([a-f0-9]{64})/i)
+  if (!match) {
+    throw new Error(`ffmpeg did not report a SHA256 stream hash: ${stdout.slice(-500)}`)
+  }
+  return match[1].toLowerCase()
+}
+
+export async function runNoiseCleanupArtifactSmoke({
+  ffmpegPath,
+  ffprobePath,
+  sourcePath,
+  outputPath,
+  filter = NOISE_CLEANUP_FILTER
+}) {
+  await run(ffmpegPath, noisySpeechFixtureArgs(sourcePath))
+  const sourceFileHashBefore = await fileSha256(sourcePath)
+  await run(ffmpegPath, noiseCleanupArgs(sourcePath, outputPath, filter))
+  const sourceFileHashAfter = await fileSha256(sourcePath)
+
+  const [sourceNoiseDb, outputNoiseDb, sourceVoiceDb, outputVoiceDb] = await Promise.all([
+    meanVolume(ffmpegPath, sourcePath, 0.5, 1),
+    meanVolume(ffmpegPath, outputPath, 0.5, 1),
+    meanVolume(ffmpegPath, sourcePath, 3, 1),
+    meanVolume(ffmpegPath, outputPath, 3, 1)
+  ])
+  const [sourceVideoHash, outputVideoHash] = await Promise.all([
+    videoStreamHash(ffmpegPath, sourcePath),
+    videoStreamHash(ffmpegPath, outputPath)
+  ])
+  const [sourceDuration, outputDuration] = await Promise.all([
+    durationSeconds(ffprobePath, sourcePath),
+    durationSeconds(ffprobePath, outputPath)
+  ])
+  const [referenceSamples, sourceSamples, outputSamples] = await Promise.all([
+    referenceVoiceSamples(ffmpegPath),
+    decodedVoiceSamples(ffmpegPath, sourcePath),
+    decodedVoiceSamples(ffmpegPath, outputPath)
+  ])
+  const sourceSnrDb = signalToNoiseRatioDb(referenceSamples, sourceSamples)
+  const outputSnrDb = signalToNoiseRatioDb(referenceSamples, outputSamples)
+
+  return {
+    preset: NOISE_CLEANUP_PRESET,
+    filter,
+    sourceFileUnchanged: sourceFileHashBefore === sourceFileHashAfter,
+    videoStreamCopied: sourceVideoHash === outputVideoHash,
+    noiseReductionDb: sourceNoiseDb - outputNoiseDb,
+    sourceSnrDb,
+    outputSnrDb,
+    snrImprovementDb: outputSnrDb - sourceSnrDb,
+    voiceLevelDeltaDb: Math.abs(sourceVoiceDb - outputVoiceDb),
+    durationDeltaMs: Math.abs(sourceDuration - outputDuration) * 1000,
+    sourceDuration,
+    outputDuration
+  }
+}
+
+export function signalToNoiseRatioDb(reference, observed) {
+  const lag = bestCorrelationLag(reference, observed)
+  const referenceStart = Math.max(0, -lag)
+  const observedStart = Math.max(0, lag)
+  const length = Math.min(reference.length - referenceStart, observed.length - observedStart)
+  if (length === 0) {
+    throw new Error('cannot calculate SNR from empty sample arrays')
+  }
+  let signalPower = 0
+  let errorPower = 0
+  for (let index = 0; index < length; index += 1) {
+    const expected = reference[referenceStart + index]
+    const error = observed[observedStart + index] - expected
+    signalPower += expected * expected
+    errorPower += error * error
+  }
+  if (signalPower === 0 || errorPower === 0) {
+    return errorPower === 0 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY
+  }
+  return 10 * Math.log10(signalPower / errorPower)
+}
+
+function bestCorrelationLag(reference, observed) {
+  const maxLag = Math.min(8192, reference.length - 1, observed.length - 1)
+  const sampleLength = Math.min(reference.length, observed.length, 48_000)
+  const stride = 32
+  let bestLag = 0
+  let bestScore = Number.NEGATIVE_INFINITY
+  for (let lag = -maxLag; lag <= maxLag; lag += 1) {
+    const referenceStart = Math.max(0, -lag)
+    const observedStart = Math.max(0, lag)
+    const length = Math.min(
+      sampleLength - referenceStart,
+      sampleLength - observedStart,
+      reference.length - referenceStart,
+      observed.length - observedStart
+    )
+    if (length <= 0) continue
+    let dot = 0
+    let referencePower = 0
+    let observedPower = 0
+    for (let index = 0; index < length; index += stride) {
+      const expected = reference[referenceStart + index]
+      const actual = observed[observedStart + index]
+      dot += expected * actual
+      referencePower += expected * expected
+      observedPower += actual * actual
+    }
+    const score = dot / Math.sqrt(referencePower * observedPower)
+    if (score > bestScore) {
+      bestScore = score
+      bestLag = lag
+    }
+  }
+  return bestLag
+}
+
+async function run(executable, args) {
+  return execFileAsync(executable, args, { maxBuffer: 8 * 1024 * 1024 })
+}
+
+async function runBinary(executable, args) {
+  return execFileAsync(executable, args, {
+    encoding: 'buffer',
+    maxBuffer: 32 * 1024 * 1024
+  })
+}
+
+async function referenceVoiceSamples(ffmpegPath) {
+  const { stdout } = await runBinary(ffmpegPath, [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-f',
+    'lavfi',
+    '-i',
+    'aevalsrc=0.18*sin(2*PI*180*t)+0.12*sin(2*PI*360*t)+0.08*sin(2*PI*720*t):s=48000:d=4',
+    '-ac',
+    '1',
+    '-ar',
+    '48000',
+    '-f',
+    'f32le',
+    'pipe:1'
+  ])
+  return float32Samples(stdout)
+}
+
+async function decodedVoiceSamples(ffmpegPath, filePath) {
+  const { stdout } = await runBinary(ffmpegPath, [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-ss',
+    '2',
+    '-t',
+    '4',
+    '-i',
+    filePath,
+    '-map',
+    '0:a:0',
+    '-ac',
+    '1',
+    '-ar',
+    '48000',
+    '-f',
+    'f32le',
+    'pipe:1'
+  ])
+  return float32Samples(stdout)
+}
+
+function float32Samples(buffer) {
+  const aligned = buffer.byteLength - (buffer.byteLength % 4)
+  return new Float32Array(buffer.buffer, buffer.byteOffset, aligned / 4)
+}
+
+async function meanVolume(ffmpegPath, filePath, startSeconds, durationSecondsValue) {
+  const { stderr } = await run(ffmpegPath, [
+    '-hide_banner',
+    '-ss',
+    String(startSeconds),
+    '-t',
+    String(durationSecondsValue),
+    '-i',
+    filePath,
+    '-vn',
+    '-af',
+    'volumedetect',
+    '-f',
+    'null',
+    '-'
+  ])
+  return parseMeanVolume(stderr)
+}
+
+async function videoStreamHash(ffmpegPath, filePath) {
+  const { stdout } = await run(ffmpegPath, [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-i',
+    filePath,
+    '-map',
+    '0:v:0',
+    '-c',
+    'copy',
+    '-f',
+    'hash',
+    '-hash',
+    'sha256',
+    'pipe:1'
+  ])
+  return parseStreamHash(stdout)
+}
+
+async function durationSeconds(ffprobePath, filePath) {
+  const { stdout } = await run(ffprobePath, [
+    '-v',
+    'error',
+    '-show_entries',
+    'format=duration',
+    '-of',
+    'default=noprint_wrappers=1:nokey=1',
+    filePath
+  ])
+  const duration = Number(stdout.trim())
+  if (!Number.isFinite(duration)) {
+    throw new Error(`ffprobe returned an invalid duration for ${filePath}: ${stdout}`)
+  }
+  return duration
+}
+
+async function fileSha256(filePath) {
+  return createHash('sha256')
+    .update(await readFile(filePath))
+    .digest('hex')
+}

--- a/scripts/lib/noise-cleanup-artifact.test.mjs
+++ b/scripts/lib/noise-cleanup-artifact.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, it } from 'node:test'
+
+import { ffmpegAvailable } from './ffmpeg-available.mjs'
+import {
+  NOISE_CLEANUP_CANDIDATES,
+  NOISE_CLEANUP_FILTER,
+  noiseCleanupArgs,
+  parseMeanVolume,
+  parseStreamHash,
+  runNoiseCleanupArtifactSmoke,
+  signalToNoiseRatioDb
+} from './noise-cleanup-artifact.mjs'
+
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+const ffprobePath = process.env.VIDEORC_SMOKE_FFPROBE_PATH ?? 'ffprobe'
+
+describe('noise cleanup artifact helpers', () => {
+  it('locks the conservative model-free speech-v1 filter and safe command shape', () => {
+    assert.equal(NOISE_CLEANUP_FILTER, 'afftdn=nr=18:nf=-34:tn=1')
+    const backendSource = readFileSync(
+      new URL('../../crates/videorc-backend/src/noise_cleanup.rs', import.meta.url),
+      'utf8'
+    )
+    assert.match(backendSource, /SPEECH_V1_FILTER: &str = "afftdn=nr=18:nf=-34:tn=1"/)
+    const args = noiseCleanupArgs('/recordings/source.mp4', '/recordings/clean.mp4')
+    assert.ok(args.includes('-nostdin'))
+    assert.ok(args.includes('-n'))
+    assert.deepEqual(args.slice(args.indexOf('-map'), args.indexOf('-map') + 2), ['-map', '0'])
+    assert.ok(args.includes('-map_metadata'))
+    assert.deepEqual(args.slice(args.indexOf('-c'), args.indexOf('-c') + 2), ['-c', 'copy'])
+    assert.deepEqual(args.slice(args.indexOf('-c:a'), args.indexOf('-c:a') + 2), ['-c:a', 'aac'])
+    assert.ok(args.includes('-progress'))
+    const mkvArgs = noiseCleanupArgs('/recordings/source.mkv', '/recordings/clean.mkv')
+    assert.deepEqual(mkvArgs.slice(mkvArgs.indexOf('-c:a'), mkvArgs.indexOf('-c:a') + 2), [
+      '-c:a',
+      'pcm_s16le'
+    ])
+    assert.ok(!mkvArgs.includes('192k'))
+  })
+
+  it('parses objective noise and stream-copy evidence', () => {
+    assert.equal(parseMeanVolume('mean_volume: -42.9 dB'), -42.9)
+    assert.equal(parseStreamHash(`SHA256=${'a'.repeat(64)}\n`), 'a'.repeat(64))
+    assert.throws(() => parseMeanVolume('no measurement'), /mean_volume/)
+    assert.throws(() => parseStreamHash('no hash'), /SHA256/)
+    assert.equal(
+      signalToNoiseRatioDb(new Float32Array([1, -1]), new Float32Array([1, -1])),
+      Infinity
+    )
+    assert.ok(signalToNoiseRatioDb(new Float32Array([1, -1]), new Float32Array([1.1, -0.9])) > 19)
+  })
+})
+
+describe(
+  'speech-v1 artifact smoke',
+  { skip: ffmpegAvailable(ffmpegPath) ? false : 'ffmpeg not installed' },
+  () => {
+    let outputDir
+    let results
+
+    before(async () => {
+      outputDir = mkdtempSync(join(tmpdir(), 'videorc-noise-cleanup-'))
+      results = await Promise.all(
+        ['mp4', 'mkv'].map((container) =>
+          runNoiseCleanupArtifactSmoke({
+            ffmpegPath,
+            ffprobePath,
+            sourcePath: join(outputDir, `source.${container}`),
+            outputPath: join(outputDir, `source-noise-cleaned.${container}`)
+          })
+        )
+      )
+    })
+
+    after(() => {
+      if (outputDir && existsSync(outputDir)) {
+        rmSync(outputDir, { recursive: true, force: true })
+      }
+    })
+
+    it('reduces stationary noise without damaging the voice band', () => {
+      for (const result of results) {
+        assert.ok(result.noiseReductionDb >= 3, JSON.stringify(result))
+        assert.ok(result.snrImprovementDb >= 2, JSON.stringify(result))
+        assert.ok(result.voiceLevelDeltaDb <= 1, JSON.stringify(result))
+      }
+    })
+
+    it('keeps the original untouched and stream-copies video with A/V duration parity', () => {
+      for (const result of results) {
+        assert.equal(result.sourceFileUnchanged, true)
+        assert.equal(result.videoStreamCopied, true)
+        assert.ok(result.durationDeltaMs <= 50, JSON.stringify(result))
+      }
+    })
+
+    it('locks speech-v1 after comparing conservative, selected, and stronger candidates', async () => {
+      const sourcePath = join(outputDir, 'candidate-source.mkv')
+      const candidates = []
+      for (const candidate of NOISE_CLEANUP_CANDIDATES) {
+        candidates.push({
+          ...candidate,
+          result: await runNoiseCleanupArtifactSmoke({
+            ffmpegPath,
+            ffprobePath,
+            sourcePath,
+            outputPath: join(outputDir, `candidate-${candidate.name}.mkv`),
+            filter: candidate.filter
+          })
+        })
+        rmSync(sourcePath, { force: true })
+      }
+      const selected = candidates.find((candidate) => candidate.name === 'speech-v1')
+      assert.ok(selected)
+      assert.ok(selected.result.snrImprovementDb >= 2, JSON.stringify(candidates))
+      assert.ok(selected.result.voiceLevelDeltaDb <= 1, JSON.stringify(candidates))
+      assert.ok(
+        selected.result.noiseReductionDb > candidates[0].result.noiseReductionDb,
+        JSON.stringify(candidates)
+      )
+      assert.ok(
+        selected.result.voiceLevelDeltaDb <= candidates[2].result.voiceLevelDeltaDb,
+        JSON.stringify(candidates)
+      )
+    })
+  }
+)

--- a/scripts/lib/recording-studio-gates.mjs
+++ b/scripts/lib/recording-studio-gates.mjs
@@ -16,6 +16,10 @@ export function buildRecordingStudioGateSteps({
         'background-assets.test.ts',
         'session-params.test.ts',
         'studio-health.test.ts',
+        'noise-cleanup-view.test.ts',
+        'library-noise-cleanup.test.ts',
+        'studio-provider.integration.test.ts',
+        'backend-rpc-contract.test.ts',
         'native-preview-present-policy.test.ts',
         'native-preview-first-frame.test.ts',
         'backend-isolation.test.ts'
@@ -45,6 +49,11 @@ export function buildRecordingStudioGateSteps({
       label: 'backend audio pipeline tests',
       command: 'cargo',
       args: ['test', '-p', 'videorc-backend', 'audio::tests::']
+    },
+    {
+      label: 'backend noise cleanup tests',
+      command: 'cargo',
+      args: ['test', '-p', 'videorc-backend', 'noise_cleanup::tests::']
     }
   ]
 
@@ -59,6 +68,11 @@ export function buildRecordingStudioGateSteps({
         label: 'live captions mute/gain and record+stream artifact smoke',
         command: 'pnpm',
         args: ['smoke:captions-live']
+      },
+      {
+        label: 'noise cleanup final-artifact smoke',
+        command: 'pnpm',
+        args: ['smoke:noise-cleanup']
       },
       {
         label: 'dev app all-layout recording artifact smoke',

--- a/scripts/lib/recording-studio-gates.test.mjs
+++ b/scripts/lib/recording-studio-gates.test.mjs
@@ -19,8 +19,10 @@ describe('buildRecordingStudioGateSteps', () => {
       'backend scene layout tests',
       'backend recording pipeline tests',
       'backend audio pipeline tests',
+      'backend noise cleanup tests',
       'live captions transport contract smoke',
       'live captions mute/gain and record+stream artifact smoke',
+      'noise cleanup final-artifact smoke',
       'dev app all-layout recording artifact smoke',
       'imported screen image recording smoke',
       'real-user launch first-frame contract smoke',
@@ -47,13 +49,18 @@ describe('buildRecordingStudioGateSteps', () => {
       'background-assets.test.ts',
       'session-params.test.ts',
       'studio-health.test.ts',
+      'noise-cleanup-view.test.ts',
+      'library-noise-cleanup.test.ts',
+      'studio-provider.integration.test.ts',
+      'backend-rpc-contract.test.ts',
       'native-preview-present-policy.test.ts',
       'native-preview-first-frame.test.ts',
       'backend-isolation.test.ts'
     ])
     assert.deepEqual(steps[1].args, ['test:scripts'])
-    assert.deepEqual(steps.at(-17).args, ['smoke:captions-contract'])
-    assert.deepEqual(steps.at(-16).args, ['smoke:captions-live'])
+    assert.deepEqual(steps.at(-18).args, ['smoke:captions-contract'])
+    assert.deepEqual(steps.at(-17).args, ['smoke:captions-live'])
+    assert.deepEqual(steps.at(-16).args, ['smoke:noise-cleanup'])
     assert.deepEqual(steps.at(-15).args, ['smoke:dev'])
     assert.deepEqual(steps.at(-14).args, ['smoke:screens'])
     assert.deepEqual(steps.at(-13).args, ['smoke:preview-real-launch'])
@@ -109,6 +116,8 @@ describe('buildRecordingStudioGateSteps', () => {
     assert.match(report, /live_layout::tests::/)
     assert.match(report, /smoke:captions-contract/)
     assert.match(report, /smoke:captions-live/)
+    assert.match(report, /noise_cleanup::tests::/)
+    assert.match(report, /smoke:noise-cleanup/)
     assert.match(report, /smoke:dev/)
     assert.match(report, /smoke:screens/)
     assert.match(report, /smoke:layout-source-loop/)
@@ -145,6 +154,21 @@ describe('buildRecordingStudioGateSteps', () => {
       packageJson.scripts['smoke:preview-interaction-stress:devices'],
       'node scripts/run-with-env.mjs --platform=darwin VIDEORC_PREVIEW_INTERACTION_DEVICE_SMOKE=1 -- node scripts/smoke-preview-interaction-stress-app.mjs'
     )
+    assert.equal(packageJson.scripts['smoke:noise-cleanup'], 'node scripts/smoke-noise-cleanup.mjs')
+    assert.equal(
+      packageJson.scripts['smoke:noise-cleanup:bundled'],
+      'node scripts/smoke-noise-cleanup.mjs --require-bundled'
+    )
+
+    for (const relativePath of [
+      '../preflight-macos-package.mjs',
+      '../preflight-windows-package.mjs'
+    ]) {
+      const source = readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+      assert.match(source, /smoke-noise-cleanup\.mjs/)
+      assert.match(source, /--require-bundled/)
+      assert.match(source, /pcm_s16le/)
+    }
   })
 
   it('waits for the finalized MP4 before analyzing the device interaction recording', () => {

--- a/scripts/lib/repair-encoder-capabilities.mjs
+++ b/scripts/lib/repair-encoder-capabilities.mjs
@@ -25,8 +25,12 @@ export const REPAIR_ENCODER_ARGS = {
 }
 
 /** Encoders every shipped macOS ffmpeg must expose: the repair/record H.264
- * path (VideoToolbox in the LGPL bundle) and aac for every audio leg. */
-export const REQUIRED_MACOS_FFMPEG_ENCODERS = ['h264_videotoolbox', 'aac']
+ * path, AAC for MP4 audio, and PCM for Noise Cleanup's MKV output policy. */
+export const REQUIRED_MACOS_FFMPEG_ENCODERS = ['h264_videotoolbox', 'aac', 'pcm_s16le']
+
+/** Audio filters required by Premium local creative transforms. `afftdn` is
+ * built into the LGPL FFmpeg bundle and needs no separately licensed model. */
+export const REQUIRED_MACOS_FFMPEG_FILTERS = ['afftdn']
 
 /** Protocols every shipped macOS ffmpeg must expose. rtmps implies a TLS
  * backend was linked (static OpenSSL since 0.9.23); tls is listed separately
@@ -68,7 +72,11 @@ function hasWord(output, word) {
  * bundle's required capability set (streaming TLS + repair/record encoders).
  * Returns `{ ok, missing }` with `protocol:<name>` / `encoder:<name>` entries.
  */
-export function assessMacosFfmpegCapabilities({ protocolsOutput = '', encodersOutput = '' }) {
+export function assessMacosFfmpegCapabilities({
+  protocolsOutput = '',
+  encodersOutput = '',
+  filtersOutput = ''
+}) {
   const missing = []
   for (const protocol of REQUIRED_MACOS_FFMPEG_PROTOCOLS) {
     if (!hasWord(protocolsOutput, protocol)) {
@@ -78,6 +86,11 @@ export function assessMacosFfmpegCapabilities({ protocolsOutput = '', encodersOu
   for (const encoder of REQUIRED_MACOS_FFMPEG_ENCODERS) {
     if (!hasWord(encodersOutput, encoder)) {
       missing.push(`encoder:${encoder}`)
+    }
+  }
+  for (const filter of REQUIRED_MACOS_FFMPEG_FILTERS) {
+    if (!hasWord(filtersOutput, filter)) {
+      missing.push(`filter:${filter}`)
     }
   }
   return { ok: missing.length === 0, missing }
@@ -95,6 +108,7 @@ export function probeMacosFfmpegCapabilities(ffmpegPath, { execFileSync }) {
     })
   return assessMacosFfmpegCapabilities({
     protocolsOutput: run('-protocols'),
-    encodersOutput: run('-encoders')
+    encodersOutput: run('-encoders'),
+    filtersOutput: run('-filters')
   })
 }

--- a/scripts/lib/repair-encoder-capabilities.test.mjs
+++ b/scripts/lib/repair-encoder-capabilities.test.mjs
@@ -4,6 +4,7 @@ import { test } from 'node:test'
 import {
   REPAIR_ENCODER_ARGS,
   REPAIR_ENCODER_PREFERENCE,
+  REQUIRED_MACOS_FFMPEG_FILTERS,
   assessMacosFfmpegCapabilities,
   parseEncoderNames,
   selectRepairEncoder
@@ -16,7 +17,8 @@ const ENCODERS_LGPL_MACOS = [
   ' ------',
   ' V....D h264_videotoolbox    VideoToolbox H.264 Encoder (codec h264)',
   ' V....D hevc_videotoolbox    VideoToolbox H.265 Encoder (codec hevc)',
-  ' A....D aac                  AAC (Advanced Audio Coding)'
+  ' A....D aac                  AAC (Advanced Audio Coding)',
+  ' A....D pcm_s16le            PCM signed 16-bit little-endian'
 ].join('\n')
 
 const ENCODERS_FULL_GPL = [
@@ -24,10 +26,12 @@ const ENCODERS_FULL_GPL = [
   ' ------',
   ' V..... libx264              libx264 H.264 / AVC / MPEG-4 AVC (codec h264)',
   ' V....D h264_videotoolbox    VideoToolbox H.264 Encoder (codec h264)',
-  ' A....D aac                  AAC (Advanced Audio Coding)'
+  ' A....D aac                  AAC (Advanced Audio Coding)',
+  ' A....D pcm_s16le            PCM signed 16-bit little-endian'
 ].join('\n')
 
 const PROTOCOLS_WITH_TLS = ['Input:', '  file', '  rtmp', '  rtmps', '  tls'].join('\n')
+const FILTERS_WITH_NOISE_CLEANUP = 'Filters:\n TS afftdn A->A Denoise audio samples using FFT.'
 
 test('parses encoder names out of -encoders output', () => {
   const names = parseEncoderNames(ENCODERS_LGPL_MACOS)
@@ -64,7 +68,8 @@ test('-crf stays exclusive to libx264 (the toast-noise regression)', () => {
 test('an LGPL macOS bundle with videotoolbox and TLS passes', () => {
   const result = assessMacosFfmpegCapabilities({
     protocolsOutput: PROTOCOLS_WITH_TLS,
-    encodersOutput: ENCODERS_LGPL_MACOS
+    encodersOutput: ENCODERS_LGPL_MACOS,
+    filtersOutput: FILTERS_WITH_NOISE_CLEANUP
   })
   assert.equal(result.ok, true)
   assert.deepEqual(result.missing, [])
@@ -73,12 +78,34 @@ test('an LGPL macOS bundle with videotoolbox and TLS passes', () => {
 test('a bundle without videotoolbox or TLS fails closed with named gaps', () => {
   const result = assessMacosFfmpegCapabilities({
     protocolsOutput: 'Input:\n  file\n  rtmp',
-    encodersOutput: 'Encoders:\n A....D aac  AAC'
+    encodersOutput: 'Encoders:\n A....D aac  AAC',
+    filtersOutput: ''
   })
   assert.equal(result.ok, false)
   assert.deepEqual(result.missing, [
     'protocol:rtmps',
     'protocol:tls',
-    'encoder:h264_videotoolbox'
+    'encoder:h264_videotoolbox',
+    'encoder:pcm_s16le',
+    'filter:afftdn'
   ])
+})
+
+test('the macOS bundle requires PCM for MKV Noise Cleanup outputs', () => {
+  const result = assessMacosFfmpegCapabilities({
+    protocolsOutput: PROTOCOLS_WITH_TLS,
+    encodersOutput: ENCODERS_LGPL_MACOS.replace(/\n A\.\.\.\.D pcm_s16le.*$/, ''),
+    filtersOutput: FILTERS_WITH_NOISE_CLEANUP
+  })
+  assert.deepEqual(result.missing, ['encoder:pcm_s16le'])
+})
+
+test('the macOS bundle requires the model-free noise cleanup filter', () => {
+  assert.deepEqual(REQUIRED_MACOS_FFMPEG_FILTERS, ['afftdn'])
+  const result = assessMacosFfmpegCapabilities({
+    protocolsOutput: PROTOCOLS_WITH_TLS,
+    encodersOutput: ENCODERS_LGPL_MACOS,
+    filtersOutput: 'Filters:\n T. loudnorm A->A EBU R128 loudness normalization'
+  })
+  assert.deepEqual(result.missing, ['filter:afftdn'])
 })

--- a/scripts/lib/windows-ffmpeg-capabilities.mjs
+++ b/scripts/lib/windows-ffmpeg-capabilities.mjs
@@ -15,10 +15,10 @@
  * separately so a partial TLS wiring still fails loudly. */
 export const REQUIRED_WINDOWS_FFMPEG_PROTOCOLS = ['rtmp', 'rtmps', 'tls']
 
-/** Encoders the Windows recording/stream path selects (MediaFoundation is
- * the platform H.264 encoder in the LGPL build; aac carries every audio
- * leg). */
-export const REQUIRED_WINDOWS_FFMPEG_ENCODERS = ['h264_mf', 'aac']
+/** Encoders the Windows recording/stream path selects: MediaFoundation H.264,
+ * AAC for MP4 audio, and PCM for Noise Cleanup's MKV output policy. */
+export const REQUIRED_WINDOWS_FFMPEG_ENCODERS = ['h264_mf', 'aac', 'pcm_s16le']
+export const REQUIRED_WINDOWS_FFMPEG_FILTERS = ['afftdn']
 
 function hasWord(output, word) {
   return new RegExp(`(^|[^A-Za-z0-9_])${word}([^A-Za-z0-9_]|$)`, 'm').test(output)
@@ -29,7 +29,11 @@ function hasWord(output, word) {
  * required capability set. Returns `{ ok, missing }` where `missing` entries
  * are `protocol:<name>` / `encoder:<name>` strings suitable for error copy.
  */
-export function assessWindowsFfmpegCapabilities({ protocolsOutput = '', encodersOutput = '' }) {
+export function assessWindowsFfmpegCapabilities({
+  protocolsOutput = '',
+  encodersOutput = '',
+  filtersOutput = ''
+}) {
   const missing = []
   for (const protocol of REQUIRED_WINDOWS_FFMPEG_PROTOCOLS) {
     if (!hasWord(protocolsOutput, protocol)) {
@@ -39,6 +43,11 @@ export function assessWindowsFfmpegCapabilities({ protocolsOutput = '', encoders
   for (const encoder of REQUIRED_WINDOWS_FFMPEG_ENCODERS) {
     if (!hasWord(encodersOutput, encoder)) {
       missing.push(`encoder:${encoder}`)
+    }
+  }
+  for (const filter of REQUIRED_WINDOWS_FFMPEG_FILTERS) {
+    if (!hasWord(filtersOutput, filter)) {
+      missing.push(`filter:${filter}`)
     }
   }
   return { ok: missing.length === 0, missing }
@@ -57,6 +66,7 @@ export function probeWindowsFfmpegCapabilities(ffmpegPath, { execFileSync }) {
     })
   return assessWindowsFfmpegCapabilities({
     protocolsOutput: run('-protocols'),
-    encodersOutput: run('-encoders')
+    encodersOutput: run('-encoders'),
+    filtersOutput: run('-filters')
   })
 }

--- a/scripts/lib/windows-ffmpeg-capabilities.test.mjs
+++ b/scripts/lib/windows-ffmpeg-capabilities.test.mjs
@@ -3,6 +3,7 @@ import { test } from 'node:test'
 
 import {
   REQUIRED_WINDOWS_FFMPEG_ENCODERS,
+  REQUIRED_WINDOWS_FFMPEG_FILTERS,
   REQUIRED_WINDOWS_FFMPEG_PROTOCOLS,
   assessWindowsFfmpegCapabilities
 } from './windows-ffmpeg-capabilities.mjs'
@@ -24,13 +25,16 @@ const PROTOCOLS_WITH_TLS = [
 const ENCODERS_WITH_MF = [
   'Encoders:',
   ' V....D h264_mf              MediaFoundation H.264 encoder (codec h264)',
-  ' A....D aac                  AAC (Advanced Audio Coding)'
+  ' A....D aac                  AAC (Advanced Audio Coding)',
+  ' A....D pcm_s16le            PCM signed 16-bit little-endian'
 ].join('\n')
+const FILTERS_WITH_NOISE_CLEANUP = 'Filters:\n TS afftdn A->A Denoise audio samples using FFT.'
 
 test('a fully capable ffmpeg passes', () => {
   const result = assessWindowsFfmpegCapabilities({
     protocolsOutput: PROTOCOLS_WITH_TLS,
-    encodersOutput: ENCODERS_WITH_MF
+    encodersOutput: ENCODERS_WITH_MF,
+    filtersOutput: FILTERS_WITH_NOISE_CLEANUP
   })
   assert.equal(result.ok, true)
   assert.deepEqual(result.missing, [])
@@ -41,7 +45,8 @@ test('an ffmpeg without a TLS stack fails on rtmps and tls (the 0.9.23 class)', 
     protocolsOutput: PROTOCOLS_WITH_TLS.split('\n')
       .filter((line) => !/rtmps|tls/.test(line))
       .join('\n'),
-    encodersOutput: ENCODERS_WITH_MF
+    encodersOutput: ENCODERS_WITH_MF,
+    filtersOutput: FILTERS_WITH_NOISE_CLEANUP
   })
   assert.equal(result.ok, false)
   assert.deepEqual(result.missing, ['protocol:rtmps', 'protocol:tls'])
@@ -50,19 +55,30 @@ test('an ffmpeg without a TLS stack fails on rtmps and tls (the 0.9.23 class)', 
 test('rtmps does not substring-match as rtmp', () => {
   const result = assessWindowsFfmpegCapabilities({
     protocolsOutput: 'Input:\n  rtmps\n  tls',
-    encodersOutput: ENCODERS_WITH_MF
+    encodersOutput: ENCODERS_WITH_MF,
+    filtersOutput: FILTERS_WITH_NOISE_CLEANUP
   })
   assert.equal(result.ok, false)
   assert.deepEqual(result.missing, ['protocol:rtmp'])
 })
 
-test('a missing MediaFoundation encoder fails', () => {
+test('missing required video and MKV audio encoders fail closed', () => {
   const result = assessWindowsFfmpegCapabilities({
     protocolsOutput: PROTOCOLS_WITH_TLS,
-    encodersOutput: 'Encoders:\n A....D aac    AAC'
+    encodersOutput: 'Encoders:\n A....D aac    AAC',
+    filtersOutput: FILTERS_WITH_NOISE_CLEANUP
   })
   assert.equal(result.ok, false)
-  assert.deepEqual(result.missing, ['encoder:h264_mf'])
+  assert.deepEqual(result.missing, ['encoder:h264_mf', 'encoder:pcm_s16le'])
+})
+
+test('the Windows bundle requires PCM for MKV Noise Cleanup outputs', () => {
+  const result = assessWindowsFfmpegCapabilities({
+    protocolsOutput: PROTOCOLS_WITH_TLS,
+    encodersOutput: ENCODERS_WITH_MF.replace(/\n A\.\.\.\.D pcm_s16le.*$/, ''),
+    filtersOutput: FILTERS_WITH_NOISE_CLEANUP
+  })
+  assert.deepEqual(result.missing, ['encoder:pcm_s16le'])
 })
 
 test('empty output reports the whole required set (fail closed)', () => {
@@ -70,6 +86,16 @@ test('empty output reports the whole required set (fail closed)', () => {
   assert.equal(result.ok, false)
   assert.deepEqual(result.missing, [
     ...REQUIRED_WINDOWS_FFMPEG_PROTOCOLS.map((name) => `protocol:${name}`),
-    ...REQUIRED_WINDOWS_FFMPEG_ENCODERS.map((name) => `encoder:${name}`)
+    ...REQUIRED_WINDOWS_FFMPEG_ENCODERS.map((name) => `encoder:${name}`),
+    ...REQUIRED_WINDOWS_FFMPEG_FILTERS.map((name) => `filter:${name}`)
   ])
+})
+
+test('the Windows bundle requires the model-free noise cleanup filter', () => {
+  const result = assessWindowsFfmpegCapabilities({
+    protocolsOutput: PROTOCOLS_WITH_TLS,
+    encodersOutput: ENCODERS_WITH_MF,
+    filtersOutput: 'Filters:\n T. loudnorm A->A EBU R128 loudness normalization'
+  })
+  assert.deepEqual(result.missing, ['filter:afftdn'])
 })

--- a/scripts/preflight-macos-package.mjs
+++ b/scripts/preflight-macos-package.mjs
@@ -75,12 +75,35 @@ if (!capabilities.ok) {
   console.error(
     `preflight-macos-package: bundled ffmpeg is missing required capabilities: ${capabilities.missing.join(', ')}.\n` +
       'Refusing to package — an ffmpeg without rtmps/tls stalls livestreams silently, and one ' +
-      'without h264_videotoolbox cannot run transcode repairs. Rebuild with: pnpm ffmpeg:build:macos'
+      'without h264_videotoolbox cannot run transcode repairs, and one without afftdn/aac/' +
+      'pcm_s16le cannot run Noise Cleanup for every supported container. Rebuild with: pnpm ffmpeg:build:macos'
   )
   process.exit(1)
 }
 console.log(
-  'preflight-macos-package: bundled ffmpeg capability probe passed (rtmp/rtmps/tls, h264_videotoolbox, aac).'
+  'preflight-macos-package: bundled ffmpeg capability probe passed (rtmp/rtmps/tls, h264_videotoolbox, aac, pcm_s16le, afftdn).'
 )
+
+try {
+  execFileSync(
+    process.execPath,
+    [join(repoRoot, 'scripts', 'smoke-noise-cleanup.mjs'), '--require-bundled'],
+    {
+      env: {
+        ...process.env,
+        VIDEORC_SMOKE_FFMPEG_PATH: ffmpegBin,
+        VIDEORC_SMOKE_FFPROBE_PATH: join(repoRoot, 'vendor', 'ffmpeg', 'current', 'bin', 'ffprobe')
+      },
+      stdio: 'inherit'
+    }
+  )
+} catch (error) {
+  console.error(
+    `preflight-macos-package: bundled ffmpeg failed the MP4/MKV Noise Cleanup artifact proof: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+  )
+  process.exit(1)
+}
 
 console.log('preflight-macos-package: all macOS packaging inputs present.')

--- a/scripts/preflight-windows-package.mjs
+++ b/scripts/preflight-windows-package.mjs
@@ -84,13 +84,41 @@ if (process.platform === 'win32') {
   if (!capabilities.ok) {
     console.error(
       `preflight-windows-package: bundled ffmpeg is missing required capabilities: ${capabilities.missing.join(', ')}.\n` +
-        'Refusing to package — an ffmpeg without rtmps/tls stalls livestreams silently (the 0.9.23 class of failure). Re-pin a build that carries them.'
+        'Refusing to package — an ffmpeg without rtmps/tls stalls livestreams silently, and one without afftdn/aac/pcm_s16le cannot run Noise Cleanup for every supported container. Re-pin a build that carries them.'
     )
     process.exit(1)
   }
   console.log(
-    'preflight-windows-package: bundled ffmpeg capability probe passed (rtmp/rtmps/tls, h264_mf, aac).'
+    'preflight-windows-package: bundled ffmpeg capability probe passed (rtmp/rtmps/tls, h264_mf, aac, pcm_s16le, afftdn).'
   )
+  try {
+    execFileSync(
+      process.execPath,
+      [join(repoRoot, 'scripts', 'smoke-noise-cleanup.mjs'), '--require-bundled'],
+      {
+        env: {
+          ...process.env,
+          VIDEORC_SMOKE_FFMPEG_PATH: ffmpegExe,
+          VIDEORC_SMOKE_FFPROBE_PATH: join(
+            repoRoot,
+            'vendor',
+            'ffmpeg',
+            'windows-x64',
+            'bin',
+            'ffprobe.exe'
+          )
+        },
+        stdio: 'inherit'
+      }
+    )
+  } catch (error) {
+    console.error(
+      `preflight-windows-package: bundled ffmpeg failed the MP4/MKV Noise Cleanup artifact proof: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+    process.exit(1)
+  }
 } else {
   console.log(
     'preflight-windows-package: skipping the ffmpeg capability probe (ffmpeg.exe cannot run on this host); it runs on the Windows box.'

--- a/scripts/smoke-noise-cleanup.mjs
+++ b/scripts/smoke-noise-cleanup.mjs
@@ -1,0 +1,89 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { runNoiseCleanupArtifactSmoke } from './lib/noise-cleanup-artifact.mjs'
+import { analyzeRecording } from './lib/recording-analyzer.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireBundled = process.argv.includes('--require-bundled')
+const bundledBin =
+  process.platform === 'win32'
+    ? join(repoRoot, 'vendor', 'ffmpeg', 'windows-x64', 'bin')
+    : join(repoRoot, 'vendor', 'ffmpeg', 'current', 'bin')
+const bundledFfmpeg = join(bundledBin, process.platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg')
+const bundledFfprobe = join(bundledBin, process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe')
+if (requireBundled && (!existsSync(bundledFfmpeg) || !existsSync(bundledFfprobe))) {
+  throw new Error(
+    `bundled Noise Cleanup proof requested, but ${bundledFfmpeg} or ${bundledFfprobe} is missing`
+  )
+}
+const usingOverride = Boolean(process.env.VIDEORC_SMOKE_FFMPEG_PATH)
+const usingBundled = requireBundled || (!usingOverride && existsSync(bundledFfmpeg))
+const ffmpegPath = requireBundled
+  ? bundledFfmpeg
+  : (process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? (usingBundled ? bundledFfmpeg : 'ffmpeg'))
+const ffprobePath = requireBundled
+  ? bundledFfprobe
+  : (process.env.VIDEORC_SMOKE_FFPROBE_PATH ??
+    (usingBundled
+      ? bundledFfprobe
+      : ffmpegPath === 'ffmpeg'
+        ? 'ffprobe'
+        : join(dirname(ffmpegPath), process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe')))
+const outputDir = mkdtempSync(join(tmpdir(), 'videorc-noise-cleanup-smoke-'))
+
+try {
+  console.log(
+    `noise-cleanup smoke: ffmpeg=${ffmpegPath} ffprobe=${ffprobePath} ` +
+      `mode=${usingBundled ? 'bundled' : usingOverride ? 'override' : 'PATH'}`
+  )
+  const evidence = []
+  for (const container of ['mp4', 'mkv']) {
+    const cleanedPath = join(outputDir, `source-noise-cleaned.${container}`)
+    const result = await runNoiseCleanupArtifactSmoke({
+      ffmpegPath,
+      ffprobePath,
+      sourcePath: join(outputDir, `source.${container}`),
+      outputPath: cleanedPath
+    })
+    const analysis = await analyzeRecording(cleanedPath, {
+      ffmpegPath,
+      ffprobePath,
+      intendedFps: 30,
+      expectAudio: true
+    })
+
+    if (
+      !result.sourceFileUnchanged ||
+      !result.videoStreamCopied ||
+      result.noiseReductionDb < 3 ||
+      result.snrImprovementDb < 2 ||
+      result.voiceLevelDeltaDb > 1 ||
+      result.durationDeltaMs > 50 ||
+      !analysis.verdict.pass
+    ) {
+      throw new Error(
+        `artifact contract failed: ${JSON.stringify({ container, result, analyzer: analysis.verdict })}`
+      )
+    }
+    evidence.push({ container, result })
+  }
+
+  const summary = evidence
+    .map(
+      ({ container, result }) =>
+        `${container.toUpperCase()} ${result.noiseReductionDb.toFixed(1)} dB noise reduction / ` +
+        `${result.snrImprovementDb.toFixed(1)} dB SNR gain / ` +
+        `${result.voiceLevelDeltaDb.toFixed(1)} dB voice delta / ` +
+        `${result.durationDeltaMs.toFixed(1)} ms duration delta`
+    )
+    .join('; ')
+  console.log(
+    `noise-cleanup smoke PASS — speech-v1 preserved both MP4/MKV sources, stream-copied ` +
+      `video, and passed the maintained final-artifact A/V analyzer (${summary}).`
+  )
+} finally {
+  rmSync(outputDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary\n\n- add Premium one-click Noise Cleanup to finished Videorc recordings in Library\n- process locally with the bundled FFmpeg afftdn filter; no upload or quota\n- publish a validated, non-destructive managed derivative while preserving the original\n- persist cancellable and restartable jobs in SQLite and let capture preempt background cleanup\n- add an explicit noise-cleanup entitlement, typed RPC/events, focus/timer refresh, and fail-closed backend enforcement\n- require afftdn, AAC, and pcm_s16le in macOS and Windows package probes\n- promote the promise in the companion web draft: https://github.com/TheOrcDev/videorc-web/pull/6\n\n## Product behavior\n\n- Basic users see a truthful Premium affordance.\n- Premium and Developer users start cleanup with one click.\n- Queued, cleaning, validating, cancel, retry, completed, missing, imported, live, reconnecting, and derivative states are explicit.\n- MP4 outputs use AAC 192 kbps; MKV outputs use pcm_s16le; video is stream-copied.\n- Imported, no-audio, multi-audio, test-tone, unsupported, live, missing, unfinished, and already-cleaned inputs fail closed.\n- Completed outputs appear as Noise Cleaned Library sessions with durable provenance.\n\n## Safety and durability\n\n- backend owns authorization, source-path resolution, identity, job state, process ownership, and publication\n- full SHA-256, sampled content, and filesystem-object identity protect against replacements and mid-run changes\n- app-owned cancellation only; no broad process scans\n- capture cancels or preempts every long identity/media phase and queued work resumes later\n- output allocation reserves every Library-owned database path, including temporarily missing media\n- unavailable volumes never delete derivative metadata\n- entitlement HTTP refresh has an 8-second request timeout inside the 10-second RPC deadline\n\n## Verification\n\n- TypeScript typecheck, lint, format check, production build: PASS\n- JS production advisory audit: PASS\n- Desktop tests: 1,034 passed, 1 existing skip across 127 files\n- Node script tests: 618 of 618 passed across 120 suites\n- Rust: fmt and clippy PASS; 1,300 tests passed, 8 ignored\n- Bundled MP4 and MKV artifact smoke: PASS\n  - MP4: 3.4 dB noise reduction, 2.0 dB SNR gain, 0.1 dB voice delta, 0.0 ms duration delta\n  - MKV: 3.1 dB noise reduction, 2.0 dB SNR gain, 0.0 dB voice delta, 1.0 ms duration delta\n  - source hashes unchanged; video packet hashes match; maintained A/V analyzer passed\n- macOS release backend, helper, universal addon build, and package preflight: PASS\n- Recording Studio aggregate: steps 1 through 23 PASS, including Noise Cleanup, all-layout artifacts, captions, native preview lifecycle/window/surface, interaction, and stress\n- Web companion: 305 of 305 tests, typecheck, build, and Vercel preview PASS; one unrelated existing contributors-image lint warning\n- final read-only review: no actionable findings\n\nDetailed evidence: [docs/acceptance/2026-07-13-noise-cleanup.md](docs/acceptance/2026-07-13-noise-cleanup.md)\n\n## Release-stage blockers\n\nThis remains draft until:\n\n- an owner completes the real-voice by-ear panel\n- Windows native/package preflight and MP4/MKV smoke run on a Windows host\n- desktop dark/light, narrow/wide, and keyboard manual QA is completed\n- the host/device ScreenCaptureKit row is rerun where a native screen source is available\n\nThe current macOS host exposes no ScreenCaptureKit screen source, so aggregate step 24 and the separately run Notes-window real-screen smoke are explicitly environment-blocked. Hosted Windows CI is green, including the installer and bundled Noise Cleanup artifact proof; physical-device release QA remains a separate rollout responsibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-click Noise Cleanup for Library recordings, producing non-destructive cleaned copies.
  * Added progress, cancellation, retry, output-opening, and source-reveal actions.
  * Added responsive status badges and accessibility support for cleanup states.
  * Added Premium entitlement gating with upgrade options.
  * Added durable processing that resumes interrupted jobs and protects active sources from conflicting actions.

* **Bug Fixes**
  * Improved entitlement refresh and cleanup-job state synchronization.
  * Added media validation and bundled FFmpeg capability checks for reliable MP4 and MKV output.

* **Documentation**
  * Added Noise Cleanup acceptance criteria and updated capability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->