### PR TITLE
Record the 0.9.36 release (short-format full canvas)

### DIFF
--- a/docs/releases/0.9.36.md
+++ b/docs/releases/0.9.36.md
@@ -1,0 +1,46 @@
+# Videorc 0.9.36 Beta 1
+
+Short-format full-canvas law: vertical mode always records a true 9:16
+canvas and every pixel is content.
+
+## Scope
+
+- **Short-format full canvas** (PR #104, four slices):
+  - Canvas orientation lock: per-mode resolution one-clicks (portrait
+    twins 720/1080p/2K/4K in vertical mode), coerceVideoToOrientation
+    at every canvas write (patchVideo/applyVideoPreset/config load),
+    orientation-filtered preset select, backend session-start refusal
+    for vertical-scene-on-landscape-canvas, orientation-symmetric
+    validate_video_settings/is_4k_video. Root cause of the owner's
+    letterboxed-phone-playback screenshot (2K landscape canvas under
+    vertical-split).
+  - One-source collapse: vertical scenes with a single active source
+    cover the whole canvas (no black camera band / dead placeholder
+    band); legacy FFmpeg fallback parity (color=black band removed).
+  - New scene `vertical-camera-only` ("Camera"): full-canvas Cover
+    camera, maskless, zoom/pan frame the crop; first vertical scene
+    usable without a screen. Wire pinned on both sides.
+  - Stale mirrors: previewProofLayerFit now covers vertical regions
+    (pre-authoritative preview no longer flashes letterboxed).
+
+## Release status
+
+- [x] PR #104 merged (CI green); prep PR #105 (Rust job flaked on two
+      encoder_bridge timing tests, green on rerun).
+- [x] Built from `ca23d2f9`, signed + notarized, validate PASS, uploaded
+      (all 8 objects verified).
+- [x] Feed serves `version: 0.9.36` (followed the 302 to R2).
+- [x] Discord announced (dry-run previewed first).
+- [x] X post drafted and returned to owner (manual post).
+
+## Owner acceptance checklist (by-eye, macOS)
+
+- [ ] Vertical mode: resolution picker offers only portrait sizes; 2K
+      picks 1440×2560.
+- [ ] Vertical recording on a phone fills edge-to-edge — screen+camera,
+      camera-only, and screen-only all without black bars.
+- [ ] New "Camera" scene in the vertical gallery: full-screen camera,
+      zoom/pan frame the crop; enabled with no screen selected.
+- [ ] Horizontal mode unchanged (screen still never cropped).
+- [ ] Blocked-smoke follow-up: run `pnpm smoke:recording-studio` from
+      `~/projects/videorc` (TCC-granted binaries) once.


### PR DESCRIPTION
Internal release record for 0.9.36-beta.1: scope (#104), build/upload/feed/Discord status, and the owner acceptance checklist (including the one-time TCC-granted smoke follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Videorc 0.9.36 Beta 1.
  * Documented vertical-mode recording and canvas improvements, including orientation-locked resolution and improved preview fitting.
  * Added details about camera-only scenes and single-source full-canvas behavior.
  * Included release verification and publishing checklists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->