### PR TITLE
Fix orientation preview and recording synchronization

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -9152,13 +9152,40 @@ function smokeRendererScript(command: string, params: Record<string, unknown>): 
       if (${JSON.stringify(command)} === 'select-layout-preset') {
         const preset = String(params.preset ?? 'screen-only');
         await openTab('layout', '[data-videorc-layout-preset]');
-        const deadline = Date.now() + 5000;
         let button = null;
+        let deadline = Date.now() + 5000;
         while (Date.now() < deadline) {
           button = Array.from(document.querySelectorAll('[data-videorc-layout-preset]'))
             .find((candidate) => candidate.getAttribute('data-videorc-layout-preset') === preset);
           if (button && !button.disabled) break;
           await sleep(50);
+        }
+        // Layout controls are mode-scoped: landscape and portrait presets are
+        // intentionally never mounted together. The QA command owns the mode
+        // transition so maintained smokes exercise the same orientation toggle
+        // users click before selecting a scene in the target vocabulary.
+        if (!button) {
+          await openTab('studio', '[aria-label="Studio orientation"]');
+          const orientationLabel = preset.startsWith('vertical-')
+            ? 'Vertical studio (9:16)'
+            : 'Horizontal studio (16:9)';
+          const orientationButton = document.querySelector(
+            'button[aria-label="' + orientationLabel + '"]'
+          );
+          if (!orientationButton || orientationButton.disabled) {
+            throw new Error('Could not switch Studio orientation for layout preset ' + preset);
+          }
+          if (orientationButton.getAttribute('aria-pressed') !== 'true') {
+            orientationButton.click();
+          }
+          await openTab('layout', '[data-videorc-layout-preset]');
+          deadline = Date.now() + 10000;
+          while (Date.now() < deadline) {
+            button = Array.from(document.querySelectorAll('[data-videorc-layout-preset]'))
+              .find((candidate) => candidate.getAttribute('data-videorc-layout-preset') === preset);
+            if (button && !button.disabled) break;
+            await sleep(50);
+          }
         }
         if (!button) {
           throw new Error('Could not find layout preset ' + preset);

--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -200,6 +200,7 @@ class StudioBackend {
   oauthTransportFailuresRemaining = 1
   oauthRetryFailuresRemaining = 1
   oauthCompletedStates = new Set<string>()
+  layoutResponseDelayMs = 0
 
   response(command: BackendCommand): unknown {
     this.commands.push(command)
@@ -461,7 +462,7 @@ class TestWebSocket {
 
   send(raw: string): void {
     const command = JSON.parse(raw) as BackendCommand
-    queueMicrotask(() => {
+    const respond = (): void => {
       try {
         this.onmessage?.({
           data: JSON.stringify({
@@ -488,7 +489,15 @@ class TestWebSocket {
           })
         })
       }
-    })
+    }
+    if (
+      command.method.startsWith('scene.layout.apply_') &&
+      TestWebSocket.backend.layoutResponseDelayMs > 0
+    ) {
+      setTimeout(respond, TestWebSocket.backend.layoutResponseDelayMs)
+    } else {
+      queueMicrotask(respond)
+    }
   }
 
   close(): void {
@@ -652,6 +661,148 @@ describe('real StudioProvider lifecycle', () => {
       sessionId: 'session-1',
       durationMs: 1_000
     })
+  })
+
+  it('commits an orientation change atomically before preview and recording consume it', async () => {
+    const backend = new StudioBackend()
+    // Windows proof presentation can take longer than the generic idle-scene
+    // reload debounce. A mode switch must not expose its portrait canvas until
+    // the matching vertical scene transaction is committed.
+    backend.layoutResponseDelayMs = 400
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    const previewAspectCalls: Array<[number, number]> = []
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      setPreviewAspectRatio: async (width, height) => {
+        previewAspectCalls.push([width, height])
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.captureConfig.sources.screenId != null &&
+        latest()?.core.captureConfig.sources.cameraId != null
+    )
+
+    const commandStart = backend.commands.length
+    await act(async () => {
+      latest()?.core.applyCameraPreset({ layoutPreset: 'vertical-screen-camera' })
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 325))
+    })
+
+    const mixedReloads = backend.commands.slice(commandStart).filter((command) => {
+      if (command.method !== 'scene.load_from_capture_config') return false
+      const params = command.params as {
+        layout?: { layoutPreset?: string }
+        video?: { width?: number; height?: number }
+      }
+      return (
+        params.layout?.layoutPreset === 'screen-camera' &&
+        params.video?.width === 1080 &&
+        params.video?.height === 1920
+      )
+    })
+    expect(mixedReloads).toEqual([])
+
+    await waitForObservation(
+      () =>
+        latest()?.core.captureConfig.layout.layoutPreset === 'vertical-screen-camera' &&
+        latest()?.core.captureConfig.video.width === 1080 &&
+        latest()?.core.captureConfig.video.height === 1920
+    )
+    expect(previewAspectCalls.at(-1)).toEqual([1080, 1920])
+    expect(
+      backend.commands.find((command) => command.method === 'scene.layout.apply_preview')?.params
+    ).toMatchObject({
+      layout: { layoutPreset: 'vertical-screen-camera' },
+      video: { width: 1080, height: 1920 }
+    })
+
+    await act(async () => {
+      await latest()?.core.startSession()
+    })
+    expect(
+      backend.commands.find((command) => command.method === 'session.start')?.params
+    ).toMatchObject({
+      layout: { layoutPreset: 'vertical-screen-camera' },
+      output: { video: { width: 1080, height: 1920 } }
+    })
+    await act(async () => {
+      await latest()?.core.stopSession()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'idle')
+
+    const reverseCommandStart = backend.commands.length
+    await act(async () => {
+      latest()?.core.applyCameraPreset({ layoutPreset: 'screen-camera' })
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 325))
+    })
+    const reverseMixedReloads = backend.commands.slice(reverseCommandStart).filter((command) => {
+      if (command.method !== 'scene.load_from_capture_config') return false
+      const params = command.params as {
+        layout?: { layoutPreset?: string }
+        video?: { width?: number; height?: number }
+      }
+      return (
+        params.layout?.layoutPreset === 'vertical-screen-camera' &&
+        params.video?.width === 2560 &&
+        params.video?.height === 1440
+      )
+    })
+    expect(reverseMixedReloads).toEqual([])
+    await waitForObservation(
+      () =>
+        latest()?.core.captureConfig.layout.layoutPreset === 'screen-camera' &&
+        latest()?.core.captureConfig.video.width === 2560 &&
+        latest()?.core.captureConfig.video.height === 1440
+    )
+    expect(previewAspectCalls.at(-1)).toEqual([2560, 1440])
+
+    await act(async () => {
+      await latest()?.core.startSession()
+    })
+    expect(
+      backend.commands.filter((command) => command.method === 'session.start').at(-1)?.params
+    ).toMatchObject({
+      layout: { layoutPreset: 'screen-camera' },
+      output: { video: { width: 2560, height: 1440 } }
+    })
+    await act(async () => {
+      await latest()?.core.stopSession()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'idle')
   })
 
   it('recovers in cooldown on the same healthy websocket and ACKs exactly once', async () => {
@@ -1024,6 +1175,7 @@ function createVideorcApi(options: {
   acknowledge: (id: string) => Promise<boolean>
   pendingProvider: () => Promise<OAuthCallbackEnvelope[]>
   acknowledgeProvider: (id: string) => Promise<boolean>
+  setPreviewAspectRatio?: (width: number, height: number) => Promise<void>
   nativePreview?: {
     getWindowState: () => PreviewWindowState
     drainHostCommands: (generation?: number) => Promise<PreviewSurfaceStatus>
@@ -1093,6 +1245,7 @@ function createVideorcApi(options: {
       setNativePreviewSurfaceFramePollingSuppressed: async () => nativePreviewStatus(),
       getPreviewWindowState: async () =>
         options.nativePreview?.getWindowState() ?? previewWindowClosed,
+      setPreviewWindowAspectRatio: options.setPreviewAspectRatio ?? (async () => undefined),
       getNotesWindowState: async () => idleNotes,
       getCommentsWindowState: async () => idleComments,
       getCaptionsWindowState: async () => idleCaptions,

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -530,6 +530,7 @@ type LayoutTransactionSnapshot = {
   scene: Scene
   layout: LayoutSettings
   compositorStatus: CompositorStatus
+  captureConfigPatch?: Pick<CaptureConfig, 'video' | 'verticalRestoreVideo'>
 }
 
 async function waitForPreviewLayoutProof(
@@ -4689,10 +4690,28 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       applyScene(snapshot.scene)
       skipNextConfigSceneReloadRef.current = true
       setCaptureConfig((current) => {
+        // Orientation and canvas are one committed program state. Derive the
+        // patch for backend-truth recovery when the response carrying the
+        // original patch was lost; ordinary successful transactions carry it.
+        const recoveredOrientationPatch = verticalOrientationVideoPatch(
+          current.layout.layoutPreset,
+          snapshot.layout.layoutPreset,
+          current.video,
+          current.verticalRestoreVideo
+        )
+        const captureConfigPatch =
+          snapshot.captureConfigPatch ??
+          (recoveredOrientationPatch
+            ? {
+                video: recoveredOrientationPatch.video,
+                verticalRestoreVideo: recoveredOrientationPatch.verticalRestoreVideo
+              }
+            : undefined)
         // The committed preset becomes its mode's remembered scene — the
         // orientation toggle re-enters each mode where the user left it.
         const next = {
           ...current,
+          ...captureConfigPatch,
           ...layoutPresetMemoryPatch(snapshot.layout.layoutPreset),
           layout: snapshot.layout
         }
@@ -4737,7 +4756,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const requestLayoutTransaction = useCallback(
     (
       layout: LayoutSettings,
-      options?: { pendingIndicator?: boolean; videoOverride?: VideoSettings }
+      options?: {
+        pendingIndicator?: boolean
+        videoOverride?: VideoSettings
+        captureConfigPatch?: Pick<CaptureConfig, 'video' | 'verticalRestoreVideo'>
+      }
     ) => {
       const sessionActive = isActiveRecordingState(recordingRef.current.state)
       if (!client || wsStatus !== 'connected') {
@@ -4775,9 +4798,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             intentId,
             sources: requestedSources,
             layout,
-            // The vertical orientation coupling patches React state and the
-            // transaction in the same tick; the ref may not have caught up,
-            // so the caller passes the canvas it just applied.
+            // Orientation and canvas commit to React only after backend proof.
+            // Until then the ref intentionally remains on the previous program
+            // state, so the transaction carries its target canvas explicitly.
             video: options?.videoOverride ?? requestedConfig.video,
             background: activeSceneBackground,
             protectedOverlayWindowIds
@@ -4786,7 +4809,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             sceneRevision: status.sceneRevision,
             scene: status.scene,
             layout: status.compositorStatus.sceneLayout ?? layout,
-            compositorStatus: status.compositorStatus
+            compositorStatus: status.compositorStatus,
+            captureConfigPatch: options?.captureConfigPatch
           }
           // Intent freshness and backend commit freshness are separate. A may be
           // superseded by B after A commits; remember A before waiting for proof
@@ -4933,6 +4957,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       // profile; leaving restores it. Mid-session the canvas is fixed (the
       // vertical card is disabled and the backend refuses the switch).
       let videoOverride: VideoSettings | undefined
+      let captureConfigPatch: Pick<CaptureConfig, 'video' | 'verticalRestoreVideo'> | undefined
       if (!isActiveRecordingState(recordingRef.current.state)) {
         const coupling = verticalOrientationVideoPatch(
           current.layout.layoutPreset,
@@ -4942,11 +4967,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         )
         if (coupling) {
           videoOverride = coupling.video
-          setCaptureConfig((config) => ({
-            ...config,
+          captureConfigPatch = {
             video: coupling.video,
             verticalRestoreVideo: coupling.verticalRestoreVideo
-          }))
+          }
         }
       }
 
@@ -4957,10 +4981,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           cameraTransformMode: 'preset',
           cameraTransform: null
         },
-        videoOverride ? { videoOverride } : undefined
+        videoOverride ? { videoOverride, captureConfigPatch } : undefined
       )
     },
-    [requestLayoutTransaction, setCaptureConfig]
+    [requestLayoutTransaction]
   )
 
   const switchSourceDeviceLive = useCallback(

--- a/scripts/smoke-layout-source-loop-app.mjs
+++ b/scripts/smoke-layout-source-loop-app.mjs
@@ -46,6 +46,12 @@ const LAYOUTS = [
   {
     preset: 'vertical-camera-only',
     expectedKinds: ['camera']
+  },
+  // Close the loop in the reverse direction too: portrait -> landscape must
+  // restore the remembered horizontal canvas and preview bounds.
+  {
+    preset: 'screen-camera',
+    expectedKinds: ['camera', 'test-pattern']
   }
 ]
 
@@ -79,11 +85,23 @@ try {
       preset: layout.preset,
       settleMs
     })
-    const surface = await smokeCommand(smoke, 'preview-surface-scene-state')
+    const [surface, previewWindow, captureState] = await Promise.all([
+      smokeCommand(smoke, 'preview-surface-scene-state'),
+      smokeCommand(smoke, 'preview-window-state'),
+      smokeCommand(smoke, 'eval-js', {
+        code: `
+          const stored = JSON.parse(localStorage.getItem('videorc.captureConfig') ?? '{}');
+          return {
+            layoutPreset: stored.layout?.layoutPreset ?? null,
+            video: stored.video ?? null
+          };
+        `
+      })
+    ])
     const scene = await request(ws, timeoutMs, 'scene.get')
-    assertLayoutLoop(layout, selected, surface, scene)
+    assertLayoutLoop(layout, selected, surface, scene, previewWindow, captureState.result)
     console.log(
-      `Layout source loop [${layout.preset}] OK - scene ${sourceKinds(scene).join(' + ') || 'empty'}, surface revision ${surface.sceneRevision}.`
+      `Layout source loop [${layout.preset}] OK - scene ${sourceKinds(scene).join(' + ') || 'empty'}, ${captureState.result.video.width}x${captureState.result.video.height} preview, surface revision ${surface.sceneRevision}.`
     )
   }
 
@@ -99,7 +117,7 @@ try {
   await launched.stop()
 }
 
-function assertLayoutLoop(layout, selected, surface, scene) {
+function assertLayoutLoop(layout, selected, surface, scene, previewWindow, captureState) {
   if (selected?.preset !== layout.preset || selected?.pressed !== true) {
     throw new Error(
       `Layout ${layout.preset} did not become active in the UI: ${JSON.stringify(selected)}`
@@ -109,6 +127,34 @@ function assertLayoutLoop(layout, selected, surface, scene) {
   if (surface.layoutPreset !== layout.preset) {
     throw new Error(
       `Detached preview surface stayed on ${surface.layoutPreset}, expected ${layout.preset}: ${JSON.stringify(surface)}`
+    )
+  }
+
+  const expectsPortrait = layout.preset.startsWith('vertical-')
+  if (captureState?.layoutPreset !== layout.preset) {
+    throw new Error(
+      `Stored capture config stayed on ${captureState?.layoutPreset}, expected ${layout.preset}.`
+    )
+  }
+  if (!captureState?.video) {
+    throw new Error(`Stored capture config has no video settings for ${layout.preset}.`)
+  }
+  const canvasIsPortrait = captureState.video.height > captureState.video.width
+  if (canvasIsPortrait !== expectsPortrait) {
+    throw new Error(
+      `${layout.preset} kept a ${captureState.video.width}x${captureState.video.height} ${canvasIsPortrait ? 'portrait' : 'landscape'} canvas.`
+    )
+  }
+  const bounds = previewWindow?.contentBounds
+  if (!previewWindow?.open || !previewWindow.visible || !bounds) {
+    throw new Error(
+      `Preview window was not visibly presenting ${layout.preset}: ${JSON.stringify(previewWindow)}`
+    )
+  }
+  const previewIsPortrait = bounds.height > bounds.width
+  if (previewIsPortrait !== expectsPortrait) {
+    throw new Error(
+      `${layout.preset} kept ${bounds.width}x${bounds.height} ${previewIsPortrait ? 'portrait' : 'landscape'} preview bounds.`
     )
   }
 


### PR DESCRIPTION
## What changed

- Commit the Studio layout and canvas dimensions atomically after backend layout proof.
- Keep detached preview aspect ratio and recording session output dimensions synchronized in both landscape-to-portrait and portrait-to-landscape transitions.
- Extend the maintained layout/source smoke command so it crosses the mode-scoped Studio UI and verifies the persisted canvas, backend scene, and visible preview bounds in both directions.
- Add an integration regression with delayed layout proof to model the slower Windows compositor path.

## Root cause

The orientation control updated `captureConfig.video` before the matching layout transaction was proven. When backend proof took longer than the generic 250 ms scene-reload debounce, the reload could send the old layout with the new canvas and overwrite the committed preview scene. Recording could then consume state that differed from the visible preview.

## User impact

Switching Horizontal/Vertical now changes the preview and the next recording together, including restoring the remembered horizontal resolution when switching back.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test:scripts` — 609 passed
- `pnpm --filter @videorc/desktop test` — 1,008 passed, 1 skipped
- `pnpm smoke:layout-source-loop` — verified 2560x1440 → 1080x1920 → 2560x1440 preview/canvas transitions
- Recording-studio artifact, live layout switch, preview placement, interaction stress, and native surface reattach stages passed

The aggregate local recording-studio run was unable to finish two unrelated host/device checks: the detached lifecycle probe intermittently lost main-window readiness during its 100-cycle loop, and ScreenCaptureKit reported a live source while delivering zero frames.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout switching when changing between horizontal and vertical studio orientations.
  * Prevented inconsistent scene reloads while applying layouts under slow response conditions.
  * Ensured preview dimensions, orientation, and capture settings stay synchronized with the selected layout.

* **Tests**
  * Expanded layout validation to cover preview visibility, aspect ratios, stored settings, and repeated orientation changes.
  * Added coverage for delayed layout responses and recovery when presets are not immediately available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->