### PR TITLE
Release 0.9.37-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.37-beta.1.md
+++ b/changelog/0.9.37-beta.1.md
@@ -1,0 +1,24 @@
+---
+version: 0.9.37-beta.1
+date: 2026-07-13
+channel: beta
+title: Preview and recording always agree when you switch orientation
+summary: Switching the Studio between horizontal and vertical could briefly leave the preview and the next recording disagreeing about the canvas — a recording could come out in the wrong shape. Both now change together, every time, in both directions.
+highlights:
+  - Flipping between horizontal and vertical mode now updates the preview and the recording canvas as one step — a recording can no longer come out in the orientation you just left.
+  - Switching back to horizontal reliably restores the exact resolution you had before going vertical.
+  - The fix covers slower machines too, where the mismatch was most likely to appear.
+---
+
+## One switch, one truth
+
+The orientation switch changes two things at once: the scene layout and the
+canvas the app records onto. On slower machines those two could briefly
+disagree — the preview showed the new orientation while the recording
+settings still carried the old one (or the other way around), and a
+recording started in that window could come out in the wrong shape.
+
+The Studio now commits the layout and the canvas as a single step, only
+after the switch is fully confirmed. What the preview shows is what the
+recording produces — in both directions, including restoring your
+remembered horizontal resolution when you come back from vertical.


### PR DESCRIPTION
Version 0.9.36 → 0.9.37 and the user-facing changelog entry for the orientation preview/recording synchronization fix (#108). `pnpm changelog:check` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistencies between the Studio preview and recordings when switching between horizontal and vertical orientations.
  * Ensured scene layout and recording canvas changes are applied together after the orientation switch is confirmed.
  * Improved restoration of the original horizontal resolution when returning from vertical orientation, including on slower machines.

* **Release**
  * Updated the desktop app version to 0.9.37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->