### PR TITLE
Record the 0.9.37 release (orientation sync fix)

### DIFF
--- a/docs/releases/0.9.37.md
+++ b/docs/releases/0.9.37.md
@@ -1,0 +1,44 @@
+# Videorc 0.9.37 Beta 1
+
+Videorc 0.9.37 ships the orientation preview/recording synchronization
+fix: switching Horizontal/Vertical commits the layout and the canvas
+atomically after backend layout proof, so the preview and the next
+recording can never disagree about orientation.
+
+## Scope
+
+- **Orientation preview/recording synchronization** (PR #108): the
+  orientation control updated `captureConfig.video` before the matching
+  layout transaction was proven; when proof outlasted the 250 ms
+  scene-reload debounce, the reload could send the old layout with the
+  new canvas and overwrite the committed preview scene — a recording
+  could consume state that differed from the visible preview. Layout +
+  canvas now commit as one step after proof, both transition directions
+  restore correctly (including the remembered horizontal resolution),
+  the layout/source-loop smoke crosses the mode-scoped UI and asserts
+  persisted canvas + backend scene + visible preview bounds both ways,
+  and an integration regression models the slower Windows compositor
+  path with delayed proof.
+
+## Release status
+
+- [x] Feature PR merged via protected `main` (#108); release prep
+      PR #109.
+- [x] Signed + notarized arm64 build (dist:release, staple verified by
+      release:validate:macos).
+- [x] Uploaded to R2; feed verified end-to-end
+      (`https://www.videorc.com/api/updates/latest-mac.yml` →
+      `version: 0.9.37`, artifact hashes present) and
+      `/api/changelog` serves the 0.9.37-beta.1 entry.
+- [x] Discord announcement posted (release:notify:discord).
+- [ ] Owner acceptance: flip orientation both directions on a slower
+      machine profile, confirm the recording matches the preview and
+      the horizontal resolution restores; spot-check a recording
+      started immediately after a switch.
+- [ ] Owner: X post (draft provided in session; posted manually).
+
+## Rollback
+
+Standard: re-upload the previous release's artifacts/manifest (0.9.36)
+per `docs/releases/release-runbook.md`; the feed is version-compared,
+so restoring the older manifest reverts updates.


### PR DESCRIPTION
Internal release record for 0.9.37-beta.1 (#108 orientation preview/recording synchronization): signed+notarized build shipped, feed verified serving 0.9.37, changelog live, Discord announced. Owner acceptance checklist inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)