### PR TITLE
fix: live preview resize on orientation change, no chat toast on recordings, stage label centering

### DIFF
--- a/apps/desktop/src/renderer/src/components/scene/scene-stage.tsx
+++ b/apps/desktop/src/renderer/src/components/scene/scene-stage.tsx
@@ -306,19 +306,35 @@ function StageSourceRect({
         x={x}
         y={y}
       />
-      {/* Label only when the rect is big enough to hold it. */}
+      {/* Label only when the rect is big enough to hold it. Shaped camera
+          bubbles (circle / strongly rounded) cut the rect's corners away, so
+          the bottom-left anchor would float OUTSIDE the visible shape —
+          center the label in those. Rectangles keep bottom-left: the HTML
+          legend chips overlay the stage's top-left, so a rect touching the
+          top edge (side-by-side's screen box) had its label buried under the
+          chips (plan 021 F4). */}
       {width > 24 && height > 10 ? (
-        <text
-          className={cn('select-none', camera ? 'fill-primary' : 'fill-muted-foreground')}
-          fontSize={4.2}
-          x={x + 2.5}
-          // Bottom-left of the rect: the HTML legend chips overlay the stage's
-          // top-left, so a rect touching the top edge (side-by-side's screen
-          // box) had its label buried under the chips (plan 021 F4).
-          y={y + height - 2.5}
-        >
-          {source.name}
-        </text>
+        cornerRadius >= Math.min(width, height) / 4 ? (
+          <text
+            className={cn('select-none', camera ? 'fill-primary' : 'fill-muted-foreground')}
+            dominantBaseline="central"
+            fontSize={4.2}
+            textAnchor="middle"
+            x={x + width / 2}
+            y={y + height / 2}
+          >
+            {source.name}
+          </text>
+        ) : (
+          <text
+            className={cn('select-none', camera ? 'fill-primary' : 'fill-muted-foreground')}
+            fontSize={4.2}
+            x={x + 2.5}
+            y={y + height - 2.5}
+          >
+            {source.name}
+          </text>
+        )
       ) : null}
     </g>
   )

--- a/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/layout-tab.tsx
@@ -35,6 +35,7 @@ import {
   layoutPresetNeedsScreen,
   layoutPresetOrientation
 } from '@/lib/capture'
+import { effectiveCameraMaskShape } from '../../../../shared/native-preview-proof-geometry'
 
 // Mode-scoped like the Scenes gallery: the tab edits the current
 // orientation's scenes; the gallery's header toggle switches modes.
@@ -167,7 +168,7 @@ export function LayoutTab(): ReactElement {
             // WYSIWYG: only the inset scenes mask the camera bubble (backend
             // camera_mask policy) — side-by-side and the vertical bands render
             // a plain rectangle, so the schematic must too.
-            cameraShape={showOverlayControls ? layout.cameraShape : 'rectangle'}
+            cameraShape={effectiveCameraMaskShape(layout)}
             dragEnabled={showOverlayControls && !isSessionActive}
             hasBackground={Boolean(scene?.background)}
             outputAspect={captureConfig.video.width / Math.max(1, captureConfig.video.height)}

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -1439,9 +1439,18 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const chatSetupWarnedRef = useRef<{ sessionId?: string; warned: Set<string> }>({
     warned: new Set()
   })
+  const [captureConfig, setCaptureConfig] = useState<CaptureConfig>(loadCaptureConfig)
   useEffect(() => {
     const sessionId = liveChatSnapshot.sessionId
     if (!sessionId) {
+      return
+    }
+    // Chat setup warnings are a GO-LIVE concern. The backend no longer
+    // attaches chat providers to record-only sessions, and this gate keeps a
+    // future backend regression from nagging every recording about comments
+    // (owner report 2026-07-13: "Twitch comments are not connected" toast on
+    // every record with a disconnected Twitch target configured).
+    if (!captureConfig.streamEnabled) {
       return
     }
     if (chatSetupWarnedRef.current.sessionId !== sessionId) {
@@ -1463,8 +1472,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         }
       })
     }
-  }, [liveChatSnapshot])
-  const [captureConfig, setCaptureConfig] = useState<CaptureConfig>(loadCaptureConfig)
+  }, [liveChatSnapshot, captureConfig.streamEnabled])
   // Live captions: status + transcript driven by captions.* events; the mic
   // audio itself never reaches the renderer (the Rust backend uploads chunks).
   const [captionsStatus, setCaptionsStatus] = useState<CaptionsStatus>({ state: 'idle' })

--- a/apps/desktop/src/shared/native-preview-proof-geometry.test.ts
+++ b/apps/desktop/src/shared/native-preview-proof-geometry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { LayoutSettings, SceneSource } from './backend'
 import {
+  effectiveCameraMaskShape,
   previewProofBackgroundStageMargin,
   previewProofLayerFit,
   previewProofLayerShape
@@ -95,5 +96,9 @@ describe('Windows proof-surface geometry', () => {
       'rectangle'
     )
     expect(previewProofLayerShape(screen, layout())).toBeUndefined()
+    // The scene-editing stage depicts the same policy through this helper —
+    // a circle in the editor that records as a rectangle is a WYSIWYG lie.
+    expect(effectiveCameraMaskShape(layout({ cameraShape: 'circle' }))).toBe('circle')
+    expect(effectiveCameraMaskShape(layout({ layoutPreset: 'side-by-side' }))).toBe('rectangle')
   })
 })

--- a/apps/desktop/src/shared/native-preview-proof-geometry.ts
+++ b/apps/desktop/src/shared/native-preview-proof-geometry.ts
@@ -57,6 +57,19 @@ export function previewProofLayerFit(
     : 'contain'
 }
 
+/**
+ * The camera mask the render paths actually draw: only the inset scenes
+ * (screen-camera and its vertical twin) shape the bubble; band, region, and
+ * full-frame scenes keep the camera rectangular. Mirrors Rust `camera_mask` —
+ * every surface that DEPICTS the camera (proof surface, scene-editing stage)
+ * must use this, or the editor shows a circle the recording won't have.
+ */
+export function effectiveCameraMaskShape(layout: LayoutSettings): CameraShape {
+  return layout.layoutPreset === 'screen-camera' || layout.layoutPreset === 'vertical-screen-camera'
+    ? layout.cameraShape
+    : 'rectangle'
+}
+
 export function previewProofLayerShape(
   source: SceneSource,
   layout: LayoutSettings
@@ -64,8 +77,5 @@ export function previewProofLayerShape(
   if (source.kind !== 'camera') {
     return undefined
   }
-  // Only the inset scenes shape the camera bubble — mirrors Rust camera_mask.
-  return layout.layoutPreset === 'screen-camera' || layout.layoutPreset === 'vertical-screen-camera'
-    ? layout.cameraShape
-    : 'rectangle'
+  return effectiveCameraMaskShape(layout)
 }

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -2392,6 +2392,17 @@ fn twitch_chat_config(
 /// Start live chat for a freshly-started session: spawn a connector per enabled OAuth
 /// destination whose token resolves. Chat failures are logged, never propagated — a chat
 /// problem must not fail the stream (slice 8). One destination's failure leaves others alone.
+/// Live comments only exist for sessions with a live audience: chat providers
+/// attach when the session actually STREAMS, never for local recordings. The
+/// renderer sends its streaming settings with every session start, so the
+/// mere presence of `streaming` is not a streaming session — gating on it
+/// warned "Twitch comments are not connected" on every plain recording
+/// whenever a disconnected stream target was configured (owner report,
+/// 2026-07-13).
+fn session_attaches_live_chat(params: &protocol::StartSessionParams) -> bool {
+    params.output.stream_enabled && params.streaming.is_some()
+}
+
 async fn spawn_session_live_chat(
     state: &AppState,
     session_id: &str,
@@ -5272,10 +5283,12 @@ async fn handle_text_message_with_role(
             match serde_json::from_value::<protocol::StartSessionParams>(params_value) {
                 Ok(params) => {
                     let streaming = params.streaming.clone();
+                    let attach_live_chat = session_attaches_live_chat(&params);
                     match validate_start_session_oauth_availability(&params) {
                         Ok(()) => match start_session(state.clone(), params).await {
                             Ok(status) => {
-                                if let Some(streaming) = streaming.as_ref()
+                                if attach_live_chat
+                                    && let Some(streaming) = streaming.as_ref()
                                     && let Some(session_id) = status.session_id.as_deref()
                                 {
                                     spawn_session_live_chat(state, session_id, streaming).await;
@@ -9066,6 +9079,54 @@ mod tests {
         assert_eq!(twitch.read, live_chat::CommentsReadState::Unavailable);
         assert_eq!(twitch.write, live_chat::CommentsWriteState::MissingScope);
         assert!(twitch.message.contains("Reconnect Twitch"));
+    }
+
+    #[test]
+    fn live_chat_attaches_only_to_streaming_sessions() {
+        let params = |stream_enabled: bool| -> protocol::StartSessionParams {
+            serde_json::from_value(serde_json::json!({
+                "sources": { "testPattern": true },
+                "layout": {
+                    "cameraCorner": "bottom-right",
+                    "cameraSize": "medium",
+                    "cameraShape": "rectangle",
+                    "cameraMargin": 32
+                },
+                "output": {
+                    "recordEnabled": true,
+                    "streamEnabled": stream_enabled,
+                    "video": {
+                        "preset": "custom",
+                        "width": 1280,
+                        "height": 720,
+                        "fps": 30,
+                        "bitrateKbps": 2000
+                    },
+                    "rtmp": { "preset": "youtube", "serverUrl": "", "streamKey": "" }
+                }
+            }))
+            .expect("minimal session params")
+        };
+        let streaming = streaming_with_enabled_target(
+            StreamPlatform::Twitch,
+            crate::streaming::StreamAuthMode::ManualRtmp,
+        );
+
+        // A recording with configured stream targets must NOT attach chat —
+        // this exact shape toasted "Twitch comments are not connected" on
+        // every plain recording.
+        let mut recording = params(false);
+        recording.streaming = Some(streaming.clone());
+        assert!(!session_attaches_live_chat(&recording));
+
+        // A real go-live with the same targets keeps the 2026-07-10 guarantee:
+        // broken chat setup at go-live must surface, never fail silently.
+        let mut live = params(true);
+        live.streaming = Some(streaming);
+        assert!(session_attaches_live_chat(&live));
+
+        // No streaming settings at all → nothing to attach either way.
+        assert!(!session_attaches_live_chat(&params(true)));
     }
 
     #[test]

--- a/crates/videorc-backend/src/preview_surface.rs
+++ b/crates/videorc-backend/src/preview_surface.rs
@@ -575,7 +575,7 @@ fn unavailable_status(message: Option<String>) -> PreviewSurfaceStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compositor::{compositor_status, stop_compositor};
+    use crate::compositor::{compositor_latest_frame_evidence, compositor_status, stop_compositor};
     use crate::native_preview_host::{NativePreviewHostActivation, NativePreviewHostCommandKind};
     use crate::protocol::{CompositorState, PreviewSurfaceBounds};
     use crate::storage::Database;
@@ -900,6 +900,59 @@ mod tests {
         assert_eq!(status.run_id, recording_status.run_id);
         assert_eq!(status.width, 640);
         assert_eq!(status.height, 360);
+    }
+
+    async fn wait_for_frame_dimensions(state: &AppState, width: u32, height: u32) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if let Some(evidence) = compositor_latest_frame_evidence(state).await
+                && evidence.width == width
+                && evidence.height == height
+            {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "compositor never published a {width}x{height} frame (latest: {:?})",
+                compositor_latest_frame_evidence(state).await
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn bounds_update_reshapes_the_live_preview_compositor() {
+        // The stale-orientation preview bug: the render loop latched its
+        // spawn-time dimensions, so an off-air canvas flip (orientation
+        // toggle) resized the surface bounds and the compositor STATUS while
+        // frames kept publishing at the OLD size until the next recording
+        // start rebuilt the pipeline. The loop must reshape mid-stream.
+        let state = test_state();
+        create_preview_surface(
+            state.clone(),
+            PreviewSurfaceCreateParams {
+                bounds: bounds(960.0, 540.0),
+                target_fps: 60,
+                source: PreviewSurfaceSource::Synthetic,
+            },
+        )
+        .await;
+        wait_for_frame_dimensions(&state, 960, 540).await;
+
+        update_preview_surface_bounds(
+            &state,
+            PreviewSurfaceBoundsParams {
+                bounds: bounds(540.0, 960.0),
+            },
+        )
+        .await;
+
+        wait_for_frame_dimensions(&state, 540, 960).await;
+        let status = compositor_status(&state).await;
+        destroy_preview_surface(&state).await;
+
+        assert_eq!(status.width, 540);
+        assert_eq!(status.height, 960);
     }
 
     #[tokio::test]

--- a/scripts/smoke-layout-source-loop-app.mjs
+++ b/scripts/smoke-layout-source-loop-app.mjs
@@ -100,6 +100,12 @@ try {
     ])
     const scene = await request(ws, timeoutMs, 'scene.get')
     assertLayoutLoop(layout, selected, surface, scene, previewWindow, captureState.result)
+    // The SEEING layer: window bounds and persisted config can both flip while
+    // the compositor keeps rendering frames at its old spawn-time dimensions
+    // (the 0.9.37 stale-orientation preview bug). Assert the pipeline itself —
+    // the render dimensions and, when Metal presents, the actual target — has
+    // adopted the expected orientation.
+    await assertPresentedOrientation(ws, layout)
     console.log(
       `Layout source loop [${layout.preset}] OK - scene ${sourceKinds(scene).join(' + ') || 'empty'}, ${captureState.result.video.width}x${captureState.result.video.height} preview, surface revision ${surface.sceneRevision}.`
     )
@@ -179,6 +185,31 @@ function assertLayoutLoop(layout, selected, surface, scene, previewWindow, captu
 
 function sourceKinds(scene) {
   return scene.sources.map((source) => source.kind).sort()
+}
+
+// The compositor resizes on the NEXT tick after the surface bounds land, and
+// the bounds themselves follow the renderer's post-proof config commit — poll
+// briefly instead of asserting one instantaneous read.
+async function assertPresentedOrientation(ws, layout) {
+  const expectsPortrait = layout.preset.startsWith('vertical-')
+  const deadline = Date.now() + 10000
+  let status = null
+  while (Date.now() < deadline) {
+    status = await request(ws, timeoutMs, 'compositor.status')
+    const renderIsPortrait = status.height > status.width
+    const target =
+      typeof status.metalTargetWidth === 'number' && typeof status.metalTargetHeight === 'number'
+        ? { width: status.metalTargetWidth, height: status.metalTargetHeight }
+        : null
+    const targetMatches = !target || target.height > target.width === expectsPortrait
+    if (renderIsPortrait === expectsPortrait && targetMatches) {
+      return
+    }
+    await sleep(200)
+  }
+  throw new Error(
+    `Compositor kept rendering ${status?.width}x${status?.height} (metal target ${status?.metalTargetWidth ?? '-'}x${status?.metalTargetHeight ?? '-'}) for ${layout.preset}, expected ${expectsPortrait ? 'portrait' : 'landscape'} — the preview pipeline did not adopt the new canvas.`
+  )
 }
 
 function smokeCommand(smoke, command, params = {}) {


### PR DESCRIPTION
## Fixes (owner-reported on 0.9.37)

### 1. Preview stuck in the old orientation after the mode toggle
Root cause (traced end-to-end): the compositor render loop **latched its dimensions at spawn** — `update_compositor_scene` swaps scene content only, `update_compositor_surface_size` wrote status only, and the compositor never reads `scene.outputs` at all (preview dims follow surface bounds). Flipping orientation resized the window/slot and the status while frames kept publishing at the old size; the next recording start rebuilt the pipeline at the true canvas, which is exactly why "press record" healed it. Third defect in this seam.

Fix: the loop carries a live-dimensions cell it re-reads **every tick**; `update_compositor_surface_size` writes it alongside status, so a bounds change reshapes the next frame (the Metal target ring already reallocates on change). The cell is only reachable through the preview-ownership guard — the pinned recording-invariant test stays green, and a new regression (`bounds_update_reshapes_the_live_preview_compositor`) proves frames adopt new dimensions mid-stream.

The layout-source-loop smoke now asserts the **seeing layer** per preset — compositor render dims + Metal target orientation via `compositor.status` — the layer where every previous orientation defect hid while window bounds and persisted config asserted green.

### 2. "Twitch comments are not connected" toast on every recording
The renderer sends streaming settings with every session start; the backend attached live-chat providers whenever the field was present, never checking `output.stream_enabled`. Recordings with a disconnected Twitch target then warned about comments for a stream that wasn't happening. Gated on both layers, with tests pinning that real go-lives keep the 2026-07-10 "broken chat setup must surface" guarantee.

### 3. Camera label floating outside the circle bubble in the scene editor
Labels anchor bottom-left (clear of the legend chips), but a circle mask cuts that corner away. Shaped bubbles now center their label; the editor's shape gate moved onto the shared `effectiveCameraMaskShape` (one classifier for editor + proof surface, mirroring Rust `camera_mask`).

## Gates
Targeted cargo tests + clippy -D warnings + fmt (full Rust suite skipped per owner directive — CI billing block) · typecheck/lint/format · 1008 desktop tests · 609 script tests · smoke:dev all-layout 7 scenarios PASS incl. both portrait artifacts. smoke:layout-source-loop blocked on this box at camera device selection (pre-existing).

Plan: vault `2026-07-13 - Videorc Orientation Toggle Stale Preview Fix Plan` (all slices executed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Camera mask shapes now render consistently across supported layouts.
  * Labels are positioned more clearly within rounded camera bubbles and other shapes.
  * Live preview surfaces now update correctly when their dimensions or orientation change.
* **Bug Fixes**
  * Recording-only sessions no longer display misleading live-chat connection warnings.
  * Layout changes now reliably apply the expected portrait or landscape preview orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->