### PR TITLE
Release 0.9.38-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.37",
+  "version": "0.9.38",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.38-beta.1.md
+++ b/changelog/0.9.38-beta.1.md
@@ -1,0 +1,42 @@
+---
+version: 0.9.38-beta.1
+date: 2026-07-13
+channel: beta
+title: Noise cleanup for your recordings — and the preview flips with you
+summary: Premium users can now clean background noise out of a recording with one click in the Library — processed entirely on your Mac, never uploaded, and the original stays untouched. Plus the orientation switch now flips the preview instantly, and recordings stop warning about live comments.
+highlights:
+  - "Noise cleanup (Premium): one click in the Library produces a cleaned copy of a recording — processed on-device with no upload, no quota, and the original file never modified."
+  - Cleanup runs as a durable job with live progress; it survives app restarts, steps aside automatically if you start recording, and can be cancelled or retried anytime.
+  - Switching the Studio between horizontal and vertical now reshapes the preview immediately — it no longer stayed in the old orientation until you pressed record.
+  - Plain recordings no longer warn that Twitch comments are not connected — that check now only runs when you actually go live.
+  - The scene editor centers the camera label inside circle bubbles.
+---
+
+## Clean audio, one click, on your machine
+
+Every recording picks up some room: fans, hum, keyboard clatter. The Library
+now has a one-click **Noise cleanup** action (Premium) that produces a
+cleaned copy of a recording alongside the original — named so you can tell
+them apart, with the source file never touched.
+
+Everything happens on your Mac with the bundled tools: nothing is uploaded,
+there is no quota, and no cloud consent is involved. Cleanup runs as a
+durable job with live progress — it survives restarting the app, politely
+steps aside if you start a recording (and resumes after), and can be
+cancelled or retried at any time. If a file can't be cleaned safely — an
+unsupported container, missing audio, an imported file — the action says
+exactly why instead of guessing.
+
+## The preview follows the orientation switch — immediately
+
+Flipping the Studio between horizontal and vertical left the preview stuck
+in the previous orientation until a recording started. The preview pipeline
+now reshapes the moment the canvas changes, in both directions, docked or
+detached.
+
+## Quieter recordings
+
+Starting a plain recording no longer warns that Twitch comments are not
+connected. Live-comment setup only concerns an actual livestream — that
+check now runs only when you go live, where a broken chat setup still
+surfaces loudly.


### PR DESCRIPTION
Version 0.9.37 → 0.9.38 and the changelog entry for premium on-device noise cleanup (#106) + the orientation preview/toast fixes (#111). `pnpm changelog:check` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-click Premium noise cleanup for Library recordings, with on-device processing, progress tracking, cancel/retry, and restart resilience.
* **Improvements**
  * Studio preview now reshapes immediately when changing orientation.
  * Twitch comment disconnection checks now apply only when starting livestreams.
  * Camera labels in scene editor bubbles are now centered.
* **Release**
  * Updated the desktop app to version 0.9.38.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->