### PR TITLE
Record the 0.9.38 release (noise cleanup + orientation fixes)

### DIFF
--- a/docs/releases/0.9.38.md
+++ b/docs/releases/0.9.38.md
@@ -1,0 +1,57 @@
+# Videorc 0.9.38 Beta 1
+
+Videorc 0.9.38 ships premium on-device noise cleanup and the 0.9.37
+regression fixes: instant preview reshape on orientation change and the
+end of the live-chat warning on plain recordings.
+
+## Scope
+
+- **Premium on-device noise cleanup** (PR #106, plan: vault `2026-07-13 -
+  Videorc Noise Cleanup Premium Feature Plan`, deterministic evidence:
+  `docs/acceptance/2026-07-13-noise-cleanup.md`): one-click Library
+  action producing a non-destructive `— Noise Cleaned` derivative;
+  local-only FFmpeg processing, durable SQLite-owned jobs with restart
+  recovery and capture precedence, fail-closed Premium gate, exact media
+  policy (MP4→AAC 192k, MKV→pcm_s16le, streams copied). Merged after
+  resolving conflicts with #108/#111 (smoke QA block + integration-test
+  file — both added test suites kept).
+- **Orientation stale-preview fix** (PR #111, plan: vault `2026-07-13 -
+  Videorc Orientation Toggle Stale Preview Fix Plan`): the compositor
+  render loop latched its dimensions at spawn; it now re-reads a live
+  dimensions cell every tick, so an off-air canvas flip reshapes the
+  next frame. Pinned by a new reshape regression + the recording-owned
+  invariant test; the layout-source-loop smoke now asserts presented
+  pipeline dimensions per preset (the seeing layer).
+- **Recording chat-toast fix** (PR #111): live-chat providers attach
+  only when `output.stream_enabled` — recordings with a disconnected
+  Twitch target no longer warn about comments; go-live behavior pinned.
+- **Scene-stage label centering** (PR #111): labels center inside
+  circle/rounded camera bubbles; editor shape gate consolidated onto
+  shared `effectiveCameraMaskShape`.
+
+## Release status
+
+- [x] PRs merged: #106, #111, prep #112 (admin-merged — GitHub Actions
+      blocked by billing; all local gates green, full Rust suite skipped
+      per owner directive, targeted suites + clippy -D warnings run).
+- [x] Signed + notarized arm64 build; staple verified by
+      release:validate:macos. (Note: release-profile build emits a
+      dead-code warning for `is_ffmpeg_error_line` — non-fatal, cleanup
+      candidate.)
+- [x] Uploaded to R2; feed verified end-to-end
+      (`https://www.videorc.com/api/updates/latest-mac.yml` →
+      `version: 0.9.38`, artifact hashes present); `/api/changelog`
+      serves 0.9.38-beta.1.
+- [x] Discord announcement posted.
+- [ ] Owner acceptance: run a noise cleanup on a real recording
+      (Premium account) — progress, derivative naming, original
+      untouched, cancel/retry; flip orientation with docked preview
+      (should reshape within a frame); record with a disconnected
+      Twitch target (no toast) and go live (warning intact).
+- [ ] Owner: X post (draft provided in session; posted manually).
+
+## Rollback
+
+Standard: re-upload 0.9.37's artifacts/manifest per
+`docs/releases/release-runbook.md`; the feed is version-compared, so
+restoring the older manifest reverts updates.


### PR DESCRIPTION
Internal release record for 0.9.38-beta.1: premium on-device noise cleanup (#106) + the 0.9.37 regression fixes (#111). Build/upload/feed/announce all verified; owner acceptance checklist inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)