### PR TITLE
fix: live captions ignore the selected style — alpha-blend overlay quads in the Metal compositor

### DIFF
--- a/crates/videorc-backend/src/bin/native_preview_host_helper.rs
+++ b/crates/videorc-backend/src/bin/native_preview_host_helper.rs
@@ -396,6 +396,7 @@ mod macos {
             crop: [0.0, 0.0, 0.0, 0.0],
             mirror: false,
             mask: crate::metal_compositor::SourceMask::None,
+            blend: false,
         };
         compositor
             .compose_bgra(16, 16, [0.0, 0.0, 0.0, 1.0], &[source])
@@ -476,6 +477,7 @@ mod macos {
             crop: [0.0, 0.0, 0.0, 0.0],
             mirror: false,
             mask: crate::metal_compositor::SourceMask::None,
+            blend: false,
         };
         compositor
             .compose_bgra(16, 16, [0.0, 0.0, 0.0, 1.0], &[source])

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -2106,6 +2106,9 @@ struct PreparedGpuSource<'a> {
     crop: [f32; 4],
     mirror: bool,
     mask: SceneMask,
+    /// Straight-alpha source-over blend (overlay bitmaps only — capture sources
+    /// must keep the opaque overwrite; see `GpuSource::blend`).
+    blend: bool,
 }
 
 #[cfg(target_os = "macos")]
@@ -2134,6 +2137,7 @@ impl<'a> PreparedGpuSource<'a> {
             crop: self.crop,
             mirror: self.mirror,
             mask: scene_mask_into_metal(self.mask),
+            blend: self.blend,
         }
     }
 }
@@ -2275,6 +2279,9 @@ fn push_caption_overlay_gpu_source<'a>(
         crop,
         mirror: false,
         mask: SceneMask::None,
+        // The bar/card is rasterized on a transparent canvas; without blending
+        // its alpha-0 pixels overwrite the frame as an opaque black box.
+        blend: true,
     });
 }
 
@@ -2343,6 +2350,7 @@ fn try_gpu_compose(
                     crop,
                     mirror: false,
                     mask: SceneMask::None,
+                    blend: false,
                 });
                 true
             } else {
@@ -2400,6 +2408,7 @@ fn try_gpu_compose(
             crop,
             mirror: false,
             mask: SceneMask::None,
+            blend: false,
         });
         if let Some(overlay) = inputs.caption_overlay {
             let safe_inset = caption_overlay_safe_inset(
@@ -2469,6 +2478,7 @@ fn try_gpu_compose(
             crop,
             mirror: false,
             mask: SceneMask::None,
+            blend: false,
         });
         if let Some(overlay) = inputs.caption_overlay {
             let safe_inset = caption_overlay_safe_inset(
@@ -2549,6 +2559,7 @@ fn try_gpu_compose(
                         crop,
                         mirror: layout.camera_mirror,
                         mask: camera_mask(layout),
+                        blend: false,
                     });
                 } else {
                     let placeholder =
@@ -2578,6 +2589,7 @@ fn try_gpu_compose(
                         crop,
                         mirror: layout.camera_mirror,
                         mask: camera_mask(layout),
+                        blend: false,
                     });
                 }
             }
@@ -2625,6 +2637,7 @@ fn try_gpu_compose(
                         crop,
                         mirror: false,
                         mask: SceneMask::None,
+                        blend: false,
                     });
                 } else {
                     let placeholder =
@@ -2651,6 +2664,7 @@ fn try_gpu_compose(
                         crop,
                         mirror: false,
                         mask: SceneMask::None,
+                        blend: false,
                     });
                 }
             }
@@ -2678,6 +2692,7 @@ fn try_gpu_compose(
                     crop,
                     mirror: false,
                     mask: SceneMask::None,
+                    blend: false,
                 });
             }
         }
@@ -7126,6 +7141,25 @@ mod tests {
             position,
             revision: 1,
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn caption_overlay_gpu_quad_requests_alpha_blending() {
+        // The bar/card bitmap is straight-alpha and mostly transparent; the
+        // Metal quad must blend or the transparent pixels burn into the stream
+        // as an opaque black box (the "black background captions" bug).
+        let overlay = test_caption_overlay(
+            8,
+            4,
+            [255, 255, 255, 255],
+            crate::captions::CaptionOverlayPosition::Bottom,
+        );
+        let mut prepared = Vec::new();
+        push_caption_overlay_gpu_source(&mut prepared, &overlay, 32, 16, 2, 0);
+        assert_eq!(prepared.len(), 1);
+        assert!(prepared[0].blend, "caption overlay quad must alpha-blend");
+        assert!(prepared[0].as_gpu_source().blend);
     }
 
     #[test]

--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -4875,6 +4875,7 @@ mod tests {
             crop: [0.0; 4],
             mirror: false,
             mask: crate::metal_compositor::SourceMask::None,
+            blend: false,
         }];
         compositor
             .compose_bgra(

--- a/crates/videorc-backend/src/metal_compositor.rs
+++ b/crates/videorc-backend/src/metal_compositor.rs
@@ -30,7 +30,7 @@ use objc2_core_video::{
 use objc2_foundation::NSString;
 use objc2_io_surface::IOSurfaceRef;
 use objc2_metal::{
-    MTLClearColor, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue,
+    MTLBlendFactor, MTLClearColor, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue,
     MTLCreateSystemDefaultDevice, MTLDevice, MTLDrawable, MTLLibrary, MTLLoadAction, MTLOrigin,
     MTLPixelFormat, MTLPrimitiveType, MTLRegion, MTLRenderCommandEncoder, MTLRenderPassDescriptor,
     MTLRenderPipelineDescriptor, MTLRenderPipelineState, MTLResourceOptions, MTLSamplerDescriptor,
@@ -150,6 +150,12 @@ pub struct GpuSource<'a> {
     /// radius of `radius_pct`% of the shorter side. Every render path (CPU, Metal,
     /// FFmpeg) derives its geometry from the same rule.
     pub mask: SourceMask,
+    /// Source-over blend this quad using its straight (non-premultiplied) alpha —
+    /// required for the caption/comment overlay bitmaps, whose transparent pixels
+    /// must show the frame beneath instead of writing opaque black. Capture
+    /// sources keep the default opaque overwrite: their alpha channels are not
+    /// trustworthy (screen frames can arrive with alpha 0).
+    pub blend: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -417,6 +423,9 @@ pub struct MetalSceneCompositor {
     device: Retained<MetalDevice>,
     queue: Retained<ProtocolObject<dyn MTLCommandQueue>>,
     pipeline: Retained<ProtocolObject<dyn MTLRenderPipelineState>>,
+    /// Same shader with straight-alpha source-over blending, selected per quad
+    /// for `GpuSource::blend` overlays (caption bar, comment highlight).
+    blend_pipeline: Retained<ProtocolObject<dyn MTLRenderPipelineState>>,
     sampler: Retained<ProtocolObject<dyn MTLSamplerState>>,
     targets: Vec<CachedTargetTexture>,
     // Index of the LAST-RENDERED slot; advanced at the start of each compose.
@@ -589,13 +598,15 @@ impl MetalSceneCompositor {
     pub fn new() -> Option<Self> {
         let device = MTLCreateSystemDefaultDevice()?;
         let queue = device.newCommandQueue()?;
-        let pipeline = build_pipeline(&device)?;
+        let pipeline = build_pipeline(&device, false)?;
+        let blend_pipeline = build_pipeline(&device, true)?;
         let sampler = build_sampler(&device)?;
         let source_texture_cache = make_texture_cache(&device).map(MetalSourceTextureCache::new);
         Some(Self {
             device,
             queue,
             pipeline,
+            blend_pipeline,
             sampler,
             targets: Vec::new(),
             target_cursor: 0,
@@ -674,7 +685,16 @@ impl MetalSceneCompositor {
         let mut source_import_stats = MetalSourceImportStats::default();
         let mut command_encode_ms = 0.0;
         let mut encode_segment_started_at = Instant::now();
+        let mut encoder_blend = false;
         for (source_index, source) in sources.iter().enumerate() {
+            if source.blend != encoder_blend {
+                encoder.setRenderPipelineState(if source.blend {
+                    &self.blend_pipeline
+                } else {
+                    &self.pipeline
+                });
+                encoder_blend = source.blend;
+            }
             let vertices = quad_vertices(source.dest);
             let buffer = unsafe {
                 self.device.newBufferWithBytes_length_options(
@@ -1030,7 +1050,7 @@ pub struct MetalPreviewPresenter {
 impl MetalPreviewPresenter {
     pub fn new(device: Retained<MetalDevice>) -> Option<Self> {
         let queue = device.newCommandQueue()?;
-        let pipeline = build_pipeline(&device)?;
+        let pipeline = build_pipeline(&device, false)?;
         let sampler = build_preview_sampler(&device)?;
         Some(Self {
             device,
@@ -1167,7 +1187,7 @@ pub fn present_texture_to_layer(
     texture: &MetalTexture,
 ) -> bool {
     let device = queue.device();
-    let Some(pipeline) = build_pipeline(&device) else {
+    let Some(pipeline) = build_pipeline(&device, false) else {
         return false;
     };
     let Some(sampler) = build_preview_sampler(&device) else {
@@ -1416,6 +1436,7 @@ fn clear_pass(texture: &MetalTexture, rgba: [f64; 4]) -> Retained<MTLRenderPassD
 
 fn build_pipeline(
     device: &MetalDevice,
+    blending: bool,
 ) -> Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>> {
     let source = NSString::from_str(SHADER_SOURCE);
     let library = device
@@ -1429,6 +1450,15 @@ fn build_pipeline(
     descriptor.setFragmentFunction(Some(&fragment));
     let attachment = unsafe { descriptor.colorAttachments().objectAtIndexedSubscript(0) };
     attachment.setPixelFormat(MTLPixelFormat::BGRA8Unorm);
+    if blending {
+        // Straight-alpha source-over: overlay bitmaps are PNG-decoded and NOT
+        // premultiplied, so the RGB factors scale by source alpha here.
+        attachment.setBlendingEnabled(true);
+        attachment.setSourceRGBBlendFactor(MTLBlendFactor::SourceAlpha);
+        attachment.setDestinationRGBBlendFactor(MTLBlendFactor::OneMinusSourceAlpha);
+        attachment.setSourceAlphaBlendFactor(MTLBlendFactor::One);
+        attachment.setDestinationAlphaBlendFactor(MTLBlendFactor::OneMinusSourceAlpha);
+    }
 
     device
         .newRenderPipelineStateWithDescriptor_error(&descriptor)
@@ -1714,11 +1744,71 @@ mod tests {
             crop: [0.0; 4],
             mirror: false,
             mask: SourceMask::None,
+            blend: false,
         }];
         let yuv = compositor.compose_yuv420p(4, 4, &sources).unwrap();
         assert_eq!(yuv.len(), 16 + 2 * 4);
         assert!(yuv[..16].iter().all(|&y| y == 76), "Y plane red");
         assert!(yuv[16..20].iter().all(|&u| u == 85), "U plane red");
+    }
+
+    #[test]
+    fn blend_source_composites_straight_alpha_over_the_frame_or_skips() {
+        let Some(mut compositor) = MetalSceneCompositor::new() else {
+            eprintln!("skipping: no Metal device available in this environment");
+            return;
+        };
+        // The caption-bar regression: the overlay PNG is straight-alpha, mostly
+        // transparent. A blend quad must show the frame through alpha-0 texels
+        // (they used to overwrite the stream as an opaque black box), land
+        // opaque texels verbatim, and mix half-alpha texels.
+        let overlay = [
+            0u8, 0, 0, 0, // transparent
+            0, 0, 255, 255, // opaque red
+            0, 0, 255, 128, // half-alpha red
+            0, 0, 0, 0, // transparent
+        ];
+        let mut source = full_frame(&overlay, 4, 1, false, SourceMask::None, [0.0; 4]);
+        source.blend = true;
+        let px = compositor
+            .compose_bgra(4, 1, [0.0, 1.0, 0.0, 1.0], &[source])
+            .unwrap();
+        assert_eq!(
+            pixel(&px, 4, 0, 0)[..3],
+            [0, 255, 0],
+            "alpha-0 texel keeps the green frame"
+        );
+        assert_eq!(
+            pixel(&px, 4, 1, 0)[..3],
+            [0, 0, 255],
+            "opaque texel lands verbatim"
+        );
+        let mixed = pixel(&px, 4, 2, 0);
+        assert!(
+            mixed[2] >= 126 && mixed[2] <= 130 && mixed[1] >= 125 && mixed[1] <= 129,
+            "half-alpha texel blends red over green, got {mixed:?}"
+        );
+        assert_eq!(
+            pixel(&px, 4, 3, 0)[..3],
+            [0, 255, 0],
+            "alpha-0 texel keeps the green frame"
+        );
+    }
+
+    #[test]
+    fn non_blend_source_keeps_the_opaque_overwrite_or_skips() {
+        let Some(mut compositor) = MetalSceneCompositor::new() else {
+            eprintln!("skipping: no Metal device available in this environment");
+            return;
+        };
+        // Capture sources keep the historical overwrite: their alpha channels
+        // are not trustworthy, so an alpha-0 texel still replaces the frame.
+        let overlay = [0u8, 0, 0, 0];
+        let source = full_frame(&overlay, 1, 1, false, SourceMask::None, [0.0; 4]);
+        let px = compositor
+            .compose_bgra(1, 1, [0.0, 1.0, 0.0, 1.0], &[source])
+            .unwrap();
+        assert_eq!(pixel(&px, 1, 0, 0)[..3], [0, 0, 0]);
     }
 
     #[test]
@@ -1953,6 +2043,7 @@ mod tests {
             crop,
             mirror,
             mask,
+            blend: false,
         }
     }
 
@@ -2131,6 +2222,7 @@ mod tests {
                 crop: [0.0; 4],
                 mirror: false,
                 mask: SourceMask::None,
+                blend: false,
             },
             GpuSource {
                 kind: GpuSourceKind::Camera,
@@ -2144,6 +2236,7 @@ mod tests {
                 crop: [0.0; 4],
                 mirror: true,
                 mask: SourceMask::None,
+                blend: false,
             },
         ];
         let yuv = compositor.compose_yuv420p(1920, 1080, &sources).unwrap();
@@ -2170,6 +2263,7 @@ mod tests {
                 crop: [0.0; 4],
                 mirror: false,
                 mask: SourceMask::None,
+                blend: false,
             },
             GpuSource {
                 kind: GpuSourceKind::Camera,
@@ -2183,6 +2277,7 @@ mod tests {
                 crop: [0.0; 4],
                 mirror: true,
                 mask: SourceMask::None,
+                blend: false,
             },
         ];
 
@@ -2258,6 +2353,7 @@ mod tests {
             crop: [0.0; 4],
             mirror: false,
             mask: SourceMask::None,
+            blend: false,
         }];
 
         let output = compositor
@@ -2303,6 +2399,7 @@ mod tests {
             crop: [0.0; 4],
             mirror: false,
             mask: SourceMask::None,
+            blend: false,
         }];
 
         let output = compositor
@@ -2486,6 +2583,7 @@ mod tests {
             crop: [0.0; 4],
             mirror: false,
             mask: SourceMask::None,
+            blend: false,
         }];
         let pixels = composite_sources(out, out, [0.0, 0.0, 1.0, 1.0], &sources).unwrap();
         assert_eq!(pixels.len(), out * out * 4);

--- a/crates/videorc-backend/src/video_toolbox_encoder.rs
+++ b/crates/videorc-backend/src/video_toolbox_encoder.rs
@@ -1111,6 +1111,7 @@ mod tests {
             crop: [0.0; 4],
             mirror: false,
             mask: crate::metal_compositor::SourceMask::None,
+            blend: false,
         }];
         compositor
             .compose_bgra(64, 64, [0.0, 0.0, 0.0, 1.0], &sources)
@@ -1210,6 +1211,7 @@ mod tests {
                 crop: [0.0; 4],
                 mirror: false,
                 mask: crate::metal_compositor::SourceMask::None,
+                blend: false,
             }];
             compositor
                 .compose_bgra(64, 64, [0.0, 0.0, 0.0, 1.0], &sources)
@@ -1309,6 +1311,7 @@ mod tests {
             crop: [0.0; 4],
             mirror: false,
             mask: crate::metal_compositor::SourceMask::None,
+            blend: false,
         }];
         compositor
             .compose_bgra(64, 64, [0.0, 0.0, 0.0, 1.0], &sources)


### PR DESCRIPTION
## Problem

Owner report: during a livestream, captions rendered as **black-background bars** even though the no-background **Classic** style was selected in the Captions tab.

## Root cause

The Metal compositor draws every source quad with **blending disabled** (masks are handled via `discard_fragment`, and no pipeline ever set a blend state). The caption bar is pushed onto the stream leg as a straight-alpha BGRA bitmap (`push_caption_overlay_gpu_source`), and it is the only deliberately semi-transparent source in the scene — so its transparent pixels (`rgba 0,0,0,0`) overwrote the frame as **opaque black**.

- **Glass** style masked the bug: its plate is near-black by design, so the missing blend just made it look fully opaque.
- **Classic** exposed it: the bitmap is ~all transparent except the text glyphs → a solid black box behind white text.
- The Captions-tab preview rasterizes in a browser canvas and the CPU compositor fallback (`composite_caption_overlay`) both blend correctly — which is why the tab looked right while the stream did not. The comment-highlight card rides the same push path and was equally affected.

## Fix

Add a second `MTLRenderPipelineState` with straight-alpha source-over blending (`SourceAlpha` / `OneMinusSourceAlpha`; alpha `One` / `OneMinusSourceAlpha` — the overlay PNGs are not premultiplied), selected per quad via a new `GpuSource::blend` flag. Only the caption bar and comment-highlight overlay set it. Capture sources keep the historical opaque overwrite: their alpha channels are not trustworthy (screen frames can arrive with alpha 0). Frames without an overlay never switch pipelines, so the hot path is unchanged.

## Verification

- New GPU tests on a real Metal device: `blend_source_composites_straight_alpha_over_the_frame_or_skips` (alpha-0 shows the frame, opaque lands verbatim, half-alpha mixes), plus `non_blend_source_keeps_the_opaque_overwrite_or_skips` as the control proving the old behavior (and the bug) for non-blend quads. Wiring test asserts the caption quad requests blending.
- Targeted backend tests (`compositor::`, `metal_compositor::`, `captions::`): 162 passed, 9 consecutive clean runs.
- `cargo clippy -p videorc-backend -- -D warnings`, `cargo fmt --check --all`: clean. (`--all-targets` clippy has 20 pre-existing test-code lint errors that also fail without this change.)
- `pnpm smoke:recording-studio`: every stage passes — including the **live captions record+stream artifact smoke** (renderer published captions to RTMP, plate metrics verified) and the real-launch contract with the Metal compositor enabled — except the layout/source preview liveness stage, which fails identically on clean origin/main with "No camera device available to select" (pre-existing environment issue, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)