### PR TITLE
fix(windows): report supported preview surface as live

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,9 @@ CI covers Rust advisory audit, Rust fmt, clippy, Rust tests, JS production advis
 
 ## Native Preview Rules
 
-- Production preview is the detached native CAMetalLayer path. MJPEG/JPEG preview routes are fallback or debug paths only.
-- Do not silently downgrade a session that claims native preview. If native CAMetalLayer cannot run, surface the fallback reason in status, diagnostics, or health copy.
+- Production macOS preview is the detached native CAMetalLayer path. MJPEG/JPEG preview routes are fallback or debug paths only.
+- The current Windows production presenter is the uncompressed, latest-wins BMP Electron proof surface documented in `docs/windows-port-plan.md`. It may report a healthy lifecycle only after its first-frame and source-liveness contracts pass, and it must remain identified as `electron-proof-surface` / `electron-browser-window`; it must never claim native CAMetalLayer transport or backing. Production PNG requests remain a transport bug.
+- Do not silently downgrade a session that claims native preview. If native CAMetalLayer cannot run on macOS, surface the fallback reason in status, diagnostics, or health copy. On Windows, surface proof-presenter startup and source stalls without mislabeling the supported proof transport as native.
 - Probe before merging preview changes. At minimum run the relevant native preview tests and use the smoke/probe command that exercises the touched path.
 - For detached preview window lifecycle, toggle, close/reopen, placement ownership, frame-polling suppression, or proof-surface teardown changes, run `pnpm probe:preview-lifecycle`; add `pnpm probe:preview-window` when placement or move/resize behavior is touched.
 - `PreviewSurfaceBounds` has mirrors in Rust protocol, shared TS types, native host/helper protocol, and normalization/comparison code. Any field change must preserve all mirrors and must include a regression test proving fields survive normalization and helper serialization.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -178,6 +178,7 @@ import {
   nativePreviewFirstFrameWatchdogEnabled,
   nativePreviewProofWatchdogEnabled,
   ProofWatchdogRendererReadSingleFlight,
+  proofPresentationFallbackReason,
   proofWatchdogRendererReadAllowed,
   WatchdogTickOwnership,
   type FirstFrameLedger,
@@ -948,6 +949,7 @@ async function runWindowsProofFrameWatchdogTick(watchdogRun: WatchdogRunToken): 
     nativePreviewProofPendingStartedAtMs = pendingStartedAtMs
     const presentedFrameId = finiteMetric(metrics?.presentedCompositorFrame)
     const sourceFrameAgeMs = finiteMetric(metrics?.sourceFrameAgeMs)
+    const sourceFrameHistoryComplete = metrics?.sourceFrameHistoryComplete === true
     const assessment = assessProofPresentationWatch({
       platform: process.platform,
       framePollingSuppressed,
@@ -955,6 +957,7 @@ async function runWindowsProofFrameWatchdogTick(watchdogRun: WatchdogRunToken): 
       sourceExpected: nativePreviewProofSourceExpected(),
       sourcePollerCount: finiteMetric(metrics?.sourcePollerCount) ?? 0,
       freshSourceLayerCount: finiteMetric(metrics?.freshSourceLayerCount) ?? 0,
+      sourceFrameHistoryComplete,
       sourceFrameAgeMs,
       pendingElapsedMs: Math.max(0, nowMs - pendingStartedAtMs)
     })
@@ -982,10 +985,11 @@ async function runWindowsProofFrameWatchdogTick(watchdogRun: WatchdogRunToken): 
       }
     } else if (nativePreviewSurfaceStatus.firstFrameContract !== 'fallback') {
       const pendingElapsedMs = Math.max(0, nowMs - pendingStartedAtMs)
-      const reason =
-        sourceFrameAgeMs === undefined
-          ? `Windows preview did not deliver a first frame within ${Math.round(pendingElapsedMs)}ms.`
-          : `Windows preview source frames have not advanced for ${Math.round(sourceFrameAgeMs)}ms; keeping the last good frame while polling retries.`
+      const reason = proofPresentationFallbackReason({
+        sourceFrameHistoryComplete,
+        sourceFrameAgeMs,
+        pendingElapsedMs
+      })
       setFirstFrameStatus('fallback', reason)
       updatePreviewWindowWaitDetail(reason)
       logBackend('warn', `[proof-preview] ${reason}`)
@@ -4552,6 +4556,7 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
               compositorSources: compositorStatus?.sources ?? [],
               layerCount: layers.size,
               sourcePollerCount: pollers.size,
+              sourceFrameHistoryComplete: proofPollersHaveCompleteFrameHistory(pollers),
               liveLayerCount,
               freshSourceLayerCount,
               sourceFrames: Object.fromEntries(sourceFrames),
@@ -5446,6 +5451,7 @@ async function presentNativePreviewSurfaceCompositor(
     sourceExpected: nativePreviewProofSourceExpected(),
     sourcePollerCount,
     freshSourceLayerCount,
+    sourceFrameHistoryComplete: metrics?.sourceFrameHistoryComplete === true,
     sourceFrameAgeMs
   })
   if (proofSourceAssessment === 'met') {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -73,6 +73,8 @@ import {
   nativePreviewPresentFailureDisposition,
   nativePreviewProofPollingSuppressed,
   nativePreviewSurfaceHasAttachedNativePixels,
+  nativePreviewSupervisorFallbackReason,
+  nativePreviewSupervisorDisposition,
   nativePreviewValidatedHandoffStatus
 } from './native-preview-host-policy'
 import { loadNativePreviewInProcessDriver } from './native-preview-in-process-loader'
@@ -167,16 +169,22 @@ import {
 } from './avatar-cache'
 import { DARK_WINDOW_PALETTE, windowPalette } from './window-palette'
 import {
+  assessProofPresentationWatch,
   assessProofSourceFrame,
   assessFirstFrame,
   assessPresenting,
   emptyFirstFrameLedger,
   emptyPresentingWatch,
   nativePreviewFirstFrameWatchdogEnabled,
+  nativePreviewProofWatchdogEnabled,
+  ProofWatchdogRendererReadSingleFlight,
+  proofWatchdogRendererReadAllowed,
+  WatchdogTickOwnership,
   type FirstFrameLedger,
   type FirstFrameSnapshot,
   type PresentingAssessment,
-  type PresentingWatchState
+  type PresentingWatchState,
+  type WatchdogRunToken
 } from './native-preview-first-frame'
 import { NATIVE_PREVIEW_PROOF_POLLER_RUNTIME_SCRIPT } from './native-preview-proof-poller-runtime'
 import { NATIVE_PREVIEW_PROOF_MEASUREMENT_RUNTIME_SCRIPT } from './native-preview-proof-measurement-runtime'
@@ -706,16 +714,24 @@ let firstFrameLastPresentedFrameId: number | null = null
 // states distinct makes the first hide update observable without a magic
 // string sentinel (and keeps this source file valid text).
 let firstFrameLastHint: string | null | undefined
-let firstFrameTickInFlight = false
+const firstFrameTickOwnership = new WatchdogTickOwnership()
+const firstFrameProofRendererReads = new ProofWatchdogRendererReadSingleFlight<Record<
+  string,
+  unknown
+> | null>()
+let firstFrameWatchdogRun: WatchdogRunToken | null = null
 // After the first frame lands the watchdog does NOT stop: it flips into the
 // presenting watch (plan 021 F1) and keeps assessing the same chain so a
 // mid-session stall self-heals instead of leaving the placeholder forever.
 let firstFrameWatchdogMode: 'first-frame' | 'presenting-watch' = 'first-frame'
 let presentingWatch: PresentingWatchState = emptyPresentingWatch()
 let presentingWatchLastKind: PresentingAssessment['kind'] = 'presenting'
+let nativePreviewProofPendingStartedAtMs: number | null = null
 
 function startFirstFrameWatchdog(): void {
   stopFirstFrameWatchdog()
+  const watchdogRun = firstFrameTickOwnership.startRun()
+  firstFrameWatchdogRun = watchdogRun
   firstFrameWatchdogStartedAtMs = Date.now()
   firstFrameLedger = emptyFirstFrameLedger()
   firstFrameLastFramesRendered = null
@@ -726,16 +742,41 @@ function startFirstFrameWatchdog(): void {
   presentingWatchLastKind = 'presenting'
   setFirstFrameStatus('pending', 'Preview surface is starting.')
   firstFrameWatchdogTimer = setInterval(() => {
-    void runFirstFrameWatchdogTick()
+    void runFirstFrameWatchdogTick(watchdogRun)
   }, FIRST_FRAME_TICK_MS)
 }
 
-function stopFirstFrameWatchdog(): void {
+function startWindowsProofFrameWatchdog(): void {
+  stopFirstFrameWatchdog()
+  const watchdogRun = firstFrameTickOwnership.startRun()
+  firstFrameWatchdogRun = watchdogRun
+  firstFrameWatchdogStartedAtMs = Date.now()
+  firstFrameLastFramesRendered = null
+  firstFrameLastHint = undefined
+  nativePreviewProofPendingStartedAtMs = firstFrameWatchdogStartedAtMs
+  const reason = 'Waiting for the Windows preview surface to deliver pixels.'
+  setFirstFrameStatus('pending', reason)
+  updatePreviewWindowWaitDetail(reason)
+  firstFrameWatchdogTimer = setInterval(() => {
+    void runWindowsProofFrameWatchdogTick(watchdogRun)
+  }, FIRST_FRAME_TICK_MS)
+}
+
+function stopFirstFrameWatchdog(expectedRun?: WatchdogRunToken): void {
+  if (expectedRun && firstFrameWatchdogRun !== expectedRun) {
+    return
+  }
   if (firstFrameWatchdogTimer) {
     clearInterval(firstFrameWatchdogTimer)
     firstFrameWatchdogTimer = null
   }
-  firstFrameTickInFlight = false
+  const watchdogRun = firstFrameWatchdogRun
+  firstFrameWatchdogRun = null
+  if (watchdogRun) {
+    firstFrameTickOwnership.stopRun(watchdogRun)
+  }
+  firstFrameProofRendererReads.retire()
+  nativePreviewProofPendingStartedAtMs = null
 }
 
 function setFirstFrameStatus(
@@ -794,40 +835,199 @@ async function fetchFirstFrameCompositorStatus(): Promise<CompositorStatus | nul
   }
 }
 
-async function runFirstFrameWatchdogTick(): Promise<void> {
-  if (firstFrameTickInFlight) {
+function observeFirstFrameCompositorProgress(compositor: CompositorStatus | null): boolean {
+  const framesRendered = compositor?.framesRendered ?? null
+  const framesAdvancing =
+    framesRendered != null &&
+    firstFrameLastFramesRendered != null &&
+    framesRendered > firstFrameLastFramesRendered
+  if (framesRendered != null) {
+    firstFrameLastFramesRendered = framesRendered
+  }
+  return framesAdvancing
+}
+
+function nativePreviewProofSourceExpected(): boolean {
+  return Boolean(
+    nativePreviewSurfaceScene?.sources.some(
+      (source) =>
+        source.visible &&
+        (source.kind === 'screen' || source.kind === 'window' || source.kind === 'camera')
+    )
+  )
+}
+
+function retireStalledNativePreviewMainPump(framesAdvancing: boolean): void {
+  const mainPumpSocket = backendEventSocket
+  const mainPumpConnection = backendAdminConnection
+  if (
+    !mainPumpSocket ||
+    !mainPumpConnection ||
+    !mainPumpFrameDeliveryStalled({
+      active: nativePreviewMainPumpActive,
+      surfaceLive: nativePreviewSurfaceStatus.state === 'live',
+      compositorFramesAdvancing: framesAdvancing,
+      activatedAtMs: nativePreviewMainPumpActivatedAtMs,
+      lastPresentDrivingEventAtMs: nativePreviewMainLastPresentDrivingEventAtMs,
+      nowMs: Date.now()
+    })
+  ) {
     return
   }
-  firstFrameTickInFlight = true
+  retireBackendEventSocket(
+    mainPumpSocket,
+    mainPumpConnection,
+    `presentation event heartbeat stalled for ${Math.max(0, Date.now() - Math.max(nativePreviewMainPumpActivatedAtMs, nativePreviewMainLastPresentDrivingEventAtMs))}ms while compositor frames advanced`
+  )
+}
+
+async function runWindowsProofFrameWatchdogTick(watchdogRun: WatchdogRunToken): Promise<void> {
+  const tick = firstFrameTickOwnership.tryAcquire(watchdogRun)
+  if (!tick) {
+    return
+  }
   try {
     const window = previewWindow
     if (!window || window.isDestroyed() || appIsQuitting) {
-      stopFirstFrameWatchdog()
+      stopFirstFrameWatchdog(watchdogRun)
+      return
+    }
+    const compositor = await fetchFirstFrameCompositorStatus()
+    if (
+      !firstFrameTickOwnership.isCurrent(tick) ||
+      firstFrameWatchdogRun !== watchdogRun ||
+      firstFrameWatchdogTimer == null ||
+      previewWindow !== window ||
+      window.isDestroyed()
+    ) {
       return
     }
 
-    const watchdogGeneration = firstFrameWatchdogStartedAtMs
+    const framePollingSuppressed = nativePreviewProofPollingIsSuppressed()
+    const intentionallyHidden = nativePreviewSurfaceStatus.bounds?.visible === false
+    const proofWindow = nativePreviewSurfaceWindow
+    const proofWindowCanPaint = Boolean(
+      proofWindow &&
+      !proofWindow.isDestroyed() &&
+      !proofWindow.webContents.isDestroyed() &&
+      proofWindow.isVisible()
+    )
+    const metrics =
+      !proofWatchdogRendererReadAllowed({
+        framePollingSuppressed,
+        intentionallyHidden,
+        proofWindowVisible: proofWindowCanPaint
+      }) || !proofWindow
+        ? null
+        : await firstFrameProofRendererReads.read(
+            { watchdogRun, webContents: proofWindow.webContents },
+            () => readNativePreviewSurfaceMetricsAfterPaint(proofWindow)
+          )
+    if (
+      !firstFrameTickOwnership.isCurrent(tick) ||
+      firstFrameWatchdogRun !== watchdogRun ||
+      firstFrameWatchdogTimer == null ||
+      previewWindow !== window ||
+      window.isDestroyed() ||
+      (proofWindow != null &&
+        (nativePreviewSurfaceWindow !== proofWindow ||
+          proofWindow.isDestroyed() ||
+          proofWindow.webContents.isDestroyed()))
+    ) {
+      return
+    }
+
+    retireStalledNativePreviewMainPump(observeFirstFrameCompositorProgress(compositor))
+    if (framePollingSuppressed || intentionallyHidden) {
+      nativePreviewProofPendingStartedAtMs = null
+      return
+    }
+
+    const nowMs = Date.now()
+    const pendingStartedAtMs = nativePreviewProofPendingStartedAtMs ?? nowMs
+    nativePreviewProofPendingStartedAtMs = pendingStartedAtMs
+    const presentedFrameId = finiteMetric(metrics?.presentedCompositorFrame)
+    const sourceFrameAgeMs = finiteMetric(metrics?.sourceFrameAgeMs)
+    const assessment = assessProofPresentationWatch({
+      platform: process.platform,
+      framePollingSuppressed,
+      surfaceReady: (presentedFrameId ?? 0) > 0,
+      sourceExpected: nativePreviewProofSourceExpected(),
+      sourcePollerCount: finiteMetric(metrics?.sourcePollerCount) ?? 0,
+      freshSourceLayerCount: finiteMetric(metrics?.freshSourceLayerCount) ?? 0,
+      sourceFrameAgeMs,
+      pendingElapsedMs: Math.max(0, nowMs - pendingStartedAtMs)
+    })
+
+    if (assessment === 'paused') {
+      nativePreviewProofPendingStartedAtMs = null
+      return
+    }
+    if (assessment === 'pending') {
+      if (nativePreviewSurfaceStatus.firstFrameContract !== 'fallback') {
+        const reason = 'Waiting for the Windows preview surface to deliver pixels.'
+        setFirstFrameStatus('pending', reason)
+        updatePreviewWindowWaitDetail(reason)
+      }
+    } else if (assessment === 'met' || assessment === 'not-applicable') {
+      nativePreviewProofPendingStartedAtMs = null
+      if (nativePreviewSurfaceStatus.firstFrameContract !== 'met') {
+        const reason =
+          assessment === 'met'
+            ? 'Windows preview pixels are live.'
+            : 'Windows preview compositor output is live.'
+        setFirstFrameStatus('met', reason)
+        updatePreviewWindowWaitDetail(null)
+        logBackend('info', '[proof-preview] presentation watchdog is live')
+      }
+    } else if (nativePreviewSurfaceStatus.firstFrameContract !== 'fallback') {
+      const pendingElapsedMs = Math.max(0, nowMs - pendingStartedAtMs)
+      const reason =
+        sourceFrameAgeMs === undefined
+          ? `Windows preview did not deliver a first frame within ${Math.round(pendingElapsedMs)}ms.`
+          : `Windows preview source frames have not advanced for ${Math.round(sourceFrameAgeMs)}ms; keeping the last good frame while polling retries.`
+      setFirstFrameStatus('fallback', reason)
+      updatePreviewWindowWaitDetail(reason)
+      logBackend('warn', `[proof-preview] ${reason}`)
+    }
+
+    syncPreviewSupervisorSurface(
+      nativePreviewSurfaceStatus,
+      previewWindowSurfaceGeneration(),
+      nativePreviewSurfaceStatus.message ?? 'Electron proof preview surface.'
+    )
+  } finally {
+    firstFrameTickOwnership.release(tick)
+  }
+}
+
+async function runFirstFrameWatchdogTick(watchdogRun: WatchdogRunToken): Promise<void> {
+  const tick = firstFrameTickOwnership.tryAcquire(watchdogRun)
+  if (!tick) {
+    return
+  }
+  try {
+    const window = previewWindow
+    if (!window || window.isDestroyed() || appIsQuitting) {
+      stopFirstFrameWatchdog(watchdogRun)
+      return
+    }
+
     const compositor = await fetchFirstFrameCompositorStatus()
     // The window may have closed — or the watchdog restarted for a new
     // surface — while the status fetch was in flight. Assessing (and above
     // all HEALING) after teardown respawns the helper post-destroy, which the
     // lifecycle probe's rapid toggle cycles catch.
     if (
+      !firstFrameTickOwnership.isCurrent(tick) ||
+      firstFrameWatchdogRun !== watchdogRun ||
       firstFrameWatchdogTimer == null ||
-      watchdogGeneration !== firstFrameWatchdogStartedAtMs ||
       previewWindow !== window ||
       window.isDestroyed()
     ) {
       return
     }
-    const framesRendered = compositor?.framesRendered ?? null
-    const framesAdvancing =
-      framesRendered != null &&
-      firstFrameLastFramesRendered != null &&
-      framesRendered > firstFrameLastFramesRendered
-    if (framesRendered != null) {
-      firstFrameLastFramesRendered = framesRendered
-    }
+    const framesAdvancing = observeFirstFrameCompositorProgress(compositor)
     const presentedFrameId = nativePreviewSurfaceStatus.presentedFrameId ?? null
     const presentationAdvancing =
       presentedFrameId != null &&
@@ -836,26 +1036,7 @@ async function runFirstFrameWatchdogTick(): Promise<void> {
     if (presentedFrameId != null) {
       firstFrameLastPresentedFrameId = presentedFrameId
     }
-    const mainPumpSocket = backendEventSocket
-    const mainPumpConnection = backendAdminConnection
-    if (
-      mainPumpSocket &&
-      mainPumpConnection &&
-      mainPumpFrameDeliveryStalled({
-        active: nativePreviewMainPumpActive,
-        surfaceLive: nativePreviewSurfaceStatus.state === 'live',
-        compositorFramesAdvancing: framesAdvancing,
-        activatedAtMs: nativePreviewMainPumpActivatedAtMs,
-        lastPresentDrivingEventAtMs: nativePreviewMainLastPresentDrivingEventAtMs,
-        nowMs: Date.now()
-      })
-    ) {
-      retireBackendEventSocket(
-        mainPumpSocket,
-        mainPumpConnection,
-        `presentation event heartbeat stalled for ${Math.max(0, Date.now() - Math.max(nativePreviewMainPumpActivatedAtMs, nativePreviewMainLastPresentDrivingEventAtMs))}ms while compositor frames advanced`
-      )
-    }
+    retireStalledNativePreviewMainPump(framesAdvancing)
 
     const snapshot: FirstFrameSnapshot = {
       elapsedMs: Date.now() - firstFrameWatchdogStartedAtMs,
@@ -908,11 +1089,11 @@ async function runFirstFrameWatchdogTick(): Promise<void> {
         setFirstFrameStatus('fallback', assessment.reason)
         updatePreviewWindowWaitDetail(`Preview could not start natively: ${assessment.reason}`)
         logBackend('warn', `[first-frame] contract failed: ${assessment.reason}`)
-        stopFirstFrameWatchdog()
+        stopFirstFrameWatchdog(watchdogRun)
         return
     }
   } finally {
-    firstFrameTickInFlight = false
+    firstFrameTickOwnership.release(tick)
   }
 }
 
@@ -3151,11 +3332,10 @@ async function openPreviewWindow(): Promise<PreviewWindowState> {
   // guarantees false resets because an IOSurface can never appear.
   if (nativePreviewFirstFrameWatchdogEnabled(process.platform)) {
     startFirstFrameWatchdog()
+  } else if (nativePreviewProofWatchdogEnabled(process.platform)) {
+    startWindowsProofFrameWatchdog()
   } else {
     stopFirstFrameWatchdog()
-    firstFrameLastHint = undefined
-    setFirstFrameStatus('pending', 'Waiting for the Windows preview surface to deliver pixels.')
-    updatePreviewWindowWaitDetail('Waiting for the Windows preview surface to deliver pixels.')
   }
   return previewWindowState()
 }
@@ -4653,18 +4833,11 @@ async function createNativePreviewSurface(
     updatedAt: new Date().toISOString(),
     message: preserveNativeSurface ? nativePreviewSurfaceStatus.message : fallbackMessage
   }
-  if (preserveNativeSurface) {
-    previewSupervisor.surfaceLive({
-      generation,
-      transport: nativePreviewSurfaceStatus.transport,
-      backing: nativePreviewSurfaceStatus.backing
-    })
-  } else {
-    previewSupervisor.surfaceFallback(
-      generation,
-      nativePreviewSurfaceStatus.message ?? 'Electron proof preview surface.'
-    )
-  }
+  syncPreviewSupervisorSurface(
+    nativePreviewSurfaceStatus,
+    generation,
+    nativePreviewSurfaceStatus.message ?? 'Electron proof preview surface.'
+  )
   return nativePreviewSurfaceStatus
 }
 
@@ -5270,6 +5443,7 @@ async function presentNativePreviewSurfaceCompositor(
   const proofSourceAssessment = assessProofSourceFrame({
     platform: process.platform,
     framePollingSuppressed: nativePreviewProofPollingIsSuppressed(),
+    sourceExpected: nativePreviewProofSourceExpected(),
     sourcePollerCount,
     freshSourceLayerCount,
     sourceFrameAgeMs
@@ -5288,13 +5462,38 @@ async function presentNativePreviewSurfaceCompositor(
       logBackend('warn', `[proof-preview] ${reason}`)
     }
   }
-  previewSupervisor.surfaceFallback(
+  syncPreviewSupervisorSurface(
+    nativePreviewSurfaceStatus,
     previewWindowSurfaceGeneration(),
     nativePreviewSurfaceStatus.message ??
       realSurfaceAttempt.reason ??
       'Electron proof preview surface.'
   )
   return nativePreviewSurfaceStatus
+}
+
+function syncPreviewSupervisorSurface(
+  status: PreviewSurfaceStatus,
+  generation: number,
+  fallbackReason: string
+): void {
+  const disposition = nativePreviewSupervisorDisposition(status, process.platform)
+  if (disposition === 'pending') {
+    previewSupervisor.requestSurface()
+    return
+  }
+  if (disposition === 'live') {
+    previewSupervisor.surfaceLive({
+      generation,
+      transport: status.transport,
+      backing: status.backing
+    })
+    return
+  }
+  previewSupervisor.surfaceFallback(
+    generation,
+    nativePreviewSupervisorFallbackReason(status, process.platform, fallbackReason)
+  )
 }
 
 type NativePreviewRealSurfacePresentAttempt =
@@ -5742,14 +5941,18 @@ async function syncNativePreviewProofPollingSuppression(): Promise<boolean> {
   return nativePreviewProofPollingIsSuppressed()
 }
 
-async function readNativePreviewSurfaceMetricsAfterPaint(): Promise<Record<
-  string,
-  unknown
-> | null> {
-  if (!nativePreviewSurfaceWindow || nativePreviewSurfaceWindow.isDestroyed()) {
+async function readNativePreviewSurfaceMetricsAfterPaint(
+  surfaceWindow: BrowserWindow | null = nativePreviewSurfaceWindow
+): Promise<Record<string, unknown> | null> {
+  if (
+    !surfaceWindow ||
+    surfaceWindow.isDestroyed() ||
+    surfaceWindow.webContents.isDestroyed() ||
+    nativePreviewSurfaceWindow !== surfaceWindow
+  ) {
     return null
   }
-  return nativePreviewSurfaceWindow.webContents.executeJavaScript(
+  return surfaceWindow.webContents.executeJavaScript(
     `window.__videorcPresentNativePreviewNow?.() ?? new Promise((resolve) => requestAnimationFrame(() => resolve(window.__videorcNativePreviewMetrics?.() ?? null)))`,
     true
   )

--- a/apps/desktop/src/main/native-preview-first-frame.test.ts
+++ b/apps/desktop/src/main/native-preview-first-frame.test.ts
@@ -1,16 +1,23 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
+  assessProofPresentationWatch,
   assessProofSourceFrame,
   assessFirstFrame,
   assessPresenting,
+  boundedProofWatchdogRead,
   DEFAULT_FIRST_FRAME_BUDGETS,
   DEFAULT_PRESENTING_WATCH_BUDGETS,
+  DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS,
   emptyFirstFrameLedger,
   emptyPresentingWatch,
   firstFrameBlockedReason,
   firstFrameContractMet,
   nativePreviewFirstFrameWatchdogEnabled,
+  nativePreviewProofWatchdogEnabled,
+  ProofWatchdogRendererReadSingleFlight,
+  proofWatchdogRendererReadAllowed,
+  WatchdogTickOwnership,
   type FirstFrameSnapshot,
   type PresentingWatchState
 } from './native-preview-first-frame'
@@ -35,6 +42,14 @@ describe('nativePreviewFirstFrameWatchdogEnabled', () => {
     expect(nativePreviewFirstFrameWatchdogEnabled('darwin')).toBe(true)
     expect(nativePreviewFirstFrameWatchdogEnabled('win32')).toBe(false)
     expect(nativePreviewFirstFrameWatchdogEnabled('linux')).toBe(false)
+  })
+})
+
+describe('nativePreviewProofWatchdogEnabled', () => {
+  it('runs the independent proof liveness watch only on Windows', () => {
+    expect(nativePreviewProofWatchdogEnabled('win32')).toBe(true)
+    expect(nativePreviewProofWatchdogEnabled('darwin')).toBe(false)
+    expect(nativePreviewProofWatchdogEnabled('linux')).toBe(false)
   })
 })
 
@@ -86,11 +101,24 @@ describe('assessProofSourceFrame', () => {
       assessProofSourceFrame({
         platform: 'win32',
         framePollingSuppressed: false,
+        sourceExpected: false,
         sourcePollerCount: 0,
         freshSourceLayerCount: 0,
         sourceFrameAgeMs: 10_000
       })
     ).toBe('not-applicable')
+  })
+
+  it('keeps an expected Windows source pending while its poller initializes', () => {
+    expect(
+      assessProofSourceFrame({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        sourceExpected: true,
+        sourcePollerCount: 0,
+        freshSourceLayerCount: 0
+      })
+    ).toBe('pending')
   })
 
   it('requires every active source poller to remain fresh', () => {
@@ -103,6 +131,213 @@ describe('assessProofSourceFrame', () => {
         sourceFrameAgeMs: 1_501
       })
     ).toBe('stalled')
+  })
+})
+
+describe('assessProofPresentationWatch', () => {
+  it('declares a stalled Windows proof surface when the first frame never arrives', () => {
+    expect(
+      assessProofPresentationWatch({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        surfaceReady: false,
+        sourceExpected: true,
+        sourcePollerCount: 0,
+        freshSourceLayerCount: 0,
+        pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
+      })
+    ).toBe('stalled')
+  })
+
+  it('detects a dropped Windows proof pump after delivered source frames become stale', () => {
+    expect(
+      assessProofPresentationWatch({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        surfaceReady: true,
+        sourceExpected: true,
+        sourcePollerCount: 1,
+        freshSourceLayerCount: 0,
+        sourceFrameAgeMs: 1_501,
+        pendingElapsedMs: 0
+      })
+    ).toBe('stalled')
+  })
+
+  it('times out an expected source whose proof poller never initializes', () => {
+    expect(
+      assessProofPresentationWatch({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        surfaceReady: true,
+        sourceExpected: true,
+        sourcePollerCount: 0,
+        freshSourceLayerCount: 0,
+        pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
+      })
+    ).toBe('stalled')
+  })
+
+  it('accepts compositor-only output when the scene expects no polled source', () => {
+    expect(
+      assessProofPresentationWatch({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        surfaceReady: true,
+        sourceExpected: false,
+        sourcePollerCount: 0,
+        freshSourceLayerCount: 0,
+        pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
+      })
+    ).toBe('not-applicable')
+  })
+})
+
+describe('boundedProofWatchdogRead', () => {
+  it('releases the watchdog when the proof renderer never answers', async () => {
+    vi.useFakeTimers()
+    try {
+      const result = boundedProofWatchdogRead(new Promise<never>(() => undefined), 500)
+      await vi.advanceTimersByTimeAsync(500)
+      await expect(result).resolves.toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('ProofWatchdogRendererReadSingleFlight', () => {
+  it('reuses one unresolved renderer read across repeated bounded timeouts', async () => {
+    vi.useFakeTimers()
+    try {
+      const reads = new ProofWatchdogRendererReadSingleFlight<never>()
+      const owner = { watchdogRun: {}, webContents: {} }
+      const startRead = vi.fn(() => new Promise<never>(() => undefined))
+
+      const first = reads.read(owner, startRead, 500)
+      await vi.advanceTimersByTimeAsync(500)
+      await expect(first).resolves.toBeNull()
+
+      const second = reads.read(owner, startRead, 500)
+      expect(startRead).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(500)
+      await expect(second).resolves.toBeNull()
+      expect(startRead).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retires an old run without letting its deferred settlement clear the reopened read', async () => {
+    let resolveOld!: (value: string) => void
+    let resolveReopened!: (value: string) => void
+    const oldRead = new Promise<string>((resolve) => {
+      resolveOld = resolve
+    })
+    const reopenedRead = new Promise<string>((resolve) => {
+      resolveReopened = resolve
+    })
+    const reads = new ProofWatchdogRendererReadSingleFlight<string>()
+    const webContents = {}
+    const oldOwner = { watchdogRun: {}, webContents }
+    const reopenedOwner = { watchdogRun: {}, webContents }
+    const startRead = vi.fn().mockReturnValueOnce(oldRead).mockReturnValueOnce(reopenedRead)
+
+    const oldResult = reads.read(oldOwner, startRead)
+    reads.retire(oldOwner)
+    const reopenedResult = reads.read(reopenedOwner, startRead)
+    resolveOld('old')
+    await expect(oldResult).resolves.toBe('old')
+
+    const reusedReopenedResult = reads.read(reopenedOwner, startRead)
+    expect(startRead).toHaveBeenCalledTimes(2)
+    resolveReopened('reopened')
+    await expect(reopenedResult).resolves.toBe('reopened')
+    await expect(reusedReopenedResult).resolves.toBe('reopened')
+  })
+
+  it('supersedes an unresolved read when the proof WebContents changes', async () => {
+    let resolveOld!: (value: string) => void
+    let resolveReplacement!: (value: string) => void
+    const oldRead = new Promise<string>((resolve) => {
+      resolveOld = resolve
+    })
+    const replacementRead = new Promise<string>((resolve) => {
+      resolveReplacement = resolve
+    })
+    const reads = new ProofWatchdogRendererReadSingleFlight<string>()
+    const watchdogRun = {}
+    const oldOwner = { watchdogRun, webContents: {} }
+    const replacementOwner = { watchdogRun, webContents: {} }
+    const startRead = vi.fn().mockReturnValueOnce(oldRead).mockReturnValueOnce(replacementRead)
+
+    const oldResult = reads.read(oldOwner, startRead)
+    const replacementResult = reads.read(replacementOwner, startRead)
+    expect(startRead).toHaveBeenCalledTimes(2)
+
+    resolveOld('old')
+    await expect(oldResult).resolves.toBe('old')
+    const reusedReplacementResult = reads.read(replacementOwner, startRead)
+    expect(startRead).toHaveBeenCalledTimes(2)
+
+    resolveReplacement('replacement')
+    await expect(replacementResult).resolves.toBe('replacement')
+    await expect(reusedReplacementResult).resolves.toBe('replacement')
+  })
+})
+
+describe('WatchdogTickOwnership', () => {
+  it('does not let a deferred old tick release the reopened watchdog tick', () => {
+    const ownership = new WatchdogTickOwnership()
+    const oldRun = ownership.startRun()
+    const oldTick = ownership.tryAcquire(oldRun)
+    expect(oldTick).not.toBeNull()
+
+    ownership.stopRun(oldRun)
+    const reopenedRun = ownership.startRun()
+    const reopenedTick = ownership.tryAcquire(reopenedRun)
+    expect(reopenedTick).not.toBeNull()
+    expect(ownership.isCurrent(oldTick!)).toBe(false)
+
+    ownership.stopRun(oldRun)
+    ownership.release(oldTick!)
+    expect(ownership.tryAcquire(reopenedRun)).toBeNull()
+
+    ownership.release(reopenedTick!)
+    expect(ownership.tryAcquire(reopenedRun)).not.toBeNull()
+  })
+})
+
+describe('proofWatchdogRendererReadAllowed', () => {
+  it('never waits on an intentionally hidden, suppressed, or non-painting proof window', () => {
+    expect(
+      proofWatchdogRendererReadAllowed({
+        framePollingSuppressed: true,
+        intentionallyHidden: false,
+        proofWindowVisible: true
+      })
+    ).toBe(false)
+    expect(
+      proofWatchdogRendererReadAllowed({
+        framePollingSuppressed: false,
+        intentionallyHidden: true,
+        proofWindowVisible: true
+      })
+    ).toBe(false)
+    expect(
+      proofWatchdogRendererReadAllowed({
+        framePollingSuppressed: false,
+        intentionallyHidden: false,
+        proofWindowVisible: false
+      })
+    ).toBe(false)
+    expect(
+      proofWatchdogRendererReadAllowed({
+        framePollingSuppressed: false,
+        intentionallyHidden: false,
+        proofWindowVisible: true
+      })
+    ).toBe(true)
   })
 })
 

--- a/apps/desktop/src/main/native-preview-first-frame.test.ts
+++ b/apps/desktop/src/main/native-preview-first-frame.test.ts
@@ -16,6 +16,7 @@ import {
   nativePreviewFirstFrameWatchdogEnabled,
   nativePreviewProofWatchdogEnabled,
   ProofWatchdogRendererReadSingleFlight,
+  proofPresentationFallbackReason,
   proofWatchdogRendererReadAllowed,
   WatchdogTickOwnership,
   type FirstFrameSnapshot,
@@ -61,6 +62,7 @@ describe('assessProofSourceFrame', () => {
         framePollingSuppressed: false,
         sourcePollerCount: 1,
         freshSourceLayerCount: 1,
+        sourceFrameHistoryComplete: true,
         sourceFrameAgeMs: 125
       })
     ).toBe('met')
@@ -70,6 +72,7 @@ describe('assessProofSourceFrame', () => {
         framePollingSuppressed: false,
         sourcePollerCount: 1,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: true,
         sourceFrameAgeMs: 1_501
       })
     ).toBe('stalled')
@@ -82,6 +85,7 @@ describe('assessProofSourceFrame', () => {
         framePollingSuppressed: true,
         sourcePollerCount: 1,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: true,
         sourceFrameAgeMs: 10_000
       })
     ).toBe('paused')
@@ -91,6 +95,7 @@ describe('assessProofSourceFrame', () => {
         framePollingSuppressed: false,
         sourcePollerCount: 1,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: true,
         sourceFrameAgeMs: 10_000
       })
     ).toBe('not-applicable')
@@ -104,6 +109,7 @@ describe('assessProofSourceFrame', () => {
         sourceExpected: false,
         sourcePollerCount: 0,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: false,
         sourceFrameAgeMs: 10_000
       })
     ).toBe('not-applicable')
@@ -116,7 +122,8 @@ describe('assessProofSourceFrame', () => {
         framePollingSuppressed: false,
         sourceExpected: true,
         sourcePollerCount: 0,
-        freshSourceLayerCount: 0
+        freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: false
       })
     ).toBe('pending')
   })
@@ -128,9 +135,24 @@ describe('assessProofSourceFrame', () => {
         framePollingSuppressed: false,
         sourcePollerCount: 2,
         freshSourceLayerCount: 1,
+        sourceFrameHistoryComplete: true,
         sourceFrameAgeMs: 1_501
       })
     ).toBe('stalled')
+  })
+
+  it('keeps a started poller pending until its first decoded frame reaches the startup budget', () => {
+    expect(
+      assessProofSourceFrame({
+        platform: 'win32',
+        framePollingSuppressed: false,
+        sourceExpected: true,
+        sourcePollerCount: 1,
+        freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: false,
+        sourceFrameAgeMs: 1_501
+      })
+    ).toBe('pending')
   })
 })
 
@@ -144,6 +166,7 @@ describe('assessProofPresentationWatch', () => {
         sourceExpected: true,
         sourcePollerCount: 0,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: false,
         pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
       })
     ).toBe('stalled')
@@ -158,6 +181,7 @@ describe('assessProofPresentationWatch', () => {
         sourceExpected: true,
         sourcePollerCount: 1,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: true,
         sourceFrameAgeMs: 1_501,
         pendingElapsedMs: 0
       })
@@ -173,6 +197,7 @@ describe('assessProofPresentationWatch', () => {
         sourceExpected: true,
         sourcePollerCount: 0,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: false,
         pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
       })
     ).toBe('stalled')
@@ -187,9 +212,61 @@ describe('assessProofPresentationWatch', () => {
         sourceExpected: false,
         sourcePollerCount: 0,
         freshSourceLayerCount: 0,
+        sourceFrameHistoryComplete: false,
         pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
       })
     ).toBe('not-applicable')
+  })
+
+  it('gives an initialized poller the full first-frame budget before declaring fallback', () => {
+    const startup = {
+      platform: 'win32' as const,
+      framePollingSuppressed: false,
+      surfaceReady: true,
+      sourceExpected: true,
+      sourcePollerCount: 1,
+      freshSourceLayerCount: 0,
+      sourceFrameHistoryComplete: false,
+      sourceFrameAgeMs: 1_501
+    }
+
+    expect(
+      assessProofPresentationWatch({
+        ...startup,
+        pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS - 1
+      })
+    ).toBe('pending')
+    expect(
+      assessProofPresentationWatch({
+        ...startup,
+        pendingElapsedMs: DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
+      })
+    ).toBe('stalled')
+  })
+})
+
+describe('proofPresentationFallbackReason', () => {
+  it('does not claim a last good frame when startup never delivered one', () => {
+    const reason = proofPresentationFallbackReason({
+      sourceFrameHistoryComplete: false,
+      sourceFrameAgeMs: 15_000,
+      pendingElapsedMs: 15_000
+    })
+
+    expect(reason).toBe('Windows preview did not deliver a first frame within 15000ms.')
+    expect(reason).not.toContain('last good frame')
+  })
+
+  it('identifies a post-live source stall and retained frame', () => {
+    expect(
+      proofPresentationFallbackReason({
+        sourceFrameHistoryComplete: true,
+        sourceFrameAgeMs: 1_501,
+        pendingElapsedMs: 200
+      })
+    ).toBe(
+      'Windows preview source frames have not advanced for 1501ms; keeping the last good frame while polling retries.'
+    )
   })
 })
 
@@ -219,8 +296,8 @@ describe('ProofWatchdogRendererReadSingleFlight', () => {
       await expect(first).resolves.toBeNull()
 
       const second = reads.read(owner, startRead, 500)
+      expect(second).toBe(first)
       expect(startRead).toHaveBeenCalledTimes(1)
-      await vi.advanceTimersByTimeAsync(500)
       await expect(second).resolves.toBeNull()
       expect(startRead).toHaveBeenCalledTimes(1)
     } finally {

--- a/apps/desktop/src/main/native-preview-first-frame.ts
+++ b/apps/desktop/src/main/native-preview-first-frame.ts
@@ -80,6 +80,8 @@ export function assessProofSourceFrame(params: {
   sourceExpected?: boolean
   sourcePollerCount: number
   freshSourceLayerCount: number
+  /** Every active source poller has decoded at least one frame in its current generation. */
+  sourceFrameHistoryComplete: boolean
   sourceFrameAgeMs?: number
   staleAfterMs?: number
 }): ProofSourceFrameAssessment {
@@ -100,7 +102,11 @@ export function assessProofSourceFrame(params: {
   ) {
     return 'met'
   }
-  if (params.sourceFrameAgeMs != null && params.sourceFrameAgeMs > staleAfterMs) {
+  if (
+    params.sourceFrameHistoryComplete &&
+    params.sourceFrameAgeMs != null &&
+    params.sourceFrameAgeMs > staleAfterMs
+  ) {
     return 'stalled'
   }
   return 'pending'
@@ -113,6 +119,7 @@ export function assessProofPresentationWatch(params: {
   sourceExpected: boolean
   sourcePollerCount: number
   freshSourceLayerCount: number
+  sourceFrameHistoryComplete: boolean
   sourceFrameAgeMs?: number
   pendingElapsedMs: number
   pendingTimeoutMs?: number
@@ -132,6 +139,20 @@ export function assessProofPresentationWatch(params: {
   return assessment === 'pending' && params.pendingElapsedMs >= pendingTimeoutMs
     ? 'stalled'
     : assessment
+}
+
+export function proofPresentationFallbackReason(params: {
+  sourceFrameHistoryComplete: boolean
+  sourceFrameAgeMs?: number
+  pendingElapsedMs: number
+}): string {
+  if (!params.sourceFrameHistoryComplete) {
+    return `Windows preview did not deliver a first frame within ${Math.round(params.pendingElapsedMs)}ms.`
+  }
+  if (params.sourceFrameAgeMs != null) {
+    return `Windows preview source frames have not advanced for ${Math.round(params.sourceFrameAgeMs)}ms; keeping the last good frame while polling retries.`
+  }
+  return `Windows preview source frame liveness did not update within ${Math.round(params.pendingElapsedMs)}ms.`
 }
 
 export function boundedProofWatchdogRead<T>(
@@ -215,11 +236,14 @@ export class WatchdogTickOwnership {
 }
 
 // The timeout bounds each watchdog tick, not Electron's non-cancellable
-// executeJavaScript call. Keep reusing that underlying call until it settles;
-// only a new watchdog run or WebContents may supersede it.
+// executeJavaScript call. Keep reusing both that underlying call and its one
+// bounded result until the read settles; otherwise every timed-out tick would
+// attach another reaction retained forever by a hung renderer promise. Only a
+// new watchdog run or WebContents may supersede them.
 export class ProofWatchdogRendererReadSingleFlight<T> {
   private owner: ProofWatchdogRendererReadOwner | null = null
   private pending: Promise<T> | null = null
+  private bounded: Promise<T | null> | null = null
 
   read(
     owner: ProofWatchdogRendererReadOwner,
@@ -228,23 +252,27 @@ export class ProofWatchdogRendererReadSingleFlight<T> {
   ): Promise<T | null> {
     if (!this.pending || !this.ownerMatches(owner)) {
       const pending = startRead()
+      const bounded = boundedProofWatchdogRead(pending, timeoutMs)
       this.owner = owner
       this.pending = pending
+      this.bounded = bounded
       const clear = (): void => {
         if (this.pending === pending && this.ownerMatches(owner)) {
           this.owner = null
           this.pending = null
+          this.bounded = null
         }
       }
       void pending.then(clear, clear)
     }
-    return boundedProofWatchdogRead(this.pending, timeoutMs)
+    return this.bounded!
   }
 
   retire(owner?: ProofWatchdogRendererReadOwner): void {
     if (!owner || this.ownerMatches(owner)) {
       this.owner = null
       this.pending = null
+      this.bounded = null
     }
   }
 

--- a/apps/desktop/src/main/native-preview-first-frame.ts
+++ b/apps/desktop/src/main/native-preview-first-frame.ts
@@ -64,13 +64,20 @@ export function nativePreviewFirstFrameWatchdogEnabled(platform: NodeJS.Platform
   return platform === 'darwin'
 }
 
+export function nativePreviewProofWatchdogEnabled(platform: NodeJS.Platform): boolean {
+  return platform === 'win32'
+}
+
 export const DEFAULT_PROOF_SOURCE_FRAME_STALE_MS = 1500
+export const DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS = 15_000
+export const DEFAULT_PROOF_WATCHDOG_READ_TIMEOUT_MS = 500
 
 export type ProofSourceFrameAssessment = 'not-applicable' | 'paused' | 'pending' | 'met' | 'stalled'
 
 export function assessProofSourceFrame(params: {
   platform: NodeJS.Platform
   framePollingSuppressed: boolean
+  sourceExpected?: boolean
   sourcePollerCount: number
   freshSourceLayerCount: number
   sourceFrameAgeMs?: number
@@ -83,7 +90,7 @@ export function assessProofSourceFrame(params: {
     return 'paused'
   }
   if (params.sourcePollerCount <= 0) {
-    return 'not-applicable'
+    return params.sourceExpected ? 'pending' : 'not-applicable'
   }
   const staleAfterMs = params.staleAfterMs ?? DEFAULT_PROOF_SOURCE_FRAME_STALE_MS
   if (
@@ -97,6 +104,163 @@ export function assessProofSourceFrame(params: {
     return 'stalled'
   }
   return 'pending'
+}
+
+export function assessProofPresentationWatch(params: {
+  platform: NodeJS.Platform
+  framePollingSuppressed: boolean
+  surfaceReady: boolean
+  sourceExpected: boolean
+  sourcePollerCount: number
+  freshSourceLayerCount: number
+  sourceFrameAgeMs?: number
+  pendingElapsedMs: number
+  pendingTimeoutMs?: number
+  staleAfterMs?: number
+}): ProofSourceFrameAssessment {
+  if (params.platform === 'darwin') {
+    return 'not-applicable'
+  }
+  if (params.framePollingSuppressed) {
+    return 'paused'
+  }
+  const pendingTimeoutMs = params.pendingTimeoutMs ?? DEFAULT_PROOF_FIRST_FRAME_TIMEOUT_MS
+  if (!params.surfaceReady) {
+    return params.pendingElapsedMs >= pendingTimeoutMs ? 'stalled' : 'pending'
+  }
+  const assessment = assessProofSourceFrame(params)
+  return assessment === 'pending' && params.pendingElapsedMs >= pendingTimeoutMs
+    ? 'stalled'
+    : assessment
+}
+
+export function boundedProofWatchdogRead<T>(
+  read: Promise<T>,
+  timeoutMs = DEFAULT_PROOF_WATCHDOG_READ_TIMEOUT_MS
+): Promise<T | null> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return Promise.resolve(null)
+  }
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (value: T | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(value)
+    }
+    const timer = setTimeout(() => finish(null), timeoutMs)
+    void read.then(
+      (value) => finish(value),
+      () => finish(null)
+    )
+  })
+}
+
+export interface ProofWatchdogRendererReadOwner {
+  watchdogRun: object
+  webContents: object
+}
+
+export interface WatchdogRunToken {
+  readonly id: symbol
+}
+
+export interface WatchdogTickToken {
+  readonly id: symbol
+  readonly run: WatchdogRunToken
+}
+
+// A stopped run releases its slot immediately so close/reopen is responsive,
+// but the old async tick still owns a distinct token. Its eventual `finally`
+// therefore cannot clear a tick already acquired by the reopened run.
+export class WatchdogTickOwnership {
+  private currentRun: WatchdogRunToken | null = null
+  private inFlight: WatchdogTickToken | null = null
+
+  startRun(): WatchdogRunToken {
+    const run = { id: Symbol('watchdog-run') }
+    this.currentRun = run
+    this.inFlight = null
+    return run
+  }
+
+  stopRun(run: WatchdogRunToken): void {
+    if (this.currentRun === run) {
+      this.currentRun = null
+      this.inFlight = null
+    }
+  }
+
+  tryAcquire(run: WatchdogRunToken): WatchdogTickToken | null {
+    if (this.currentRun !== run || this.inFlight) {
+      return null
+    }
+    const tick = { id: Symbol('watchdog-tick'), run }
+    this.inFlight = tick
+    return tick
+  }
+
+  isCurrent(tick: WatchdogTickToken): boolean {
+    return this.currentRun === tick.run && this.inFlight === tick
+  }
+
+  release(tick: WatchdogTickToken): void {
+    if (this.inFlight === tick) {
+      this.inFlight = null
+    }
+  }
+}
+
+// The timeout bounds each watchdog tick, not Electron's non-cancellable
+// executeJavaScript call. Keep reusing that underlying call until it settles;
+// only a new watchdog run or WebContents may supersede it.
+export class ProofWatchdogRendererReadSingleFlight<T> {
+  private owner: ProofWatchdogRendererReadOwner | null = null
+  private pending: Promise<T> | null = null
+
+  read(
+    owner: ProofWatchdogRendererReadOwner,
+    startRead: () => Promise<T>,
+    timeoutMs = DEFAULT_PROOF_WATCHDOG_READ_TIMEOUT_MS
+  ): Promise<T | null> {
+    if (!this.pending || !this.ownerMatches(owner)) {
+      const pending = startRead()
+      this.owner = owner
+      this.pending = pending
+      const clear = (): void => {
+        if (this.pending === pending && this.ownerMatches(owner)) {
+          this.owner = null
+          this.pending = null
+        }
+      }
+      void pending.then(clear, clear)
+    }
+    return boundedProofWatchdogRead(this.pending, timeoutMs)
+  }
+
+  retire(owner?: ProofWatchdogRendererReadOwner): void {
+    if (!owner || this.ownerMatches(owner)) {
+      this.owner = null
+      this.pending = null
+    }
+  }
+
+  private ownerMatches(owner: ProofWatchdogRendererReadOwner): boolean {
+    return (
+      this.owner?.watchdogRun === owner.watchdogRun && this.owner.webContents === owner.webContents
+    )
+  }
+}
+
+export function proofWatchdogRendererReadAllowed(input: {
+  framePollingSuppressed: boolean
+  intentionallyHidden: boolean
+  proofWindowVisible: boolean
+}): boolean {
+  return !input.framePollingSuppressed && !input.intentionallyHidden && input.proofWindowVisible
 }
 
 export type FirstFrameAssessment =

--- a/apps/desktop/src/main/native-preview-host-policy.test.ts
+++ b/apps/desktop/src/main/native-preview-host-policy.test.ts
@@ -9,7 +9,9 @@ import {
   nativePreviewPlacementOwnedByNativeSurface,
   nativePreviewFramePollingSuppressionStatus,
   nativePreviewHelperFallbackAllowed,
-  nativePreviewProofPollingSuppressed
+  nativePreviewProofPollingSuppressed,
+  nativePreviewSupervisorFallbackReason,
+  nativePreviewSupervisorDisposition
 } from './native-preview-host-policy'
 
 describe('native preview host policy', () => {
@@ -84,6 +86,56 @@ describe('native preview host policy', () => {
   it('allows the transitional helper only through an explicit diagnostic route', () => {
     expect(nativePreviewHelperFallbackAllowed({ fallbackFlag: '1' })).toBe(true)
     expect(nativePreviewHelperFallbackAllowed({ explicitHelperPath: '/tmp/helper' })).toBe(true)
+  })
+
+  it('treats the supported Windows proof presenter as live', () => {
+    expect(
+      nativePreviewSupervisorDisposition(
+        surfaceStatus({
+          transport: 'electron-proof-surface',
+          backing: 'electron-browser-window',
+          firstFrameContract: 'met'
+        }),
+        'win32'
+      )
+    ).toBe('live')
+  })
+
+  it('keeps the Windows proof presenter pending until its first-frame contract is met', () => {
+    const proof = surfaceStatus({
+      transport: 'electron-proof-surface',
+      backing: 'electron-browser-window'
+    })
+    expect(nativePreviewSupervisorDisposition(proof, 'win32')).toBe('pending')
+    expect(
+      nativePreviewSupervisorDisposition({ ...proof, firstFrameContract: 'pending' }, 'win32')
+    ).toBe('pending')
+  })
+
+  it('keeps macOS proof presentation and a stalled Windows presenter truthful', () => {
+    const proof = surfaceStatus({
+      transport: 'electron-proof-surface',
+      backing: 'electron-browser-window',
+      firstFrameContract: 'met'
+    })
+    expect(nativePreviewSupervisorDisposition(proof, 'darwin')).toBe('fallback')
+    expect(
+      nativePreviewSupervisorDisposition({ ...proof, firstFrameContract: 'fallback' }, 'win32')
+    ).toBe('fallback')
+  })
+
+  it('uses the Windows first-frame stall diagnosis instead of healthy compositor copy', () => {
+    expect(
+      nativePreviewSupervisorFallbackReason(
+        surfaceStatus({
+          transport: 'electron-proof-surface',
+          firstFrameContract: 'fallback',
+          firstFrameReason: 'Windows preview source frames stopped advancing.'
+        }),
+        'win32',
+        'Preview is displaying compositor output.'
+      )
+    ).toBe('Windows preview source frames stopped advancing.')
   })
 
   it('suppresses only the Electron poller while an attached CAMetalLayer keeps presenting', () => {

--- a/apps/desktop/src/main/native-preview-host-policy.ts
+++ b/apps/desktop/src/main/native-preview-host-policy.ts
@@ -17,6 +17,56 @@ export type NativePreviewPresentFailureDisposition =
   | 'retain-native'
   | 'disable-native'
 
+export type NativePreviewSupervisorDisposition = 'pending' | 'live' | 'fallback'
+
+/**
+ * Classify the active preview host for the user-facing lifecycle supervisor.
+ *
+ * macOS promises a CAMetalLayer, so its Electron proof surface is a truthful
+ * fallback. Windows intentionally uses the Electron surface as its supported
+ * presenter; it is live only after the first-frame contract proves source
+ * pixels are present, and remains pending before that proof arrives.
+ */
+export function nativePreviewSupervisorDisposition(
+  status: Pick<PreviewSurfaceStatus, 'transport' | 'firstFrameContract'>,
+  platform: NodeJS.Platform
+): NativePreviewSupervisorDisposition {
+  if (status.transport === 'native-surface') {
+    return 'live'
+  }
+  if (
+    status.transport === 'electron-proof-surface' &&
+    platform === 'win32' &&
+    status.firstFrameContract === 'met'
+  ) {
+    return 'live'
+  }
+  if (
+    status.transport === 'electron-proof-surface' &&
+    platform === 'win32' &&
+    status.firstFrameContract !== 'fallback'
+  ) {
+    return 'pending'
+  }
+  return 'fallback'
+}
+
+export function nativePreviewSupervisorFallbackReason(
+  status: Pick<PreviewSurfaceStatus, 'transport' | 'firstFrameContract' | 'firstFrameReason'>,
+  platform: NodeJS.Platform,
+  fallbackReason: string
+): string {
+  if (
+    platform === 'win32' &&
+    status.transport === 'electron-proof-surface' &&
+    status.firstFrameContract === 'fallback' &&
+    status.firstFrameReason?.trim()
+  ) {
+    return status.firstFrameReason
+  }
+  return fallbackReason
+}
+
 export function nativePreviewPresentFailureDisposition(input: {
   driverKind: 'in-process' | 'external-module' | 'helper-process' | null
   surfaceVisible: boolean

--- a/apps/desktop/src/main/native-preview-proof-poller-runtime.test.ts
+++ b/apps/desktop/src/main/native-preview-proof-poller-runtime.test.ts
@@ -36,6 +36,7 @@ type ProofPollerRuntime = {
     now: number,
     freshnessBudgetMs: number
   ) => boolean
+  proofPollersHaveCompleteFrameHistory: (pollers: Map<string, RuntimePoller>) => boolean
 }
 
 function loadRuntime(
@@ -55,7 +56,8 @@ function loadRuntime(
       proofPollerFrameAgeMs,
       proofPollerTransportAgeMs,
       proofPollerFrameIsFresh,
-      proofPollerTransportIsFresh
+      proofPollerTransportIsFresh,
+      proofPollersHaveCompleteFrameHistory
     };`
   )
   const pixels = new Uint8ClampedArray(8 * 8 * 4)
@@ -143,6 +145,32 @@ describe('Windows proof poller runtime', () => {
     expect(runtime.proofPollerFrameAgeMs(current, 2_000)).toBe(1_500)
     expect(runtime.proofPollerTransportIsFresh(current, 2_000, 1_000)).toBe(true)
     expect(runtime.proofPollerFrameIsFresh(current, 2_000, 1_000)).toBe(false)
+  })
+
+  it('tracks first-frame history only for the active poller generation', () => {
+    const established = poller()
+    const replacement = { ...poller(), lastFrameAdvanceAt: established.lastFrameAdvanceAt }
+    const newGeneration = { ...poller(), lastFrameAdvanceAt: null }
+    const runtime = loadRuntime(new Map(), vi.fn())
+
+    expect(runtime.proofPollersHaveCompleteFrameHistory(new Map([['screen', established]]))).toBe(
+      true
+    )
+    expect(
+      runtime.proofPollersHaveCompleteFrameHistory(
+        new Map([
+          ['screen', established],
+          ['camera', newGeneration]
+        ])
+      )
+    ).toBe(false)
+    expect(runtime.proofPollersHaveCompleteFrameHistory(new Map([['screen', replacement]]))).toBe(
+      true
+    )
+    expect(runtime.proofPollersHaveCompleteFrameHistory(new Map([['screen', newGeneration]]))).toBe(
+      false
+    )
+    expect(runtime.proofPollersHaveCompleteFrameHistory(new Map())).toBe(false)
   })
 
   it('counts only decoded images with no visible pixels as blank', () => {

--- a/apps/desktop/src/main/native-preview-proof-poller-runtime.ts
+++ b/apps/desktop/src/main/native-preview-proof-poller-runtime.ts
@@ -94,6 +94,11 @@ function proofPollerFrameIsFresh(poller, now, freshnessBudgetMs) {
     proofPollerFrameAgeMs(poller, now) <= freshnessBudgetMs;
 }
 
+function proofPollersHaveCompleteFrameHistory(activePollers) {
+  return activePollers.size > 0 &&
+    [...activePollers.values()].every((poller) => poller.lastFrameAdvanceAt != null);
+}
+
 function proofPollerTransportIsFresh(poller, now, freshnessBudgetMs) {
   return poller.lastTransportSuccessAt != null &&
     proofPollerTransportAgeMs(poller, now) <= freshnessBudgetMs;

--- a/docs/adr/0001-obs-parity-native-capture-architecture.md
+++ b/docs/adr/0001-obs-parity-native-capture-architecture.md
@@ -41,6 +41,18 @@ The implementation direction is:
 - FFmpeg stays as the first downstream encoder/muxer backend, fed by Videorc-owned capture/render output.
 - Recordings remain MKV-first, with optional MP4 remux after stop.
 
+### Current platform implementation note
+
+As of 2026-07-14, macOS implements the native preview decision with the
+detached CAMetalLayer presenter. The Windows alpha has an explicit, temporary
+platform exception: its supported presenter is the uncompressed, latest-wins
+BMP Electron proof surface described in `docs/windows-port-plan.md`. A healthy
+Windows proof presenter may be live at the product-lifecycle level only after
+its first-frame and source-liveness contracts pass, but it must continue to
+report `electron-proof-surface` / `electron-browser-window` and must never be
+counted as native-rendered OBS-parity evidence. A future Windows-native host can
+replace this exception without changing the lifecycle contract.
+
 ## Source References
 
 The OBS source references used for behavior mapping live in [OBS parity source map](../obs-parity-source-map.md).

--- a/scripts/lib/native-preview-window-gates.mjs
+++ b/scripts/lib/native-preview-window-gates.mjs
@@ -13,11 +13,17 @@ export function previewWindowSurfaceReady(
     : windowState?.surface?.visible === true &&
       surfaceStatus?.nativePreviewHostKind === 'proof-surface' &&
       surfaceStatus?.framePollingSuppressed === false
+  const supervisorReady =
+    windowState?.supervisor?.lifecycleState === 'surface-live' &&
+    windowState?.supervisor?.surfaceActive === true
+  const firstFrameReady = expectNativeMetalPreview || surfaceStatus?.firstFrameContract === 'met'
 
   return (
     windowState?.open === true &&
     windowState?.visible === true &&
     windowState?.surface?.exists === true &&
+    supervisorReady &&
+    firstFrameReady &&
     placementReady &&
     surfaceStatus?.state === 'live' &&
     surfaceStatus?.transport === expectedTransport &&

--- a/scripts/lib/native-preview-window-gates.test.mjs
+++ b/scripts/lib/native-preview-window-gates.test.mjs
@@ -14,6 +14,10 @@ const windowsEvidence = () => ({
     open: true,
     visible: true,
     nativeOwnsPlacement: false,
+    supervisor: {
+      lifecycleState: 'surface-live',
+      surfaceActive: true
+    },
     surface: { exists: true, visible: true }
   },
   surfaceStatus: {
@@ -23,6 +27,7 @@ const windowsEvidence = () => ({
     targetFps: 60,
     nativePreviewHostKind: 'proof-surface',
     framePollingSuppressed: false,
+    firstFrameContract: 'met',
     pendingHostCommandCount: 0,
     bounds: { width: 960, height: 540 }
   }
@@ -46,10 +51,21 @@ test('Windows proof readiness accepts a visible unsuppressed proof host', () => 
   assert.equal(previewWindowSurfaceReady(windowsEvidence(), windowsOptions), true)
 })
 
+test('Windows proof readiness rejects a supervisor that still calls the supported host fallback', () => {
+  const evidence = windowsEvidence()
+  evidence.windowState.supervisor = {
+    lifecycleState: 'surface-fallback',
+    surfaceActive: false
+  }
+
+  assert.equal(previewWindowSurfaceReady(evidence, windowsOptions), false)
+})
+
 test('Windows proof readiness rejects hidden, suppressed, or pending hosts', () => {
   for (const mutate of [
     (evidence) => (evidence.windowState.surface.visible = false),
     (evidence) => (evidence.surfaceStatus.framePollingSuppressed = true),
+    (evidence) => (evidence.surfaceStatus.firstFrameContract = 'pending'),
     (evidence) => (evidence.surfaceStatus.pendingHostCommandCount = 1),
     (evidence) => (evidence.surfaceStatus.bounds.width = 0)
   ]) {


### PR DESCRIPTION
## Problem

Windows intentionally presents preview through Videorc's Electron proof surface, but the main process unconditionally reported that presenter to the lifecycle supervisor as a fallback. Studio therefore showed **Preview Is Using Fallback Rendering** even after the supported Windows presenter was live.

The inverse edge matters too: a pending, never-first-frame, or stalled proof presenter must not be promoted to healthy merely because its BrowserWindow exists.

## Plan and implementation

- Centralize the mapping from `PreviewSurfaceStatus` to the user-facing supervisor lifecycle.
- Treat the Windows Electron proof surface as `surface-live` only after its first-frame contract is `met`.
- Preserve `starting-surface` while the first source frame/poller is pending.
- Keep the Electron proof path a truthful fallback on macOS, where production preview promises CAMetalLayer.
- Document the platform contract explicitly in `AGENTS.md` and ADR 0001: macOS remains CAMetalLayer-native, while Windows' currently supported production presenter is the uncompressed latest-wins BMP proof surface and must never be described as native.
- Add a Windows proof-surface watchdog independent of the macOS Metal watchdog:
  - compositor-only/no-source scenes may become healthy after proof presentation;
  - scenes that expect screen, window, or camera pixels remain pending for the full 15-second startup budget until every active source poller has delivered once;
  - only previously-live source pollers use the 1.5-second stall budget, and missing-first-frame versus retained-last-frame failures show different truthful diagnoses;
  - hidden/suppressed proof surfaces are paused, and renderer metric reads are bounded and single-flight so a hung proof renderer cannot wedge health reporting or accumulate abandoned reads;
  - watchdog run/tick ownership prevents a deferred close/reopen tick from mutating or clearing the replacement window's health check.
- Strengthen the maintained preview-window gate so Windows readiness requires a live supervisor and a met first-frame contract, not merely a visible BrowserWindow.

## Acceptance criteria

- [x] A healthy Windows proof presenter transitions the supervisor to `surface-live` and clears the false fallback warning.
- [x] Pending/undefined first-frame state remains `starting-surface`.
- [x] A source scene with no poller/first frame eventually reports a real fallback instead of false health.
- [x] A previously healthy source that stalls reports the source-frame diagnosis, not healthy compositor copy.
- [x] A compositor-only scene has an explicit healthy outcome.
- [x] macOS proof-surface fallback semantics remain unchanged.
- [x] Preview-window smoke evidence requires both supervisor and first-frame proof.

## Verification

- Desktop unit suite, Node script suite, TypeScript typecheck/lint/format, and desktop build.
- Native preview lifecycle, preview-window, strict preview-surface, scene-commit, pump-diagnostics, click/focus, and interaction-stress probes.
- Device-backed preview interaction recording and real ScreenCaptureKit live-layout record/stream artifact analysis.
- `pnpm smoke:recording-studio` was run; see **Known gate blockers** below.

## Known gate blockers

- The maintained vertical-layout source-loop test currently leaves the Metal target at `960x540` instead of adopting portrait `540x960`. The identical failure reproduces from an untouched comparison branch and is outside this Windows supervisor-status change.
- The comment-highlight split record/stream artifact scenario reports zero highlight frames on the untouched path while its stream-only scenario passes.
- This macOS desktop session intermittently cannot expose the foreground stimulus/native display to the standalone real-screen gate. The separate device interaction and real ScreenCaptureKit record/stream gates passed.

## Non-goals and follow-up

- This does not add a native DirectComposition/D3D Windows presenter or claim a rendering-performance improvement. It makes the existing supported presenter truthful and keeps genuine stalls visible.
- Final acceptance still needs the Windows CI job plus a physical Windows alpha run that opens, closes, and reopens Preview with real screen/camera sources.
- PR #116 also edits `apps/desktop/src/main/index.ts`; whichever lands second may need a focused rebase.

Closes #115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview startup reliability by preventing stale checks from affecting restarted or closed previews.
  - Windows previews now verify that frames are actively presented before reporting readiness.
  - Preview windows no longer appear ready while still pending, stalled, or in fallback.
  - Added clearer fallback details when native preview transport is unavailable or presentation stalls.
- **Documentation**
  - Clarified platform-specific native preview behavior and Windows proof-surface expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->