### PR TITLE
fix(windows): apply live microphone gain and mute

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,6 +109,11 @@ jobs:
         # testers will see a SmartScreen warning until signing lands.
         run: pnpm dist:desktop:windows
 
+      - name: Verify bundled FFmpeg live microphone controls
+        run: pnpm probe:live-audio-controls
+        env:
+          VIDEORC_SMOKE_FFMPEG_PATH: ${{ github.workspace }}\apps\desktop\release\win-unpacked\resources\ffmpeg\bin\ffmpeg.exe
+
       - name: Verify packaged 1080p recording duration and A/V
         run: pnpm smoke:packaged:bundled
         env:

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -266,6 +266,7 @@ import { buildStartSessionParams } from '@/lib/session-params'
 import { findDevice, isActiveRecordingState, mergeStreamHealth } from '@/lib/format'
 import {
   activeAudioProcessingUpdateParams,
+  LatestWinsLiveAudioProcessingQueue,
   rejectedLiveAudioProcessingUpdate,
   type LiveAudioProcessingValues
 } from '@/lib/live-audio-processing'
@@ -2066,10 +2067,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const qualityToastSessionsRef = useRef<Set<string>>(new Set())
   const captureConfigRef = useRef(captureConfig)
   const liveAudioProcessingSyncRef = useRef<{
+    token: object
     sessionId: string
     lastApplied: LiveAudioProcessingValues
     disabled: boolean
-    requestRevision: number
+    queue: LatestWinsLiveAudioProcessingQueue
   } | null>(null)
   const layoutIntentIdRef = useRef(Date.now())
   const layoutIntentAwaitingProofRef = useRef<number | null>(null)
@@ -2078,6 +2080,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   useEffect(() => {
     captureConfigRef.current = captureConfig
   }, [captureConfig])
+  useEffect(
+    () => () => {
+      liveAudioProcessingSyncRef.current?.queue.stop()
+    },
+    []
+  )
   useEffect(() => {
     latestLayoutTransactionCommitRef.current = null
   }, [client])
@@ -6134,24 +6142,93 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         microphoneMuted: captureConfig.audio.microphoneMuted
       }
     )
-    if (!params) {
+    if (!params || !client || wsStatus !== 'connected' || stopRequestPending) {
+      liveAudioProcessingSyncRef.current?.queue.stop()
       liveAudioProcessingSyncRef.current = null
       return
     }
-    if (!client || wsStatus !== 'connected') return
 
     let sync = liveAudioProcessingSyncRef.current
+    let created = false
     if (!sync || sync.sessionId !== params.sessionId) {
-      sync = {
+      sync?.queue.stop()
+      const token = {}
+      const queue = new LatestWinsLiveAudioProcessingQueue(
+        params.sessionId,
+        (requested) =>
+          client.request<AudioProcessingUpdateResult>('audio.processing.update', requested),
+        ({ requested, result, error }) => {
+          const latest = liveAudioProcessingSyncRef.current
+          if (
+            latest?.token !== token ||
+            recordingRef.current.sessionId !== requested.sessionId ||
+            !['recording', 'streaming'].includes(recordingRef.current.state)
+          ) {
+            return false
+          }
+
+          const validResult = result?.sessionId === requested.sessionId ? result : undefined
+          const protocolError =
+            result && !validResult
+              ? new Error('Backend returned live microphone state for a different session.')
+              : undefined
+          if (validResult?.applied) {
+            latest.lastApplied = {
+              microphoneGainDb: validResult.microphoneGainDb,
+              microphoneMuted: validResult.microphoneMuted
+            }
+            return true
+          }
+
+          const rejection = rejectedLiveAudioProcessingUpdate({
+            recording: recordingRef.current,
+            current: captureConfigRef.current.audio,
+            requested,
+            result: validResult,
+            lastApplied: latest.lastApplied
+          })
+          if (!rejection) return true
+
+          latest.disabled = rejection.disableForSession
+          setCaptureConfig((current) => {
+            const currentRejection = rejectedLiveAudioProcessingUpdate({
+              recording: recordingRef.current,
+              current: current.audio,
+              requested,
+              result: validResult,
+              lastApplied: latest.lastApplied
+            })
+            if (!currentRejection) return current
+            return {
+              ...current,
+              audio: { ...current.audio, ...currentRejection.rollback }
+            }
+          })
+
+          const requestError = protocolError ?? error
+          const detail =
+            requestError instanceof Error
+              ? ` ${requestError.message}`
+              : requestError
+                ? ` ${String(requestError)}`
+                : ''
+          reportError(new Error(`${rejection.message}${detail}`))
+          return !rejection.disableForSession
+        }
+      )
+      const nextSync = {
+        token,
         sessionId: params.sessionId,
         lastApplied: {
           microphoneGainDb: params.microphoneGainDb,
           microphoneMuted: params.microphoneMuted
         },
         disabled: false,
-        requestRevision: 0
+        queue
       }
-      liveAudioProcessingSyncRef.current = sync
+      sync = nextSync
+      liveAudioProcessingSyncRef.current = nextSync
+      created = true
     }
 
     // Once this session proves it has no native post-controls path, keep every
@@ -6171,80 +6248,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       return
     }
 
-    sync.requestRevision += 1
-    const requestRevision = sync.requestRevision
-    const lastApplied = sync.lastApplied
+    const desiredMatchesLastApplied =
+      params.microphoneGainDb === sync.lastApplied.microphoneGainDb &&
+      params.microphoneMuted === sync.lastApplied.microphoneMuted
+    if (!created && !sync.queue.hasOutstandingWork && desiredMatchesLastApplied) return
 
-    const rejectCurrentRequest = (
-      result?: AudioProcessingUpdateResult
-    ): ReturnType<typeof rejectedLiveAudioProcessingUpdate> => {
-      const latest = liveAudioProcessingSyncRef.current
-      if (
-        !latest ||
-        latest.sessionId !== params.sessionId ||
-        latest.requestRevision !== requestRevision
-      ) {
-        return null
-      }
-      const rejection = rejectedLiveAudioProcessingUpdate({
-        recording: recordingRef.current,
-        current: captureConfigRef.current.audio,
-        requested: params,
-        result,
-        lastApplied
-      })
-      if (!rejection) return null
-
-      latest.disabled = rejection.disableForSession
-      setCaptureConfig((current) => {
-        const currentRejection = rejectedLiveAudioProcessingUpdate({
-          recording: recordingRef.current,
-          current: current.audio,
-          requested: params,
-          result,
-          lastApplied
-        })
-        if (!currentRejection) return current
-        return {
-          ...current,
-          audio: { ...current.audio, ...currentRejection.rollback }
-        }
-      })
-      return rejection
-    }
-
-    void client
-      .request<AudioProcessingUpdateResult>('audio.processing.update', params)
-      .then((result) => {
-        const latest = liveAudioProcessingSyncRef.current
-        if (
-          !latest ||
-          latest.sessionId !== params.sessionId ||
-          latest.requestRevision !== requestRevision ||
-          result.sessionId !== params.sessionId ||
-          recordingRef.current.sessionId !== params.sessionId ||
-          !['recording', 'streaming'].includes(recordingRef.current.state)
-        ) {
-          return
-        }
-        if (result.applied) {
-          latest.lastApplied = {
-            microphoneGainDb: result.microphoneGainDb,
-            microphoneMuted: result.microphoneMuted
-          }
-          return
-        }
-
-        const rejection = rejectCurrentRequest(result)
-        if (!rejection) return
-        reportError(new Error(rejection.message))
-      })
-      .catch((error) => {
-        const rejection = rejectCurrentRequest()
-        if (!rejection) return
-        const detail = error instanceof Error ? error.message : String(error)
-        reportError(new Error(`${rejection.message} ${detail}`))
-      })
+    sync.queue.enqueue(params)
   }, [
     client,
     recording.sessionId,
@@ -6252,6 +6261,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     captureConfig.audio.microphoneGainDb,
     captureConfig.audio.microphoneMuted,
     reportError,
+    stopRequestPending,
     wsStatus
   ])
 
@@ -8040,6 +8050,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       setLastError(null)
       platformLifecycleRun.current += 1
       setStopRequestPending(true)
+      liveAudioProcessingSyncRef.current?.queue.stop()
       // Docs order: END the X broadcast while the feed is still up, THEN stop
       // the encoder. Bounded so a slow END can never hold the stop hostage.
       const cleaned = await endPreparedXBroadcasts(

--- a/apps/desktop/src/renderer/src/lib/live-audio-processing.test.ts
+++ b/apps/desktop/src/renderer/src/lib/live-audio-processing.test.ts
@@ -2,8 +2,32 @@ import { describe, expect, it } from 'vitest'
 
 import {
   activeAudioProcessingUpdateParams,
+  LatestWinsLiveAudioProcessingQueue,
   rejectedLiveAudioProcessingUpdate
 } from './live-audio-processing'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill
+  })
+  return { promise, resolve }
+}
+
+function appliedResult(
+  microphoneGainDb: number,
+  microphoneMuted = false
+): import('@/lib/backend').AudioProcessingUpdateResult {
+  return {
+    applied: true,
+    sessionId: 'session-1',
+    microphoneGainDb,
+    microphoneMuted
+  }
+}
 
 describe('activeAudioProcessingUpdateParams', () => {
   it.each(['recording', 'streaming'] as const)(
@@ -70,7 +94,61 @@ describe('activeAudioProcessingUpdateParams', () => {
     })
   })
 
-  it('ignores a stale rejection after the user has made a newer mic edit', () => {
+  it('disables live edits when the active capture has no live audio control target', () => {
+    expect(
+      rejectedLiveAudioProcessingUpdate({
+        recording: { state: 'recording', sessionId: 'session-1' },
+        current: { microphoneGainDb: 8, microphoneMuted: true },
+        requested: {
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true
+        },
+        result: {
+          applied: false,
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true,
+          reasonCode: 'live-audio-control-unavailable'
+        },
+        lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
+      })
+    ).toEqual({
+      rollback: { microphoneGainDb: -2, microphoneMuted: false },
+      disableForSession: true,
+      message:
+        'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
+    })
+  })
+
+  it('does not claim restoration when FFmpeg could not confirm the captured audio state', () => {
+    expect(
+      rejectedLiveAudioProcessingUpdate({
+        recording: { state: 'recording', sessionId: 'session-1' },
+        current: { microphoneGainDb: 8, microphoneMuted: true },
+        requested: {
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true
+        },
+        result: {
+          applied: false,
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: true,
+          reasonCode: 'live-audio-control-state-unknown'
+        },
+        lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
+      })
+    ).toEqual({
+      rollback: { microphoneGainDb: -2, microphoneMuted: false },
+      disableForSession: true,
+      message:
+        'The live microphone change could not be confirmed, and the captured audio state may differ from the controls shown. Stop and restart this capture before relying on microphone gain or mute.'
+    })
+  })
+
+  it('ignores a stale non-controller rejection after the user has made a newer mic edit', () => {
     expect(
       rejectedLiveAudioProcessingUpdate({
         recording: { state: 'recording', sessionId: 'session-1' },
@@ -85,11 +163,40 @@ describe('activeAudioProcessingUpdateParams', () => {
           sessionId: 'session-1',
           microphoneGainDb: 8,
           microphoneMuted: true,
-          reasonCode: 'native-audio-unavailable'
+          reasonCode: 'stale-session'
         },
         lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
       })
     ).toBeNull()
+  })
+
+  it('prefers backend-confirmed rollback truth when an overlapping newer edit is visible', () => {
+    expect(
+      rejectedLiveAudioProcessingUpdate({
+        recording: { state: 'recording', sessionId: 'session-1' },
+        current: { microphoneGainDb: 12, microphoneMuted: true },
+        requested: {
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: false
+        },
+        result: {
+          applied: false,
+          sessionId: 'session-1',
+          microphoneGainDb: 8,
+          microphoneMuted: false,
+          reasonCode: 'live-audio-control-unavailable',
+          confirmedMicrophoneGainDb: 3,
+          confirmedMicrophoneMuted: false
+        },
+        lastApplied: { microphoneGainDb: -2, microphoneMuted: true }
+      })
+    ).toEqual({
+      rollback: { microphoneGainDb: 3, microphoneMuted: false },
+      disableForSession: true,
+      message:
+        'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
+    })
   })
 
   it('does not roll back a live change the backend applied', () => {
@@ -114,7 +221,7 @@ describe('activeAudioProcessingUpdateParams', () => {
   })
 
   it.each(['recording', 'streaming'] as const)(
-    'restores and disables a current %s-session edit when the request rejects',
+    'reports unknown state for a current %s-session edit when transport rejects after possible apply',
     (state) => {
       expect(
         rejectedLiveAudioProcessingUpdate({
@@ -131,7 +238,7 @@ describe('activeAudioProcessingUpdateParams', () => {
         rollback: { microphoneGainDb: -2, microphoneMuted: false },
         disableForSession: true,
         message:
-          'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
+          'The live microphone change could not be confirmed, and the captured audio state may differ from the controls shown. Stop and restart this capture before relying on microphone gain or mute.'
       })
     }
   )
@@ -149,5 +256,133 @@ describe('activeAudioProcessingUpdateParams', () => {
         lastApplied: { microphoneGainDb: -2, microphoneMuted: false }
       })
     ).toBeNull()
+  })
+})
+
+describe('LatestWinsLiveAudioProcessingQueue', () => {
+  it('coalesces a drag flood to one in-flight command plus the newest complete state', async () => {
+    const first = deferred<ReturnType<typeof appliedResult>>()
+    const second = deferred<ReturnType<typeof appliedResult>>()
+    const sent: Array<{ microphoneGainDb: number; microphoneMuted: boolean }> = []
+    const settled: number[] = []
+    const queue = new LatestWinsLiveAudioProcessingQueue(
+      'session-1',
+      async (params) => {
+        sent.push(params)
+        return sent.length === 1 ? first.promise : second.promise
+      },
+      ({ result }) => {
+        if (result) settled.push(result.microphoneGainDb)
+        return true
+      }
+    )
+
+    queue.enqueue({
+      sessionId: 'session-1',
+      microphoneGainDb: 1,
+      microphoneMuted: false
+    })
+    await Promise.resolve()
+    for (let gain = 2; gain <= 40; gain += 1) {
+      queue.enqueue({
+        sessionId: 'session-1',
+        microphoneGainDb: gain,
+        microphoneMuted: gain === 40
+      })
+    }
+
+    expect(sent).toEqual([{ sessionId: 'session-1', microphoneGainDb: 1, microphoneMuted: false }])
+    first.resolve(appliedResult(1))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(sent).toEqual([
+      { sessionId: 'session-1', microphoneGainDb: 1, microphoneMuted: false },
+      { sessionId: 'session-1', microphoneGainDb: 40, microphoneMuted: true }
+    ])
+
+    second.resolve(appliedResult(40, true))
+    await queue.waitForIdle()
+    expect(settled).toEqual([1, 40])
+  })
+
+  it('drops a flooded pending tail and ignores the in-flight reply at the stop boundary', async () => {
+    const first = deferred<ReturnType<typeof appliedResult>>()
+    const sent: number[] = []
+    const settled: number[] = []
+    const queue = new LatestWinsLiveAudioProcessingQueue(
+      'session-1',
+      async (params) => {
+        sent.push(params.microphoneGainDb)
+        return first.promise
+      },
+      ({ result }) => {
+        if (result) settled.push(result.microphoneGainDb)
+        return true
+      }
+    )
+
+    queue.enqueue({ sessionId: 'session-1', microphoneGainDb: 1, microphoneMuted: false })
+    await Promise.resolve()
+    for (let gain = 2; gain <= 40; gain += 1) {
+      queue.enqueue({ sessionId: 'session-1', microphoneGainDb: gain, microphoneMuted: false })
+    }
+    queue.stop()
+    first.resolve(appliedResult(1))
+    await queue.waitForIdle()
+
+    expect(sent).toEqual([1])
+    expect(settled).toEqual([])
+    expect(queue.hasOutstandingWork).toBe(false)
+  })
+
+  it('stops before dispatching a pending latest value when settlement marks the controller unhealthy', async () => {
+    const first = deferred<ReturnType<typeof appliedResult>>()
+    const sent: number[] = []
+    const queue = new LatestWinsLiveAudioProcessingQueue(
+      'session-1',
+      async (params) => {
+        sent.push(params.microphoneGainDb)
+        return first.promise
+      },
+      () => false
+    )
+
+    queue.enqueue({ sessionId: 'session-1', microphoneGainDb: 1, microphoneMuted: false })
+    await Promise.resolve()
+    queue.enqueue({ sessionId: 'session-1', microphoneGainDb: 24, microphoneMuted: true })
+    first.resolve(appliedResult(1))
+    await queue.waitForIdle()
+
+    expect(sent).toEqual([1])
+  })
+
+  it('treats sender rejection after a possible apply as unknown captured state', async () => {
+    let rejection: ReturnType<typeof rejectedLiveAudioProcessingUpdate> = null
+    const queue = new LatestWinsLiveAudioProcessingQueue(
+      'session-1',
+      async () => {
+        throw new Error('socket closed before the response arrived')
+      },
+      ({ requested, result }) => {
+        rejection = rejectedLiveAudioProcessingUpdate({
+          recording: { state: 'recording', sessionId: 'session-1' },
+          current: { microphoneGainDb: 6, microphoneMuted: false },
+          requested,
+          result,
+          lastApplied: { microphoneGainDb: 0, microphoneMuted: false }
+        })
+        return !rejection?.disableForSession
+      }
+    )
+
+    queue.enqueue({ sessionId: 'session-1', microphoneGainDb: 6, microphoneMuted: false })
+    await queue.waitForIdle()
+
+    expect(rejection).toEqual({
+      rollback: { microphoneGainDb: 0, microphoneMuted: false },
+      disableForSession: true,
+      message:
+        'The live microphone change could not be confirmed, and the captured audio state may differ from the controls shown. Stop and restart this capture before relying on microphone gain or mute.'
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/lib/live-audio-processing.ts
+++ b/apps/desktop/src/renderer/src/lib/live-audio-processing.ts
@@ -13,6 +13,95 @@ export interface RejectedLiveAudioProcessingUpdate {
   message: string
 }
 
+export interface LiveAudioProcessingUpdateSettlement {
+  requested: AudioProcessingUpdateParams
+  result?: AudioProcessingUpdateResult
+  error?: unknown
+}
+
+export type LiveAudioProcessingUpdateSender = (
+  params: AudioProcessingUpdateParams
+) => Promise<AudioProcessingUpdateResult>
+
+/**
+ * FFmpeg polls runtime commands on its stats cadence, so a slider drag must not
+ * turn into a FIFO of several-second websocket requests. Keep one request in
+ * flight and replace the pending request with the newest complete mic state.
+ * Stopping a session drops pending work and makes the eventual in-flight reply
+ * inert; the backend stop marker independently rejects requests already queued
+ * at the native session mutex.
+ */
+export class LatestWinsLiveAudioProcessingQueue {
+  private inFlight: AudioProcessingUpdateParams | null = null
+  private pending: AudioProcessingUpdateParams | null = null
+  private drainPromise: Promise<void> | null = null
+  private stopped = false
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly send: LiveAudioProcessingUpdateSender,
+    private readonly onSettled: (settlement: LiveAudioProcessingUpdateSettlement) => boolean
+  ) {}
+
+  get hasOutstandingWork(): boolean {
+    return this.inFlight !== null || this.pending !== null
+  }
+
+  enqueue(params: AudioProcessingUpdateParams): void {
+    if (this.stopped || params.sessionId !== this.sessionId) return
+    if (sameAudioProcessingParams(params, this.pending ?? this.inFlight)) return
+
+    this.pending = params
+    if (!this.drainPromise) {
+      this.drainPromise = this.drain().finally(() => {
+        this.drainPromise = null
+      })
+    }
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.pending = null
+  }
+
+  async waitForIdle(): Promise<void> {
+    await this.drainPromise
+  }
+
+  private async drain(): Promise<void> {
+    while (!this.stopped && this.pending) {
+      const requested = this.pending
+      this.pending = null
+      this.inFlight = requested
+
+      let settlement: LiveAudioProcessingUpdateSettlement
+      try {
+        settlement = { requested, result: await this.send(requested) }
+      } catch (error) {
+        settlement = { requested, error }
+      }
+
+      this.inFlight = null
+      if (this.stopped) break
+      if (!this.onSettled(settlement)) {
+        this.stop()
+      }
+    }
+  }
+}
+
+function sameAudioProcessingParams(
+  left: AudioProcessingUpdateParams,
+  right: AudioProcessingUpdateParams | null
+): boolean {
+  return (
+    right !== null &&
+    left.sessionId === right.sessionId &&
+    left.microphoneGainDb === right.microphoneGainDb &&
+    left.microphoneMuted === right.microphoneMuted
+  )
+}
+
 /**
  * Central live-sync decision for every mic control. Individual controls only
  * update captureConfig; StudioProvider turns the latest shared settings into
@@ -50,23 +139,42 @@ export function rejectedLiveAudioProcessingUpdate(input: {
     !['recording', 'streaming'].includes(input.recording.state) ||
     input.recording.sessionId !== input.requested.sessionId ||
     input.result?.applied ||
-    (input.result && input.result.sessionId !== input.requested.sessionId) ||
-    input.current.microphoneGainDb !== input.requested.microphoneGainDb ||
-    input.current.microphoneMuted !== input.requested.microphoneMuted
+    (input.result && input.result.sessionId !== input.requested.sessionId)
   ) {
     return null
   }
 
-  // A rejected request provides no acknowledgement that the native session
-  // changed. Treat it as unavailable for the rest of this capture: restoring
-  // the last acknowledged values is the only state the UI can claim truthfully.
-  const nativeAudioUnavailable =
-    !input.result || input.result.reasonCode === 'native-audio-unavailable'
+  // A rejected request provides no acknowledgement that the active capture
+  // changed. Treat a missing or unhealthy controller as unavailable for the
+  // rest of this capture: restoring the last acknowledged values is the only
+  // state the UI can claim truthfully.
+  const liveAudioControlStateUnknown =
+    !input.result || input.result.reasonCode === 'live-audio-control-state-unknown'
+  const liveAudioControlsUnavailable =
+    liveAudioControlStateUnknown ||
+    input.result?.reasonCode === 'native-audio-unavailable' ||
+    input.result?.reasonCode === 'live-audio-control-unavailable'
+  const currentRequestStillVisible =
+    input.current.microphoneGainDb === input.requested.microphoneGainDb &&
+    input.current.microphoneMuted === input.requested.microphoneMuted
+  if (!liveAudioControlsUnavailable && !currentRequestStillVisible) {
+    return null
+  }
+  const backendConfirmedRollback =
+    input.result?.confirmedMicrophoneGainDb !== undefined &&
+    input.result.confirmedMicrophoneMuted !== undefined
+      ? {
+          microphoneGainDb: input.result.confirmedMicrophoneGainDb,
+          microphoneMuted: input.result.confirmedMicrophoneMuted
+        }
+      : null
   return {
-    rollback: input.lastApplied,
-    disableForSession: nativeAudioUnavailable,
-    message: nativeAudioUnavailable
-      ? 'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
-      : 'The live microphone change was not applied. The previous gain and mute settings were restored.'
+    rollback: backendConfirmedRollback ?? input.lastApplied,
+    disableForSession: liveAudioControlsUnavailable,
+    message: liveAudioControlStateUnknown
+      ? 'The live microphone change could not be confirmed, and the captured audio state may differ from the controls shown. Stop and restart this capture before relying on microphone gain or mute.'
+      : liveAudioControlsUnavailable
+        ? 'Live microphone controls are unavailable for this capture. The previous gain and mute settings were restored.'
+        : 'The live microphone change was not applied. The previous gain and mute settings were restored.'
   }
 }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1162,7 +1162,16 @@ export interface AudioProcessingUpdateParams {
 
 export interface AudioProcessingUpdateResult extends AudioProcessingUpdateParams {
   applied: boolean
-  reasonCode?: 'no-active-session' | 'stale-session' | 'native-audio-unavailable'
+  reasonCode?:
+    | 'no-active-session'
+    | 'stale-session'
+    | 'native-audio-unavailable'
+    | 'live-audio-control-unavailable'
+    | 'live-audio-control-state-unknown'
+  /** Present when the backend can conclusively report settings remaining after rejection. */
+  confirmedMicrophoneGainDb?: number
+  /** Present when the backend can conclusively report settings remaining after rejection. */
+  confirmedMicrophoneMuted?: boolean
 }
 
 export interface RemuxSessionParams {

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -3316,6 +3316,11 @@ const WEBSOCKET_RELIABLE_QUEUE_CAPACITY: usize = 128;
 const WEBSOCKET_COMMAND_QUEUE_CAPACITY: usize = 64;
 const WEBSOCKET_TELEMETRY_KIND_CAPACITY: usize = 32;
 const WEBSOCKET_LAYOUT_CONCURRENCY: usize = 8;
+// The renderer already sends live audio updates single-flight/latest-wins.
+// Keep the transport path independently bounded so a malformed/raw client
+// cannot build a task backlog, while session.stop remains dispatchable during
+// FFmpeg's acknowledgement wait.
+const WEBSOCKET_AUDIO_PROCESSING_CONCURRENCY: usize = 1;
 const WEBSOCKET_RELIABLE_BURST_LIMIT: usize = 8;
 // The desktop clients are loopback peers. Five seconds is deliberately far
 // above normal socket jitter while still bounding the lifetime of queued
@@ -3816,10 +3821,38 @@ fn websocket_command_may_overlap(text: &str) -> bool {
     })
 }
 
+fn websocket_audio_processing_command_id(text: &str) -> Option<String> {
+    serde_json::from_str::<ClientCommand>(text)
+        .ok()
+        .filter(|command| command.method == "audio.processing.update")
+        .map(|command| command.id)
+}
+
+fn websocket_command_is_session_stop(text: &str) -> bool {
+    serde_json::from_str::<ClientCommand>(text)
+        .is_ok_and(|command| command.method == "session.stop")
+}
+
 async fn drain_websocket_layout_commands(tasks: &mut tokio::task::JoinSet<()>) {
     while let Some(completed) = tasks.join_next().await {
         if let Err(error) = completed {
             tracing::warn!("WebSocket layout command task failed: {error}");
+        }
+    }
+}
+
+async fn drain_websocket_audio_processing_commands(tasks: &mut tokio::task::JoinSet<()>) {
+    while let Some(completed) = tasks.join_next().await {
+        if let Err(error) = completed {
+            tracing::warn!("WebSocket audio processing command task failed: {error}");
+        }
+    }
+}
+
+fn reap_websocket_audio_processing_commands(tasks: &mut tokio::task::JoinSet<()>) {
+    while let Some(completed) = tasks.try_join_next() {
+        if let Err(error) = completed {
+            tracing::warn!("WebSocket audio processing command task failed: {error}");
         }
     }
 }
@@ -3834,9 +3867,11 @@ async fn run_websocket_command_dispatcher(
     command_handler: WebSocketCommandHandler,
 ) {
     let mut layout_tasks = tokio::task::JoinSet::new();
+    let mut audio_processing_tasks = tokio::task::JoinSet::new();
 
     while let Some(text) = commands.recv().await {
         command_metrics.record_dequeue_oldest();
+        reap_websocket_audio_processing_commands(&mut audio_processing_tasks);
         if websocket_command_may_overlap(text.as_str()) {
             if layout_tasks.len() >= WEBSOCKET_LAYOUT_CONCURRENCY
                 && let Some(completed) = layout_tasks.join_next().await
@@ -3862,10 +3897,51 @@ async fn run_websocket_command_dispatcher(
             continue;
         }
 
+        if let Some(command_id) = websocket_audio_processing_command_id(text.as_str()) {
+            // Audio gain/mute is independent from scene layout. Do not hold the
+            // dispatcher during FFmpeg's acknowledgement cadence; a following
+            // session.stop must be able to publish its stopping marker.
+            if audio_processing_tasks.len() >= WEBSOCKET_AUDIO_PROCESSING_CONCURRENCY {
+                let response = ServerResponse::error(
+                    command_id,
+                    "audio-processing-busy",
+                    "A live microphone update is already awaiting acknowledgement.",
+                );
+                if !queue_websocket_response(&outgoing, &reliable_metrics, &slow_pressure, response)
+                    .await
+                {
+                    break;
+                }
+                continue;
+            }
+
+            let command_state = state.clone();
+            let response_tx = outgoing.clone();
+            let response_metrics = reliable_metrics.clone();
+            let response_pressure = slow_pressure.clone();
+            let handler = command_handler.clone();
+            audio_processing_tasks.spawn(async move {
+                let response = handler(command_state, text).await;
+                let _ = queue_websocket_response(
+                    &response_tx,
+                    &response_metrics,
+                    &response_pressure,
+                    response,
+                )
+                .await;
+            });
+            continue;
+        }
+
         // A stateful non-layout command is an ordering barrier. All layouts
         // accepted before it finish first, and later commands remain queued
-        // until this mutation completes.
+        // until this mutation completes. session.stop is the deliberate narrow
+        // exception for an in-flight live audio acknowledgement: the backend's
+        // session mutex and stop marker preserve native ordering.
         drain_websocket_layout_commands(&mut layout_tasks).await;
+        if !websocket_command_is_session_stop(text.as_str()) {
+            drain_websocket_audio_processing_commands(&mut audio_processing_tasks).await;
+        }
         let response = command_handler(state.clone(), text).await;
         if !queue_websocket_response(&outgoing, &reliable_metrics, &slow_pressure, response).await {
             break;
@@ -3873,6 +3949,7 @@ async fn run_websocket_command_dispatcher(
     }
 
     drain_websocket_layout_commands(&mut layout_tasks).await;
+    drain_websocket_audio_processing_commands(&mut audio_processing_tasks).await;
 }
 
 async fn ws_handler(
@@ -8478,6 +8555,193 @@ mod tests {
             .unwrap()
             .forget();
         assert_eq!(*order.lock().await, ["start", "stop"]);
+
+        let _ = socket.close(None).await;
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn websocket_session_stop_bypasses_bounded_live_audio_acknowledgement() {
+        let order = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<&'static str>::new()));
+        let audio_entered = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let stop_entered = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let release_audio = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let handler: WebSocketCommandHandler = {
+            let order = order.clone();
+            let audio_entered = audio_entered.clone();
+            let stop_entered = stop_entered.clone();
+            let release_audio = release_audio.clone();
+            std::sync::Arc::new(move |_state, text| {
+                let order = order.clone();
+                let audio_entered = audio_entered.clone();
+                let stop_entered = stop_entered.clone();
+                let release_audio = release_audio.clone();
+                Box::pin(async move {
+                    let command: serde_json::Value = serde_json::from_str(&text).unwrap();
+                    let id = command["id"].as_str().unwrap().to_string();
+                    match command["method"].as_str().unwrap() {
+                        "audio.processing.update" => {
+                            audio_entered.add_permits(1);
+                            release_audio.acquire().await.unwrap().forget();
+                            order.lock().await.push("audio-ack");
+                        }
+                        "session.stop" => {
+                            stop_entered.add_permits(1);
+                            order.lock().await.push("stop");
+                        }
+                        method => panic!("unexpected test command: {method}"),
+                    }
+                    ServerResponse::ok(id, json!({}))
+                })
+            })
+        };
+        let (mut socket, server, _) = connect_test_websocket(handler).await;
+
+        socket
+            .send(tokio_tungstenite::tungstenite::Message::Text(
+                json!({
+                    "id": "audio-first",
+                    "method": "audio.processing.update",
+                    "params": {}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        timeout(Duration::from_secs(1), audio_entered.acquire())
+            .await
+            .expect("first audio update should run off the dispatcher")
+            .unwrap()
+            .forget();
+
+        for (id, method) in [
+            ("audio-excess", "audio.processing.update"),
+            ("stop", "session.stop"),
+        ] {
+            socket
+                .send(tokio_tungstenite::tungstenite::Message::Text(
+                    json!({ "id": id, "method": method, "params": {} })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+        }
+
+        timeout(Duration::from_secs(1), stop_entered.acquire())
+            .await
+            .expect("session.stop must dispatch before the delayed audio acknowledgement")
+            .unwrap()
+            .forget();
+        assert_eq!(*order.lock().await, ["stop"]);
+
+        let early_responses = timeout(Duration::from_secs(1), async {
+            let mut responses = std::collections::HashMap::new();
+            while responses.len() < 2 {
+                let message = socket.next().await.unwrap().unwrap();
+                let tokio_tungstenite::tungstenite::Message::Text(text) = message else {
+                    continue;
+                };
+                let response: serde_json::Value = serde_json::from_str(&text).unwrap();
+                if let Some(id) = response["id"].as_str() {
+                    responses.insert(id.to_string(), response);
+                }
+            }
+            responses
+        })
+        .await
+        .expect("busy and stop responses must not wait for the audio acknowledgement");
+        assert_eq!(early_responses["audio-excess"]["ok"], false);
+        assert_eq!(
+            early_responses["audio-excess"]["error"]["code"],
+            "audio-processing-busy"
+        );
+        assert_eq!(early_responses["stop"]["ok"], true);
+
+        release_audio.add_permits(1);
+        let audio_response = timeout(Duration::from_secs(1), async {
+            loop {
+                let message = socket.next().await.unwrap().unwrap();
+                let tokio_tungstenite::tungstenite::Message::Text(text) = message else {
+                    continue;
+                };
+                let response: serde_json::Value = serde_json::from_str(&text).unwrap();
+                if response["id"] == "audio-first" {
+                    break response;
+                }
+            }
+        })
+        .await
+        .expect("the accepted audio update still owes its response after stop");
+        assert_eq!(audio_response["ok"], true);
+        assert_eq!(*order.lock().await, ["stop", "audio-ack"]);
+
+        let _ = socket.close(None).await;
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn websocket_ordinary_barrier_waits_for_live_audio_acknowledgement() {
+        let audio_entered = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let barrier_entered = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let release_audio = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let handler: WebSocketCommandHandler = {
+            let audio_entered = audio_entered.clone();
+            let barrier_entered = barrier_entered.clone();
+            let release_audio = release_audio.clone();
+            std::sync::Arc::new(move |_state, text| {
+                let audio_entered = audio_entered.clone();
+                let barrier_entered = barrier_entered.clone();
+                let release_audio = release_audio.clone();
+                Box::pin(async move {
+                    let command: serde_json::Value = serde_json::from_str(&text).unwrap();
+                    let id = command["id"].as_str().unwrap().to_string();
+                    match command["method"].as_str().unwrap() {
+                        "audio.processing.update" => {
+                            audio_entered.add_permits(1);
+                            release_audio.acquire().await.unwrap().forget();
+                        }
+                        "test.mutation.ordered" => barrier_entered.add_permits(1),
+                        method => panic!("unexpected test command: {method}"),
+                    }
+                    ServerResponse::ok(id, json!({}))
+                })
+            })
+        };
+        let (mut socket, server, _) = connect_test_websocket(handler).await;
+
+        for (id, method) in [
+            ("audio", "audio.processing.update"),
+            ("barrier", "test.mutation.ordered"),
+        ] {
+            socket
+                .send(tokio_tungstenite::tungstenite::Message::Text(
+                    json!({ "id": id, "method": method, "params": {} })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+        }
+
+        timeout(Duration::from_secs(1), audio_entered.acquire())
+            .await
+            .expect("audio update should start")
+            .unwrap()
+            .forget();
+        assert!(
+            timeout(Duration::from_millis(100), barrier_entered.acquire())
+                .await
+                .is_err(),
+            "ordinary ordered commands must retain the live audio barrier"
+        );
+        release_audio.add_permits(1);
+        timeout(Duration::from_secs(1), barrier_entered.acquire())
+            .await
+            .expect("ordinary barrier should run after audio acknowledgement")
+            .unwrap()
+            .forget();
 
         let _ = socket.close(None).await;
         server.abort();

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -942,6 +942,10 @@ pub struct AudioProcessingUpdateResult {
     pub microphone_muted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmed_microphone_gain_db: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmed_microphone_muted: Option<bool>,
 }
 
 fn default_microphone_sync_offset_ms() -> i32 {

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -10,9 +10,9 @@ use std::time::Instant;
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use tokio::fs;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, ChildStdout, Command};
-use tokio::sync::{Mutex, OwnedMutexGuard, oneshot};
+use tokio::sync::{Mutex, OwnedMutexGuard, mpsc, oneshot};
 use tokio::time::{Duration, sleep, timeout};
 use uuid::Uuid;
 
@@ -250,6 +250,283 @@ const POST_RECORDING_REPAIR_TIMEOUT: Duration = Duration::from_secs(180);
 // blocking the bridge and starving both recording and preview.
 const ENCODER_BRIDGE_RAW_VIDEO_INPUT_QUEUE_FRAMES: u32 = 16;
 const ENCODER_BRIDGE_VIDEO_OUTPUT_ENV: &str = "VIDEORC_ENCODER_BRIDGE_VIDEO_OUTPUT";
+const FFMPEG_LIVE_MIC_FILTER_TARGET: &str = "videorc_live_mic";
+const FFMPEG_PROGRESS_REPORT_PERIOD_SECONDS: u64 = 2;
+// FFmpeg only polls stdin for filter commands on its progress-report cadence.
+// Keep a full extra reporting interval plus scheduling headroom so a command
+// written just after a report cannot time out after FFmpeg has applied it.
+const FFMPEG_LIVE_AUDIO_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FfmpegFilterCommandReply {
+    return_code: i32,
+}
+
+#[derive(Debug)]
+enum FfmpegLiveAudioCommandFailure {
+    Rejected(i32),
+    Uncertain(anyhow::Error),
+}
+
+#[derive(Debug)]
+struct FfmpegLiveAudioApplyFailure {
+    error: anyhow::Error,
+    state_unknown: bool,
+    confirmed_settings: Option<AudioProcessingSettings>,
+}
+
+/// Runtime gain/mute control for microphones captured directly by FFmpeg
+/// (currently Windows DirectShow). FFmpeg's command replies are untagged, so
+/// one session-owned receiver serializes updates and becomes permanently
+/// unhealthy after a timeout rather than letting a late reply acknowledge a
+/// later command.
+#[derive(Debug)]
+struct FfmpegLiveAudioControl {
+    expected_replies: usize,
+    replies: mpsc::UnboundedReceiver<FfmpegFilterCommandReply>,
+    last_applied: AudioProcessingSettings,
+    healthy: bool,
+    state_unknown: bool,
+}
+
+impl FfmpegLiveAudioControl {
+    fn new(
+        expected_replies: usize,
+        replies: mpsc::UnboundedReceiver<FfmpegFilterCommandReply>,
+        initial: AudioProcessingSettings,
+    ) -> Self {
+        Self {
+            expected_replies,
+            replies,
+            last_applied: initial,
+            healthy: expected_replies > 0,
+            state_unknown: false,
+        }
+    }
+
+    async fn apply<W>(
+        &mut self,
+        stdin: &mut W,
+        settings: AudioProcessingSettings,
+    ) -> std::result::Result<(), FfmpegLiveAudioApplyFailure>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        if !self.healthy {
+            return Err(FfmpegLiveAudioApplyFailure {
+                error: if self.state_unknown {
+                    anyhow::anyhow!(
+                        "FFmpeg live microphone control state is unknown for this session"
+                    )
+                } else {
+                    anyhow::anyhow!(
+                        "FFmpeg live microphone control is unavailable for this session"
+                    )
+                },
+                state_unknown: self.state_unknown,
+                confirmed_settings: (!self.state_unknown).then_some(self.last_applied),
+            });
+        }
+
+        // There should be no queued reply while commands are serialized under
+        // the session mutex. Discarding one here protects the next command if
+        // a protocol anomaly delivered an extra acknowledgement.
+        while self.replies.try_recv().is_ok() {}
+
+        let previous = self.last_applied;
+        match self.send_and_confirm(stdin, settings).await {
+            Ok(()) => {}
+            Err(FfmpegLiveAudioCommandFailure::Rejected(return_code)) => {
+                // Every reply arrived, so it is safe to issue one best-effort
+                // broadcast rollback without confusing the two commands. A
+                // rejected command can otherwise leave repeated output graphs
+                // at different values.
+                let rollback = self.send_and_confirm(stdin, previous).await;
+                self.healthy = false;
+                return match rollback {
+                    Ok(()) => Err(FfmpegLiveAudioApplyFailure {
+                        error: anyhow::anyhow!(
+                            "FFmpeg rejected the live microphone command with ret:{return_code}; the previous microphone settings were restored"
+                        ),
+                        state_unknown: false,
+                        confirmed_settings: Some(previous),
+                    }),
+                    Err(rollback_error) => Err(FfmpegLiveAudioApplyFailure {
+                        error: {
+                            self.state_unknown = true;
+                            anyhow::anyhow!(
+                                "FFmpeg rejected the live microphone command with ret:{return_code}, and rollback could not be confirmed: {rollback_error:?}"
+                            )
+                        },
+                        state_unknown: true,
+                        confirmed_settings: None,
+                    }),
+                };
+            }
+            Err(FfmpegLiveAudioCommandFailure::Uncertain(error)) => {
+                // A timeout leaves later untagged replies ambiguous. Never send
+                // another command or let a late reply acknowledge a new value.
+                self.healthy = false;
+                self.state_unknown = true;
+                return Err(FfmpegLiveAudioApplyFailure {
+                    error,
+                    state_unknown: true,
+                    confirmed_settings: None,
+                });
+            }
+        }
+
+        self.last_applied = settings;
+        Ok(())
+    }
+
+    async fn send_and_confirm<W>(
+        &mut self,
+        stdin: &mut W,
+        settings: AudioProcessingSettings,
+    ) -> std::result::Result<(), FfmpegLiveAudioCommandFailure>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        let command = ffmpeg_live_microphone_command(settings);
+        stdin
+            .write_all(command.as_bytes())
+            .await
+            .context("Could not write the live microphone command to FFmpeg")
+            .map_err(FfmpegLiveAudioCommandFailure::Uncertain)?;
+        stdin
+            .flush()
+            .await
+            .context("Could not flush the live microphone command to FFmpeg")
+            .map_err(FfmpegLiveAudioCommandFailure::Uncertain)?;
+
+        let replies = timeout(FFMPEG_LIVE_AUDIO_REPLY_TIMEOUT, async {
+            let mut first_failure = None;
+            for _ in 0..self.expected_replies {
+                let Some(reply) = self.replies.recv().await else {
+                    bail!("FFmpeg closed the live microphone command reply channel");
+                };
+                if reply.return_code != 0 && first_failure.is_none() {
+                    first_failure = Some(reply.return_code);
+                }
+            }
+            Ok::<Option<i32>, anyhow::Error>(first_failure)
+        })
+        .await;
+
+        match replies {
+            Ok(Ok(Some(return_code))) => Err(FfmpegLiveAudioCommandFailure::Rejected(return_code)),
+            Ok(Ok(None)) => Ok(()),
+            Ok(Err(error)) => Err(FfmpegLiveAudioCommandFailure::Uncertain(error)),
+            Err(error) => Err(FfmpegLiveAudioCommandFailure::Uncertain(
+                anyhow::Error::new(error)
+                    .context("FFmpeg did not acknowledge the live microphone command in time"),
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FfmpegLiveAudioSession {
+    stdin: Option<ChildStdin>,
+    control: FfmpegLiveAudioControl,
+}
+
+impl FfmpegLiveAudioSession {
+    async fn apply(
+        &mut self,
+        settings: AudioProcessingSettings,
+    ) -> std::result::Result<(), FfmpegLiveAudioApplyFailure> {
+        let Some(stdin) = self.stdin.as_mut() else {
+            let state_unknown = self.control.state_unknown;
+            return Err(FfmpegLiveAudioApplyFailure {
+                error: anyhow::anyhow!("FFmpeg live microphone control stdin is closed"),
+                state_unknown,
+                confirmed_settings: (!state_unknown).then_some(self.control.last_applied),
+            });
+        };
+        self.control.apply(stdin, settings).await
+    }
+
+    async fn quit(&mut self) -> Result<()> {
+        let mut stdin = self
+            .stdin
+            .take()
+            .context("FFmpeg live microphone control stdin was already closed")?;
+        stdin
+            .write_all(b"q\n")
+            .await
+            .context("Could not send stop command to FFmpeg")?;
+        let _ = stdin.shutdown().await;
+        Ok(())
+    }
+
+    async fn close_stdin(&mut self) -> Result<()> {
+        let Some(mut stdin) = self.stdin.take() else {
+            return Ok(());
+        };
+        stdin
+            .shutdown()
+            .await
+            .context("Could not close FFmpeg live microphone control stdin")
+    }
+}
+
+#[derive(Debug)]
+struct FfmpegLiveAudioSessionHandle {
+    stopping: AtomicBool,
+    session: Mutex<FfmpegLiveAudioSession>,
+}
+
+impl FfmpegLiveAudioSessionHandle {
+    fn new(stdin: ChildStdin, control: FfmpegLiveAudioControl) -> Self {
+        Self {
+            stopping: AtomicBool::new(false),
+            session: Mutex::new(FfmpegLiveAudioSession {
+                stdin: Some(stdin),
+                control,
+            }),
+        }
+    }
+
+    fn begin_stop(&self) {
+        self.stopping.store(true, Ordering::Release);
+    }
+
+    async fn apply(
+        &self,
+        settings: AudioProcessingSettings,
+    ) -> std::result::Result<(), FfmpegLiveAudioApplyFailure> {
+        let mut session = self.session.lock().await;
+        if self.stopping.load(Ordering::Acquire) {
+            let state_unknown = session.control.state_unknown;
+            return Err(FfmpegLiveAudioApplyFailure {
+                error: anyhow::anyhow!("FFmpeg live microphone control is stopping"),
+                state_unknown,
+                confirmed_settings: (!state_unknown).then_some(session.control.last_applied),
+            });
+        }
+        session.apply(settings).await
+    }
+
+    async fn quit(&self) -> Result<()> {
+        self.session.lock().await.quit().await
+    }
+
+    async fn close_stdin(&self) -> Result<()> {
+        self.session.lock().await.close_stdin().await
+    }
+}
+
+type SharedFfmpegLiveAudioSession = Arc<FfmpegLiveAudioSessionHandle>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FfmpegLiveAudioStopMode {
+    /// Legacy FFmpeg owns the recording lifecycle and accepts `q` on stdin.
+    Quit,
+    /// Encoder-bridge FIFO EOF owns the lifecycle; close only the command pipe.
+    CloseCommandPipe,
+}
 
 #[derive(Debug)]
 pub struct ActiveRecording {
@@ -269,6 +546,7 @@ pub struct ActiveRecording {
     pub audio_tracks: Vec<AudioTrack>,
     pub pipeline: RecordingPipeline,
     pub native_audio: Option<NativeAudioCaptureSession>,
+    ffmpeg_live_audio_session: Option<SharedFfmpegLiveAudioSession>,
     pub screen_overlay: Option<ScreenOverlaySession>,
     pub encoder_bridge: Option<EncoderBridgeRecordingSession>,
     pub encoder_bridge_stream: Option<EncoderBridgeRecordingSession>,
@@ -422,44 +700,78 @@ pub async fn active_capture_elapsed_seconds(state: &AppState) -> Option<f64> {
     )
 }
 
-/// Applies renderer mic controls to the currently active native capture
-/// session. The session id makes delayed websocket commands harmless across a
-/// stop/start boundary; the CoreAudio callback consumes the update atomically.
+/// Applies renderer mic controls to the active CoreAudio or FFmpeg-owned
+/// capture session. The session id and recording lock make delayed websocket
+/// commands harmless across stop/start boundaries. CoreAudio consumes updates
+/// atomically; FFmpeg reports success only after every output graph replies.
 pub async fn update_active_audio_processing(
     state: &AppState,
     params: AudioProcessingUpdateParams,
 ) -> AudioProcessingUpdateResult {
-    let settings = AudioProcessingSettings {
-        gain_db: if params.microphone_gain_db.is_finite() {
-            params.microphone_gain_db.clamp(-24.0, 24.0)
-        } else {
-            0.0
-        },
-        muted: params.microphone_muted,
-    };
+    let settings =
+        normalized_audio_processing_settings(params.microphone_gain_db, params.microphone_muted);
     let mut result = AudioProcessingUpdateResult {
         applied: false,
         session_id: params.session_id.clone(),
         microphone_gain_db: settings.gain_db,
         microphone_muted: settings.muted,
         reason_code: None,
+        confirmed_microphone_gain_db: None,
+        confirmed_microphone_muted: None,
     };
 
-    let recording = state.recording.lock().await;
-    let Some(active) = recording.as_ref() else {
-        result.reason_code = Some("no-active-session".to_string());
+    let ffmpeg_live_audio_session = {
+        let recording = state.recording.lock().await;
+        let Some(active) = recording.as_ref() else {
+            result.reason_code = Some("no-active-session".to_string());
+            return result;
+        };
+        if active.session_id != params.session_id {
+            result.reason_code = Some("stale-session".to_string());
+            return result;
+        }
+        if active.stop_requested {
+            result.reason_code = Some("live-audio-control-unavailable".to_string());
+            return result;
+        }
+
+        if let Some(native_audio) = active.native_audio.as_ref() {
+            native_audio.update_processing_settings(settings);
+            result.applied = true;
+            return result;
+        }
+
+        active.ffmpeg_live_audio_session.clone()
+    };
+
+    let Some(ffmpeg_live_audio_session) = ffmpeg_live_audio_session else {
+        result.reason_code = Some("live-audio-control-unavailable".to_string());
         return result;
     };
-    if active.session_id != params.session_id {
-        result.reason_code = Some("stale-session".to_string());
+    let update = ffmpeg_live_audio_session.apply(settings).await;
+    if let Err(failure) = update {
+        state.emit_log(
+            "warn",
+            format!(
+                "Live microphone update was not applied: {:#}",
+                failure.error
+            ),
+        );
+        result.reason_code = Some(
+            if failure.state_unknown {
+                "live-audio-control-state-unknown"
+            } else {
+                "live-audio-control-unavailable"
+            }
+            .to_string(),
+        );
+        if let Some(confirmed) = failure.confirmed_settings {
+            result.confirmed_microphone_gain_db = Some(confirmed.gain_db);
+            result.confirmed_microphone_muted = Some(confirmed.muted);
+        }
         return result;
     }
-    let Some(native_audio) = active.native_audio.as_ref() else {
-        result.reason_code = Some("native-audio-unavailable".to_string());
-        return result;
-    };
 
-    native_audio.update_processing_settings(settings);
     result.applied = true;
     result
 }
@@ -1172,6 +1484,23 @@ pub async fn start_session(
             screen_overlay.as_ref(),
         )?
     };
+    let ffmpeg_live_audio_filter_count = ffmpeg_live_microphone_filter_count(&args);
+    let retain_ffmpeg_stdin =
+        retain_ffmpeg_stdin_for_session(use_encoder_bridge, ffmpeg_live_audio_filter_count);
+    let (ffmpeg_audio_reply_sender, pending_ffmpeg_live_audio_control) =
+        if ffmpeg_live_audio_filter_count > 0 {
+            let (sender, replies) = mpsc::unbounded_channel();
+            (
+                Some(sender),
+                Some(FfmpegLiveAudioControl::new(
+                    ffmpeg_live_audio_filter_count,
+                    replies,
+                    audio_processing_settings(&params),
+                )),
+            )
+        } else {
+            (None, None)
+        };
 
     publish_authorized_session_start(
         &state,
@@ -1192,10 +1521,10 @@ pub async fn start_session(
     let mut command = ffmpeg_command(&ffmpeg_path);
     command
         .args(&args)
-        .stdin(if use_encoder_bridge {
-            Stdio::null()
-        } else {
+        .stdin(if retain_ffmpeg_stdin {
             Stdio::piped()
+        } else {
+            Stdio::null()
         })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -1205,10 +1534,18 @@ pub async fn start_session(
 
     let stderr = child.stderr.take();
     let stdout = child.stdout.take();
-    let stdin = if use_encoder_bridge {
-        None
-    } else {
-        child.stdin.take()
+    let mut stdin = retain_ffmpeg_stdin.then(|| child.stdin.take()).flatten();
+    let ffmpeg_live_audio_session = match pending_ffmpeg_live_audio_control {
+        Some(control) => {
+            let control_stdin = stdin
+                .take()
+                .context("FFmpeg live microphone control stdin was unavailable")?;
+            Some(Arc::new(FfmpegLiveAudioSessionHandle::new(
+                control_stdin,
+                control,
+            )))
+        }
+        None => None,
     };
     let pid = child.id().unwrap_or_default();
     // FFmpeg opens every declared input before it starts draining raw video.
@@ -1317,6 +1654,7 @@ pub async fn start_session(
         audio_tracks,
         pipeline,
         native_audio: attached_native_audio,
+        ffmpeg_live_audio_session,
         screen_overlay: match screen_overlay_fifo {
             Some(screen_overlay_fifo) => Some(ScreenOverlaySession::start(
                 screen_overlay_fifo,
@@ -1421,12 +1759,29 @@ pub async fn start_session(
         let log_state = state.clone();
         let log_session_id = session_id.clone();
         let target_fps = params.output.video.fps;
+        let ffmpeg_audio_reply_sender = ffmpeg_audio_reply_sender;
         tokio::spawn(async move {
             let mut stream_runtime = stream_runtime;
             let mut lines = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 let trimmed = line.trim();
                 if trimmed.is_empty() {
+                    continue;
+                }
+
+                if let Some(reply) = parse_ffmpeg_filter_command_reply(trimmed) {
+                    if let Some(sender) = ffmpeg_audio_reply_sender.as_ref() {
+                        let _ = sender.send(reply);
+                    }
+                    if reply.return_code == 0 {
+                        tracing::debug!("{trimmed}");
+                    } else {
+                        log_state.emit_log("warn", trimmed);
+                    }
+                    continue;
+                }
+                if is_ffmpeg_filter_command_prompt(trimmed) {
+                    tracing::debug!("{trimmed}");
                     continue;
                 }
 
@@ -1703,6 +2058,8 @@ pub async fn stop_recording(state: AppState) -> Result<RecordingStatus> {
     let session_id = active.session_id.clone();
     let wait_session_id = session_id.clone();
     let mut force_stop_now = false;
+    let mut ffmpeg_live_audio_stop_session = None;
+    let mut legacy_ffmpeg_stdin = None;
     if !active.stop_requested {
         // Send before touching FFmpeg stdin. The monitor gives an already-ready
         // process exit priority over this signal, closing the old wait -> lock
@@ -1718,18 +2075,23 @@ pub async fn stop_recording(state: AppState) -> Result<RecordingStatus> {
     active
         .pipeline
         .mark_finalizing("Waiting for FFmpeg to flush and close output files.");
+    let uses_encoder_bridge = active.encoder_bridge.is_some();
+    if let Some(session) = active.ffmpeg_live_audio_session.take() {
+        // Make the stop edge visible to updates that cloned the handle before
+        // `stop_requested` was set. Once they reach the session mutex they must
+        // fail without writing another command.
+        session.begin_stop();
+        ffmpeg_live_audio_stop_session =
+            Some((session, ffmpeg_live_audio_stop_mode(uses_encoder_bridge)));
+    }
     if let Some(encoder_bridge) = &active.encoder_bridge {
         if let Some(encoder_bridge_stream) = &active.encoder_bridge_stream {
             encoder_bridge_stream.stop();
         }
         encoder_bridge.stop();
-    } else if let Some(mut stdin) = active.stdin.take() {
-        stdin
-            .write_all(b"q\n")
-            .await
-            .context("Could not send stop command to FFmpeg")?;
-        let _ = stdin.shutdown().await;
-    } else {
+    } else if let Some(stdin) = active.stdin.take() {
+        legacy_ffmpeg_stdin = Some(stdin);
+    } else if ffmpeg_live_audio_stop_session.is_none() {
         force_stop_now = true;
     }
 
@@ -1749,6 +2111,8 @@ pub async fn stop_recording(state: AppState) -> Result<RecordingStatus> {
             .await;
     drop(guard);
 
+    // Publish the authoritative user-visible stop edge before any session
+    // mutex or FFmpeg I/O can wait behind an in-flight command acknowledgement.
     state.emit_event("recording.status", status.clone());
     let _ = emit_session_log(
         &state,
@@ -1758,6 +2122,27 @@ pub async fn stop_recording(state: AppState) -> Result<RecordingStatus> {
         "Stop requested; waiting for FFmpeg to finalize outputs.",
         None,
     );
+
+    if let Some((session, stop_mode)) = ffmpeg_live_audio_stop_session {
+        match stop_mode {
+            FfmpegLiveAudioStopMode::Quit => session.quit().await?,
+            FfmpegLiveAudioStopMode::CloseCommandPipe => {
+                if let Err(error) = session.close_stdin().await {
+                    state.emit_log(
+                        "warn",
+                        format!("Could not close FFmpeg live microphone command pipe: {error:#}"),
+                    );
+                }
+            }
+        }
+    } else if let Some(mut stdin) = legacy_ffmpeg_stdin {
+        stdin
+            .write_all(b"q\n")
+            .await
+            .context("Could not send stop command to FFmpeg")?;
+        let _ = stdin.shutdown().await;
+    }
+
     if force_stop_now {
         state.emit_log("warn", "Stop requested again; sending SIGTERM to FFmpeg.");
         let _ = send_process_signal(pid, "TERM").await;
@@ -2891,11 +3276,20 @@ async fn stop_recording_process_for_shutdown(recording: Option<ActiveRecording>)
         return;
     };
 
+    let ffmpeg_live_audio_session = recording.ffmpeg_live_audio_session.take();
+    if let Some(session) = ffmpeg_live_audio_session.as_ref() {
+        session.begin_stop();
+    }
     if let Some(encoder_bridge) = &recording.encoder_bridge {
         if let Some(encoder_bridge_stream) = &recording.encoder_bridge_stream {
             encoder_bridge_stream.stop();
         }
         encoder_bridge.stop();
+        if let Some(session) = ffmpeg_live_audio_session {
+            let _ = session.close_stdin().await;
+        }
+    } else if let Some(session) = ffmpeg_live_audio_session {
+        let _ = session.quit().await;
     } else if let Some(mut stdin) = recording.stdin.take() {
         let _ = stdin.write_all(b"q\n").await;
         let _ = stdin.shutdown().await;
@@ -6128,7 +6522,7 @@ fn bridge_compositor_ffmpeg_args(
         "warning".to_string(),
         "-stats".to_string(),
         "-stats_period".to_string(),
-        "2".to_string(),
+        FFMPEG_PROGRESS_REPORT_PERIOD_SECONDS.to_string(),
         "-progress".to_string(),
         "pipe:2".to_string(),
     ];
@@ -6394,7 +6788,7 @@ fn bridge_ffmpeg_base_args() -> Vec<String> {
         "warning".to_string(),
         "-stats".to_string(),
         "-stats_period".to_string(),
-        "2".to_string(),
+        FFMPEG_PROGRESS_REPORT_PERIOD_SECONDS.to_string(),
         "-progress".to_string(),
         "pipe:2".to_string(),
     ]
@@ -6684,7 +7078,7 @@ fn ffmpeg_args(
         "warning".to_string(),
         "-stats".to_string(),
         "-stats_period".to_string(),
-        "2".to_string(),
+        FFMPEG_PROGRESS_REPORT_PERIOD_SECONDS.to_string(),
         "-progress".to_string(),
         "pipe:2".to_string(),
     ];
@@ -7229,11 +7623,15 @@ fn capture_audio_filter(input_layout: &InputLayout, audio: &AudioSettings) -> St
         // ffmpeg-owned mic capture records the raw device signal, so mute and
         // gain live here — mirroring the native path's in-process processing
         // (muted wins and records digital silence, keeping the track alive).
-        if audio.microphone_muted {
-            filters.push("volume=0".to_string());
-        } else if audio.microphone_gain_db != 0.0 {
-            filters.push(format!("volume={}dB", audio.microphone_gain_db));
-        }
+        // The stable instance name is also the runtime command target. Keep it
+        // present at neutral gain so Windows live controls never depend on the
+        // session's initial slider value.
+        let settings =
+            normalized_audio_processing_settings(audio.microphone_gain_db, audio.microphone_muted);
+        filters.push(format!(
+            "volume@{FFMPEG_LIVE_MIC_FILTER_TARGET}={}",
+            ffmpeg_live_microphone_volume(settings)
+        ));
     }
 
     if has_mono_input {
@@ -7241,6 +7639,78 @@ fn capture_audio_filter(input_layout: &InputLayout, audio: &AudioSettings) -> St
     }
     filters.push(CAPTURE_AUDIO_FILTER.to_string());
     filters.join(",")
+}
+
+fn normalized_audio_processing_settings(gain_db: f32, muted: bool) -> AudioProcessingSettings {
+    AudioProcessingSettings {
+        gain_db: if gain_db.is_finite() {
+            gain_db.clamp(-24.0, 24.0)
+        } else {
+            0.0
+        },
+        muted,
+    }
+}
+
+fn ffmpeg_live_microphone_volume(settings: AudioProcessingSettings) -> String {
+    if settings.muted {
+        "0".to_string()
+    } else if !settings.gain_db.is_finite() || settings.gain_db == 0.0 {
+        "1".to_string()
+    } else {
+        format!("{}dB", settings.gain_db.clamp(-24.0, 24.0))
+    }
+}
+
+fn ffmpeg_live_microphone_command(settings: AudioProcessingSettings) -> String {
+    // Uppercase C broadcasts to every matching filter instance. Record+stream
+    // and multistream sessions can repeat the same named filter in independent
+    // output graphs, and FFmpeg acknowledges each instance separately.
+    format!(
+        "Cvolume@{FFMPEG_LIVE_MIC_FILTER_TARGET} -1 volume {}\n",
+        ffmpeg_live_microphone_volume(settings)
+    )
+}
+
+fn ffmpeg_live_microphone_filter_count(args: &[String]) -> usize {
+    let needle = format!("volume@{FFMPEG_LIVE_MIC_FILTER_TARGET}=");
+    args.windows(2)
+        .filter(|pair| pair[0] == "-af" || pair[0].starts_with("-filter:a"))
+        .map(|pair| pair[1].match_indices(&needle).count())
+        .sum()
+}
+
+fn retain_ffmpeg_stdin_for_session(
+    use_encoder_bridge: bool,
+    ffmpeg_live_audio_filter_count: usize,
+) -> bool {
+    // Legacy FFmpeg sessions use `q` on stdin for graceful stop. Encoder-bridge
+    // sessions stop through FIFO EOF and only retain stdin when a named live
+    // microphone filter needs the runtime command channel.
+    !use_encoder_bridge || ffmpeg_live_audio_filter_count > 0
+}
+
+fn ffmpeg_live_audio_stop_mode(use_encoder_bridge: bool) -> FfmpegLiveAudioStopMode {
+    if use_encoder_bridge {
+        FfmpegLiveAudioStopMode::CloseCommandPipe
+    } else {
+        FfmpegLiveAudioStopMode::Quit
+    }
+}
+
+fn parse_ffmpeg_filter_command_reply(line: &str) -> Option<FfmpegFilterCommandReply> {
+    let line = line.trim();
+    if !line.starts_with("Command reply for stream ") {
+        return None;
+    }
+    let value = line.split_once("ret:")?.1.split_whitespace().next()?;
+    Some(FfmpegFilterCommandReply {
+        return_code: value.parse().ok()?,
+    })
+}
+
+fn is_ffmpeg_filter_command_prompt(line: &str) -> bool {
+    line.trim_start().starts_with("Enter command:")
 }
 
 fn audio_output_channels(input_layout: &InputLayout) -> u16 {
@@ -8932,10 +9402,10 @@ fn output_mode(record_enabled: bool, stream_enabled: bool) -> &'static str {
 }
 
 fn audio_processing_settings(params: &StartSessionParams) -> AudioProcessingSettings {
-    AudioProcessingSettings {
-        gain_db: params.audio.microphone_gain_db.clamp(-24.0, 24.0),
-        muted: params.audio.microphone_muted,
-    }
+    normalized_audio_processing_settings(
+        params.audio.microphone_gain_db,
+        params.audio.microphone_muted,
+    )
 }
 
 fn parse_avfoundation_id(id: &str) -> Option<usize> {
@@ -12879,7 +13349,7 @@ mod tests {
 
         let graph = capture_audio_filter(&microphone_input_layout(true), &audio);
         assert!(
-            graph.contains("volume=6.5dB"),
+            graph.contains("volume@videorc_live_mic=6.5dB"),
             "ffmpeg-owned mic must carry gain in the graph: {graph}"
         );
     }
@@ -12894,7 +13364,7 @@ mod tests {
 
         let filter = capture_audio_filter(&microphone_input_layout(true), &audio);
         assert!(
-            filter.contains("volume=0"),
+            filter.contains("volume@videorc_live_mic=0"),
             "muted ffmpeg-owned mic must record digital silence: {filter}"
         );
         assert!(
@@ -12905,6 +13375,472 @@ mod tests {
             filter.contains(CAPTURE_AUDIO_FILTER),
             "resample contract stays regardless of gain handling: {filter}"
         );
+    }
+
+    #[test]
+    fn ffmpeg_owned_mic_keeps_a_live_control_target_at_neutral_gain() {
+        let audio = AudioSettings {
+            microphone_gain_db: 0.0,
+            microphone_muted: false,
+            microphone_sync_offset_ms: 0,
+        };
+
+        let filter = capture_audio_filter(&microphone_input_layout(true), &audio);
+        assert!(
+            filter.contains("volume@videorc_live_mic=1"),
+            "the running FFmpeg graph needs a stable command target: {filter}"
+        );
+    }
+
+    #[test]
+    fn ffmpeg_live_microphone_commands_are_broadcast_clamped_and_injection_safe() {
+        assert_eq!(
+            ffmpeg_live_microphone_command(AudioProcessingSettings {
+                gain_db: 6.5,
+                muted: false,
+            }),
+            "Cvolume@videorc_live_mic -1 volume 6.5dB\n"
+        );
+        assert_eq!(
+            ffmpeg_live_microphone_command(AudioProcessingSettings {
+                gain_db: 99.0,
+                muted: false,
+            }),
+            "Cvolume@videorc_live_mic -1 volume 24dB\n"
+        );
+        assert_eq!(
+            ffmpeg_live_microphone_command(AudioProcessingSettings {
+                gain_db: f32::NAN,
+                muted: false,
+            }),
+            "Cvolume@videorc_live_mic -1 volume 1\n"
+        );
+        assert_eq!(
+            ffmpeg_live_microphone_command(AudioProcessingSettings {
+                gain_db: -12.0,
+                muted: true,
+            }),
+            "Cvolume@videorc_live_mic -1 volume 0\n"
+        );
+    }
+
+    #[test]
+    fn ffmpeg_filter_command_replies_are_parsed_without_logging_prompts_as_health() {
+        assert_eq!(
+            parse_ffmpeg_filter_command_reply("Command reply for stream -1: ret:0 res:"),
+            Some(FfmpegFilterCommandReply { return_code: 0 })
+        );
+        assert_eq!(
+            parse_ffmpeg_filter_command_reply("Command reply for stream 0: ret:-78 res:"),
+            Some(FfmpegFilterCommandReply { return_code: -78 })
+        );
+        assert_eq!(parse_ffmpeg_filter_command_reply("ret:0 res:"), None);
+        assert_eq!(
+            parse_ffmpeg_filter_command_reply("Command reply for stream 0: ret:nope res:"),
+            None
+        );
+        assert!(is_ffmpeg_filter_command_prompt(
+            "Enter command: <target>|all <time>|-1 <command>[ <argument>]"
+        ));
+        assert!(!is_ffmpeg_filter_command_prompt(
+            "Error writing trailer: Broken pipe"
+        ));
+    }
+
+    #[test]
+    fn ffmpeg_live_microphone_filter_count_tracks_every_output_graph() {
+        let args = vec![
+            "-af".to_string(),
+            "volume@videorc_live_mic=1,aresample=async=1:first_pts=0".to_string(),
+            "-af".to_string(),
+            "volume@videorc_live_mic=1,aresample=async=1:first_pts=0".to_string(),
+            "rtmp://example.invalid/live/volume@videorc_live_mic=1".to_string(),
+        ];
+        assert_eq!(ffmpeg_live_microphone_filter_count(&args), 2);
+        assert_eq!(
+            ffmpeg_live_microphone_filter_count(&["volume=1".to_string()]),
+            0
+        );
+    }
+
+    #[test]
+    fn ffmpeg_live_audio_reply_timeout_has_progress_cadence_headroom() {
+        assert!(
+            FFMPEG_LIVE_AUDIO_REPLY_TIMEOUT
+                > Duration::from_secs(FFMPEG_PROGRESS_REPORT_PERIOD_SECONDS * 2),
+            "a command written just after a progress report needs the next interval plus scheduling headroom"
+        );
+    }
+
+    #[test]
+    fn encoder_bridge_retains_stdin_only_for_live_audio_and_closes_it_on_stop() {
+        assert!(retain_ffmpeg_stdin_for_session(false, 0));
+        assert!(retain_ffmpeg_stdin_for_session(false, 1));
+        assert!(!retain_ffmpeg_stdin_for_session(true, 0));
+        assert!(retain_ffmpeg_stdin_for_session(true, 1));
+        assert_eq!(
+            ffmpeg_live_audio_stop_mode(true),
+            FfmpegLiveAudioStopMode::CloseCommandPipe
+        );
+        assert_eq!(
+            ffmpeg_live_audio_stop_mode(false),
+            FfmpegLiveAudioStopMode::Quit
+        );
+    }
+
+    #[tokio::test]
+    async fn ffmpeg_live_audio_control_waits_for_every_output_acknowledgement() {
+        let (sender, replies) = mpsc::unbounded_channel();
+        let mut control =
+            FfmpegLiveAudioControl::new(2, replies, AudioProcessingSettings::default());
+        let (mut stdin, mut ffmpeg_stdin) = tokio::io::duplex(1024);
+        let acknowledgements = tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+        });
+
+        control
+            .apply(
+                &mut stdin,
+                AudioProcessingSettings {
+                    gain_db: 6.0,
+                    muted: false,
+                },
+            )
+            .await
+            .unwrap();
+        acknowledgements.await.unwrap();
+
+        let expected = b"Cvolume@videorc_live_mic -1 volume 6dB\n";
+        let mut written = vec![0; expected.len()];
+        ffmpeg_stdin.read_exact(&mut written).await.unwrap();
+        assert_eq!(written, expected);
+        assert!(control.healthy);
+        assert_eq!(control.last_applied.gain_db, 6.0);
+    }
+
+    #[tokio::test]
+    async fn ffmpeg_live_audio_control_rejects_partial_multi_output_success() {
+        let (sender, replies) = mpsc::unbounded_channel();
+        let mut control =
+            FfmpegLiveAudioControl::new(2, replies, AudioProcessingSettings::default());
+        let (mut stdin, ffmpeg_stdin) = tokio::io::duplex(1024);
+        let acknowledgements = tokio::spawn(async move {
+            let mut commands = BufReader::new(ffmpeg_stdin).lines();
+            commands.next_line().await.unwrap().unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+
+            commands.next_line().await.unwrap().unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: -78 })
+                .unwrap();
+
+            commands.next_line().await.unwrap().unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+        });
+
+        control
+            .apply(
+                &mut stdin,
+                AudioProcessingSettings {
+                    gain_db: 3.0,
+                    muted: false,
+                },
+            )
+            .await
+            .unwrap();
+        let error = control
+            .apply(
+                &mut stdin,
+                AudioProcessingSettings {
+                    gain_db: -6.0,
+                    muted: false,
+                },
+            )
+            .await
+            .unwrap_err();
+        acknowledgements.await.unwrap();
+
+        assert!(error.error.to_string().contains("ret:-78"));
+        assert!(!error.state_unknown);
+        let confirmed = error
+            .confirmed_settings
+            .expect("successful rollback must return backend-confirmed settings");
+        assert_eq!(confirmed.gain_db, 3.0);
+        assert!(!confirmed.muted);
+        assert!(!control.healthy);
+        assert_eq!(control.last_applied.gain_db, 3.0);
+    }
+
+    #[tokio::test]
+    async fn ffmpeg_live_audio_control_reports_unknown_state_when_rollback_is_unconfirmed() {
+        let (sender, replies) = mpsc::unbounded_channel();
+        let mut control =
+            FfmpegLiveAudioControl::new(2, replies, AudioProcessingSettings::default());
+        let (mut stdin, _ffmpeg_stdin) = tokio::io::duplex(1024);
+        let acknowledgements = tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            sender
+                .send(FfmpegFilterCommandReply { return_code: 0 })
+                .unwrap();
+            sender
+                .send(FfmpegFilterCommandReply { return_code: -78 })
+                .unwrap();
+        });
+
+        let error = control
+            .apply(
+                &mut stdin,
+                AudioProcessingSettings {
+                    gain_db: -6.0,
+                    muted: false,
+                },
+            )
+            .await
+            .unwrap_err();
+        acknowledgements.await.unwrap();
+
+        assert!(error.state_unknown);
+        assert!(
+            error
+                .error
+                .to_string()
+                .contains("rollback could not be confirmed")
+        );
+        assert!(!control.healthy);
+    }
+
+    #[tokio::test]
+    async fn ffmpeg_live_audio_control_reports_unknown_state_when_reply_channel_closes() {
+        let (sender, replies) = mpsc::unbounded_channel();
+        drop(sender);
+        let mut control =
+            FfmpegLiveAudioControl::new(1, replies, AudioProcessingSettings::default());
+        let (mut stdin, _ffmpeg_stdin) = tokio::io::duplex(1024);
+
+        let error = control
+            .apply(
+                &mut stdin,
+                AudioProcessingSettings {
+                    gain_db: 6.0,
+                    muted: false,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.state_unknown);
+        assert!(error.error.to_string().contains("closed"));
+        assert!(!control.healthy);
+
+        let later_error = control
+            .apply(
+                &mut stdin,
+                AudioProcessingSettings {
+                    gain_db: -6.0,
+                    muted: true,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(later_error.state_unknown);
+        assert!(later_error.error.to_string().contains("state is unknown"));
+    }
+
+    async fn spawn_test_stdin_sink() -> (tokio::process::Child, ChildStdin) {
+        #[cfg(target_os = "windows")]
+        let mut command = {
+            let mut command = Command::new("cmd");
+            command.args(["/C", "more > NUL"]);
+            command
+        };
+        #[cfg(not(target_os = "windows"))]
+        let mut command = {
+            let mut command = Command::new("sh");
+            command.args(["-c", "cat >/dev/null"]);
+            command
+        };
+        command
+            .kill_on_drop(true)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = command.spawn().expect("spawn stdin sink");
+        let stdin = child.stdin.take().expect("stdin sink pipe");
+        (child, stdin)
+    }
+
+    #[tokio::test]
+    async fn live_audio_ack_wait_releases_global_lock_and_publishes_stop_before_session_wait() {
+        let state = test_state();
+        let mut events = state.events.subscribe();
+        let (mut child, stdin) = spawn_test_stdin_sink().await;
+        let (reply_sender, replies) = mpsc::unbounded_channel();
+        let live_audio_session = Arc::new(FfmpegLiveAudioSessionHandle::new(
+            stdin,
+            FfmpegLiveAudioControl::new(1, replies, AudioProcessingSettings::default()),
+        ));
+        let audio_tracks = vec![microphone_audio_track()];
+        let (stop_intent_sender, stop_intent_receiver) = oneshot::channel();
+        *state.recording.lock().await = Some(ActiveRecording {
+            session_id: "live-audio-lock-test".to_string(),
+            pid: child.id().unwrap_or_default(),
+            stdin: None,
+            output_path: None,
+            stream_url: None,
+            ffmpeg_path: "test-ffmpeg".to_string(),
+            started_at: Utc::now().to_rfc3339(),
+            capture_epoch: Arc::new(std::sync::OnceLock::new()),
+            capture_started_fallback: Instant::now(),
+            mode: "record".to_string(),
+            audio_tracks: audio_tracks.clone(),
+            pipeline: RecordingPipeline::new(true, false, &audio_tracks),
+            native_audio: None,
+            ffmpeg_live_audio_session: Some(live_audio_session.clone()),
+            screen_overlay: None,
+            encoder_bridge: None,
+            encoder_bridge_stream: None,
+            captioned_copy_requested: false,
+            comment_highlight_available: false,
+            _capture_permit: None,
+            stop_intent_sender: Some(stop_intent_sender),
+            stop_requested: false,
+        });
+
+        let update_state = state.clone();
+        let update = tokio::spawn(async move {
+            update_active_audio_processing(
+                &update_state,
+                AudioProcessingUpdateParams {
+                    session_id: "live-audio-lock-test".to_string(),
+                    microphone_gain_db: 6.0,
+                    microphone_muted: false,
+                },
+            )
+            .await
+        });
+
+        let session_waiting_for_reply = timeout(Duration::from_secs(1), async {
+            loop {
+                if live_audio_session.session.try_lock().is_err() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            session_waiting_for_reply.is_ok(),
+            "live update never entered its session-scoped acknowledgement wait"
+        );
+
+        let stop_state = state.clone();
+        let stop = tokio::spawn(async move { stop_recording(stop_state).await });
+
+        timeout(Duration::from_millis(100), stop_intent_receiver)
+            .await
+            .expect("stop intent must not wait for FFmpeg acknowledgement")
+            .expect("authoritative stop intent");
+
+        let stopping_event = timeout(Duration::from_secs(1), async {
+            loop {
+                let event = events.recv().await.expect("recording event");
+                if event.event == "recording.status" {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("Stopping status must be published before the session acknowledgement wait");
+        assert_eq!(stopping_event.payload["state"], "stopping");
+        assert!(
+            !update.is_finished(),
+            "the live update should still be waiting for its FFmpeg acknowledgement"
+        );
+        assert!(
+            !stop.is_finished(),
+            "stop should be waiting behind the in-flight session command only after publication"
+        );
+
+        reply_sender
+            .send(FfmpegFilterCommandReply { return_code: 0 })
+            .unwrap();
+        let result = update.await.unwrap();
+        assert!(result.applied);
+
+        timeout(Duration::from_secs(1), child.wait())
+            .await
+            .expect("FFmpeg stdin sink should close after the acknowledgement")
+            .expect("wait for stdin sink");
+        stop.abort();
+        let _ = stop.await;
+        state.recording.lock().await.take();
+        drop(live_audio_session);
+    }
+
+    #[tokio::test]
+    async fn live_audio_stop_marker_rejects_a_precloned_late_update() {
+        let (mut child, stdin) = spawn_test_stdin_sink().await;
+        let (_reply_sender, replies) = mpsc::unbounded_channel();
+        let live_audio_session = Arc::new(FfmpegLiveAudioSessionHandle::new(
+            stdin,
+            FfmpegLiveAudioControl::new(1, replies, AudioProcessingSettings::default()),
+        ));
+        let precloned_session = live_audio_session.clone();
+
+        live_audio_session.begin_stop();
+        let error = timeout(
+            Duration::from_millis(100),
+            precloned_session.apply(AudioProcessingSettings {
+                gain_db: 6.0,
+                muted: false,
+            }),
+        )
+        .await
+        .expect("stopped session update must not wait for an FFmpeg reply")
+        .unwrap_err();
+
+        assert!(!error.state_unknown);
+        assert!(error.error.to_string().contains("stopping"));
+
+        {
+            let mut session = live_audio_session.session.lock().await;
+            session.control.healthy = false;
+            session.control.state_unknown = true;
+        }
+        let sticky_error = precloned_session
+            .apply(AudioProcessingSettings {
+                gain_db: -6.0,
+                muted: true,
+            })
+            .await
+            .unwrap_err();
+        assert!(sticky_error.state_unknown);
+        assert!(sticky_error.confirmed_settings.is_none());
+
+        live_audio_session.close_stdin().await.unwrap();
+        timeout(Duration::from_secs(1), child.wait())
+            .await
+            .expect("closed live command pipe should reach EOF")
+            .expect("wait for stdin sink");
     }
 
     #[test]

--- a/docs/windows-port-plan.md
+++ b/docs/windows-port-plan.md
@@ -4,7 +4,7 @@ Goal: ship a Windows version of Videorc that hits the project's real bar — a
 smooth preview and a correct recording (docs/, memory: OBS parity is dropped).
 Dark-glass UI carries over; macOS-only niceties degrade gracefully.
 
-## Current status (reconciled 2026-07-12)
+## Current status (reconciled 2026-07-14)
 
 Windows has crossed the tracer-bullet milestone: the tester build compiles,
 launches, discovers working audio, and records real media. The 0.9.30 timing
@@ -14,6 +14,13 @@ follow-up removes production PNG compression from the Windows proof surface in
 favor of a latest-wins uncompressed BMP transport; PNG source routes are now
 explicit debug endpoints and diagnostics count any production request as a
 transport bug.
+
+Windows microphone gain and mute are no longer start-time-only controls. The
+DirectShow/FFmpeg path keeps a stable named `volume` filter in every output
+graph and applies live edits through FFmpeg's command protocol. Updates are
+single-flight/latest-wins in the renderer, acknowledged by every matching
+output graph, and fail closed for the rest of the capture if FFmpeg cannot
+confirm either the requested state or a rollback.
 
 What remains is release acceptance, not first implementation: rerun the full
 packaged Windows 11 device matrix, retain analyzer/support-bundle evidence, and
@@ -99,10 +106,12 @@ release acceptance is complete:
   than killing 4K overlays when one frame exceeds the 16 MiB pipe buffer.
   Compile-checked by `pnpm check:windows`; end-to-end write→ffmpeg-read proof
   needs the Windows box. The same slice made the dshow microphone honour
-  gain/mute through a `volume=` filter leg (the in-process CoreAudio path is
-  unchanged), bundled `ffprobe.exe` next to the Windows ffmpeg, and gave the
-  package preflight a fail-closed on-box capability probe (rtmp/rtmps/tls +
-  h264_mf/aac — the 0.9.23 TLS-less-ffmpeg lesson applied to Windows).
+  initial gain/mute through a `volume=` filter leg; the current implementation
+  retains that named filter for acknowledged live gain/mute updates as well
+  (the in-process CoreAudio path is unchanged). It also bundled `ffprobe.exe`
+  next to the Windows ffmpeg and gave the package preflight a fail-closed
+  on-box capability probe (rtmp/rtmps/tls + h264_mf/aac — the 0.9.23
+  TLS-less-ffmpeg lesson applied to Windows).
 - **Crash-orphan ownership is closed in code (2026-07-08).** The backend now
   waits on a `VIDEORC_SUPERVISOR_PID` process handle on Windows and exits when
   Electron dies (including crash/force-kill), which drops the backend-owned
@@ -302,12 +311,12 @@ verify before any Windows code lands.
   format matrix behind `camera_capture.rs` stub; ID = MF symbolic link
   (stable across renames/duplicates; dshow accepts it as
   `video=@device_pnp_…`); capture via `-f dshow`.
-- **Mic:** `-f dshow` audio input + `-af volume=<gain>dB` (mute → drop the
-  input). Verified: gain/mute are start-time params with no live-update
-  command (`protocol.rs:592-594`, no Set/Update handler), so the filter
-  gives FULL functional parity with the mac native path — no feature loss
-  in the MVP. The native WASAPI port is Phase 3 and motivated by epoch
-  alignment + future system audio, not by missing knobs.
+- **Mic:** `-f dshow` audio input + a stable named `volume` filter. The original
+  Phase 2 baseline only applied gain/mute at startup; that historical limitation
+  is now superseded by session-scoped FFmpeg commands with per-output
+  acknowledgements, rollback, and latest-wins renderer scheduling. The native
+  WASAPI port remains motivated by epoch alignment + future system audio, not
+  by missing gain/mute controls.
 - **Encoder:** default `h264_mf` (MediaFoundation = the VideoToolbox analog
   in LGPL ffmpeg). The recording argument builders now choose the platform
   H.264 encoder instead of hardcoding `h264_videotoolbox` on every OS. The
@@ -334,8 +343,8 @@ Outcome: Windows quality matches macOS daily-driver quality.
 - **WASAPI mic capture** ported into `audio.rs`'s ring-buffer design, with
   the FIFO replaced by a named pipe (`\\.\pipe\videorc-audio-…`) or stdin
   pipe; restores mono→stereo handling and video-epoch alignment (gain/mute
-  already have parity via the Phase 2 volume filter). Design the module
-  WASAPI-loopback-ready: system audio is plan-only on macOS today
+  already have parity via the commandable Phase 2 volume filter). Design the
+  module WASAPI-loopback-ready: system audio is plan-only on macOS today
   (docs/system-audio-capture-plan.md, `DeviceKind::SystemAudio` always
   Unavailable), and when SA lands, Windows loopback capture is the _easy_
   platform — don't paint it out.
@@ -447,7 +456,7 @@ assumed.
 | #   | Question                                                                              | Resolution (evidence)                                                                                                                                                                                                                                                                                                                                                 |
 | --- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Is streaming in Windows v1 or recording-only?                                         | **In v1, nearly free.** RTMP chain is flv/tee + fifo isolation, fully portable (`recording.rs:3872-3892`); only mac-ism is the `h264_videotoolbox` codec literal (`recording.rs:3816`) which the encoder probe replaces.                                                                                                                                              |
-| 2   | Does the dshow-direct mic MVP lose user-facing features vs the native CoreAudio path? | **No.** Native path's gain/mute are start-time params (`protocol.rs:592-594`) with no live-update command; an `-af volume` filter at spawn matches them. The avfoundation _fallback_ on mac loses gain/mute today — the Windows MVP with the filter is actually closer to parity than mac's own fallback.                                                             |
+| 2   | Does the dshow-direct mic MVP lose user-facing features vs the native CoreAudio path? | **No.** The named FFmpeg `volume` filter applies initial settings and accepts acknowledged live gain/mute commands for every output graph. The renderer coalesces continuous slider edits to one in-flight command plus the newest desired state, while an unconfirmed command disables further edits for that capture.                                               |
 | 3   | Will preview + recording fight over the same device (dshow opens are exclusive)?      | **No contention in the default path.** Encoder-bridge recording composites from the preview pipelines' frame stores (`recording.rs:532-615`, `compositor.rs:314-316`) — one open per device. Implication: port the _preview_ capture first; recording follows. The legacy direct path (fps > 30) is the only second-open risk and shares the same input-builder seam. |
 | 4   | Must Windows v1 capture individual windows?                                           | **No.** Window selection is metadata-only on macOS too — recording warns `window-capture-fallback` and records the display (`recording.rs:5268-5271`). Display-only is parity.                                                                                                                                                                                        |
 | 5   | System audio in scope?                                                                | **No — plan-only on macOS** (docs/system-audio-capture-plan.md; `DeviceKind::SystemAudio` always Unavailable). Phase 3's WASAPI module just keeps loopback reachable for when SA lands.                                                                                                                                                                               |

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "probe:comments-window": "node scripts/comments-window-probe.mjs",
     "probe:preview-lifecycle": "node scripts/preview-lifecycle-probe.mjs --gate",
     "probe:split-flv": "node scripts/probe-split-flv-capture.mjs",
+    "probe:live-audio-controls": "node scripts/probe-live-audio-controls.mjs",
     "smoke:preview-surface": "node scripts/smoke-preview-surface-app.mjs",
     "smoke:preview-endurance": "node scripts/run-with-env.mjs VIDEORC_SMOKE_TIMEOUT_MS=720000 VIDEORC_PREVIEW_SURFACE_SAMPLE_MS=600000 -- node scripts/smoke-preview-surface-app.mjs",
     "smoke:preview-performance": "node scripts/perf-idle-probe.mjs --gate",

--- a/scripts/lib/recording-studio-gates.mjs
+++ b/scripts/lib/recording-studio-gates.mjs
@@ -31,6 +31,11 @@ export function buildRecordingStudioGateSteps({
       args: ['test:scripts']
     },
     {
+      label: 'FFmpeg live microphone control probe',
+      command: 'pnpm',
+      args: ['probe:live-audio-controls']
+    },
+    {
       label: 'backend live layout tests',
       command: 'cargo',
       args: ['test', '-p', 'videorc-backend', 'live_layout::tests::']

--- a/scripts/lib/recording-studio-gates.test.mjs
+++ b/scripts/lib/recording-studio-gates.test.mjs
@@ -15,6 +15,7 @@ describe('buildRecordingStudioGateSteps', () => {
     assert.deepEqual(labels, [
       'desktop recording studio unit tests',
       'script artifact analyzer and A/V sync tests',
+      'FFmpeg live microphone control probe',
       'backend live layout tests',
       'backend scene layout tests',
       'backend recording pipeline tests',
@@ -58,6 +59,7 @@ describe('buildRecordingStudioGateSteps', () => {
       'backend-isolation.test.ts'
     ])
     assert.deepEqual(steps[1].args, ['test:scripts'])
+    assert.deepEqual(steps[2].args, ['probe:live-audio-controls'])
     assert.deepEqual(steps.at(-18).args, ['smoke:captions-contract'])
     assert.deepEqual(steps.at(-17).args, ['smoke:captions-live'])
     assert.deepEqual(steps.at(-16).args, ['smoke:noise-cleanup'])
@@ -113,6 +115,7 @@ describe('buildRecordingStudioGateSteps', () => {
     assert.match(report, /recording-studio-gates: plan/)
     assert.match(report, /capture\.test\.ts/)
     assert.match(report, /test:scripts/)
+    assert.match(report, /probe:live-audio-controls/)
     assert.match(report, /live_layout::tests::/)
     assert.match(report, /smoke:captions-contract/)
     assert.match(report, /smoke:captions-live/)
@@ -156,6 +159,10 @@ describe('buildRecordingStudioGateSteps', () => {
     )
     assert.equal(packageJson.scripts['smoke:noise-cleanup'], 'node scripts/smoke-noise-cleanup.mjs')
     assert.equal(
+      packageJson.scripts['probe:live-audio-controls'],
+      'node scripts/probe-live-audio-controls.mjs'
+    )
+    assert.equal(
       packageJson.scripts['smoke:noise-cleanup:bundled'],
       'node scripts/smoke-noise-cleanup.mjs --require-bundled'
     )
@@ -169,6 +176,33 @@ describe('buildRecordingStudioGateSteps', () => {
       assert.match(source, /--require-bundled/)
       assert.match(source, /pcm_s16le/)
     }
+  })
+
+  it('runs the live audio control probe against bundled FFmpeg on hosted Windows', () => {
+    const workflow = readFileSync(
+      new URL('../../.github/workflows/windows.yml', import.meta.url),
+      'utf8'
+    )
+    const buildStep = workflow.indexOf('run: pnpm dist:desktop:windows')
+    const probeStep = workflow.indexOf('run: pnpm probe:live-audio-controls')
+
+    assert.notEqual(buildStep, -1)
+    assert.ok(probeStep > buildStep)
+    assert.match(
+      workflow,
+      /VIDEORC_SMOKE_FFMPEG_PATH: \$\{\{ github\.workspace \}\}\\apps\\desktop\\release\\win-unpacked\\resources\\ffmpeg\\bin\\ffmpeg\.exe/
+    )
+
+    const probe = readFileSync(new URL('../probe-live-audio-controls.mjs', import.meta.url), 'utf8')
+    assert.match(probe, /const productionStatsPeriodSeconds = 2/)
+    assert.match(probe, /const productionReplyTimeoutMs = 5000/)
+    assert.match(probe, /'-stats',\s*'-stats_period',\s*String\(productionStatsPeriodSeconds\)/)
+    assert.match(probe, /line\.trim\(\) === 'progress=continue'/)
+    assert.match(probe, /latencyMs < productionReplyTimeoutMs/)
+    assert.match(
+      probe,
+      /latencyMs >= productionStatsPeriodSeconds \* 1000 - acknowledgementCadenceJitterMs/
+    )
   })
 
   it('waits for the finalized MP4 before analyzing the device interaction recording', () => {

--- a/scripts/probe-live-audio-controls.mjs
+++ b/scripts/probe-live-audio-controls.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+const productionStatsPeriodSeconds = 2
+const productionReplyTimeoutMs = 5000
+const legacyReplyTimeoutMs = 2000
+const acknowledgementCadenceJitterMs = 150
+// FFmpeg can have roughly one second of -re audio already buffered when it
+// acknowledges the graph command. Sample after that queued audio drains.
+const artifactApplicationSettleSeconds = 1
+const liveCommands = [
+  { label: '+6 dB', command: 'Cvolume@videorc_live_mic -1 volume 6dB\n' },
+  { label: 'mute', command: 'Cvolume@videorc_live_mic -1 volume 0\n' },
+  { label: 'unmute', command: 'Cvolume@videorc_live_mic -1 volume 1\n' }
+]
+const probeDurationSeconds = 16
+const processTimeoutMs = 30000
+const audibleMaxVolumeDb = -40
+const mutedMaxVolumeDb = -80
+const gainDeltaDb = 6
+const amplitudeToleranceDb = 0.75
+const outputDirectory = await mkdtemp(join(tmpdir(), 'videorc-live-audio-controls-'))
+const artifacts = [
+  join(outputDirectory, 'recording-output.wav'),
+  join(outputDirectory, 'stream-output.wav')
+]
+
+try {
+  console.log(`live-audio-controls probe: ffmpeg=${ffmpegPath}`)
+  assert.ok(
+    productionReplyTimeoutMs > productionStatsPeriodSeconds * 2 * 1000,
+    'live command timeout must include two production stats periods plus scheduling headroom'
+  )
+  assert.ok(
+    legacyReplyTimeoutMs <= productionStatsPeriodSeconds * 1000,
+    'the regression probe must retain the unsafe legacy 2s deadline as a caught boundary'
+  )
+  const { stderr, acknowledgements } = await runLiveAudioControlProbe()
+  const acknowledgementLatencyMs = acknowledgements.map(({ latencyMs }) => latencyMs)
+  const successfulReplies = stderr.match(/Command reply for stream [^\r\n]*ret:0/g) ?? []
+  assert.equal(
+    successfulReplies.length,
+    artifacts.length * liveCommands.length,
+    `expected ${artifacts.length * liveCommands.length} successful live volume command replies, got ${successfulReplies.length}:\n${stderr.slice(-2000)}`
+  )
+  assert.equal(
+    acknowledgementLatencyMs.length,
+    liveCommands.length,
+    `expected one complete acknowledgement timing for each live command, got ${acknowledgementLatencyMs.length}`
+  )
+  for (const [index, latencyMs] of acknowledgementLatencyMs.entries()) {
+    assert.ok(
+      latencyMs < productionReplyTimeoutMs,
+      `live command ${liveCommands[index].label} acknowledgement took ${latencyMs}ms, exceeding the ${productionReplyTimeoutMs}ms production deadline`
+    )
+  }
+  assert.ok(
+    acknowledgementLatencyMs.some(
+      (latencyMs) =>
+        latencyMs >= productionStatsPeriodSeconds * 1000 - acknowledgementCadenceJitterMs
+    ),
+    `expected a command written just after progress=continue to wait for the next ${productionStatsPeriodSeconds}s poll; observed ${acknowledgementLatencyMs.join(',')}ms`
+  )
+
+  const preWindow = windowBefore(acknowledgements[0].appliedAtSeconds)
+  const gainWindow = windowBetween(
+    acknowledgements[0].appliedAtSeconds,
+    acknowledgements[1].appliedAtSeconds
+  )
+  const mutedWindow = windowBetween(
+    acknowledgements[1].appliedAtSeconds,
+    acknowledgements[2].appliedAtSeconds
+  )
+  const restoredWindow = {
+    startSeconds: acknowledgements[2].appliedAtSeconds + artifactApplicationSettleSeconds,
+    durationSeconds: 0.75
+  }
+  console.log(
+    `live-audio-controls probe: acknowledgements=${acknowledgementLatencyMs.join(',')}ms ` +
+      `applied-at=${acknowledgements.map(({ appliedAtSeconds }) => appliedAtSeconds.toFixed(3)).join(',')}s`
+  )
+  console.log(
+    `live-audio-controls probe: analysis-windows=${[
+      preWindow,
+      gainWindow,
+      mutedWindow,
+      restoredWindow
+    ]
+      .map(
+        ({ startSeconds, durationSeconds }) =>
+          `${startSeconds.toFixed(3)}+${durationSeconds.toFixed(3)}s`
+      )
+      .join(',')}`
+  )
+
+  const analyses = await Promise.all(
+    artifacts.map(async (artifactPath) => ({
+      artifactPath,
+      preMaxVolumeDb: await detectMaxVolume(
+        artifactPath,
+        preWindow.startSeconds,
+        preWindow.durationSeconds
+      ),
+      gainMaxVolumeDb: await detectMaxVolume(
+        artifactPath,
+        gainWindow.startSeconds,
+        gainWindow.durationSeconds
+      ),
+      mutedMaxVolumeDb: await detectMaxVolume(
+        artifactPath,
+        mutedWindow.startSeconds,
+        mutedWindow.durationSeconds
+      ),
+      restoredMaxVolumeDb: await detectMaxVolume(
+        artifactPath,
+        restoredWindow.startSeconds,
+        restoredWindow.durationSeconds
+      )
+    }))
+  )
+
+  for (const analysis of analyses) {
+    assert.ok(
+      Number.isFinite(analysis.preMaxVolumeDb) && analysis.preMaxVolumeDb > audibleMaxVolumeDb,
+      `${analysis.artifactPath} was not audible before the command: ${formatDb(analysis.preMaxVolumeDb)}`
+    )
+    assert.ok(
+      Math.abs(analysis.gainMaxVolumeDb - (analysis.preMaxVolumeDb + gainDeltaDb)) <=
+        amplitudeToleranceDb,
+      `${analysis.artifactPath} did not apply +${gainDeltaDb} dB live gain: pre=${formatDb(analysis.preMaxVolumeDb)} gain=${formatDb(analysis.gainMaxVolumeDb)}`
+    )
+    assert.ok(
+      analysis.mutedMaxVolumeDb <= mutedMaxVolumeDb,
+      `${analysis.artifactPath} was not muted after the command: ${formatDb(analysis.mutedMaxVolumeDb)}`
+    )
+    assert.ok(
+      Math.abs(analysis.restoredMaxVolumeDb - analysis.preMaxVolumeDb) <= amplitudeToleranceDb,
+      `${analysis.artifactPath} did not restore audible gain after unmute: pre=${formatDb(analysis.preMaxVolumeDb)} restored=${formatDb(analysis.restoredMaxVolumeDb)}`
+    )
+    console.log(
+      `live-audio-controls probe: ${analysis.artifactPath.split(/[\\/]/).at(-1)} ` +
+        `pre=${formatDb(analysis.preMaxVolumeDb)} gain=${formatDb(analysis.gainMaxVolumeDb)} ` +
+        `muted=${formatDb(analysis.mutedMaxVolumeDb)} restored=${formatDb(analysis.restoredMaxVolumeDb)}`
+    )
+  }
+
+  console.log(
+    `live-audio-controls probe: acknowledgements=${acknowledgementLatencyMs.join(',')}ms ` +
+      `deadline=${productionReplyTimeoutMs}ms stats-period=${productionStatsPeriodSeconds}s`
+  )
+  console.log('live-audio-controls probe: PASS')
+} finally {
+  await rm(outputDirectory, { recursive: true, force: true })
+}
+
+function runLiveAudioControlProbe() {
+  const ffmpeg = spawn(
+    ffmpegPath,
+    [
+      '-hide_banner',
+      '-loglevel',
+      'warning',
+      '-stats',
+      '-stats_period',
+      String(productionStatsPeriodSeconds),
+      '-progress',
+      'pipe:2',
+      '-y',
+      '-re',
+      '-f',
+      'lavfi',
+      '-i',
+      `sine=frequency=1000:sample_rate=48000:duration=${probeDurationSeconds}`,
+      '-map',
+      '0:a:0',
+      '-filter:a',
+      'volume@videorc_live_mic=1',
+      '-c:a',
+      'pcm_s16le',
+      artifacts[0],
+      '-map',
+      '0:a:0',
+      '-filter:a',
+      'volume@videorc_live_mic=1',
+      '-c:a',
+      'pcm_s16le',
+      artifacts[1]
+    ],
+    { stdio: ['pipe', 'ignore', 'pipe'] }
+  )
+
+  return new Promise((resolveProbe, rejectProbe) => {
+    let stderr = ''
+    const commandTimers = []
+    let commandsSent = 0
+    let processError = null
+    let timedOut = false
+    let successfulRepliesSeen = 0
+    const commandSentAt = []
+    const acknowledgements = []
+    let processStartedAt = 0
+    let progressLineBuffer = ''
+    let commandScheduled = false
+
+    const scheduleNextCommand = () => {
+      if (commandScheduled || commandsSent >= liveCommands.length) return
+      commandScheduled = true
+      const commandIndex = commandsSent
+      commandTimers.push(
+        setTimeout(() => {
+          commandScheduled = false
+          const liveCommand = liveCommands[commandIndex]
+          commandSentAt[commandIndex] = Date.now()
+          commandsSent += 1
+          ffmpeg.stdin.write(liveCommand.command, (error) => {
+            if (error) {
+              processError ??= error
+            }
+          })
+        }, 0)
+      )
+    }
+
+    const processProtocolLine = (line) => {
+      const successfulReplies = line.match(/Command reply for stream [^\r\n]*ret:0/g) ?? []
+      for (const _reply of successfulReplies) {
+        successfulRepliesSeen += 1
+        if (successfulRepliesSeen % artifacts.length !== 0) continue
+        const commandIndex = successfulRepliesSeen / artifacts.length - 1
+        const sentAt = commandSentAt[commandIndex]
+        if (sentAt !== undefined && acknowledgements[commandIndex] === undefined) {
+          acknowledgements[commandIndex] = {
+            latencyMs: Date.now() - sentAt,
+            appliedAtSeconds: (Date.now() - processStartedAt) / 1000
+          }
+        }
+      }
+
+      if (
+        line.trim() === 'progress=continue' &&
+        successfulRepliesSeen >= commandsSent * artifacts.length
+      ) {
+        // Write just after FFmpeg's production report/poll boundary. The reply
+        // must then survive a full 2s stats period, exposing the old 2s
+        // deadline as a zero-headroom race while proving the 5s contract.
+        scheduleNextCommand()
+      }
+    }
+
+    ffmpeg.stderr.setEncoding('utf8')
+    ffmpeg.stderr.on('data', (chunk) => {
+      stderr += chunk
+      progressLineBuffer += chunk
+      const lines = progressLineBuffer.split(/[\r\n]/)
+      progressLineBuffer = lines.pop() ?? ''
+      for (const line of lines) {
+        processProtocolLine(line)
+      }
+    })
+    ffmpeg.once('spawn', () => {
+      processStartedAt = Date.now()
+    })
+    ffmpeg.stdin.on('error', (error) => {
+      processError ??= error
+    })
+    ffmpeg.on('error', (error) => {
+      processError ??= error
+    })
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      ffmpeg.kill()
+    }, processTimeoutMs)
+
+    ffmpeg.on('close', (code, signal) => {
+      clearTimeout(timeout)
+      for (const commandTimer of commandTimers) {
+        clearTimeout(commandTimer)
+      }
+      if (timedOut) {
+        rejectProbe(new Error(`live FFmpeg probe timed out after ${processTimeoutMs}ms`))
+        return
+      }
+      if (processError) {
+        rejectProbe(processError)
+        return
+      }
+      if (commandsSent !== liveCommands.length) {
+        rejectProbe(
+          new Error(
+            `FFmpeg exited after ${commandsSent}/${liveCommands.length} live volume commands:\n${stderr.slice(-2000)}`
+          )
+        )
+        return
+      }
+      if (code !== 0) {
+        rejectProbe(
+          new Error(
+            `live FFmpeg probe exited with code=${code} signal=${signal}:\n${stderr.slice(-2000)}`
+          )
+        )
+        return
+      }
+      if (progressLineBuffer) {
+        processProtocolLine(progressLineBuffer)
+      }
+      resolveProbe({ stderr, acknowledgements })
+    })
+  })
+}
+
+function windowBefore(appliedAtSeconds) {
+  const durationSeconds = 0.75
+  return {
+    startSeconds: Math.max(0.1, appliedAtSeconds - durationSeconds - 0.3),
+    durationSeconds
+  }
+}
+
+function windowBetween(appliedAtSeconds, nextAppliedAtSeconds) {
+  const startSeconds = appliedAtSeconds + artifactApplicationSettleSeconds
+  const durationSeconds = Math.min(0.75, nextAppliedAtSeconds - startSeconds - 0.3)
+  assert.ok(
+    durationSeconds >= 0.35,
+    `acknowledgements were too close for artifact analysis: ${appliedAtSeconds}s -> ${nextAppliedAtSeconds}s`
+  )
+  return { startSeconds, durationSeconds }
+}
+
+async function detectMaxVolume(filePath, startSeconds, durationSeconds) {
+  const stderr = await runFfmpeg([
+    '-hide_banner',
+    '-loglevel',
+    'info',
+    '-nostats',
+    '-nostdin',
+    '-ss',
+    String(startSeconds),
+    '-t',
+    String(durationSeconds),
+    '-i',
+    filePath,
+    '-map',
+    '0:a:0',
+    '-af',
+    'volumedetect',
+    '-f',
+    'null',
+    '-'
+  ])
+  const match = stderr.match(/max_volume:\s*(-?inf|-?\d+(?:\.\d+)?)\s*dB/i)
+  if (!match) {
+    throw new Error(
+      `volumedetect did not report max_volume for ${filePath}:\n${stderr.slice(-1000)}`
+    )
+  }
+  return match[1].toLowerCase() === '-inf' ? Number.NEGATIVE_INFINITY : Number(match[1])
+}
+
+function runFfmpeg(args) {
+  return new Promise((resolveRun, rejectRun) => {
+    const ffmpeg = spawn(ffmpegPath, args, { stdio: ['ignore', 'ignore', 'pipe'] })
+    let stderr = ''
+
+    ffmpeg.stderr.setEncoding('utf8')
+    ffmpeg.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    ffmpeg.on('error', rejectRun)
+    ffmpeg.on('close', (code, signal) => {
+      if (code === 0) {
+        resolveRun(stderr)
+        return
+      }
+      rejectRun(
+        new Error(
+          `FFmpeg analysis exited with code=${code} signal=${signal}:\n${stderr.slice(-1000)}`
+        )
+      )
+    })
+  })
+}
+
+function formatDb(value) {
+  return `${Number.isFinite(value) ? value.toFixed(1) : '-inf'} dB`
+}


### PR DESCRIPTION
## Problem

Windows microphones are captured directly by FFmpeg through DirectShow. Initial gain/mute values were baked into the FFmpeg filter graph, while Videorc's live update RPC only knew how to update the in-process CoreAudio capture path. A Windows recording therefore returned `native-audio-unavailable`, rolled the controls back, and showed the warning from #117 even though microphone capture itself was healthy.

The System Audio placeholder shown in the issue is a separate missing native adapter; it is not the cause of the microphone control failure.

## Plan and implementation

- Give every FFmpeg-owned microphone volume filter a stable `volume@videorc_live_mic` command target, including neutral-gain sessions.
- Retain FFmpeg stdin only for session shapes that need it and use FFmpeg's broadcast filter-command protocol so record, stream, and split-output graphs update together.
- Parse command acknowledgements from stderr and report success only after every matching output graph returns `ret:0`.
- Keep command serialization session-scoped instead of holding the global recording mutex while waiting for FFmpeg. The acknowledgement deadline is 5 seconds because production FFmpeg polls stdin on its 2-second stats cadence; the previous 2-second boundary could expire after the command had already applied.
- Coalesce continuous slider edits in the renderer with a one-in-flight/latest-wins queue: at most the active command and the newest complete gain/mute state survive, and pending work is retired at the session stop edge.
- Publish the authoritative stopping state before waiting on command I/O; prevent delayed updates from crossing the stop edge; preserve FIFO-owned shutdown for encoder-bridge sessions.
- If one output rejects a command, attempt and verify rollback across all outputs and return the backend-confirmed rollback values. If timeout, transport loss, channel loss, or rollback failure makes the captured state uncertain, keep that unknown state sticky, disable live edits, and show explicit state-unknown guidance instead of claiming restoration.
- Count live-control targets only in actual FFmpeg audio-filter arguments so an output path or stream key containing the filter name cannot create phantom acknowledgements.
- Add a maintained artifact probe that applies +6 dB, mute, and unmute to two simultaneous outputs, deliberately writes just after production's `progress=continue` boundary, proves acknowledgement crosses the unsafe legacy 2-second deadline but stays below 5 seconds, and verifies both finished WAV artifacts with FFmpeg.
- Run that probe in the recording-studio gate and against the bundled FFmpeg in hosted Windows CI.
- Update the Windows port plan's current capability statement to record acknowledged, coalesced live gain/mute support while keeping System Audio out of scope.

FFmpeg command-loop behavior is grounded in the upstream implementation: https://www.ffmpeg.org/doxygen/8.0/ffmpeg_8c_source.html

## Acceptance criteria

- [x] Windows DirectShow mic graphs always expose a stable live-control target.
- [x] Gain, mute, and unmute update every active output graph without restarting capture.
- [x] The backend acknowledges success only after every expected FFmpeg reply succeeds.
- [x] A slider drag cannot build a FIFO of stale multi-second commands; only the newest pending settings survive.
- [x] Stop intent/status is not blocked by a missing command acknowledgement.
- [x] Delayed updates cannot write after the session stop edge.
- [x] Confirmed rollback values, controller-unavailable state, and unknown captured state produce distinct truthful UI outcomes; a lost RPC response never claims restoration.
- [x] Existing CoreAudio live controls retain their in-process behavior.
- [x] Encoder-bridge sessions without live FFmpeg targets retain their previous null-stdin lifecycle.

## Verification

- Focused Rust controller, routing, rollback, stop-race, filter-construction, parser, and real-WebSocket dispatcher tests; the transport suite proves prompt stop dispatch, bounded busy rejection, ordinary barriers, and late ID-correlated replies.
- Maintained two-output FFmpeg artifact probe (+6 dB -> mute -> unmute): acknowledgements took `2004/2000/2000ms` against the 5-second deadline, and both WAVs measured `-18.1 -> -12.1 -> -91.0 -> -18.1 dB`.
- Desktop unit suite (`1042` passed, `1` skipped), Node script suite (`619` passed), TypeScript typecheck/lint/format, and desktop production build.
- Rust format, clippy with warnings denied, full backend suite (`1269` passed, `8` ignored, one unrelated test skipped), and Windows cross-check (pass with the existing target-only warnings).
- Active-session live-layout record and record+stream artifacts passed with a valid local RTMP capture.
- `pnpm smoke:recording-studio` was run; see **Known gate blockers** below.

## Known gate blockers

- The existing native-preview portrait-resize test/source-loop currently renders `476x847` while leaving the Metal target at `960x540` instead of adopting portrait output; the identical failure reproduces from the preview-untouched comparison branch and prevents the aggregate recording-studio command from reaching its final steps.
- Physical DirectShow microphone validation is not possible from this macOS host. Hosted Windows CI exercises the packaged FFmpeg command path; final alpha acceptance should also record a real Windows microphone while changing gain, muting, unmuting, and stopping during a queued update.

## Non-goals and follow-up

- This does not implement Windows System Audio/WASAPI loopback.
- It does not add source switching, meter behavior, or live microphone sync-offset changes.
- PR #116 and PR #118 touch parts of the recording/backend surface; PR #45 touches the Windows workflow. Rebase conflicts should preserve the named-filter protocol, session-scoped stop ordering, and bundled-FFmpeg probe.

Closes #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live microphone gain and mute controls for FFmpeg-based Windows capture.
  * Changes are applied in order, with rapid updates consolidated to the latest setting.
  * Added confirmation and rollback handling when microphone changes cannot be verified.
  * Added a Windows smoke probe to validate gain, mute, and unmute behavior.

* **Bug Fixes**
  * Improved session shutdown ordering and handling of unavailable or uncertain microphone controls.
  * Prevented stale updates from overriding newer microphone settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->