### PR TITLE
feat: dual-orientation simulcast — vertical multistream to YouTube, TikTok, Instagram

### DIFF
--- a/apps/desktop/src/renderer/src/components/chat-platform-icon.tsx
+++ b/apps/desktop/src/renderer/src/components/chat-platform-icon.tsx
@@ -1,4 +1,12 @@
-import { Broadcast, TwitchLogo, XLogo, YoutubeLogo, type Icon } from '@phosphor-icons/react'
+import {
+  Broadcast,
+  InstagramLogo,
+  TiktokLogo,
+  TwitchLogo,
+  XLogo,
+  YoutubeLogo,
+  type Icon
+} from '@phosphor-icons/react'
 import type { ReactElement } from 'react'
 
 import type { StreamPlatform } from '@/lib/backend'
@@ -13,6 +21,8 @@ export const CHAT_PLATFORM_LABELS: Record<StreamPlatform, string> = {
   youtube: 'YouTube',
   twitch: 'Twitch',
   x: 'X',
+  tiktok: 'TikTok',
+  instagram: 'Instagram',
   custom: 'Custom'
 }
 
@@ -20,6 +30,8 @@ const CHAT_PLATFORM_ICON: Record<StreamPlatform, Icon> = {
   youtube: YoutubeLogo,
   twitch: TwitchLogo,
   x: XLogo,
+  tiktok: TiktokLogo,
+  instagram: InstagramLogo,
   custom: Broadcast
 }
 
@@ -27,6 +39,8 @@ const CHAT_PLATFORM_TINT: Record<StreamPlatform, string> = {
   youtube: 'text-[#ff0033]',
   twitch: 'text-[#a970ff]',
   x: 'text-foreground',
+  tiktok: 'text-foreground',
+  instagram: 'text-[#e1306c]',
   custom: 'text-muted-foreground'
 }
 

--- a/apps/desktop/src/renderer/src/components/go-live-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/go-live-dialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { useStudioCore } from '@/hooks/use-studio'
+import { simulcastArmed } from '@/lib/capture'
 import type {
   CommentsReadState,
   CommentsWriteState,
@@ -182,6 +183,8 @@ export function GoLiveConfirmationDialog({
                 )}
               </div>
             </div>
+
+            <GoLiveSimulcastAdvisory />
 
             {entitlementBlocker ? (
               <div className="flex flex-col gap-2 rounded-row border border-warning/35 bg-warning/10 p-3">
@@ -512,7 +515,47 @@ function platformLabel(platform: StreamPlatform): string {
       return 'Twitch'
     case 'x':
       return 'X'
+    case 'tiktok':
+      return 'TikTok'
+    case 'instagram':
+      return 'Instagram'
     case 'custom':
       return 'Custom RTMP'
   }
+}
+
+// Dual-orientation sessions double the encode count and the upstream
+// bandwidth — an ADVISORY, never a block (per-target dropped-frame status is
+// the honest live signal). Instagram's manual publish step lives here because
+// it happens AT Go Live time, not while configuring the card.
+function GoLiveSimulcastAdvisory(): ReactElement | null {
+  const { captureConfig } = useStudioCore()
+  if (!simulcastArmed(captureConfig)) {
+    return null
+  }
+  const { streaming } = captureConfig
+  const enabled = streaming.targets.filter(
+    (target) => target.enabled && streaming.enabledTargetIds.includes(target.id)
+  )
+  const totalKbps = enabled.reduce(
+    (sum, target) => sum + (target.outputBitrateKbps ?? streaming.defaultBitrateKbps),
+    0
+  )
+  const mbps = Math.max(1, Math.round(totalKbps / 1000))
+  const hasInstagram = enabled.some((target) => target.platform === 'instagram')
+  return (
+    <div className="flex flex-col gap-1 rounded-row border border-border bg-muted/20 p-3">
+      <span className="text-sm font-medium">Streaming both orientations</span>
+      <span className="text-xs text-muted-foreground">
+        The horizontal scene streams to your landscape destinations while the saved vertical scene
+        streams to the vertical ones — about {mbps} Mbps upstream across all legs.
+      </span>
+      {hasInstagram ? (
+        <span className="text-xs text-muted-foreground">
+          Instagram: once Videorc starts sending, press “Go live” in Instagram Live Producer to
+          publish the stream to your profile.
+        </span>
+      ) : null}
+    </div>
+  )
 }

--- a/apps/desktop/src/renderer/src/components/studio/scenes-gallery.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/scenes-gallery.tsx
@@ -155,7 +155,7 @@ export function ScenesGallery(): ReactElement {
 // A small diagram of each preset's arrangement — clearer (and more honest) than
 // a generic icon, and it never claims to be a live thumbnail of the program.
 // Vertical scenes draw on a portrait frame so the whole gallery reads 9:16.
-function LayoutThumb({ preset }: { preset: LayoutPreset }): ReactElement {
+export function LayoutThumb({ preset }: { preset: LayoutPreset }): ReactElement {
   if (layoutPresetOrientation(preset) === 'vertical') {
     return (
       <div className="relative mx-auto aspect-[9/16] w-3/5 overflow-hidden rounded-chip border bg-gradient-to-br from-muted/40 to-muted/70">

--- a/apps/desktop/src/renderer/src/components/studio/vertical-leg-monitor.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/vertical-leg-monitor.tsx
@@ -1,0 +1,48 @@
+import { DeviceMobile } from '@phosphor-icons/react'
+import type { ReactElement } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { LayoutThumb } from '@/components/studio/scenes-gallery'
+import { useStudioCore } from '@/hooks/use-studio'
+import { simulcastArmed } from '@/lib/capture'
+
+/**
+ * The vertical leg's view-only monitor (dual-orientation simulcast). Phase 1
+ * shows the SCENE SCHEMATIC, not live pixels: the schematic is geometry truth
+ * (the same honesty rule as the scenes gallery), while live vertical pixels
+ * need the preview host's surface-id split — deferred with the engine plan's
+ * fallback posture. The preview window keeps showing the horizontal program.
+ */
+export function VerticalLegMonitor(): ReactElement | null {
+  const { captureConfig, isSessionActive } = useStudioCore()
+  if (!simulcastArmed(captureConfig)) {
+    return null
+  }
+  const verticalPreset = captureConfig.lastVerticalPreset
+  return (
+    <section
+      className="flex items-center gap-3 rounded-panel border border-border p-3"
+      data-slot="vertical-leg-monitor"
+    >
+      <div className="w-14 shrink-0">
+        <LayoutThumb preset={verticalPreset} />
+      </div>
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="flex items-center gap-1.5 text-sm font-medium">
+          <DeviceMobile className="size-4 text-muted-foreground" />
+          Vertical stream
+          {isSessionActive ? (
+            <Badge variant="success">Live</Badge>
+          ) : (
+            <Badge variant="outline">Armed</Badge>
+          )}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {isSessionActive
+            ? 'Streaming your saved vertical scene beside the horizontal program.'
+            : 'Goes live with your vertical scene when you start streaming. Edit it in the vertical Studio mode.'}
+        </span>
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/streaming-tab.tsx
@@ -11,6 +11,8 @@ import {
   MagnifyingGlass,
   SignOut,
   TextAa,
+  InstagramLogo,
+  TiktokLogo,
   TwitchLogo,
   Warning,
   WarningCircle,
@@ -83,6 +85,8 @@ const PLATFORM_ICON: Record<StreamPlatform, Icon> = {
   youtube: YoutubeLogo,
   twitch: TwitchLogo,
   x: XLogo,
+  tiktok: TiktokLogo,
+  instagram: InstagramLogo,
   custom: Broadcast
 }
 
@@ -496,7 +500,12 @@ function DestinationCard({
         icon={<PlatformGlyph platform={target.platform} />}
         title={target.label}
         context={account?.accountLabel ?? (oauthMode ? undefined : 'Manual RTMP')}
-        meta={<Badge variant={badge.tone}>{badge.label}</Badge>}
+        meta={
+          <span className="flex items-center gap-1.5">
+            {target.outputOrientation === 'vertical' ? <Badge variant="outline">9:16</Badge> : null}
+            <Badge variant={badge.tone}>{badge.label}</Badge>
+          </span>
+        }
         role="button"
         aria-expanded={expanded}
         onClick={() => setExpanded((value) => !value)}
@@ -538,6 +547,19 @@ function DestinationCard({
       </ListRow>
       {statusMessage ? (
         <span className="-mt-2 text-xs text-muted-foreground">{statusMessage}</span>
+      ) : null}
+      {expanded && manualKeyGuidance(target.platform) ? (
+        <div className="-mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="min-w-0">{manualKeyGuidance(target.platform)?.copy}</span>
+          <Button
+            className="h-auto px-0 text-xs"
+            size="xs"
+            variant="link"
+            onClick={() => openExternalUrl(manualKeyGuidance(target.platform)?.url ?? '')}
+          >
+            {manualKeyGuidance(target.platform)?.linkLabel}
+          </Button>
+        </div>
       ) : null}
       {enableLockGate ? (
         <div
@@ -836,7 +858,33 @@ const PLATFORM_GLYPH_TINT: Record<StreamPlatform, string> = {
   youtube: 'bg-[#ff0033]/15 text-[#ff0033]',
   twitch: 'bg-[#9146ff]/15 text-[#a970ff]',
   x: 'bg-foreground/10 text-foreground',
+  tiktok: 'bg-foreground/10 text-foreground',
+  instagram: 'bg-[#e1306c]/15 text-[#e1306c]',
   custom: 'bg-foreground/10 text-muted-foreground'
+}
+
+// Manual-key platforms rotate their key per broadcast and gate LIVE access on
+// their side — link the user to the source of truth instead of promising
+// automation Videorc cannot deliver (no public ingest APIs).
+function manualKeyGuidance(
+  platform: StreamPlatform
+): { copy: string; url: string; linkLabel: string } | null {
+  switch (platform) {
+    case 'tiktok':
+      return {
+        copy: 'TikTok keys change every broadcast and need LIVE access on your account — paste a fresh server URL and key each time from',
+        url: 'https://livecenter.tiktok.com',
+        linkLabel: 'TikTok LIVE Center'
+      }
+    case 'instagram':
+      return {
+        copy: 'Instagram keys come from Live Producer (professional accounts): start the stream here, then press "Go live" in',
+        url: 'https://www.instagram.com/live/producer/',
+        linkLabel: 'Live Producer'
+      }
+    default:
+      return null
+  }
 }
 
 function PlatformGlyph({ platform }: { platform: StreamPlatform }): ReactElement {

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -11,6 +11,7 @@ import { StatusBadge } from '@/components/status-badge'
 import { AudioMixer } from '@/components/studio/audio-mixer'
 import { QuickSettings } from '@/components/studio/quick-settings'
 import { ScenesGallery } from '@/components/studio/scenes-gallery'
+import { VerticalLegMonitor } from '@/components/studio/vertical-leg-monitor'
 import { SessionMicSliver } from '@/components/studio/session-mic-sliver'
 import { SessionPanel } from '@/components/studio/session-panel'
 import { Button } from '@/components/ui/button'
@@ -185,6 +186,7 @@ export function StudioTab(): ReactElement {
               single column below lg. */}
           <div className="grid gap-5 lg:grid-cols-2">
             <ScenesGallery />
+            <VerticalLegMonitor />
             <AudioMixer />
           </div>
         </PageStack>

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -7701,7 +7701,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             'streamTargets.youtube.prepare',
             {
               accountId: target.accountId,
-              video: captureConfig.video
+              // The vertical-bound broadcast advertises the PORTRAIT profile —
+              // the same transposition the simulcast leg composes at.
+              video:
+                target.outputOrientation === 'vertical'
+                  ? coerceVideoToOrientation(captureConfig.video, 'vertical')
+                  : captureConfig.video
             }
           )
           nextStreaming = patchPreparedStreamTarget(nextStreaming, target.id, {

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -10,6 +10,7 @@ import type {
   LayoutSettings,
   RtmpPreset,
   SideBySideSplit,
+  SimulcastParams,
   SourceSelection,
   StreamingSettings,
   StreamPlatform,
@@ -146,6 +147,50 @@ export function coerceVideoToOrientation(
     return video
   }
   return { ...video, preset: 'custom', width: video.height, height: video.width }
+}
+
+/**
+ * Whether this config arms the dual-orientation simulcast leg: streaming is
+ * on, at least one enabled destination is vertical-bound, and the Studio is
+ * editing a horizontal scene (the vertical leg composes from vertical-mode
+ * memory). In vertical Studio mode the single canvas IS portrait — no second
+ * leg exists to arm.
+ */
+export function simulcastArmed(
+  config: Pick<CaptureConfig, 'streamEnabled' | 'streaming' | 'layout'>
+): boolean {
+  return (
+    config.streamEnabled &&
+    config.streaming.enabled &&
+    layoutPresetOrientation(config.layout.layoutPreset) === 'horizontal' &&
+    config.streaming.targets.some(
+      (target) =>
+        target.enabled &&
+        target.outputOrientation === 'vertical' &&
+        config.streaming.enabledTargetIds.includes(target.id)
+    )
+  )
+}
+
+/**
+ * The vertical leg's session params, built from vertical-mode memory: the
+ * remembered vertical scene preset on the transposed (portrait) canvas.
+ * Camera transform memory stays preset-mode — vertical scenes are band/full
+ * layouts, and a landscape custom drag must never leak into the portrait leg.
+ */
+export function buildSimulcastParams(config: CaptureConfig): SimulcastParams | undefined {
+  if (!simulcastArmed(config)) {
+    return undefined
+  }
+  return {
+    layout: {
+      ...config.layout,
+      layoutPreset: config.lastVerticalPreset,
+      cameraTransformMode: 'preset',
+      cameraTransform: null
+    },
+    video: coerceVideoToOrientation(config.video, 'vertical')
+  }
 }
 
 export type ResolutionOption = {
@@ -1179,6 +1224,12 @@ function normalizeStreamTarget(
       typeof saved.outputBitrateKbps === 'number'
         ? clampNumber(saved.outputBitrateKbps, 6000, 1000, 50000)
         : undefined,
+    // Leg binding survives reloads; anything unexpected (and every legacy
+    // config) falls back to the platform default's orientation.
+    outputOrientation:
+      saved.outputOrientation === 'horizontal' || saved.outputOrientation === 'vertical'
+        ? saved.outputOrientation
+        : base.outputOrientation,
     createdAt: typeof saved.createdAt === 'string' ? saved.createdAt : base.createdAt,
     updatedAt: typeof saved.updatedAt === 'string' ? saved.updatedAt : base.updatedAt
   }

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -11,6 +11,7 @@ import type {
   RtmpPreset,
   SideBySideSplit,
   SimulcastParams,
+  StreamOutputOrientation,
   SourceSelection,
   StreamingSettings,
   StreamPlatform,
@@ -360,39 +361,97 @@ export const rtmpDefaults: Record<RtmpPreset, string> = {
 }
 
 // Fixed destination order for the Streaming tab (YouTube, Twitch, X, Custom).
-export const STREAM_PLATFORM_ORDER: readonly StreamPlatform[] = ['youtube', 'twitch', 'x', 'custom']
+export const STREAM_PLATFORM_ORDER: readonly StreamPlatform[] = [
+  'youtube',
+  'twitch',
+  'x',
+  'tiktok',
+  'instagram',
+  'custom'
+]
 
 const STREAM_PLATFORM_LABELS: Record<StreamPlatform, string> = {
   youtube: 'YouTube',
   twitch: 'Twitch',
   x: 'X / Twitter',
+  tiktok: 'TikTok',
+  instagram: 'Instagram',
   custom: 'Custom RTMP'
 }
 
+/**
+ * The built-in destination cards, ID-keyed (two YouTube cards share one
+ * platform): the horizontal trio, the vertical trio (YouTube Vertical is a
+ * SECOND broadcast on the same channel; TikTok and Instagram are manual-key
+ * only), then Custom RTMP.
+ */
+export const STREAM_TARGET_DEFS: ReadonlyArray<{
+  id: string
+  platform: StreamPlatform
+  label: string
+  serverUrl: string
+  outputOrientation?: StreamOutputOrientation
+}> = [
+  { id: 'youtube', platform: 'youtube', label: 'YouTube', serverUrl: rtmpDefaults.youtube },
+  { id: 'twitch', platform: 'twitch', label: 'Twitch', serverUrl: rtmpDefaults.twitch },
+  { id: 'x', platform: 'x', label: 'X / Twitter', serverUrl: '' },
+  {
+    id: 'youtube-vertical',
+    platform: 'youtube',
+    label: 'YouTube Vertical',
+    serverUrl: rtmpDefaults.youtube,
+    outputOrientation: 'vertical'
+  },
+  {
+    id: 'tiktok',
+    platform: 'tiktok',
+    label: 'TikTok',
+    serverUrl: '',
+    outputOrientation: 'vertical'
+  },
+  {
+    id: 'instagram',
+    platform: 'instagram',
+    label: 'Instagram',
+    serverUrl: 'rtmps://live-upload.instagram.com:443/rtmp/',
+    outputOrientation: 'vertical'
+  },
+  { id: 'custom', platform: 'custom', label: 'Custom RTMP', serverUrl: '' }
+]
+
 export function oauthUnavailableReason(platform: StreamPlatform): string | null {
-  return platform === 'custom' ? 'Custom RTMP does not support OAuth.' : null
+  if (platform === 'custom') {
+    return 'Custom RTMP does not support OAuth.'
+  }
+  if (platform === 'tiktok' || platform === 'instagram') {
+    return `${STREAM_PLATFORM_LABELS[platform]} livestreams use a manual stream key — there is no OAuth to connect.`
+  }
+  return null
 }
 
 export function isPlatformOAuthAvailable(platform: StreamPlatform): boolean {
-  return platform !== 'custom' && !oauthUnavailableReason(platform)
+  return !oauthUnavailableReason(platform)
 }
 
 function isStreamPlatform(value: unknown): value is StreamPlatform {
   return typeof value === 'string' && (STREAM_PLATFORM_ORDER as readonly string[]).includes(value)
 }
 
-function makeStreamTarget(platform: StreamPlatform, now: string): StreamTargetSettings {
+function makeStreamTarget(
+  def: (typeof STREAM_TARGET_DEFS)[number],
+  now: string
+): StreamTargetSettings {
   return {
-    // One built-in target per platform in v1, so the platform name is a stable id.
-    id: platform,
-    platform,
-    label: STREAM_PLATFORM_LABELS[platform],
+    id: def.id,
+    platform: def.platform,
+    label: def.label,
     enabled: false,
-    serverUrl: rtmpDefaults[platform],
+    serverUrl: def.serverUrl,
     urlMode: 'server-and-key',
     streamKey: '',
     streamKeyPresent: false,
     authMode: 'manual-rtmp',
+    ...(def.outputOrientation ? { outputOrientation: def.outputOrientation } : {}),
     status: { state: 'not-configured' },
     createdAt: now,
     updatedAt: now
@@ -400,7 +459,7 @@ function makeStreamTarget(platform: StreamPlatform, now: string): StreamTargetSe
 }
 
 function defaultStreamTargets(now: string = new Date().toISOString()): StreamTargetSettings[] {
-  return STREAM_PLATFORM_ORDER.map((platform) => makeStreamTarget(platform, now))
+  return STREAM_TARGET_DEFS.map((def) => makeStreamTarget(def, now))
 }
 
 export function defaultStreamingSettings(): StreamingSettings {
@@ -547,6 +606,20 @@ export const streamPlatformOutputCapabilities: Record<
     true4k: false
   },
   x: {
+    maxWidth: 1920,
+    maxHeight: 1080,
+    maxFps: 30,
+    maxBitrateKbps: 6000,
+    true4k: false
+  },
+  tiktok: {
+    maxWidth: 1920,
+    maxHeight: 1080,
+    maxFps: 30,
+    maxBitrateKbps: 6000,
+    true4k: false
+  },
+  instagram: {
     maxWidth: 1920,
     maxHeight: 1080,
     maxFps: 30,
@@ -1239,13 +1312,17 @@ export function normalizeStreamingSettings(value: unknown): StreamingSettings {
   const candidate = (value && typeof value === 'object' ? value : {}) as Partial<StreamingSettings>
   const now = new Date().toISOString()
   const persisted = Array.isArray(candidate.targets) ? candidate.targets : []
-  const targets = STREAM_PLATFORM_ORDER.map((platform) => {
-    const base = makeStreamTarget(platform, now)
+  const targets = STREAM_TARGET_DEFS.map((def) => {
+    const base = makeStreamTarget(def, now)
     const saved = persisted.find(
       (target) =>
         target &&
         typeof target === 'object' &&
-        (target.id === platform || target.platform === platform)
+        (target.id === def.id ||
+          // Legacy configs stored one target per platform with id == platform;
+          // only the original horizontal cards may match by platform so a saved
+          // "youtube" can never hydrate the vertical card's credentials.
+          (def.id === def.platform && target.id == null && target.platform === def.platform))
     )
     return saved ? normalizeStreamTarget(base, saved) : base
   })
@@ -1354,10 +1431,14 @@ export function bridgeStreamingToLegacy(config: CaptureConfig): CaptureConfig {
     : undefined
 
   if (primary) {
+    const legacyPreset: RtmpPreset =
+      primary.platform === 'tiktok' || primary.platform === 'instagram'
+        ? 'custom'
+        : primary.platform
     return {
       ...config,
       streamEnabled: true,
-      rtmpPreset: primary.platform,
+      rtmpPreset: legacyPreset,
       rtmpServerUrl: primary.serverUrl,
       streamKey: primary.streamKey
     }

--- a/apps/desktop/src/renderer/src/lib/entitlement-ui.test.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlement-ui.test.ts
@@ -51,7 +51,8 @@ const premiumEntitlements: EntitlementsSnapshot = {
       maxHeight: 2160,
       maxFps: 30,
       maxBitrateKbps: 30000,
-      maxDestinations: 3
+      maxDestinations: 6,
+      maxDestinationsPerOrientation: 3
     }
   }
 }
@@ -67,6 +68,13 @@ const developerEntitlements: EntitlementsSnapshot = {
   }))
 }
 
+function gateSettings(enabledTargetIds: string[]) {
+  return {
+    enabledTargetIds,
+    targets: ['youtube', 'twitch', 'x', 'custom'].map((id) => ({ id }))
+  }
+}
+
 function destinationGate(
   enabledTargetIds: string[],
   targetId: string,
@@ -74,7 +82,7 @@ function destinationGate(
 ) {
   return streamingDestinationEnableGate({
     entitlements,
-    streaming: { enabledTargetIds },
+    streaming: gateSettings(enabledTargetIds),
     targetId
   })
 }
@@ -121,7 +129,7 @@ describe('entitlement UI gates', () => {
     expect(
       goLiveEntitlementGate({
         entitlements: basicEntitlements,
-        streaming: { enabledTargetIds: ['youtube', 'twitch'] }
+        streaming: gateSettings(['youtube', 'twitch'])
       })
     ).toEqual({
       allowed: false,
@@ -139,7 +147,7 @@ describe('entitlement UI gates', () => {
     expect(destinationGate(['youtube', 'twitch', 'x'], 'custom', premiumEntitlements)).toEqual({
       allowed: false,
       featureId: 'multistreaming',
-      reason: 'Your current plan allows up to 3 streaming destinations.'
+      reason: 'Your current plan allows up to 3 horizontal streaming destinations.'
     })
   })
 
@@ -155,14 +163,14 @@ describe('entitlement UI gates', () => {
     expect(
       goLiveEntitlementGate({
         entitlements: basicEntitlements,
-        streaming: { enabledTargetIds: ['youtube'] }
+        streaming: gateSettings(['youtube'])
       })
     ).toEqual({ allowed: true })
 
     expect(
       goLiveEntitlementGate({
         entitlements: premiumEntitlements,
-        streaming: { enabledTargetIds: ['youtube', 'twitch', 'x'] }
+        streaming: gateSettings(['youtube', 'twitch', 'x'])
       })
     ).toEqual({ allowed: true })
   })
@@ -271,7 +279,7 @@ describe('entitlement UI gates', () => {
       destinationGate(['youtube'], 'twitch'),
       goLiveEntitlementGate({
         entitlements: basicEntitlements,
-        streaming: { enabledTargetIds: ['youtube', 'twitch'] }
+        streaming: gateSettings(['youtube', 'twitch'])
       }),
       cloudAiUploadGate(basicEntitlements),
       noiseCleanupGate(basicEntitlements),

--- a/apps/desktop/src/renderer/src/lib/entitlement-ui.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlement-ui.ts
@@ -1,4 +1,10 @@
-import type { EntitlementsSnapshot, FeatureId, StreamingSettings, VideoSettings } from './backend'
+import type {
+  EntitlementsSnapshot,
+  FeatureId,
+  StreamOutputOrientation,
+  StreamTargetSettings,
+  VideoSettings
+} from './backend'
 import {
   DEFAULT_BASIC_ENTITLEMENTS,
   entitlementDisabledReason,
@@ -16,15 +22,22 @@ export type EntitlementUiGate =
       allowFixAction?: boolean
     }
 
+/** The slice of streaming settings the destination gates read: enabled ids
+ *  plus each target's leg binding (absent = horizontal). */
+export interface StreamingGateSettings {
+  enabledTargetIds: string[]
+  targets: ReadonlyArray<Pick<StreamTargetSettings, 'id' | 'outputOrientation'>>
+}
+
 export interface StreamingDestinationEnableGateInput {
   entitlements: EntitlementsSnapshot | null
-  streaming: Pick<StreamingSettings, 'enabledTargetIds'>
+  streaming: StreamingGateSettings
   targetId: string
 }
 
 export interface GoLiveEntitlementGateInput {
   entitlements: EntitlementsSnapshot | null
-  streaming: Pick<StreamingSettings, 'enabledTargetIds'>
+  streaming: StreamingGateSettings
 }
 
 export interface VideoProfileEntitlementGateInput {
@@ -48,11 +61,19 @@ export function streamingDestinationEnableGate({
   }
 
   const maxDestinations = streamingMaxDestinations(entitlements)
-  if (streaming.enabledTargetIds.length < maxDestinations) {
-    return { allowed: true }
+  if (streaming.enabledTargetIds.length >= maxDestinations) {
+    return destinationsLimitGate(entitlements, maxDestinations)
   }
 
-  return destinationsLimitGate(entitlements, maxDestinations)
+  // Per-orientation cap: each composed leg fans out ONE encode; 3 targets per
+  // leg is the tested shape, so enabling counts against the target's leg.
+  const orientation = targetOrientation(streaming, targetId)
+  const perOrientationCap = streamingMaxDestinationsPerOrientation(entitlements)
+  if (enabledCountForOrientation(streaming, orientation) >= perOrientationCap) {
+    return destinationsLimitGate(entitlements, perOrientationCap, orientation)
+  }
+
+  return { allowed: true }
 }
 
 export function goLiveEntitlementGate({
@@ -65,11 +86,17 @@ export function goLiveEntitlementGate({
   }
 
   const maxDestinations = streamingMaxDestinations(entitlements)
-  if (streaming.enabledTargetIds.length <= maxDestinations) {
+  const perOrientationCap = streamingMaxDestinationsPerOrientation(entitlements)
+  const overOrientation = (['horizontal', 'vertical'] as const).find(
+    (orientation) => enabledCountForOrientation(streaming, orientation) > perOrientationCap
+  )
+  if (streaming.enabledTargetIds.length <= maxDestinations && !overOrientation) {
     return { allowed: true }
   }
 
-  const limitGate = destinationsLimitGate(entitlements, maxDestinations)
+  const limitGate = overOrientation
+    ? destinationsLimitGate(entitlements, perOrientationCap, overOrientation)
+    : destinationsLimitGate(entitlements, maxDestinations)
   if (limitGate.allowed) {
     return limitGate
   }
@@ -139,14 +166,34 @@ function featureGate(
 
 function destinationsLimitGate(
   entitlements: EntitlementsSnapshot | null,
-  maxDestinations: number
+  maxDestinations: number,
+  orientation?: StreamOutputOrientation
 ): EntitlementUiGate {
+  const scope = orientation ? `${orientation} streaming destinations` : 'streaming destinations'
   const reason = !isFeatureEntitled(entitlements, 'multistreaming')
     ? (entitlementDisabledReason(entitlements, 'multistreaming') ??
       'Multistreaming requires Videorc Premium.')
-    : `Your current plan allows up to ${maxDestinations} streaming destinations.`
+    : `Your current plan allows up to ${maxDestinations} ${scope}.`
 
   return lockedGate('multistreaming', reason)
+}
+
+function targetOrientation(
+  streaming: Pick<StreamingGateSettings, 'targets'>,
+  targetId: string
+): StreamOutputOrientation {
+  return (
+    streaming.targets.find((target) => target.id === targetId)?.outputOrientation ?? 'horizontal'
+  )
+}
+
+function enabledCountForOrientation(
+  streaming: StreamingGateSettings,
+  orientation: StreamOutputOrientation
+): number {
+  return streaming.enabledTargetIds.filter(
+    (id) => targetOrientation(streaming, id) === orientation
+  ).length
 }
 
 function lockedGate(
@@ -167,6 +214,15 @@ function streamingMaxDestinations(entitlements: EntitlementsSnapshot | null): nu
   return (
     entitlements?.limits.streaming.maxDestinations ??
     DEFAULT_BASIC_ENTITLEMENTS.limits.streaming.maxDestinations
+  )
+}
+
+function streamingMaxDestinationsPerOrientation(
+  entitlements: EntitlementsSnapshot | null
+): number {
+  return (
+    entitlements?.limits.streaming.maxDestinationsPerOrientation ??
+    DEFAULT_BASIC_ENTITLEMENTS.limits.streaming.maxDestinationsPerOrientation
   )
 }
 

--- a/apps/desktop/src/renderer/src/lib/entitlement-ui.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlement-ui.ts
@@ -191,9 +191,8 @@ function enabledCountForOrientation(
   streaming: StreamingGateSettings,
   orientation: StreamOutputOrientation
 ): number {
-  return streaming.enabledTargetIds.filter(
-    (id) => targetOrientation(streaming, id) === orientation
-  ).length
+  return streaming.enabledTargetIds.filter((id) => targetOrientation(streaming, id) === orientation)
+    .length
 }
 
 function lockedGate(
@@ -217,9 +216,7 @@ function streamingMaxDestinations(entitlements: EntitlementsSnapshot | null): nu
   )
 }
 
-function streamingMaxDestinationsPerOrientation(
-  entitlements: EntitlementsSnapshot | null
-): number {
+function streamingMaxDestinationsPerOrientation(entitlements: EntitlementsSnapshot | null): number {
   return (
     entitlements?.limits.streaming.maxDestinationsPerOrientation ??
     DEFAULT_BASIC_ENTITLEMENTS.limits.streaming.maxDestinationsPerOrientation

--- a/apps/desktop/src/renderer/src/lib/entitlements.test.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlements.test.ts
@@ -49,7 +49,8 @@ const developerEntitlements: EntitlementsSnapshot = {
       maxHeight: 1080,
       maxFps: 30,
       maxBitrateKbps: 6000,
-      maxDestinations: 3
+      maxDestinations: 6,
+      maxDestinationsPerOrientation: 3
     }
   }
 }
@@ -83,7 +84,8 @@ describe('entitlements', () => {
       maxHeight: 1080,
       maxFps: 30,
       maxBitrateKbps: 6000,
-      maxDestinations: 1
+      maxDestinations: 1,
+      maxDestinationsPerOrientation: 1
     })
   })
 
@@ -112,7 +114,8 @@ describe('entitlements', () => {
           maxHeight: 1080,
           maxFps: 30,
           maxBitrateKbps: 6000,
-          maxDestinations: 1
+          maxDestinations: 1,
+      maxDestinationsPerOrientation: 1
         }
       }
     }

--- a/apps/desktop/src/renderer/src/lib/entitlements.test.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlements.test.ts
@@ -115,7 +115,7 @@ describe('entitlements', () => {
           maxFps: 30,
           maxBitrateKbps: 6000,
           maxDestinations: 1,
-      maxDestinationsPerOrientation: 1
+          maxDestinationsPerOrientation: 1
         }
       }
     }

--- a/apps/desktop/src/renderer/src/lib/entitlements.ts
+++ b/apps/desktop/src/renderer/src/lib/entitlements.ts
@@ -42,7 +42,8 @@ export const DEFAULT_BASIC_ENTITLEMENTS: EntitlementsSnapshot = {
       maxHeight: 1080,
       maxFps: 30,
       maxBitrateKbps: 6000,
-      maxDestinations: 1
+      maxDestinations: 1,
+      maxDestinationsPerOrientation: 1
     }
   }
 }

--- a/apps/desktop/src/renderer/src/lib/session-params.ts
+++ b/apps/desktop/src/renderer/src/lib/session-params.ts
@@ -4,7 +4,12 @@ import {
   captionsSuppressedForSession,
   captionSessionOutputReadiness
 } from './captions-preflight'
-import { streamOutputVideosForTargets, type CaptureConfig, type SettingsState } from './capture'
+import {
+  buildSimulcastParams,
+  streamOutputVideosForTargets,
+  type CaptureConfig,
+  type SettingsState
+} from './capture'
 
 export function buildStartSessionParams(input: {
   captureConfig: CaptureConfig
@@ -62,6 +67,9 @@ export function buildStartSessionParams(input: {
       styleRevision: captureConfig.captions.styleRevision,
       position: captureConfig.captions.position,
       textSize: captureConfig.captions.textSize
-    }
+    },
+    // Present only when a vertical destination is armed on a horizontal
+    // session — the backend refuses vertical targets without this leg.
+    simulcast: buildSimulcastParams(captureConfig)
   }
 }

--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -77,7 +77,8 @@ describe('backend RPC contract', () => {
           maxHeight: 2160,
           maxFps: 30,
           maxBitrateKbps: 30_000,
-          maxDestinations: 3
+          maxDestinations: 6,
+          maxDestinationsPerOrientation: 3
         }
       },
       checkedAt: '2026-07-13T10:00:00.000Z'

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -244,7 +244,8 @@ const entitlementsSchema = objectSchema(
             maxHeight: numberSchema({ integer: true, min: 1, max: 65_536 }),
             maxFps: numberSchema({ integer: true, min: 1, max: 1000 }),
             maxBitrateKbps: nonNegativeInteger,
-            maxDestinations: numberSchema({ integer: true, min: 1, max: 1000 })
+            maxDestinations: numberSchema({ integer: true, min: 1, max: 1000 }),
+            maxDestinationsPerOrientation: numberSchema({ integer: true, min: 1, max: 1000 })
           },
           { allowUnknown: false }
         )
@@ -636,7 +637,19 @@ const sessionStartParamsSchema = objectSchema(
     ),
     audio: optionalSchema(boundedBackendParamValueSchema),
     streaming: optionalSchema(boundedBackendParamValueSchema),
-    captions: optionalSchema(boundedBackendParamValueSchema)
+    captions: optionalSchema(boundedBackendParamValueSchema),
+    // Dual-orientation simulcast: the vertical leg's layout is validated with
+    // the same strict layout schema as the primary.
+    simulcast: optionalSchema(
+      objectSchema(
+        {
+          layout: layoutSchema,
+          scene: optionalSchema(sceneSchema),
+          video: boundedBackendParamValueSchema
+        },
+        { allowUnknown: false }
+      )
+    )
   },
   { allowUnknown: false }
 )

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -618,7 +618,7 @@ export interface RtmpSettings {
 // Multi-platform streaming (per-target) model. Session start consumes it
 // (recording.rs reads params.streaming for the per-target fan-out); the legacy
 // single-RTMP fields remain only as the no-settings fallback.
-export type StreamPlatform = 'youtube' | 'twitch' | 'x' | 'custom'
+export type StreamPlatform = 'youtube' | 'twitch' | 'x' | 'tiktok' | 'instagram' | 'custom'
 /**
  * Which composed leg a destination consumes in a dual-orientation session.
  * Explicit per-target property — never inferred from resolution equality.

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -80,7 +80,10 @@ export interface StreamingEntitlementLimits {
   maxHeight: number
   maxFps: number
   maxBitrateKbps: number
+  /** Total enabled destinations across both orientations. */
   maxDestinations: number
+  /** Enabled destinations per orientation leg (Premium 3+3, Basic 1). */
+  maxDestinationsPerOrientation: number
 }
 
 export interface EntitlementLimits {
@@ -612,10 +615,16 @@ export interface RtmpSettings {
   streamKey: string
 }
 
-// Multi-platform streaming (per-target) model. Replaces the single RtmpSettings
-// streaming config over phases M1-M4; today it is migrated alongside the legacy
-// fields and not yet consumed by session start.
+// Multi-platform streaming (per-target) model. Session start consumes it
+// (recording.rs reads params.streaming for the per-target fan-out); the legacy
+// single-RTMP fields remain only as the no-settings fallback.
 export type StreamPlatform = 'youtube' | 'twitch' | 'x' | 'custom'
+/**
+ * Which composed leg a destination consumes in a dual-orientation session.
+ * Explicit per-target property — never inferred from resolution equality.
+ * Absent means horizontal (legacy migration).
+ */
+export type StreamOutputOrientation = 'horizontal' | 'vertical'
 export type StreamUrlMode = 'server-and-key' | 'full-url'
 export type StreamAuthMode = 'manual-rtmp' | 'oauth'
 export type StreamPrivacy = 'public' | 'unlisted' | 'private'
@@ -664,6 +673,8 @@ export interface StreamTargetSettings {
   platformStreamId?: string
   outputPreset?: VideoPreset
   outputBitrateKbps?: number
+  /** Dual-orientation leg binding; absent = horizontal (legacy migration). */
+  outputOrientation?: StreamOutputOrientation
   status?: StreamTargetStatus
   createdAt: string
   updatedAt: string
@@ -1131,6 +1142,20 @@ export interface StartSessionParams {
   audio?: AudioSettings
   streaming?: StreamingSettings
   captions?: CaptionsSessionParams
+  /**
+   * Dual-orientation simulcast: a second composed leg with its own vertical
+   * scene from the same captured sources. Present only when a vertical-bound
+   * destination is armed; vertical targets consume this leg.
+   */
+  simulcast?: SimulcastParams
+}
+
+/** The vertical leg of a dual-orientation session: a vertical scene preset on
+ *  a portrait canvas, validated per leg at session start. */
+export interface SimulcastParams {
+  layout: LayoutSettings
+  scene?: Scene
+  video: VideoSettings
 }
 
 /** Burn-in intent for the session (shapes output legs; see burn-in plan A0/R1)

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -191,6 +191,10 @@ impl CompositorPixelFormat {
 pub struct CompositorRuntime {
     pub status: CompositorStatus,
     scene: Option<CompositorSceneSnapshot>,
+    /// The vertical leg's scene in a dual-orientation session. Composed by the
+    /// auxiliary output when it is simulcast-bound; independent of (and never
+    /// a rescale of) the primary snapshot.
+    simulcast_scene: Option<CompositorSceneSnapshot>,
     image_sources: CompositorImageCache,
     frame_store: CompositorFrameStore,
     stream_frame_store: Option<CompositorFrameStore>,
@@ -251,6 +255,9 @@ pub struct CompositorAuxiliaryOutput {
     pub width: u32,
     pub height: u32,
     pub frame_consumer: CompositorFrameConsumer,
+    /// Simulcast-bound aux composes its OWN scene (the vertical leg) instead
+    /// of re-rendering the primary snapshot at a second resolution.
+    pub composes_simulcast_scene: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -359,6 +366,7 @@ struct CompositorRenderCache {
     frame_store: CompositorFrameStore,
     stream_frame_store: Option<CompositorFrameStore>,
     snapshot: Option<CompositorSceneSnapshot>,
+    simulcast_snapshot: Option<CompositorSceneSnapshot>,
     active_image_source: Option<CompositorImageSource>,
     background_image_source: Option<CompositorImageSource>,
 }
@@ -397,6 +405,7 @@ impl CompositorRenderCache {
             frame_store: compositor.frame_store.clone(),
             stream_frame_store: compositor.stream_frame_store.clone(),
             snapshot: compositor.scene.clone(),
+            simulcast_snapshot: compositor.simulcast_scene.clone(),
             active_image_source,
             background_image_source,
         }
@@ -817,6 +826,7 @@ pub fn initial_compositor_state() -> CompositorRuntime {
     CompositorRuntime {
         status: stopped_status(Some("Compositor is not running.".to_string())),
         scene: None,
+        simulcast_scene: None,
         image_sources: CompositorImageCache::new(
             COMPOSITOR_IMAGE_CACHE_BUDGET_BYTES,
             COMPOSITOR_IMAGE_CACHE_ENTRY_BUDGET,
@@ -1273,6 +1283,48 @@ pub async fn update_compositor_scene(
     };
     state.emit_event("compositor.status", status.clone());
     status
+}
+
+/// Set (or replace) the vertical leg's scene. Revision-ordered like the
+/// primary; stale revisions are ignored. Image-cache pinning stays owned by
+/// the primary snapshot — vertical scenes are camera-first by design (0.9.36
+/// one-source collapse), and the aux render reuses the primary's image cache.
+pub async fn update_compositor_simulcast_scene(
+    state: &AppState,
+    params: CompositorSceneUpdateParams,
+) {
+    let CompositorSceneUpdateParams {
+        revision,
+        scene,
+        layout,
+        active_screen,
+    } = params;
+    let mut compositor = state.compositor.lock().await;
+    if compositor
+        .simulcast_scene
+        .as_ref()
+        .is_some_and(|current| revision < current.revision)
+    {
+        return;
+    }
+    compositor.simulcast_scene = Some(CompositorSceneSnapshot {
+        revision,
+        scene,
+        layout,
+        active_screen,
+    });
+}
+
+/// Session stop / non-dual sessions: the vertical leg has no scene.
+pub async fn clear_compositor_simulcast_scene(state: &AppState) {
+    let mut compositor = state.compositor.lock().await;
+    compositor.simulcast_scene = None;
+}
+
+/// Whether a simulcast scene is currently committed (live_layout uses this to
+/// route vertical-scene transactions to the vertical leg instead of bailing).
+pub async fn has_compositor_simulcast_scene(state: &AppState) -> bool {
+    state.compositor.lock().await.simulcast_scene.is_some()
 }
 
 pub async fn update_compositor_active_screen(
@@ -3073,11 +3125,18 @@ async fn publish_compositor_frame(
     let frame_store = render_cache.frame_store.clone();
     let stream_frame_store = render_cache.stream_frame_store.clone();
     let snapshot = render_cache.snapshot.clone();
+    // The simulcast leg composes its own scene; without a simulcast-bound aux
+    // it is inert and the tick behaves byte-identically to before.
+    let simulcast_snapshot = stream_output
+        .filter(|output| output.composes_simulcast_scene)
+        .and_then(|_| render_cache.simulcast_snapshot.clone());
     let active_image_source = render_cache.active_image_source.clone();
     let background_image_source = render_cache.background_image_source.clone();
     let scene_snapshot_ms = scene_snapshot_started_at.elapsed().as_secs_f64() * 1000.0;
     let (camera_frame, camera_frame_fetch_ms) =
-        if scene_needs_live_camera_frame(snapshot.as_ref(), active_image_source.as_ref()) {
+        if scene_needs_live_camera_frame(snapshot.as_ref(), active_image_source.as_ref())
+            || scene_needs_live_camera_frame(simulcast_snapshot.as_ref(), None)
+        {
             let camera_fetch_started_at = Instant::now();
             (
                 live_sources.latest_camera_frame(),
@@ -3087,7 +3146,9 @@ async fn publish_compositor_frame(
             (None, 0.0)
         };
     let (screen_frame, screen_frame_fetch_ms) =
-        if scene_needs_live_screen_frame(snapshot.as_ref(), active_image_source.as_ref()) {
+        if scene_needs_live_screen_frame(snapshot.as_ref(), active_image_source.as_ref())
+            || scene_needs_live_screen_frame(simulcast_snapshot.as_ref(), None)
+        {
             let screen_fetch_started_at = Instant::now();
             (
                 live_sources.latest_screen_frame(),
@@ -3211,22 +3272,37 @@ async fn publish_compositor_frame(
         timings.frame_store_publish_ms = publish_started_at.elapsed().as_secs_f64() * 1000.0;
     }
     if let (Some(stream_output), Some(stream_frame_store)) = (stream_output, stream_frame_store) {
+        // A simulcast-bound aux composes the VERTICAL scene; the classic
+        // caption/profile-split aux re-renders the primary snapshot. The
+        // vertical leg streams clean in Phase 1 (no caption bar/highlight —
+        // their rasters are sized for the primary geometry).
+        let aux_snapshot = if stream_output.composes_simulcast_scene {
+            simulcast_snapshot.as_ref()
+        } else {
+            snapshot.as_ref()
+        };
         let inputs = CompositorRenderInputs {
             sequence,
             width: stream_output.width.max(1),
             height: stream_output.height.max(1),
-            snapshot: snapshot.as_ref(),
+            snapshot: aux_snapshot,
             active_image_source: active_image_source.as_ref(),
             background_image_source: background_image_source.as_ref(),
             camera_frame: camera_frame.as_ref().map(|(frame, _layout)| frame),
             screen_frame: screen_frame.as_ref(),
             // The auxiliary (stream) leg carries the bar per the leg plan.
-            caption_overlay: caption_overlay_for_output(
-                &caption_overlays,
-                crate::captions::CaptionOverlayTarget::Auxiliary,
-                caption_overlay_on_aux,
-            ),
-            highlight_overlay: if highlight_overlay_on_aux {
+            caption_overlay: if stream_output.composes_simulcast_scene {
+                None
+            } else {
+                caption_overlay_for_output(
+                    &caption_overlays,
+                    crate::captions::CaptionOverlayTarget::Auxiliary,
+                    caption_overlay_on_aux,
+                )
+            },
+            highlight_overlay: if highlight_overlay_on_aux
+                && !stream_output.composes_simulcast_scene
+            {
                 highlight_overlay.as_ref()
             } else {
                 None
@@ -6099,6 +6175,7 @@ mod tests {
                     width: 320,
                     height: 180,
                     frame_consumer: CompositorFrameConsumer::RawYuvEncoder,
+                    composes_simulcast_scene: false,
                 }),
                 caption_overlay_on_primary: false,
                 caption_overlay_on_aux: false,
@@ -6169,6 +6246,164 @@ mod tests {
         assert!(compositor_stream_frame_store(&state).await.is_none());
     }
 
+    #[tokio::test]
+    async fn simulcast_bound_aux_composes_its_own_vertical_scene() {
+        let state = test_state();
+        start_synthetic_compositor(
+            state.clone(),
+            CompositorStartParams {
+                target_fps: 30,
+                width: 640,
+                height: 360,
+                frame_consumer: CompositorFrameConsumer::RawYuvEncoder,
+                stream_output: Some(CompositorAuxiliaryOutput {
+                    // A PORTRAIT aux canvas: the vertical leg is its own
+                    // composition, never a rescale of the landscape frame.
+                    width: 180,
+                    height: 320,
+                    frame_consumer: CompositorFrameConsumer::RawYuvEncoder,
+                    composes_simulcast_scene: true,
+                }),
+                caption_overlay_on_primary: false,
+                caption_overlay_on_aux: false,
+                highlight_overlay_on_primary: false,
+                highlight_overlay_on_aux: false,
+            },
+        )
+        .await;
+        let sources = SourceSelection {
+            screen_id: None,
+            window_id: None,
+            camera_id: None,
+            microphone_id: None,
+            test_pattern: true,
+        };
+        let horizontal_layout = crate::protocol::default_layout_settings();
+        let horizontal_scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            sources: sources.clone(),
+            layout: horizontal_layout.clone(),
+            video: Some(VideoSettings {
+                preset: VideoPreset::Custom,
+                width: 640,
+                height: 360,
+                fps: 30,
+                bitrate_kbps: 2000,
+            }),
+            background: None,
+            protected_overlay_window_ids: Vec::new(),
+        });
+        update_compositor_scene(
+            &state,
+            CompositorSceneUpdateParams {
+                revision: 1,
+                scene: Some(horizontal_scene),
+                layout: horizontal_layout,
+                active_screen: None,
+            },
+        )
+        .await;
+        let mut vertical_layout = crate::protocol::default_layout_settings();
+        vertical_layout.layout_preset = crate::protocol::LayoutPreset::VerticalCameraOnly;
+        let vertical_scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            sources,
+            layout: vertical_layout.clone(),
+            video: Some(VideoSettings {
+                preset: VideoPreset::Custom,
+                width: 180,
+                height: 320,
+                fps: 30,
+                bitrate_kbps: 2000,
+            }),
+            background: None,
+            protected_overlay_window_ids: Vec::new(),
+        });
+        update_compositor_simulcast_scene(
+            &state,
+            CompositorSceneUpdateParams {
+                revision: 1,
+                scene: Some(vertical_scene),
+                layout: vertical_layout,
+                active_screen: None,
+            },
+        )
+        .await;
+        assert!(has_compositor_simulcast_scene(&state).await);
+
+        let recording_store = compositor_frame_store(&state).await;
+        let stream_store = compositor_stream_frame_store(&state)
+            .await
+            .expect("stream frame store");
+        let mut recording_latest = None;
+        let mut stream_latest = None;
+        for _ in 0..50 {
+            recording_latest = recording_store
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .latest();
+            stream_latest = stream_store
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .latest();
+            if recording_latest.is_some() && stream_latest.is_some() {
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        stop_compositor(&state).await;
+
+        // One frame tick published BOTH orientations: the primary landscape
+        // scene and the simulcast portrait scene, each on its own canvas.
+        let recording = recording_latest.expect("recording frame");
+        let stream = stream_latest.expect("stream frame");
+        assert_eq!((recording.width, recording.height), (640, 360));
+        assert_eq!((stream.width, stream.height), (180, 320));
+        assert_eq!(stream.bytes.len(), raw_yuv420p_len(180, 320));
+
+        clear_compositor_simulcast_scene(&state).await;
+        assert!(!has_compositor_simulcast_scene(&state).await);
+    }
+
+    #[tokio::test]
+    async fn simulcast_scene_updates_are_revision_ordered() {
+        let state = test_state();
+        let layout = {
+            let mut layout = crate::protocol::default_layout_settings();
+            layout.layout_preset = crate::protocol::LayoutPreset::VerticalCameraOnly;
+            layout
+        };
+        let update = |revision: u64| CompositorSceneUpdateParams {
+            revision,
+            scene: None,
+            layout: layout.clone(),
+            active_screen: None,
+        };
+        update_compositor_simulcast_scene(&state, update(5)).await;
+        // A stale revision is ignored…
+        update_compositor_simulcast_scene(&state, update(3)).await;
+        {
+            let compositor = state.compositor.lock().await;
+            assert_eq!(
+                compositor
+                    .simulcast_scene
+                    .as_ref()
+                    .map(|snapshot| snapshot.revision),
+                Some(5)
+            );
+        }
+        // …a newer one lands.
+        update_compositor_simulcast_scene(&state, update(9)).await;
+        {
+            let compositor = state.compositor.lock().await;
+            assert_eq!(
+                compositor
+                    .simulcast_scene
+                    .as_ref()
+                    .map(|snapshot| snapshot.revision),
+                Some(9)
+            );
+        }
+    }
+
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn compositor_publishes_auxiliary_stream_metal_target_or_skips() {
@@ -6234,6 +6469,7 @@ mod tests {
                 width: 32,
                 height: 18,
                 frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+                composes_simulcast_scene: false,
             }),
             Some(&mut stream_gpu),
             false,

--- a/crates/videorc-backend/src/entitlements.rs
+++ b/crates/videorc-backend/src/entitlements.rs
@@ -19,12 +19,18 @@ const BASIC_STREAMING_MAX_HEIGHT: u32 = 1080;
 const BASIC_STREAMING_MAX_FPS: u32 = 30;
 const BASIC_STREAMING_MAX_BITRATE_KBPS: u32 = 6000;
 const BASIC_STREAMING_MAX_DESTINATIONS: u32 = 1;
+const BASIC_STREAMING_MAX_DESTINATIONS_PER_ORIENTATION: u32 = 1;
 // Premium streams up to 4K30 (the YouTube 4K30 preset); basic stays HD.
 const PREMIUM_STREAMING_MAX_WIDTH: u32 = 3840;
 const PREMIUM_STREAMING_MAX_HEIGHT: u32 = 2160;
 const PREMIUM_STREAMING_MAX_FPS: u32 = 30;
 const PREMIUM_STREAMING_MAX_BITRATE_KBPS: u32 = 30_000;
-const PREMIUM_STREAMING_MAX_DESTINATIONS: u32 = 3;
+// Dual-orientation multistream: up to 3 destinations per composed leg
+// (horizontal + vertical), 6 total. The per-orientation cap exists because a
+// leg's fan-out is copies of ONE encode — 3 legs per encode is the tested
+// shape; 6 horizontal targets would be an untested fan-out.
+const PREMIUM_STREAMING_MAX_DESTINATIONS: u32 = 6;
+const PREMIUM_STREAMING_MAX_DESTINATIONS_PER_ORIENTATION: u32 = 3;
 
 const MULTISTREAMING_DISABLED_REASON: &str =
     "Multistreaming requires Videorc Premium. Basic can stream to one destination at HD.";
@@ -277,6 +283,7 @@ fn basic_limits() -> EntitlementLimits {
             max_fps: BASIC_STREAMING_MAX_FPS,
             max_bitrate_kbps: BASIC_STREAMING_MAX_BITRATE_KBPS,
             max_destinations: BASIC_STREAMING_MAX_DESTINATIONS,
+            max_destinations_per_orientation: BASIC_STREAMING_MAX_DESTINATIONS_PER_ORIENTATION,
         },
     }
 }
@@ -290,6 +297,7 @@ fn premium_limits() -> EntitlementLimits {
             max_fps: PREMIUM_STREAMING_MAX_FPS,
             max_bitrate_kbps: PREMIUM_STREAMING_MAX_BITRATE_KBPS,
             max_destinations: PREMIUM_STREAMING_MAX_DESTINATIONS,
+            max_destinations_per_orientation: PREMIUM_STREAMING_MAX_DESTINATIONS_PER_ORIENTATION,
         },
     }
 }
@@ -516,7 +524,11 @@ mod tests {
         assert!(feature_entitled(&snapshot, FeatureId::CloudAi));
         assert_eq!(snapshot.limits.recording.max_width, 3840);
         assert_eq!(snapshot.limits.recording.max_height, 2160);
-        assert_eq!(snapshot.limits.streaming.max_destinations, 3);
+        assert_eq!(snapshot.limits.streaming.max_destinations, 6);
+        assert_eq!(
+            snapshot.limits.streaming.max_destinations_per_orientation,
+            3
+        );
     }
 
     // Permanent regression guard: no env value may ever unlock premium in a
@@ -546,7 +558,11 @@ mod tests {
         assert_eq!(snapshot.source, EntitlementSource::EnvOverride);
         assert!(feature_entitled(&snapshot, FeatureId::Multistreaming));
         assert!(feature_entitled(&snapshot, FeatureId::CloudAi));
-        assert_eq!(snapshot.limits.streaming.max_destinations, 3);
+        assert_eq!(snapshot.limits.streaming.max_destinations, 6);
+        assert_eq!(
+            snapshot.limits.streaming.max_destinations_per_orientation,
+            3
+        );
         assert_eq!(
             capability(&snapshot, FeatureId::Multistreaming)
                 .expect("multistreaming capability")
@@ -658,7 +674,11 @@ mod tests {
             value["capabilities"][1]["state"],
             json!("developer-override")
         );
-        assert_eq!(value["limits"]["streaming"]["maxDestinations"], json!(3));
+        assert_eq!(value["limits"]["streaming"]["maxDestinations"], json!(6));
+        assert_eq!(
+            value["limits"]["streaming"]["maxDestinationsPerOrientation"],
+            json!(3)
+        );
     }
 
     fn test_signing_key() -> ed25519_dalek::SigningKey {

--- a/crates/videorc-backend/src/live_chat.rs
+++ b/crates/videorc-backend/src/live_chat.rs
@@ -332,6 +332,20 @@ pub fn chat_capability(
                 message: crate::x_chat::x_chat_message(x_live_ready).to_string(),
             }
         }
+        StreamPlatform::Tiktok | StreamPlatform::Instagram => ChatCapability {
+            platform,
+            state: ChatCapabilityState::Unsupported,
+            read: CommentsReadState::Unavailable,
+            write: CommentsWriteState::Unavailable,
+            chat_read_available: false,
+            required_scope: None,
+            account_id: None,
+            account_label: None,
+            message: format!(
+                "{} has no public comments API — watch chat in their app while you stream.",
+                crate::streaming::stream_platform_label(platform)
+            ),
+        },
         StreamPlatform::Custom => ChatCapability {
             platform,
             state: ChatCapabilityState::Unsupported,
@@ -1212,7 +1226,7 @@ pub async fn start_live_chat(state: &AppState, params: LiveChatStartParams) -> L
                 .x
                 .as_ref()
                 .and_then(|config| config.target_id.clone()),
-            StreamPlatform::Custom => None,
+            StreamPlatform::Tiktok | StreamPlatform::Instagram | StreamPlatform::Custom => None,
         };
         let configured_target_id = configured_target_id.or_else(|| {
             params

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -415,6 +415,43 @@ async fn apply_scene_transaction(
                 .is_some_and(|layout| layout.layout_preset.is_vertical())
         };
         if running_vertical != requested_vertical {
+            // Dual-orientation session: a vertical-scene transaction lands on
+            // the SIMULCAST leg's snapshot without touching the primary; the
+            // bail fires only when no leg matches the requested orientation.
+            if requested_vertical && crate::compositor::has_compositor_simulcast_scene(state).await
+            {
+                let revision = {
+                    let compositor = state.compositor.lock().await;
+                    compositor.status.scene_revision
+                };
+                let revision = next_scene_revision(
+                    revision,
+                    u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0),
+                );
+                crate::compositor::update_compositor_simulcast_scene(
+                    state,
+                    crate::protocol::CompositorSceneUpdateParams {
+                        revision,
+                        scene: Some(scene.clone()),
+                        layout: params.layout.clone(),
+                        active_screen: None,
+                    },
+                )
+                .await;
+                let compositor_status = {
+                    let compositor = state.compositor.lock().await;
+                    compositor.status.clone()
+                };
+                let status = SceneCommitStatus {
+                    applied: true,
+                    mode: "hot".to_string(),
+                    scene_revision: revision,
+                    scene: scene.clone(),
+                    compositor_status,
+                    message: None,
+                };
+                return Ok(layout_apply_status(intent_id, "hot", scene, status, None));
+            }
             bail!(
                 "Switching between horizontal and vertical scenes changes the canvas orientation — stop the session first."
             );

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -2503,7 +2503,7 @@ async fn spawn_session_live_chat(
                     params.platforms.push(StreamPlatform::X);
                 }
             }
-            StreamPlatform::Custom => {}
+            StreamPlatform::Tiktok | StreamPlatform::Instagram | StreamPlatform::Custom => {}
         }
     }
     if !params.destinations.is_empty() {

--- a/crates/videorc-backend/src/oauth.rs
+++ b/crates/videorc-backend/src/oauth.rs
@@ -35,7 +35,11 @@ pub fn provider_oauth_unavailable_message(platform: StreamPlatform) -> Option<&'
         StreamPlatform::Youtube if !youtube_oauth_enabled() => {
             Some(YOUTUBE_OAUTH_UNAVAILABLE_MESSAGE)
         }
-        StreamPlatform::Twitch | StreamPlatform::X | StreamPlatform::Custom => None,
+        StreamPlatform::Twitch
+        | StreamPlatform::X
+        | StreamPlatform::Tiktok
+        | StreamPlatform::Instagram
+        | StreamPlatform::Custom => None,
         StreamPlatform::Youtube => None,
     }
 }
@@ -509,7 +513,9 @@ impl OAuthSessions {
             StreamPlatform::Youtube => &self.youtube_finalization,
             StreamPlatform::Twitch => &self.twitch_finalization,
             StreamPlatform::X => &self.x_finalization,
-            StreamPlatform::Custom => &self.custom_finalization,
+            StreamPlatform::Tiktok | StreamPlatform::Instagram | StreamPlatform::Custom => {
+                &self.custom_finalization
+            }
         };
         lock.clone().lock_owned().await
     }
@@ -2197,6 +2203,10 @@ fn parse_provider_profile(
         StreamPlatform::Twitch => parse_twitch_profile(value),
         StreamPlatform::X => parse_x_profile(value),
         StreamPlatform::Custom => anyhow::bail!("Custom RTMP does not support OAuth profiles."),
+        StreamPlatform::Tiktok | StreamPlatform::Instagram => anyhow::bail!(
+            "{} livestreams use a manual stream key — there is no OAuth to connect.",
+            crate::streaming::stream_platform_label(platform)
+        ),
     }
 }
 
@@ -2320,6 +2330,10 @@ impl OAuthTokenResponse {
 
 fn provider_config(platform: StreamPlatform) -> Result<OAuthProviderConfig> {
     match platform {
+        StreamPlatform::Tiktok | StreamPlatform::Instagram => anyhow::bail!(
+            "{} livestreams use a manual stream key — there is no OAuth to connect.",
+            crate::streaming::stream_platform_label(platform)
+        ),
         StreamPlatform::Youtube => {
             if let Some(message) = provider_oauth_unavailable_message(platform) {
                 anyhow::bail!("{message}");

--- a/crates/videorc-backend/src/preflight.rs
+++ b/crates/videorc-backend/src/preflight.rs
@@ -410,12 +410,11 @@ mod tests {
     fn preflight_blocks_youtube_oauth_while_twitch_is_ready_and_x_is_blocked() {
         let mut targets = default_stream_targets();
         for target in &mut targets {
-            match target.platform {
-                StreamPlatform::Youtube | StreamPlatform::Twitch | StreamPlatform::X => {
-                    target.enabled = true;
-                    target.auth_mode = StreamAuthMode::Oauth;
-                }
-                StreamPlatform::Custom => {}
+            // Enable the horizontal trio by ID — the platform alone is
+            // ambiguous now that YouTube Vertical shares StreamPlatform::Youtube.
+            if matches!(target.id.as_str(), "youtube" | "twitch" | "x") {
+                target.enabled = true;
+                target.auth_mode = StreamAuthMode::Oauth;
             }
         }
         let streaming = StreamingSettings {
@@ -687,6 +686,8 @@ mod tests {
             StreamPlatform::Youtube => "youtube",
             StreamPlatform::Twitch => "twitch",
             StreamPlatform::X => "x",
+            StreamPlatform::Tiktok => "tiktok",
+            StreamPlatform::Instagram => "instagram",
             StreamPlatform::Custom => "custom",
         }
     }

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -143,7 +143,16 @@ pub struct StreamingEntitlementLimits {
     pub max_height: u32,
     pub max_fps: u32,
     pub max_bitrate_kbps: u32,
+    /// TOTAL enabled destinations across both orientations.
     pub max_destinations: u32,
+    /// Enabled destinations per orientation leg (dual-orientation simulcast:
+    /// Premium = 3 horizontal + 3 vertical; Basic = 1 total).
+    #[serde(default = "default_max_destinations_per_orientation")]
+    pub max_destinations_per_orientation: u32,
+}
+
+fn default_max_destinations_per_orientation() -> u32 {
+    1
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -835,6 +844,24 @@ pub struct StartSessionParams {
     pub streaming: Option<StreamingSettings>,
     #[serde(default)]
     pub captions: Option<CaptionsSessionParams>,
+    /// Dual-orientation simulcast: a SECOND composed leg with its own scene
+    /// geometry (the saved vertical scene) from the same captured sources.
+    /// Present only when a vertical-bound destination is armed; vertical
+    /// targets consume this leg, horizontal targets the primary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub simulcast: Option<SimulcastParams>,
+}
+
+/// The vertical leg of a dual-orientation session. The layout must be a
+/// vertical preset on a portrait canvas — validated per leg at session start,
+/// mirroring the primary's orientation rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulcastParams {
+    pub layout: LayoutSettings,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scene: Option<Scene>,
+    pub video: VideoSettings,
 }
 
 /// Live-caption output intent for this session. Stream selection shapes the

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -6291,8 +6291,18 @@ fn bridge_compositor_split_output_ffmpeg_args(
     stream_output: CompositorAuxiliaryOutput,
 ) -> Result<Vec<String>> {
     validate_stream_targets_for_ffmpeg(stream_targets)?;
-    let output_path =
-        output_path.context("Split output encoder bridge requires a local recording path")?;
+    let simulcast_mode = stream_output.composes_simulcast_scene;
+    // The caption/profile split exists to protect a local recording, so it
+    // requires one; a dual-orientation session may be stream-only.
+    let output_path = match output_path {
+        Some(path) => Some(path),
+        None if simulcast_mode => None,
+        None => {
+            return Err(anyhow::anyhow!(
+                "Split output encoder bridge requires a local recording path"
+            ));
+        }
+    };
     if stream_targets.is_empty() {
         bail!("Split output encoder bridge requires at least one stream target");
     }
@@ -6336,20 +6346,22 @@ fn bridge_compositor_split_output_ffmpeg_args(
         microphone_graph_gain: microphone_needs_graph_gain(capture.microphone.as_ref()),
     };
 
-    args.extend([
-        "-map".to_string(),
-        format!("{recording_video_input_index}:v"),
-    ]);
-    append_audio_output_args(&mut args, &input_layout);
-    args.extend([
-        "-c:v".to_string(),
-        "copy".to_string(),
-        "-tag:v".to_string(),
-        "0".to_string(),
-    ]);
-    append_audio_encoding_args(&mut args, &input_layout, &params.audio, true);
-    args.push("-shortest".to_string());
-    args.push(output_path.display().to_string());
+    if let Some(output_path) = output_path {
+        args.extend([
+            "-map".to_string(),
+            format!("{recording_video_input_index}:v"),
+        ]);
+        append_audio_output_args(&mut args, &input_layout);
+        args.extend([
+            "-c:v".to_string(),
+            "copy".to_string(),
+            "-tag:v".to_string(),
+            "0".to_string(),
+        ]);
+        append_audio_encoding_args(&mut args, &input_layout, &params.audio, true);
+        args.push("-shortest".to_string());
+        args.push(output_path.display().to_string());
+    }
 
     let stream_input_layout = InputLayout {
         video_input_index: stream_video_input_index,
@@ -6362,25 +6374,42 @@ fn bridge_compositor_split_output_ffmpeg_args(
     let mut uses_recording_stream_input = false;
     let mut uses_companion_stream_input = false;
     for target in stream_targets {
-        let target_video = target.output_video.as_ref().unwrap_or(&stream_video);
-        // Prefer the auxiliary stream input on a profile tie. A tie only exists
-        // for the forced same-profile caption split; routing primary first would
-        // silently send the clean recording pixels to RTMP.
-        let video_input_index = if same_video_profile(target_video, &stream_video) {
-            uses_companion_stream_input = true;
-            stream_video_input_index
-        } else if same_video_profile(target_video, &params.output.video) {
-            uses_recording_stream_input = true;
-            recording_video_input_index
+        // Dual-orientation: the EXPLICIT leg binding routes the target —
+        // vertical destinations consume the simulcast encode, horizontal ones
+        // the primary. Profile equality is a trap here (a 1080×1920 recording
+        // and an identical vertical stream profile would tie).
+        let video_input_index = if simulcast_mode {
+            match target.output_orientation {
+                crate::streaming::StreamOutputOrientation::Vertical => {
+                    uses_companion_stream_input = true;
+                    stream_video_input_index
+                }
+                crate::streaming::StreamOutputOrientation::Horizontal => {
+                    uses_recording_stream_input = true;
+                    recording_video_input_index
+                }
+            }
         } else {
-            bail!(
-                "Target {} resolves to unsupported mixed stream profile {}x{}@{} {}kbps",
-                target.label,
-                target_video.width,
-                target_video.height,
-                target_video.fps,
-                target_video.bitrate_kbps
-            );
+            let target_video = target.output_video.as_ref().unwrap_or(&stream_video);
+            // Prefer the auxiliary stream input on a profile tie. A tie only
+            // exists for the forced same-profile caption split; routing primary
+            // first would silently send the clean recording pixels to RTMP.
+            if same_video_profile(target_video, &stream_video) {
+                uses_companion_stream_input = true;
+                stream_video_input_index
+            } else if same_video_profile(target_video, &params.output.video) {
+                uses_recording_stream_input = true;
+                recording_video_input_index
+            } else {
+                bail!(
+                    "Target {} resolves to unsupported mixed stream profile {}x{}@{} {}kbps",
+                    target.label,
+                    target_video.width,
+                    target_video.height,
+                    target_video.fps,
+                    target_video.bitrate_kbps
+                );
+            }
         };
         stream_routes.push((target, video_input_index));
     }
@@ -8140,6 +8169,14 @@ fn validate_caption_output_policy(params: &StartSessionParams) -> Result<()> {
     if !captions.effective_burn_target().burns_stream() || !params.output.stream_enabled {
         return Ok(());
     }
+    // The simulcast leg claims the ONE auxiliary output, and stream-burned
+    // captions need it for the clean-recording split — the two are mutually
+    // exclusive in Phase 1 (documented engine-plan fallback).
+    if params.simulcast.is_some() {
+        bail!(
+            "Live caption burn-in and dual-orientation streaming cannot run together yet. Set captions to Off or Recording, or disable the vertical destinations."
+        );
+    }
     let plan = caption_leg_plan(params);
     let live_caption_profiles = resolved_enabled_stream_output_videos(params)?;
 
@@ -8341,14 +8378,44 @@ fn recording_compositor_stream_output(
     params: &StartSessionParams,
     video_output: EncoderBridgeVideoOutput,
 ) -> Result<Option<CompositorAuxiliaryOutput>> {
-    if !params.output.record_enabled || !params.output.stream_enabled {
-        return Ok(None);
-    }
     if !matches!(
         video_output,
         EncoderBridgeVideoOutput::VideoToolboxH264AnnexB
             | EncoderBridgeVideoOutput::VideoToolboxH264MpegTs
     ) {
+        return Ok(None);
+    }
+    // Dual-orientation simulcast claims the auxiliary output: the vertical
+    // leg composes its own scene and encodes at the simulcast profile. Works
+    // for stream-only sessions too (unlike the caption/profile split, which
+    // exists to keep a local recording clean). Horizontal targets must share
+    // ONE encode with the primary — a third encoded leg is unsupported, and
+    // the caption×simulcast exclusivity is enforced at validation.
+    if let Some(simulcast) = params.simulcast.as_ref() {
+        if params.output.stream_enabled {
+            let horizontal_companions =
+                companion_stream_outputs_for_recording(params, &params.output.video)?;
+            if let Some(profile) = horizontal_companions.first() {
+                bail!(
+                    "Dual-orientation streaming shares one horizontal encode: make every horizontal destination use the session profile {}x{}@{} (found {}x{}@{}).",
+                    params.output.video.width,
+                    params.output.video.height,
+                    params.output.video.fps,
+                    profile.width,
+                    profile.height,
+                    profile.fps
+                );
+            }
+            return Ok(Some(CompositorAuxiliaryOutput {
+                width: simulcast.video.width,
+                height: simulcast.video.height,
+                frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+                composes_simulcast_scene: true,
+            }));
+        }
+        return Ok(None);
+    }
+    if !params.output.record_enabled || !params.output.stream_enabled {
         return Ok(None);
     }
     let recording = &params.output.video;
@@ -8414,6 +8481,11 @@ fn resolved_enabled_stream_output_videos(
     {
         return Ok(enabled_streaming_targets(params)
             .into_iter()
+            .filter(|target| {
+                params.simulcast.is_none()
+                    || target.effective_output_orientation()
+                        == crate::streaming::StreamOutputOrientation::Horizontal
+            })
             .map(|target| stream_target_output_video(streaming, target))
             .collect());
     }
@@ -8431,6 +8503,24 @@ fn resolve_auxiliary_stream_output_video(
     params: &StartSessionParams,
     stream_output: &CompositorAuxiliaryOutput,
 ) -> Result<VideoSettings> {
+    if stream_output.composes_simulcast_scene {
+        let simulcast = params
+            .simulcast
+            .as_ref()
+            .context("Simulcast-bound auxiliary output without simulcast params")?;
+        if simulcast.video.width != stream_output.width
+            || simulcast.video.height != stream_output.height
+        {
+            bail!(
+                "Simulcast compositor target {}x{} does not match the vertical profile {}x{}",
+                stream_output.width,
+                stream_output.height,
+                simulcast.video.width,
+                simulcast.video.height
+            );
+        }
+        return Ok(simulcast.video.clone());
+    }
     let companion_outputs = companion_stream_outputs_for_recording(params, &params.output.video)?;
     companion_outputs
         .into_iter()
@@ -14799,6 +14889,8 @@ mod tests {
                 target.id = format!("target-{index}");
                 target.enabled = true;
                 target.output_orientation = Some(*orientation);
+                // Unique keys so per-leg routing tests can tell URLs apart.
+                target.stream_key = format!("key{index}");
                 target
             })
             .collect();
@@ -14897,6 +14989,164 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("horizontal"), "{error}");
+    }
+
+    /// The nearest `-map N:v` above a URL names the encoded input its FLV leg
+    /// consumes.
+    fn video_input_for_url(args: &[String], url: &str) -> String {
+        let url_index = args
+            .iter()
+            .position(|arg| arg == url)
+            .unwrap_or_else(|| panic!("url {url} not in args: {args:?}"));
+        args[..url_index]
+            .windows(2)
+            .rev()
+            .find(|pair| pair[0] == "-map" && pair[1].ends_with(":v"))
+            .map(|pair| pair[1].clone())
+            .unwrap_or_else(|| panic!("no video map before {url}: {args:?}"))
+    }
+
+    fn simulcast_split_params(record_enabled: bool) -> (StartSessionParams, Vec<StreamTarget>) {
+        use crate::streaming::StreamOutputOrientation as Orientation;
+        let mut params = base_params(record_enabled, true);
+        params.output.video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            bitrate_kbps: 6000,
+        };
+        let mut streaming =
+            streaming_with_orientations(&[Orientation::Horizontal, Orientation::Vertical]);
+        streaming.default_output_preset = VideoPreset::StreamSafe1080p30;
+        streaming.default_bitrate_kbps = 6000;
+        params.streaming = Some(streaming.clone());
+        params.simulcast = Some(simulcast_leg());
+        let targets = stream_targets_from_streaming(&streaming).unwrap();
+        (params, targets)
+    }
+
+    #[test]
+    fn simulcast_split_routes_targets_by_orientation_binding() {
+        let (params, targets) = simulcast_split_params(true);
+        let stream_output = recording_compositor_stream_output(
+            &params,
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+        )
+        .unwrap()
+        .expect("simulcast auxiliary output");
+        assert!(stream_output.composes_simulcast_scene);
+        assert_eq!((stream_output.width, stream_output.height), (1080, 1920));
+
+        let args = bridge_compositor_split_output_ffmpeg_args(
+            &CaptureInputs {
+                video: VideoInput::TestPattern,
+                camera_index: None,
+                microphone: None,
+            },
+            &params,
+            Some(Path::new("/tmp/videorc-simulcast-split.mkv")),
+            &targets,
+            Path::new("/tmp/videorc-simulcast-recording.h264"),
+            Path::new("/tmp/videorc-simulcast-stream.h264"),
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+            stream_output,
+        )
+        .unwrap();
+
+        // The horizontal destination consumes the PRIMARY encode (input 1) and
+        // the vertical destination the simulcast encode (input 2) — routed by
+        // the explicit binding, not profile equality.
+        assert_eq!(
+            video_input_for_url(&args, "rtmp://a.rtmp.youtube.com/live2/key0"),
+            "1:v"
+        );
+        assert_eq!(
+            video_input_for_url(&args, "rtmp://a.rtmp.youtube.com/live2/key1"),
+            "2:v"
+        );
+        assert!(args.contains(&"/tmp/videorc-simulcast-split.mkv".to_string()));
+        assert!(!args.contains(&"tee".to_string()));
+        assert_eq!(
+            args.windows(2)
+                .filter(|window| window[0] == "-f" && window[1] == "fifo")
+                .count(),
+            2,
+            "every target stays an isolated fifo-muxer leg: {args:?}"
+        );
+    }
+
+    #[test]
+    fn simulcast_split_supports_stream_only_sessions() {
+        let (params, targets) = simulcast_split_params(false);
+        let stream_output = recording_compositor_stream_output(
+            &params,
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+        )
+        .unwrap()
+        .expect("stream-only simulcast auxiliary output");
+
+        let args = bridge_compositor_split_output_ffmpeg_args(
+            &CaptureInputs {
+                video: VideoInput::TestPattern,
+                camera_index: None,
+                microphone: None,
+            },
+            &params,
+            None,
+            &targets,
+            Path::new("/tmp/videorc-simulcast-recording.h264"),
+            Path::new("/tmp/videorc-simulcast-stream.h264"),
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+            stream_output,
+        )
+        .unwrap();
+
+        assert!(
+            !args.iter().any(|arg| arg.ends_with(".mkv")),
+            "stream-only dual session must not write a file: {args:?}"
+        );
+        assert_eq!(
+            video_input_for_url(&args, "rtmp://a.rtmp.youtube.com/live2/key0"),
+            "1:v"
+        );
+        assert_eq!(
+            video_input_for_url(&args, "rtmp://a.rtmp.youtube.com/live2/key1"),
+            "2:v"
+        );
+    }
+
+    #[test]
+    fn simulcast_refuses_mixed_horizontal_profiles_and_stream_burned_captions() {
+        use crate::streaming::StreamOutputOrientation as Orientation;
+        // A horizontal target with a DIFFERENT profile would need a third
+        // encode — refuse with the profile-matching copy.
+        let (mut params, _) = simulcast_split_params(true);
+        if let Some(streaming) = params.streaming.as_mut() {
+            streaming.targets[0].output_preset = Some(VideoPreset::StreamSafe1080p60);
+        }
+        let error = recording_compositor_stream_output(
+            &params,
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("one horizontal encode"), "{error}");
+
+        // Captions burning the stream leg conflict with the simulcast aux.
+        let (mut params, _) = simulcast_split_params(true);
+        params.captions = Some(crate::protocol::CaptionsSessionParams {
+            enabled: true,
+            burn_target: crate::captions::CaptionBurnTarget::Stream,
+            ..Default::default()
+        });
+        let error = validate_outputs(&params).unwrap_err().to_string();
+        assert!(error.contains("dual-orientation"), "{error}");
+
+        // Sanity: the untouched dual shape still validates.
+        let (params, _) = simulcast_split_params(true);
+        let _ = streaming_with_orientations(&[Orientation::Horizontal]);
+        validate_outputs(&params).unwrap();
     }
 
     #[test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -1078,6 +1078,32 @@ pub async fn start_session(
             u64::try_from(Utc::now().timestamp_millis()).unwrap_or(0),
         )
         .await;
+        // Dual-orientation: seed the vertical leg's scene from the simulcast
+        // params (same sources, its own vertical geometry). Non-dual sessions
+        // clear any stale leftover so the aux can never compose a dead scene.
+        if let Some(simulcast) = params.simulcast.as_ref() {
+            let simulcast_scene = simulcast.scene.clone().unwrap_or_else(|| {
+                crate::scene::scene_from_capture_config(crate::protocol::SceneConfigParams {
+                    sources: params.sources.clone(),
+                    layout: simulcast.layout.clone(),
+                    video: Some(simulcast.video.clone()),
+                    background: None,
+                    protected_overlay_window_ids: Vec::new(),
+                })
+            });
+            crate::compositor::update_compositor_simulcast_scene(
+                &state,
+                crate::protocol::CompositorSceneUpdateParams {
+                    revision: startup_scene.scene_revision,
+                    scene: Some(simulcast_scene),
+                    layout: simulcast.layout.clone(),
+                    active_screen: None,
+                },
+            )
+            .await;
+        } else {
+            crate::compositor::clear_compositor_simulcast_scene(&state).await;
+        }
         let startup_scene_revision = startup_scene.scene_revision;
         recording_startup_scene = Some(startup_scene);
         match await_recording_startup_barrier(
@@ -8337,6 +8363,7 @@ fn recording_compositor_stream_output(
                 width: recording.width,
                 height: recording.height,
                 frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+                composes_simulcast_scene: false,
             }));
         }
         return Ok(None);
@@ -8351,6 +8378,7 @@ fn recording_compositor_stream_output(
         width: stream.width,
         height: stream.height,
         frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+        composes_simulcast_scene: false,
     }))
 }
 
@@ -12514,6 +12542,7 @@ mod tests {
                 width: 1920,
                 height: 1080,
                 frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+                composes_simulcast_scene: false,
             }
         );
 
@@ -12576,6 +12605,7 @@ mod tests {
             width: 1920,
             height: 1080,
             frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+            composes_simulcast_scene: false,
         };
 
         let error = bridge_compositor_split_output_ffmpeg_args(
@@ -15000,6 +15030,7 @@ mod tests {
                 width: 1920,
                 height: 1080,
                 frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+                composes_simulcast_scene: false,
             })
         );
     }
@@ -15053,6 +15084,7 @@ mod tests {
                 width: params.output.video.width,
                 height: params.output.video.height,
                 frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+                composes_simulcast_scene: false,
             })
         );
         let stream_plan = caption_leg_plan(&params);
@@ -15575,6 +15607,7 @@ mod tests {
                 width: 1920,
                 height: 1080,
                 frame_consumer: CompositorFrameConsumer::VideoToolboxEncoder,
+                composes_simulcast_scene: false,
             })
         );
         validate_outputs(&params).unwrap();

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -15150,6 +15150,81 @@ mod tests {
     }
 
     #[test]
+    fn simulcast_six_destinations_fan_out_two_encodes() {
+        use crate::streaming::StreamOutputOrientation as Orientation;
+        // The full Premium shape: 3 horizontal + 3 vertical destinations in
+        // ONE command line — six isolated FLV legs consuming exactly TWO
+        // encoded inputs (bandwidth is the budget, not encodes).
+        let mut params = base_params(false, true);
+        params.output.video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            bitrate_kbps: 6000,
+        };
+        let mut streaming = streaming_with_orientations(&[
+            Orientation::Horizontal,
+            Orientation::Horizontal,
+            Orientation::Horizontal,
+            Orientation::Vertical,
+            Orientation::Vertical,
+            Orientation::Vertical,
+        ]);
+        streaming.default_output_preset = VideoPreset::StreamSafe1080p30;
+        streaming.default_bitrate_kbps = 6000;
+        params.streaming = Some(streaming.clone());
+        params.simulcast = Some(simulcast_leg());
+        let targets = stream_targets_from_streaming(&streaming).unwrap();
+        let stream_output = recording_compositor_stream_output(
+            &params,
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+        )
+        .unwrap()
+        .expect("simulcast auxiliary output");
+
+        let args = bridge_compositor_split_output_ffmpeg_args(
+            &CaptureInputs {
+                video: VideoInput::TestPattern,
+                camera_index: None,
+                microphone: None,
+            },
+            &params,
+            None,
+            &targets,
+            Path::new("/tmp/videorc-six-recording.h264"),
+            Path::new("/tmp/videorc-six-stream.h264"),
+            EncoderBridgeVideoOutput::VideoToolboxH264MpegTs,
+            stream_output,
+        )
+        .unwrap();
+
+        // Six isolated fifo-muxer legs; a dead platform is a dead LEG.
+        assert_eq!(
+            args.windows(2)
+                .filter(|window| window[0] == "-f" && window[1] == "fifo")
+                .count(),
+            6,
+            "{args:?}"
+        );
+        for (index, expected_input) in [
+            (0, "1:v"),
+            (1, "1:v"),
+            (2, "1:v"),
+            (3, "2:v"),
+            (4, "2:v"),
+            (5, "2:v"),
+        ] {
+            let url = format!("rtmp://a.rtmp.youtube.com/live2/key{index}");
+            assert_eq!(
+                video_input_for_url(&args, &url),
+                expected_input,
+                "target {index} routed wrong"
+            );
+        }
+    }
+
+    #[test]
     fn canvas_bounds_are_orientation_symmetric() {
         let mut params = base_params(true, false);
         params.layout.layout_preset = LayoutPreset::VerticalCameraTop;

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -2197,6 +2197,7 @@ pub async fn create_preview_snapshot(
         },
         audio: Default::default(),
         streaming: None,
+        simulcast: None,
     };
     let mut capture = resolve_capture_inputs(&ffmpeg_path, &session_params).await;
     capture.microphone = None;
@@ -2487,6 +2488,7 @@ fn live_preview_session_params(
         },
         audio: Default::default(),
         streaming: None,
+        simulcast: None,
     }
 }
 
@@ -4778,6 +4780,9 @@ struct StreamTarget {
     platform: StreamPlatform,
     label: String,
     output_video: Option<VideoSettings>,
+    /// Which composed leg this destination consumes (explicit binding — never
+    /// inferred from resolution equality).
+    output_orientation: crate::streaming::StreamOutputOrientation,
 }
 
 /// An enabled stream destination that was skipped this session because its
@@ -7911,6 +7916,24 @@ fn validate_session_entitlements(
                 destination_count
             );
         }
+        // Dual-orientation simulcast caps destinations PER LEG: each leg's
+        // fan-out is copies of one encode, and 3-per-leg is the tested shape.
+        let (horizontal_count, vertical_count) =
+            ready_stream_destination_counts_by_orientation(params)?;
+        let per_leg_cap = snapshot.limits.streaming.max_destinations_per_orientation;
+        for (orientation, count) in [
+            ("horizontal", horizontal_count),
+            ("vertical", vertical_count),
+        ] {
+            if count > per_leg_cap {
+                if per_leg_cap <= 1 {
+                    entitlements::require_feature(snapshot, FeatureId::Multistreaming)?;
+                }
+                bail!(
+                    "This plan allows up to {per_leg_cap} {orientation} livestream destination(s); this session has {count} ready."
+                );
+            }
+        }
         let stream_video = resolve_stream_output_video(params)?;
         if stream_video.width > snapshot.limits.streaming.max_width
             || stream_video.height > snapshot.limits.streaming.max_height
@@ -7951,6 +7974,36 @@ fn ready_stream_destination_count(params: &StartSessionParams) -> Result<u32> {
     Ok(u32::try_from(count).unwrap_or(u32::MAX))
 }
 
+/// Ready destinations split by their explicit leg binding. The legacy
+/// single-RTMP path (no streaming settings) counts as one horizontal.
+fn ready_stream_destination_counts_by_orientation(
+    params: &StartSessionParams,
+) -> Result<(u32, u32)> {
+    if !params.output.stream_enabled {
+        return Ok((0, 0));
+    }
+    let Some(streaming) = params
+        .streaming
+        .as_ref()
+        .filter(|streaming| streaming.enabled)
+    else {
+        return Ok((1, 0));
+    };
+    let mut horizontal = 0u32;
+    let mut vertical = 0u32;
+    for target in stream_targets_from_streaming(streaming)? {
+        match target.output_orientation {
+            crate::streaming::StreamOutputOrientation::Horizontal => {
+                horizontal = horizontal.saturating_add(1);
+            }
+            crate::streaming::StreamOutputOrientation::Vertical => {
+                vertical = vertical.saturating_add(1);
+            }
+        }
+    }
+    Ok((horizontal, vertical))
+}
+
 fn validate_outputs(params: &StartSessionParams) -> Result<()> {
     if !params.output.record_enabled && !params.output.stream_enabled {
         bail!("Enable local recording, RTMP streaming, or both");
@@ -7972,7 +8025,11 @@ fn validate_outputs(params: &StartSessionParams) -> Result<()> {
     }
 
     validate_video_settings(&params.output.video)?;
+    if let Some(simulcast) = params.simulcast.as_ref() {
+        validate_video_settings(&simulcast.video)?;
+    }
     validate_canvas_orientation(params)?;
+    validate_simulcast_targets(params)?;
     validate_caption_output_policy(params)?;
     validate_video_profile_policy(params)?;
 
@@ -7984,6 +8041,9 @@ fn validate_outputs(params: &StartSessionParams) -> Result<()> {
 /// active scene (capture.ts::coerceVideoToOrientation); this refusal is the
 /// defense in depth so a mismatched config can never record vertical bands
 /// tiled across a landscape canvas (owner screenshot, 2026-07-13).
+/// With a simulcast leg the rule applies PER LEG: the primary must be a
+/// horizontal scene on a landscape canvas and the simulcast leg a vertical
+/// scene on a portrait canvas.
 fn validate_canvas_orientation(params: &StartSessionParams) -> Result<()> {
     if params.layout.layout_preset.is_vertical()
         && params.output.video.width > params.output.video.height
@@ -7993,6 +8053,50 @@ fn validate_canvas_orientation(params: &StartSessionParams) -> Result<()> {
         );
     }
 
+    if let Some(simulcast) = params.simulcast.as_ref() {
+        if params.layout.layout_preset.is_vertical() {
+            bail!(
+                "Dual-orientation streaming composes the vertical leg from the simulcast scene — switch the Studio to a horizontal scene to go live in both orientations."
+            );
+        }
+        if !simulcast.layout.layout_preset.is_vertical() {
+            bail!("The simulcast leg must use a vertical scene preset.");
+        }
+        if simulcast.video.width > simulcast.video.height {
+            bail!(
+                "The simulcast leg composes a portrait canvas — its resolution must be taller than wide."
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Vertical-bound destinations only have pixels to consume when the simulcast
+/// leg exists; refusing here beats silently feeding them landscape frames.
+fn validate_simulcast_targets(params: &StartSessionParams) -> Result<()> {
+    if !params.output.stream_enabled {
+        return Ok(());
+    }
+    let Some(streaming) = params
+        .streaming
+        .as_ref()
+        .filter(|streaming| streaming.enabled)
+    else {
+        return Ok(());
+    };
+    let (_, vertical_count) = ready_stream_destination_counts_by_orientation(params)?;
+    let _ = streaming;
+    if vertical_count > 0 && params.simulcast.is_none() {
+        bail!(
+            "A vertical destination is enabled but no vertical scene is armed for this session. Arm \"Also stream vertical\" or disable the vertical destination."
+        );
+    }
+    if vertical_count == 0 && params.simulcast.is_some() && params.output.stream_enabled {
+        bail!(
+            "The vertical simulcast leg has no enabled vertical destination — enable one or disarm vertical streaming."
+        );
+    }
     Ok(())
 }
 
@@ -8605,6 +8709,8 @@ fn build_stream_url(settings: &RtmpSettings) -> Result<StreamTarget> {
         platform,
         label: stream_platform_label(platform).to_string(),
         output_video: None,
+        // Legacy single-RTMP sessions are the horizontal leg by definition.
+        output_orientation: crate::streaming::StreamOutputOrientation::default(),
     })
 }
 
@@ -8648,6 +8754,7 @@ fn resolve_stream_target(
             platform: target.platform,
             label: target.label.clone(),
             output_video,
+            output_orientation: target.effective_output_orientation(),
         });
     }
     let stream_key = target.stream_key.trim().trim_start_matches('/');
@@ -8664,6 +8771,7 @@ fn resolve_stream_target(
         platform: target.platform,
         label: target.label.clone(),
         output_video,
+        output_orientation: target.effective_output_orientation(),
     })
 }
 
@@ -9899,6 +10007,7 @@ mod tests {
                 ..Default::default()
             },
             streaming: None,
+            simulcast: None,
         }
     }
 
@@ -10642,6 +10751,7 @@ mod tests {
             platform: StreamPlatform::Custom,
             label: "Forged".to_string(),
             output_video: None,
+            output_orientation: crate::streaming::StreamOutputOrientation::Horizontal,
         };
         let error = ffmpeg_args(
             &CaptureInputs {
@@ -14621,6 +14731,144 @@ mod tests {
         validate_outputs(&params).unwrap();
     }
 
+    fn portrait_1080() -> VideoSettings {
+        VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1080,
+            height: 1920,
+            fps: 30,
+            bitrate_kbps: 6000,
+        }
+    }
+
+    fn simulcast_leg() -> crate::protocol::SimulcastParams {
+        let mut layout = crate::protocol::default_layout_settings();
+        layout.layout_preset = LayoutPreset::VerticalCameraTop;
+        crate::protocol::SimulcastParams {
+            layout,
+            scene: None,
+            video: portrait_1080(),
+        }
+    }
+
+    /// Streaming settings with one enabled target per requested orientation.
+    fn streaming_with_orientations(
+        orientations: &[crate::streaming::StreamOutputOrientation],
+    ) -> StreamingSettings {
+        let mut streaming = streaming_for(&[(
+            StreamPlatform::Youtube,
+            "rtmp://a.rtmp.youtube.com/live2",
+            "yt",
+        )]);
+        let template = streaming.targets[0].clone();
+        streaming.targets = orientations
+            .iter()
+            .enumerate()
+            .map(|(index, orientation)| {
+                let mut target = template.clone();
+                target.id = format!("target-{index}");
+                target.enabled = true;
+                target.output_orientation = Some(*orientation);
+                target
+            })
+            .collect();
+        streaming.enabled_target_ids = streaming.targets.iter().map(|t| t.id.clone()).collect();
+        streaming
+    }
+
+    #[test]
+    fn simulcast_leg_must_be_a_vertical_scene_on_a_portrait_canvas() {
+        use crate::streaming::StreamOutputOrientation as Orientation;
+        let mut params = base_params(false, true);
+        params.output.video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            bitrate_kbps: 6000,
+        };
+        params.streaming = Some(streaming_with_orientations(&[
+            Orientation::Horizontal,
+            Orientation::Vertical,
+        ]));
+        params.simulcast = Some(simulcast_leg());
+        validate_outputs(&params).unwrap();
+
+        // Landscape simulcast canvas refuses.
+        let mut landscape = params.clone();
+        landscape.simulcast.as_mut().unwrap().video.width = 1920;
+        landscape.simulcast.as_mut().unwrap().video.height = 1080;
+        let error = validate_outputs(&landscape).unwrap_err().to_string();
+        assert!(error.contains("portrait"), "{error}");
+
+        // Horizontal simulcast preset refuses.
+        let mut horizontal = params.clone();
+        horizontal.simulcast.as_mut().unwrap().layout.layout_preset = LayoutPreset::ScreenCamera;
+        let error = validate_outputs(&horizontal).unwrap_err().to_string();
+        assert!(error.contains("vertical scene preset"), "{error}");
+
+        // A vertical PRIMARY cannot also carry a simulcast leg.
+        let mut vertical_primary = params.clone();
+        vertical_primary.layout.layout_preset = LayoutPreset::VerticalSplit;
+        vertical_primary.output.video = portrait_1080();
+        let error = validate_outputs(&vertical_primary).unwrap_err().to_string();
+        assert!(error.contains("horizontal scene"), "{error}");
+    }
+
+    #[test]
+    fn vertical_targets_require_the_simulcast_leg_and_vice_versa() {
+        use crate::streaming::StreamOutputOrientation as Orientation;
+        // Vertical destination without a simulcast leg: refuse with the arm copy.
+        let mut params = base_params(false, true);
+        params.streaming = Some(streaming_with_orientations(&[
+            Orientation::Horizontal,
+            Orientation::Vertical,
+        ]));
+        let error = validate_outputs(&params).unwrap_err().to_string();
+        assert!(error.contains("vertical destination"), "{error}");
+
+        // Simulcast leg without any vertical destination: refuse.
+        let mut params = base_params(false, true);
+        params.streaming = Some(streaming_with_orientations(&[Orientation::Horizontal]));
+        params.simulcast = Some(simulcast_leg());
+        let error = validate_outputs(&params).unwrap_err().to_string();
+        assert!(error.contains("no enabled vertical destination"), "{error}");
+    }
+
+    #[test]
+    fn destination_caps_count_per_orientation_leg() {
+        use crate::streaming::StreamOutputOrientation as Orientation;
+        let snapshot = entitlements::developer_test_entitlements();
+
+        // 3 horizontal + 3 vertical = the full Premium shape: allowed.
+        let mut params = base_params(false, true);
+        params.streaming = Some(streaming_with_orientations(&[
+            Orientation::Horizontal,
+            Orientation::Horizontal,
+            Orientation::Horizontal,
+            Orientation::Vertical,
+            Orientation::Vertical,
+            Orientation::Vertical,
+        ]));
+        params.simulcast = Some(simulcast_leg());
+        validate_session_entitlements(&params, &snapshot).unwrap();
+
+        // A 4th destination on ONE leg refuses even though the total (5) fits.
+        let mut params = base_params(false, true);
+        params.streaming = Some(streaming_with_orientations(&[
+            Orientation::Horizontal,
+            Orientation::Horizontal,
+            Orientation::Horizontal,
+            Orientation::Horizontal,
+            Orientation::Vertical,
+        ]));
+        params.simulcast = Some(simulcast_leg());
+        let error = validate_session_entitlements(&params, &snapshot)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("horizontal"), "{error}");
+    }
+
     #[test]
     fn canvas_bounds_are_orientation_symmetric() {
         let mut params = base_params(true, false);
@@ -14942,6 +15190,7 @@ mod tests {
             platform: StreamPlatform::Custom,
             label: "Test".to_string(),
             output_video: None,
+            output_orientation: crate::streaming::StreamOutputOrientation::Horizontal,
         };
         let args = bridge_compositor_split_output_ffmpeg_args(
             &CaptureInputs {

--- a/crates/videorc-backend/src/streaming.rs
+++ b/crates/videorc-backend/src/streaming.rs
@@ -22,6 +22,18 @@ pub enum StreamPlatform {
     Custom,
 }
 
+/// Which composed leg a destination consumes in a dual-orientation session.
+/// EXPLICIT per-target property (one home) — never inferred from resolution
+/// equality, which ties when recording and vertical stream share 1080×1920.
+/// Absent (legacy configs) means horizontal.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum StreamOutputOrientation {
+    #[default]
+    Horizontal,
+    Vertical,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum StreamUrlMode {
@@ -100,10 +112,19 @@ pub struct StreamTargetSettings {
     pub output_preset: Option<VideoPreset>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_bitrate_kbps: Option<u32>,
+    /// Dual-orientation leg binding; absent = horizontal (legacy migration).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_orientation: Option<StreamOutputOrientation>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<StreamTargetStatus>,
     pub created_at: String,
     pub updated_at: String,
+}
+
+impl StreamTargetSettings {
+    pub fn effective_output_orientation(&self) -> StreamOutputOrientation {
+        self.output_orientation.unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -540,6 +561,7 @@ fn default_stream_target(
         // The renderer owns timestamps; the backend default leaves them blank.
         created_at: String::new(),
         updated_at: String::new(),
+        output_orientation: None,
     }
 }
 

--- a/crates/videorc-backend/src/streaming.rs
+++ b/crates/videorc-backend/src/streaming.rs
@@ -19,6 +19,8 @@ pub enum StreamPlatform {
     Youtube,
     Twitch,
     X,
+    Tiktok,
+    Instagram,
     Custom,
 }
 
@@ -443,6 +445,8 @@ pub(crate) fn stream_platform_id(platform: StreamPlatform) -> &'static str {
         StreamPlatform::Youtube => "youtube",
         StreamPlatform::Twitch => "twitch",
         StreamPlatform::X => "x",
+        StreamPlatform::Tiktok => "tiktok",
+        StreamPlatform::Instagram => "instagram",
         StreamPlatform::Custom => "custom",
     }
 }
@@ -515,6 +519,8 @@ pub(crate) fn stream_platform_label(platform: StreamPlatform) -> &'static str {
         StreamPlatform::Youtube => "YouTube",
         StreamPlatform::Twitch => "Twitch",
         StreamPlatform::X => "X / Twitter",
+        StreamPlatform::Tiktok => "TikTok",
+        StreamPlatform::Instagram => "Instagram",
         StreamPlatform::Custom => "Custom RTMP",
     }
 }
@@ -533,8 +539,24 @@ fn default_stream_target(
     label: &str,
     server_url: &str,
 ) -> StreamTargetSettings {
+    default_stream_target_with_id(
+        stream_platform_id(platform),
+        platform,
+        label,
+        server_url,
+        None,
+    )
+}
+
+fn default_stream_target_with_id(
+    id: &str,
+    platform: StreamPlatform,
+    label: &str,
+    server_url: &str,
+    output_orientation: Option<StreamOutputOrientation>,
+) -> StreamTargetSettings {
     StreamTargetSettings {
-        id: stream_platform_id(platform).to_string(),
+        id: id.to_string(),
         platform,
         label: label.to_string(),
         enabled: false,
@@ -561,11 +583,15 @@ fn default_stream_target(
         // The renderer owns timestamps; the backend default leaves them blank.
         created_at: String::new(),
         updated_at: String::new(),
-        output_orientation: None,
+        output_orientation,
     }
 }
 
-/// The fixed built-in destinations (YouTube, Twitch, X, Custom) in display order.
+/// The fixed built-in destinations in display order: the horizontal trio
+/// (YouTube, Twitch, X), the vertical trio (YouTube Vertical — a SECOND
+/// broadcast on the same channel — TikTok, Instagram), then Custom RTMP.
+/// Vertical destinations are pinned to the vertical leg; TikTok and
+/// Instagram are manual-key only (no public ingest APIs).
 pub fn default_stream_targets() -> Vec<StreamTargetSettings> {
     vec![
         default_stream_target(
@@ -579,6 +605,27 @@ pub fn default_stream_targets() -> Vec<StreamTargetSettings> {
             "rtmp://live.twitch.tv/app",
         ),
         default_stream_target(StreamPlatform::X, "X / Twitter", ""),
+        default_stream_target_with_id(
+            "youtube-vertical",
+            StreamPlatform::Youtube,
+            "YouTube Vertical",
+            "rtmp://a.rtmp.youtube.com/live2",
+            Some(StreamOutputOrientation::Vertical),
+        ),
+        default_stream_target_with_id(
+            "tiktok",
+            StreamPlatform::Tiktok,
+            "TikTok",
+            "",
+            Some(StreamOutputOrientation::Vertical),
+        ),
+        default_stream_target_with_id(
+            "instagram",
+            StreamPlatform::Instagram,
+            "Instagram",
+            "rtmps://live-upload.instagram.com:443/rtmp/",
+            Some(StreamOutputOrientation::Vertical),
+        ),
         default_stream_target(StreamPlatform::Custom, "Custom RTMP", ""),
     ]
 }


### PR DESCRIPTION
## What

One Go Live streams the **horizontal scene to YouTube + Twitch + X** while the **saved vertical scene streams to YouTube (portrait broadcast) + TikTok + Instagram** — six destinations at once, as Premium. Each vertical destination gets a true 9:16 composition from the vertical Studio scene, never a crop of the landscape frame. A failing destination kills only its own leg.

Executes the vault plan `2026-07-14 - Videorc Vertical Multistream YouTube TikTok Instagram Plan` (V0–V6), which consolidates the dual-orientation simulcast engine plan.

## How

- **Engine (S1–S3):** `StartSessionParams.simulcast` carries the vertical leg (layout/scene/portrait canvas, per-leg validation); the compositor's auxiliary output can now compose its **own scene snapshot** — the vertical leg is its own composition from the same captured sources, not a rescale. The bridge routes each target by its **explicit `outputOrientation`** (vertical → simulcast encode, horizontal → primary; profile equality is a trap when the profiles share dims), works for stream-only sessions, and keeps every target an isolated fifo-muxer FLV leg. Six destinations = **two encodes** — bandwidth is the budget, not CPU. Mid-session vertical scene edits land on the simulcast snapshot; the cross-orientation "stop the session" bail fires only when no leg matches. Stream-burned captions × simulcast are mutually exclusive (the aux-slot conflict; documented fallback), and mixed horizontal profiles are refused with profile-matching copy.
- **Premium reshape (V0):** destination caps become per-orientation — Premium 3 horizontal + 3 vertical (6 total), Basic stays 1. Renderer gates count per leg and name it in the limit copy; the backend session check stays fail-closed. Pricing copy PR: TheOrcDev/videorc-web#7.
- **Destinations (V3–V5):** ID-keyed card lineup — YouTube, Twitch, X, **YouTube Vertical** (second broadcast on the same channel; prepare advertises the transposed portrait profile), **TikTok**, **Instagram**, Custom. TikTok/IG are manual-key only (no public ingest APIs): OAuth refused with honest copy, cards link TikTok LIVE Center / Instagram Live Producer with rotating-key guidance, Comments shows the honest no-chat state. Go Live confirmation gains a dual-orientation bandwidth advisory and Instagram's "press Go live in Live Producer after ingest starts" step. Legacy configs migrate by id; a saved `youtube` can never hydrate the vertical card's key.
- **Vertical monitor (V2, scope deviation):** ships as a **schematic** monitor (saved vertical scene diagram + Armed/Live states) rather than live pixels — the live monitor needs the preview host's surface-id split, deferred per the engine plan's own fallback posture so the historically fragile primary preview stays untouched.

## Verification

- Pinned engine tests: one compositor tick publishes 640×360 (horizontal scene) and 180×320 (vertical scene) simultaneously; simulcast scene updates are revision-ordered; orientation routing maps key0→1:v / key1→2:v in one command line (record+stream and stream-only); **six-leg pin**: 3×1:v + 3×2:v across six fifo legs; per-leg validation and per-orientation cap refusals.
- Full backend module suites (recording/captions/compositor/streaming/entitlements/preflight — 353+ green), full desktop suite (1035), script tests (618), `cargo clippy -D warnings`, fmt, typecheck/lint/format.
- ⚠️ `smoke:recording-studio` still fails at the layout/source liveness stage on clean main (pre-existing camera-enumeration issue, tracked); all other stages passed on the branch's parent commits.

## Update 2026-09-17 — rebased onto current main (0.9.93)

The branch was 210 commits behind main with 14 conflicting files. Main was merged in and the simulcast engine was refit onto what shipped since July:

- **Multistreaming is free (0.9.92).** The per-orientation Premium cap (3 horizontal + 3 vertical) is gone; the one shared cap of 5 destinations (`STREAMING_MAX_DESTINATIONS`) now counts both legs together. `maxDestinationsPerOrientation` left the wire, the renderer gates are main's, and the refusal copy never mentions Premium. Engine tests still pin the six-leg / two-encode topology above the product cap.
- **Provider stream output plan (main's model).** Vertical-bound destinations no longer enter the horizontal provider plan; they take the simulcast leg's portrait profile directly. While a simulcast leg is armed the plan never grants a separate horizontal encoded role (the one auxiliary role is the vertical leg's), so every horizontal destination is a copy of the primary encode; a mismatched horizontal profile folds onto the shared provider-safe profile instead of a third encode. The TypeScript mirror (`resolveProviderStreamOutputPlan`) takes the same `simulcastArmed` option, threaded from every caller.
- **Auxiliary output.** The simulcast aux uses the effective bridge's frame consumer (VideoToolbox or Media Foundation), and the stream-only + simulcast shape still owns the aux. The unified Windows D3D11 media path names `dual-orientation-simulcast` as an unsupported scene feature and takes its named fallback (it re-renders the primary scene on its aux and cannot compose a second scene).
- **Scene motion.** The simulcast scene ignores `transition_ms`; it switches instantly.
- **Icons.** TikTok and Instagram brand marks are registered in `components/icons.tsx` (the phosphor registry rule); the vertical monitor uses `MobileIcon`. The monitor lives in `StudioDashboardBottomRow` (main's lazy bottom row).
- **Vertical Studio mode.** A vertical-bound destination on a portrait primary no longer demands a simulcast leg (there is nothing to arm; the primary already is portrait).
- **RPC contract.** Main's contract had grown three hard-coded four-platform enums (stream target snapshots, OAuth callback results, co-host question provenance); they now share one `streamPlatformSchema` that includes `tiktok` and `instagram`, so a dual session's `stream.targets` events are not rejected at the renderer boundary.

### Verification (2026-09-17)

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test:scripts` (1364), full desktop unit suite (1677 passed, including the StudioProvider integration file — its fixtures now pick the horizontal cards by id because YouTube Vertical shares the YouTube platform), `cargo fmt --check`, `cargo clippy -p videorc-backend -- -D warnings`, `cargo test -p videorc-backend` for recording / compositor / streaming / entitlements / preflight / live_chat / oauth / live_layout / protocol (764 passed). Smoke gates need the packaged app and real accounts; see the owner list above.

### Observed on main (out of scope here)

A vertical Studio-mode livestream (portrait primary, 1080×1920) is refused by the pre-existing profile policy ("4K livestreaming is not enabled for v1" for stream-only, or the shared-encoder rule for record+stream) because stream target presets are landscape. Worth a separate look if vertical-mode live is expected to work without the simulcast leg.

## Pending (owner)

Staged acceptance per the plan: dual YouTube first, then + Twitch/X, then the full six on real accounts (TikTok LIVE access + IG professional account needed); the S2 perf exit-gate measurement on a real dual live run; bandwidth reality check on the owner's uplink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TikTok and Instagram as streaming destinations with platform icons, labels, and manual stream-key guidance.
  * Added vertical streaming for YouTube, TikTok, and Instagram, including simultaneous horizontal and vertical broadcasts.
  * Added vertical stream status monitoring and orientation indicators in the studio.
  * Added bitrate guidance and Instagram publishing instructions before going live.
* **Improvements**
  * Vertical scenes can now be updated during an active session.
  * TikTok and Instagram chat are identified as unavailable when comment APIs are unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

