### PR TITLE
Release 0.9.39-beta.1: green screen + caption style fix (bump, changelog, record)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.39-beta.1.md
+++ b/changelog/0.9.39-beta.1.md
@@ -1,0 +1,43 @@
+---
+version: 0.9.39-beta.1
+date: 2026-07-14
+channel: beta
+title: Green screen for your camera — and captions in the style you picked
+summary: Key out your background with the new Green screen control and put yourself over any scene or backdrop — it works in every camera layout, live and recorded. Plus live captions finally render in the style you chose instead of a black box, and two Windows fixes for the preview and microphone controls.
+highlights:
+  - "Green screen: flip one switch in the camera Inspector to key out a green or blue screen — works in every camera layout, on the live stream, in recordings, and with the camera bubble shapes."
+  - Similarity, smoothness, and spill-removal sliders tune the key live while you watch, and the keyed camera over a background image makes a clean virtual set.
+  - Live captions now render in the style you picked in the Captions tab — the no-background Classic style no longer shows up as a black box on your stream.
+  - "Windows: the preview now reports live correctly, and microphone gain and mute apply during a session."
+---
+
+## Key out your background
+
+The camera Inspector in the Layout tab has a new **Green screen** section:
+flip "Key out background" and Videorc keys a green or blue screen out of
+your camera in real time. It works in **every** camera layout — over the
+screen, side-by-side, the vertical scenes — and putting your keyed camera
+over a background image from Assets gives you a clean virtual set.
+
+Three sliders tune the key while you watch: **Similarity** decides how much
+of the screen color disappears, **Smoothness** softens the edges around
+hair and shoulders, and **Spill removal** clears the green tint that
+lighting bounces onto you. The same key is applied everywhere a frame is
+composed — the preview, the live stream, and the recording all agree — and
+it composes cleanly with the round and rounded camera bubbles.
+
+You'll get the best results from an evenly lit screen behind you; the
+defaults are a solid starting point, and the sliders take it from there.
+
+## Captions wear the style you chose
+
+Live captions burned onto a stream now render in the style selected in the
+Captions tab. Previously every style came out as a black box — the
+no-background Classic style most visibly — because the stream compositor
+ignored the caption art's transparency. If you stream with captions on,
+they now look exactly like the preview.
+
+## Windows fixes
+
+The preview surface now reports itself live correctly, and microphone gain
+and mute changes apply while a session is running.

--- a/docs/releases/0.9.39.md
+++ b/docs/releases/0.9.39.md
@@ -1,0 +1,46 @@
+# Videorc 0.9.39 Beta 1
+
+Videorc 0.9.39 ships the camera green screen (chroma key) and the caption
+style fix — live captions now render in the selected style instead of a
+black box — plus two Windows session fixes.
+
+## Scope
+
+- **Green screen / chroma key** (PR #116, plan: vault `2026-07-13 -
+  Videorc Green Screen Chroma Key Plan`): "Key out background" in the
+  camera Inspector with Green/Blue presets and Similarity / Smoothness /
+  Spill removal sliders, live-appliable mid-session. ONE keyer formula
+  (BT.601 CbCr distance + ramp + dominant-channel despill) consumed by
+  all three render paths — Metal shader (rides the #114 blend pipeline),
+  CPU blit, and the FFmpeg leg (`chromakey`+`despill`, keyed at native
+  camera resolution; geq shape masks now preserve incoming alpha).
+  Pinned by on-device Metal pixel tests, a CPU↔Metal parity fixture,
+  and exact filter-string tests; verified against the bundled LGPL
+  ffmpeg end-to-end.
+- **Caption style fix** (PR #114): the Metal compositor drew every quad
+  with blending disabled, so the caption bar's transparent pixels burned
+  onto the stream as an opaque black box (the Glass plate hid it; the
+  no-background Classic style exposed it). Fixed with a per-quad
+  straight-alpha blend pipeline used only by the caption/comment-highlight
+  overlays; capture sources keep the opaque overwrite. The captions live
+  RTMP artifact gate passed with the fix in.
+- **Windows fixes** (PRs #119, #120): the preview surface reports live
+  correctly, and microphone gain/mute apply during a session.
+
+## Release status
+
+- [x] PRs merged: #114, #116 (admin-merged — GitHub Actions blocked by
+      billing; all local gates green per PR bodies), #119, #120.
+- [x] Signed + notarized build (release/0.9.39-build; notarization Accepted, stapled)
+- [x] Uploaded to R2 + feed serves 0.9.39 (verified via www redirect)
+- [x] Discord announcement (posted 2026-07-14)
+- [ ] Owner acceptance: green-screen by-eye with a real green screen
+      (similarity 40 / smoothness 8 / spill 10 defaults untuned) and a
+      captioned stream spot-check (Classic style renders without a box).
+
+## Known follow-ups
+
+- Vertical multistream (PR #121) is NOT in this release — pending owner
+  staged acceptance on real accounts and the dual-encode perf gate.
+- `smoke:layout-source-loop` still fails on clean main ("No camera
+  device available to select") — pre-existing, tracked via task chip.


### PR DESCRIPTION
Version bump to 0.9.39, changelog entry, and the release record.

Shipped: signed + notarized (Accepted, stapled), uploaded to R2 (all artifacts verified), feed serves 0.9.39 via www redirect, Discord announced.

Contents: green screen / chroma key (#116), caption style fix (#114), Windows preview-live + mic gain/mute fixes (#119, #120).

Owner acceptance pending: green-screen by-eye with a real screen (defaults 40/8/10) and a captioned-stream spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera green screen controls, including background removal and adjustable keying settings.
  * Green screen effects apply consistently to previews, live sessions, recordings, and camera layouts.

* **Bug Fixes**
  * Fixed live captions displaying with incorrect styles or unwanted black backgrounds.
  * Improved Windows preview updates and microphone gain/mute behavior during active sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->