### PR TITLE
fix: restore horizontal preview after vertical mode

### DIFF
--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -200,6 +200,18 @@ pub struct CompositorRuntime {
     stop_tx: Option<watch::Sender<bool>>,
     render_task: Option<JoinHandle<()>>,
     worker_activity: Arc<CompositorWorkerActivity>,
+    /// Writable dimensions for the current preview-only render loop. Recording
+    /// compositors deliberately keep this `None`: their canvas is fixed at
+    /// session start and must never follow a later preview-window resize.
+    preview_render_dimensions: Option<Arc<AtomicU64>>,
+}
+
+fn pack_render_dimensions(width: u32, height: u32) -> u64 {
+    (u64::from(width.max(1)) << 32) | u64::from(height.max(1))
+}
+
+fn unpack_render_dimensions(packed: u64) -> (u32, u32) {
+    (((packed >> 32) as u32).max(1), (packed as u32).max(1))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -258,8 +270,7 @@ pub struct CompositorAuxiliaryOutput {
 struct CompositorRenderLoopParams {
     run_id: String,
     target_fps: u32,
-    width: u32,
-    height: u32,
+    render_dimensions: Arc<AtomicU64>,
     frame_consumer: CompositorFrameConsumer,
     stream_output: Option<CompositorAuxiliaryOutput>,
     caption_overlay_on_primary: bool,
@@ -829,6 +840,7 @@ pub fn initial_compositor_state() -> CompositorRuntime {
         stop_tx: None,
         render_task: None,
         worker_activity: Arc::new(CompositorWorkerActivity::default()),
+        preview_render_dimensions: None,
     }
 }
 
@@ -889,6 +901,14 @@ pub async fn start_synthetic_compositor(
     let stream_frame_store = params
         .stream_output
         .map(|_| Arc::new(StdMutex::new(FrameStore::new(2))));
+    let render_dimensions = Arc::new(AtomicU64::new(pack_render_dimensions(
+        status.width,
+        status.height,
+    )));
+    let preview_render_dimensions = (params.frame_consumer
+        == CompositorFrameConsumer::NativePreview
+        && params.stream_output.is_none())
+    .then(|| render_dimensions.clone());
 
     {
         let mut compositor = state.compositor.lock().await;
@@ -898,6 +918,7 @@ pub async fn start_synthetic_compositor(
         compositor.status = status.clone();
         compositor.run_id = Some(run_id.clone());
         compositor.stop_tx = Some(stop_tx);
+        compositor.preview_render_dimensions = preview_render_dimensions;
         // Spawn and publish the worker handle while holding the ownership lock. A concurrent
         // replacement can therefore never observe a live run id without the handle it must
         // await, avoiding the ineffective `abort` race of `spawn_blocking` workers.
@@ -906,8 +927,7 @@ pub async fn start_synthetic_compositor(
             CompositorRenderLoopParams {
                 run_id: run_id.clone(),
                 target_fps,
-                width: status.width,
-                height: status.height,
+                render_dimensions,
                 frame_consumer: params.frame_consumer,
                 stream_output: params.stream_output,
                 caption_overlay_on_primary: params.caption_overlay_on_primary,
@@ -924,16 +944,28 @@ pub async fn start_synthetic_compositor(
     status
 }
 
-pub async fn update_compositor_surface_size(
+pub async fn resize_preview_compositor_if_run_id(
     state: &AppState,
+    expected_run_id: &str,
     width: u32,
     height: u32,
-) -> CompositorStatus {
+) -> Option<CompositorStatus> {
     let status = {
         let mut compositor = state.compositor.lock().await;
+        if compositor.run_id.as_deref() != Some(expected_run_id) {
+            return None;
+        }
+        let dimensions = compositor.preview_render_dimensions.clone()?;
         compositor.status.width = width.max(1);
         compositor.status.height = height.max(1);
         compositor.status.updated_at = Utc::now().to_rfc3339();
+        // One packed atomic keeps width/height coherent without tying the hot
+        // render loop to the compositor mutex. Relaxed ordering is sufficient:
+        // no other state is published through this value.
+        dimensions.store(
+            pack_render_dimensions(compositor.status.width, compositor.status.height),
+            Ordering::Relaxed,
+        );
         compositor.status.clone()
     };
     state.emit_event("compositor.status", status.clone());
@@ -947,7 +979,7 @@ pub async fn update_compositor_surface_size(
         "diagnostics.stats",
         apply_runtime_diagnostics_snapshot(diagnostic_stats, state.ffmpeg_work.snapshot()),
     );
-    status
+    Some(status)
 }
 
 #[cfg(test)]
@@ -989,6 +1021,7 @@ pub async fn stop_compositor_if_run_id(state: &AppState, run_id: &str) -> Option
         let mut compositor = state.compositor.lock().await;
         if compositor.run_id.as_deref() == Some(run_id) {
             compositor.run_id = None;
+            compositor.preview_render_dimensions = None;
         }
         compositor.latest_frame_evidence = None;
         compositor.stream_frame_store = None;
@@ -1503,6 +1536,7 @@ async fn stop_current_compositor(state: &AppState) -> bool {
     }
     let mut compositor = state.compositor.lock().await;
     compositor.run_id = None;
+    compositor.preview_render_dimensions = None;
     compositor.latest_frame_evidence = None;
     compositor.stream_frame_store = None;
     true
@@ -1571,8 +1605,7 @@ async fn run_synthetic_compositor_loop(
     let CompositorRenderLoopParams {
         run_id,
         target_fps,
-        width,
-        height,
+        render_dimensions,
         frame_consumer,
         stream_output,
         caption_overlay_on_primary,
@@ -1657,6 +1690,12 @@ async fn run_synthetic_compositor_loop(
                 let render_started_at = Instant::now();
                 frames_rendered = frames_rendered.saturating_add(1);
                 frames_in_window = frames_in_window.saturating_add(1);
+                // Preview bounds can change without restarting the compositor
+                // (including portrait <-> landscape). Re-read every tick so
+                // the next published frame and Metal target adopt the new
+                // canvas instead of retaining the loop's startup dimensions.
+                let (width, height) =
+                    unpack_render_dimensions(render_dimensions.load(Ordering::Relaxed));
                 let published =
                     publish_compositor_frame(
                         &state,

--- a/crates/videorc-backend/src/preview_surface.rs
+++ b/crates/videorc-backend/src/preview_surface.rs
@@ -1,6 +1,6 @@
 use crate::compositor::{
-    CompositorFrameConsumer, CompositorStartParams, start_synthetic_compositor,
-    stop_compositor_if_run_id, update_compositor_surface_size,
+    CompositorFrameConsumer, CompositorStartParams, resize_preview_compositor_if_run_id,
+    start_synthetic_compositor, stop_compositor_if_run_id,
 };
 use crate::diagnostics::{apply_preview_surface_resize, apply_runtime_diagnostics_snapshot};
 use crate::native_preview_host::{
@@ -155,7 +155,7 @@ async fn try_reuse_live_surface(
         return None;
     }
 
-    let status = {
+    let (status, preview_run_id) = {
         let mut slot = state.preview_surface.lock().await;
         if slot.status.state != PreviewSurfaceState::Live {
             return None;
@@ -182,12 +182,13 @@ async fn try_reuse_live_surface(
             slot.run_id = None;
         }
         slot.status = next.clone();
-        next
+        (next, slot.run_id.clone())
     };
 
     register_preview_surface_resize(state).await;
-    if !capture_owns_compositor(state) && preview_surface_owns_current_compositor(state).await {
-        update_compositor_surface_size(state, status.width, status.height).await;
+    if let Some(run_id) = preview_run_id {
+        let _ =
+            resize_preview_compositor_if_run_id(state, &run_id, status.width, status.height).await;
     }
     state.emit_event("preview.surface.status", status.clone());
     Some(status)
@@ -198,7 +199,7 @@ pub async fn update_preview_surface_bounds(
     params: PreviewSurfaceBoundsParams,
 ) -> PreviewSurfaceStatus {
     let _lifecycle = state.preview_surface_lifecycle.lock().await;
-    let status = {
+    let (status, preview_run_id) = {
         let mut slot = state.preview_surface.lock().await;
         let mut next = slot.status.clone();
         next.width = surface_dimension(params.bounds.width);
@@ -220,12 +221,13 @@ pub async fn update_preview_surface_bounds(
         }
         next.pending_host_command_count = pending_host_command_count(&slot);
         slot.status = next.clone();
-        next
+        (next, slot.run_id.clone())
     };
 
     register_preview_surface_resize(state).await;
-    if !capture_owns_compositor(state) && preview_surface_owns_current_compositor(state).await {
-        update_compositor_surface_size(state, status.width, status.height).await;
+    if let Some(run_id) = preview_run_id {
+        let _ =
+            resize_preview_compositor_if_run_id(state, &run_id, status.width, status.height).await;
     }
     state.emit_event("preview.surface.status", status.clone());
     status
@@ -575,7 +577,10 @@ fn unavailable_status(message: Option<String>) -> PreviewSurfaceStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compositor::{compositor_latest_frame_evidence, compositor_status, stop_compositor};
+    use crate::compositor::{
+        CompositorFrameEvidence, compositor_latest_frame_evidence, compositor_status,
+        stop_compositor,
+    };
     use crate::native_preview_host::{NativePreviewHostActivation, NativePreviewHostCommandKind};
     use crate::protocol::{CompositorState, PreviewSurfaceBounds};
     use crate::storage::Database;
@@ -902,20 +907,27 @@ mod tests {
         assert_eq!(status.height, 360);
     }
 
-    async fn wait_for_frame_dimensions(state: &AppState, width: u32, height: u32) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    async fn wait_for_frame_dimensions_after(
+        state: &AppState,
+        width: u32,
+        height: u32,
+        after_sequence: Option<u64>,
+    ) -> Result<CompositorFrameEvidence, String> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
-            if let Some(evidence) = compositor_latest_frame_evidence(state).await
+            let latest = compositor_latest_frame_evidence(state).await;
+            if let Some(evidence) = latest
                 && evidence.width == width
                 && evidence.height == height
+                && after_sequence.is_none_or(|sequence| evidence.sequence > sequence)
             {
-                return;
+                return Ok(evidence);
             }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "compositor never published a {width}x{height} frame (latest: {:?})",
-                compositor_latest_frame_evidence(state).await
-            );
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "compositor never published a {width}x{height} frame after sequence {after_sequence:?} (latest: {latest:?})"
+                ));
+            }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
     }
@@ -931,28 +943,53 @@ mod tests {
         create_preview_surface(
             state.clone(),
             PreviewSurfaceCreateParams {
-                bounds: bounds(960.0, 540.0),
+                bounds: bounds(160.0, 90.0),
                 target_fps: 60,
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
         .await;
-        wait_for_frame_dimensions(&state, 960, 540).await;
+        let verification = async {
+            let initial = wait_for_frame_dimensions_after(&state, 160, 90, None).await?;
+            let initial_status = compositor_status(&state).await;
 
-        update_preview_surface_bounds(
-            &state,
-            PreviewSurfaceBoundsParams {
-                bounds: bounds(540.0, 960.0),
-            },
-        )
+            update_preview_surface_bounds(
+                &state,
+                PreviewSurfaceBoundsParams {
+                    bounds: bounds(90.0, 160.0),
+                },
+            )
+            .await;
+            let portrait =
+                wait_for_frame_dimensions_after(&state, 90, 160, Some(initial.sequence)).await?;
+
+            // The owner's 2026-07-14 regression was this reverse direction:
+            // horizontal mode returned while the compositor kept publishing
+            // the previous portrait canvas inside the landscape preview.
+            update_preview_surface_bounds(
+                &state,
+                PreviewSurfaceBoundsParams {
+                    bounds: bounds(160.0, 90.0),
+                },
+            )
+            .await;
+            let landscape =
+                wait_for_frame_dimensions_after(&state, 160, 90, Some(portrait.sequence)).await?;
+            let final_status = compositor_status(&state).await;
+            Ok::<_, String>((initial_status, portrait, landscape, final_status))
+        }
         .await;
-
-        wait_for_frame_dimensions(&state, 540, 960).await;
-        let status = compositor_status(&state).await;
         destroy_preview_surface(&state).await;
 
-        assert_eq!(status.width, 540);
-        assert_eq!(status.height, 960);
+        let (initial_status, portrait, landscape, final_status) =
+            verification.expect("preview compositor should follow both orientation changes");
+        assert_eq!(portrait.width, 90);
+        assert_eq!(portrait.height, 160);
+        assert_eq!(landscape.width, 160);
+        assert_eq!(landscape.height, 90);
+        assert_eq!(final_status.run_id, initial_status.run_id);
+        assert_eq!(final_status.width, 160);
+        assert_eq!(final_status.height, 90);
     }
 
     #[tokio::test]
@@ -961,19 +998,26 @@ mod tests {
         create_preview_surface(
             state.clone(),
             PreviewSurfaceCreateParams {
-                bounds: bounds(960.0, 540.0),
+                bounds: bounds(160.0, 90.0),
                 target_fps: 60,
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
         .await;
+        wait_for_frame_dimensions_after(&state, 160, 90, None)
+            .await
+            .expect("preview compositor should publish before ownership changes");
+        let preview_run_id = compositor_status(&state)
+            .await
+            .run_id
+            .expect("preview compositor run id");
 
         let recording_status = start_synthetic_compositor(
             state.clone(),
             CompositorStartParams {
                 target_fps: 30,
-                width: 640,
-                height: 360,
+                width: 160,
+                height: 90,
                 frame_consumer: CompositorFrameConsumer::RawYuvEncoder,
                 stream_output: None,
                 caption_overlay_on_primary: false,
@@ -987,16 +1031,34 @@ mod tests {
         update_preview_surface_bounds(
             &state,
             PreviewSurfaceBoundsParams {
-                bounds: bounds(1280.0, 720.0),
+                bounds: bounds(90.0, 160.0),
             },
+        )
+        .await;
+        let stale_run_resize =
+            resize_preview_compositor_if_run_id(&state, &preview_run_id, 90, 160).await;
+        let recording_run_resize = resize_preview_compositor_if_run_id(
+            &state,
+            recording_status
+                .run_id
+                .as_deref()
+                .expect("recording run id"),
+            90,
+            160,
         )
         .await;
         let status = compositor_status(&state).await;
         stop_compositor(&state).await;
 
+        assert_ne!(
+            recording_status.run_id.as_deref(),
+            Some(preview_run_id.as_str())
+        );
+        assert!(stale_run_resize.is_none());
+        assert!(recording_run_resize.is_none());
         assert_eq!(status.run_id, recording_status.run_id);
-        assert_eq!(status.width, 640);
-        assert_eq!(status.height, 360);
+        assert_eq!(status.width, 160);
+        assert_eq!(status.height, 90);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keep the preview-only compositor canvas synchronized with live surface bounds, including portrait-to-landscape changes
- fence resize writes to the preview-owned compositor run so stale preview state cannot reshape recording or split-output canvases
- cover landscape -> portrait -> landscape frame publication and recording ownership isolation with Rust regressions

## Root cause

Surface bounds and compositor status changed when orientation changed, but the render loop kept the immutable width and height captured when it started. The horizontal native surface therefore continued receiving portrait frames until the compositor was rebuilt.

## Validation

- `cargo test -p videorc-backend` (53 native helper + 1,284 backend tests passed; 8 ignored)
- `cargo clippy -p videorc-backend -- -D warnings`
- `cargo fmt --check --all`
- `pnpm smoke:layout-source-loop` (native Metal 2560x1440 -> 1080x1920 -> 2560x1440 round trip passed)
- `pnpm smoke:preview-scene-commit`
- `pnpm smoke:preview-pump-diagnostics`
- `pnpm smoke:preview-click-focus`
- `pnpm smoke:preview-interaction-stress`
- `pnpm probe:preview-window`
- strict `pnpm smoke:preview-surface` (about 60 fps, 20 ms p95, 110 ms reattach)
- recording-studio stages through all-layout artifact recording, imported-screen recording, real-launch first frame, native layout round trip, and active-session recording/stream switching
- `pnpm --filter @videorc/desktop test` (1,063 passed; 1 skipped)
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`

## Existing gate blockers

- `pnpm smoke:recording-studio` stops later at the split-output comment-highlight artifact check (0 highlight frames). The identical failure reproduces on clean `origin/main`; stream-only passes.
- `pnpm probe:preview-lifecycle` loses the harness main-window-ready signal after repeated close/reopen cycles. The identical fully-closed-state failure reproduces on clean `origin/main`.
- `pnpm smoke:screen-recording-real` selects the permitted 3024x1964 ScreenCaptureKit display, then the unchanged harness calls `preview.surface.create` with renderer authority and is rejected before recording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview dimensions now update immediately when the preview is resized or its orientation changes.
  * Preview resizing is safely tied to the active compositor run, preventing stale updates.

* **Bug Fixes**
  * Improved preview behavior when recording starts or compositor runs change.
  * Ensured preview rendering targets stay synchronized with the current dimensions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->