### PR TITLE
Release 0.9.40-beta.1: preview orientation sync (bump, changelog, record)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.40-beta.1.md
+++ b/changelog/0.9.40-beta.1.md
@@ -1,0 +1,21 @@
+---
+version: 0.9.40-beta.1
+date: 2026-07-14
+channel: beta
+title: The preview follows every orientation switch
+summary: Switching back to horizontal after using vertical mode no longer leaves the preview stuck in the old shape — the preview window now follows every orientation and size change immediately, while recordings keep their fixed canvas.
+highlights:
+  - The preview now reshapes instantly on every orientation switch — including switching back to horizontal after vertical mode, which could previously leave it stuck in the old shape.
+  - Recording and streaming canvases stay locked at their session size — only the idle preview follows window and orientation changes.
+---
+
+## The preview follows you — both ways
+
+0.9.38 made the preview flip when you switched the Studio to vertical.
+This release fixes the return trip: switching back to horizontal (or any
+later orientation or preview-window size change) now reshapes the preview
+immediately instead of leaving it stuck in the previous shape.
+
+Under the hood, only the idle preview follows these live changes — a
+running recording or stream keeps the exact canvas it started with, so a
+window resize mid-session can never touch your output.

--- a/docs/releases/0.9.40.md
+++ b/docs/releases/0.9.40.md
@@ -1,0 +1,32 @@
+# Videorc 0.9.40 Beta 1
+
+Videorc 0.9.40 ships one fix: the native preview now follows every
+orientation switch — including returning to horizontal after vertical
+mode, which previously left the preview stuck in the old shape.
+
+## Scope
+
+- **Preview orientation sync** (PR #123): preview-only compositor render
+  loops re-read their dimensions from a live cell every frame, and
+  surface resize writes are fenced to the preview-owned run ID — so the
+  idle preview follows orientation and window-size changes immediately,
+  while recording/streaming compositors keep the canvas fixed at session
+  start (a mid-session resize can never touch the output).
+
+## Verification
+
+- Touched-area suites (`compositor::`, `preview_surface::`): 131 tests
+  green across four consecutive runs.
+- `pnpm probe:preview-lifecycle` fails on this machine with "Main window
+  is not ready for preview motion smoke" — **identically on the 0.9.39
+  baseline commit without #123** (verified by detached-HEAD run), so the
+  failure is a pre-existing probe/environment issue, not this fix.
+
+## Release status
+
+- [x] Signed + notarized build (release/0.9.40-build; notarization Accepted, stapled)
+- [x] Uploaded to R2 + feed serves 0.9.40 (verified via www redirect)
+- [x] Discord announcement (posted 2026-07-14)
+- [ ] Owner acceptance: switch vertical → horizontal off-air and confirm
+      the preview reshapes; resize the preview window mid-recording and
+      confirm the recording canvas is untouched.


### PR DESCRIPTION
Version bump to 0.9.40, changelog entry, and the release record.

Shipped: signed + notarized (Accepted, stapled), uploaded to R2 (all artifacts verified), feed serves 0.9.40 via www redirect, Discord announced.

Contents: preview orientation sync fix (#123) — the idle preview follows every orientation/size change while recording canvases stay fixed.

Verification: compositor + preview_surface suites 131 green ×4 runs; preview-lifecycle probe fails identically on the 0.9.39 baseline without #123 (pre-existing environment issue, documented in the record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed idle previews not updating correctly after switching orientations, including returning from vertical to horizontal.
  * Recording and streaming canvases now retain their session dimensions during window resizing.

* **Release**
  * Released version 0.9.40 Beta 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->