### PR TITLE
Release 0.9.41-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.41-beta.1.md
+++ b/changelog/0.9.41-beta.1.md
@@ -1,0 +1,34 @@
+---
+version: 0.9.41-beta.1
+date: 2026-07-14
+channel: beta
+title: Recording stays out of your streaming setup — plus Windows mic and reliability fixes
+summary: Starting a plain recording no longer touches your streaming destinations at all — no platform checks, no chat setup — unless you actually go live. Deleting sessions is handled more reliably, and Windows gets a batch of live-microphone and recording fixes.
+highlights:
+  - Starting a local recording no longer runs any streaming setup — no destination validation, no live-chat attachment — unless you explicitly go live.
+  - The microphone you had selected at the start of a session is preserved exactly, so an untouched mic no longer sends a redundant mid-session change.
+  - Deleting recordings is handled more reliably in the Library.
+  - "Windows: live microphone gain and mute now apply correctly while recording and streaming."
+  - Windows: recording captures your device's native audio format and normalizes cleanly to 48 kHz stereo.
+---
+
+## Recording and streaming, cleanly separated
+
+Hitting Record is a local action — it shouldn't care about your Twitch, X, or
+YouTube setup. Now it truly doesn't: starting a plain recording runs no
+destination validation, no platform activation, and no live-chat attachment
+unless streaming is explicitly turned on. Going live still does all of that,
+loudly, where it belongs.
+
+That also means the microphone you picked before starting is sent exactly as
+it was — an untouched mic no longer triggers a redundant live-audio change
+partway through the session.
+
+## Windows: microphone and recording fixes
+
+A batch of Windows-specific reliability work: live microphone **gain and
+mute** now apply correctly both while recording and while streaming, capture
+lets the physical device negotiate its native input shape and then normalizes
+to a clean 48 kHz stereo track, and stopping a session reports its end
+without a spurious microphone warning. Deleting sessions with a pending
+cleanup is handled correctly across the board.


### PR DESCRIPTION
Version 0.9.40 → 0.9.41 and the changelog for #127 — record/stream isolation (cross-platform), preserved mic snapshot, pending-deletion contract fix, and the Windows live-audio + recording regression batch. `pnpm changelog:check` valid (42 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recording sessions now remain separate from streaming unless streaming is explicitly enabled.
  - The initially selected microphone remains unchanged throughout a session.
  - Improved Windows audio capture, including consistent 48 kHz stereo output and better microphone gain and mute behavior.

- **Bug Fixes**
  - Improved reliability when deleting Library items during pending cleanup.
  - Removed misleading microphone warnings when stopping sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->