### PR TITLE
Record the 0.9.41 release (record/stream isolation + Windows audio batch)

### DIFF
--- a/docs/releases/0.9.41.md
+++ b/docs/releases/0.9.41.md
@@ -1,0 +1,56 @@
+# Videorc 0.9.41 Beta 1
+
+Videorc 0.9.41 ships PR #127: record-start isolated from streaming
+destinations (cross-platform), a preserved microphone snapshot, a
+pending-deletion contract fix, and the Windows live-audio + recording
+regression batch.
+
+## Scope
+
+- **Record/stream isolation** (cross-platform): starting a local
+  recording runs no destination validation, platform activation, or
+  live-chat attachment unless streaming is explicitly enabled —
+  extending the record-only chat gate from #111.
+- **Preserved mic snapshot**: the microphone sent at session start is
+  kept exact, so an untouched capture emits no redundant mid-session
+  live-audio mutation.
+- **Pending-deletion contract**: the strict renderer contract for
+  non-empty `sessions.delete.pending` handles is aligned while keeping
+  private filesystem paths out of renderer state.
+- **Windows live audio + recording**: DirectShow negotiates the device's
+  native input shape then normalizes to 48 kHz stereo with the named
+  live-volume filter; the live-audio lane is readiness/dispatch/ack/stop/
+  terminal-aware; capture termination reports `session-ended` without a
+  secondary mic warning. Adds a packaged, renderer-driven physical
+  Windows acceptance gate (gain/mute/latest-wins/stop-race) with honest
+  `BLOCKED` propagation.
+
+## Release status
+
+- [x] PR merged: #127; prep #128 (admin-merged — GitHub Actions blocked
+      by billing; all local gates green per PR #127's verification
+      matrix, full Rust suite skipped per owner directive).
+- [x] Signed + notarized arm64 build; staple verified by
+      release:validate:macos. (Note: release-profile build still warns
+      `is_ffmpeg_error_line` dead code — non-fatal, cleanup candidate,
+      carried since 0.9.38.)
+- [x] Uploaded to R2; feed verified end-to-end
+      (`https://www.videorc.com/api/updates/latest-mac.yml` →
+      `version: 0.9.41`, artifact hashes present); `/api/changelog`
+      serves 0.9.41-beta.1.
+- [x] Discord announcement posted.
+- [ ] Owner acceptance (macOS): start a plain recording with stream
+      destinations configured — confirm no chat/validation runs; go live
+      and confirm it still does. Delete a recording and confirm the
+      Library stays consistent.
+- [ ] Windows device acceptance: run `pnpm smoke:local-gates:windows` on
+      the tester's Windows box with the packaged app and a physical
+      DirectShow mic (the physical row reports `BLOCKED` on darwin — not
+      yet accepted on real hardware).
+- [ ] Owner: X post (draft provided in session; posted manually).
+
+## Rollback
+
+Standard: re-upload 0.9.40's artifacts/manifest per
+`docs/releases/release-runbook.md`; the feed is version-compared, so
+restoring the older manifest reverts updates.


### PR DESCRIPTION
Internal release record for 0.9.41-beta.1 (#127): record/stream isolation + preserved mic + pending-deletion contract + Windows live-audio batch. Build/upload/feed/announce verified; owner + Windows-device acceptance checklist inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)