### PR TITLE
Fix macOS camera permission registration on first use

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -132,7 +132,11 @@ import {
   buildRuntimeInfo,
   permissionUrlForPane
 } from './runtime-info'
-import { requestMediaAccessWithRestart, type MediaAccessResult } from './media-access'
+import {
+  requestMediaAccessWithRestart,
+  type MediaAccessRestartResult,
+  type MediaAccessResult
+} from './media-access'
 import {
   clearGpuFallbackState,
   decideGpuFallback,
@@ -9770,8 +9774,9 @@ async function openSystemPermissions(pane: SystemPermissionPane = 'privacy'): Pr
   }
 }
 
-// Permissions onboarding: fire the native macOS grant prompt without also
-// jumping to System Settings (openSystemPermissions does both). Restart logic
+// Fire the native macOS grant prompt without jumping to System Settings.
+// openSystemPermissions remains navigation-only; renderer policy selects the
+// correct user-initiated path from the exact TCC status. Restart logic
 // lives in media-access.ts (FX1: an already-granted pane must NOT restart the
 // backend — that restart raced the renderer's follow-up meter sample).
 async function requestMediaAccessNative(pane: 'camera' | 'microphone'): Promise<MediaAccessResult> {
@@ -9858,11 +9863,22 @@ function retainDeferredPermissionRestart(reason: string): void {
   deferredPermissionRestartState = deferred.state
 }
 
-async function runPermissionBackendRestart(reason: string): Promise<boolean> {
+function currentBackendRestartBoundary(): MediaAccessRestartResult['staleBackend'] {
+  const connection = backendConnection
+  return connection
+    ? { port: connection.port, ...(connection.pid === undefined ? {} : { pid: connection.pid }) }
+    : undefined
+}
+
+async function runPermissionBackendRestart(reason: string): Promise<MediaAccessRestartResult> {
+  let staleBackend = currentBackendRestartBoundary()
   try {
     const restarted = await runBackendInterruptingAction(
       () => acquireCurrentBackendInterruption(reason),
-      () => restartBackend(reason)
+      () => {
+        staleBackend = currentBackendRestartBoundary()
+        return restartBackend(reason)
+      }
     )
     if (!restarted) {
       retainDeferredPermissionRestart(reason)
@@ -9871,7 +9887,10 @@ async function runPermissionBackendRestart(reason: string): Promise<boolean> {
         'Permission restart deferred because capture became active, started, or could not be confirmed idle.'
       )
     }
-    return restarted
+    return {
+      restarted,
+      ...(staleBackend ? { staleBackend } : {})
+    }
   } catch (error) {
     retainDeferredPermissionRestart(reason)
     throw error
@@ -9890,7 +9909,7 @@ function updateMainCaptureState(payload: unknown): void {
   }
 }
 
-async function requestPermissionBackendRestart(reason: string): Promise<boolean> {
+async function requestPermissionBackendRestart(reason: string): Promise<MediaAccessRestartResult> {
   const decision = requestPermissionRestart(
     deferredPermissionRestartState,
     mainCaptureState,
@@ -9899,7 +9918,11 @@ async function requestPermissionBackendRestart(reason: string): Promise<boolean>
   deferredPermissionRestartState = decision.state
   if (!decision.runReason) {
     logBackend('info', 'Permission restart deferred until the active capture is idle.')
-    return false
+    const staleBackend = currentBackendRestartBoundary()
+    return {
+      restarted: false,
+      ...(staleBackend ? { staleBackend } : {})
+    }
   }
   return runPermissionBackendRestart(decision.runReason)
 }

--- a/apps/desktop/src/main/media-access.test.ts
+++ b/apps/desktop/src/main/media-access.test.ts
@@ -6,7 +6,7 @@ function deps(overrides: Partial<MediaAccessDeps> = {}): MediaAccessDeps {
   return {
     getStatus: vi.fn(() => 'not-determined'),
     askForAccess: vi.fn(async () => true),
-    restartBackend: vi.fn(async () => undefined),
+    restartBackend: vi.fn(async () => ({ restarted: true })),
     stopGrantWatcher: vi.fn(),
     log: vi.fn(),
     ...overrides
@@ -25,21 +25,33 @@ describe('requestMediaAccessWithRestart', () => {
   })
 
   it('not-determined → user grants → watcher stopped + backend restarted', async () => {
-    const d = deps()
+    const d = deps({
+      restartBackend: vi.fn(async () => ({
+        restarted: true,
+        staleBackend: { pid: 42, port: 9988 }
+      }))
+    })
     await expect(requestMediaAccessWithRestart(d, 'camera')).resolves.toEqual({
       granted: true,
-      restarted: true
+      restarted: true,
+      staleBackend: { pid: 42, port: 9988 }
     })
     expect(d.stopGrantWatcher).toHaveBeenCalledOnce()
     expect(d.restartBackend).toHaveBeenCalledOnce()
   })
 
   it('reports a granted permission without claiming a deferred restart already ran', async () => {
-    const d = deps({ restartBackend: vi.fn(async () => false) })
+    const d = deps({
+      restartBackend: vi.fn(async () => ({
+        restarted: false,
+        staleBackend: { pid: 43, port: 9989 }
+      }))
+    })
 
     await expect(requestMediaAccessWithRestart(d, 'camera')).resolves.toEqual({
       granted: true,
-      restarted: false
+      restarted: false,
+      staleBackend: { pid: 43, port: 9989 }
     })
   })
 

--- a/apps/desktop/src/main/media-access.ts
+++ b/apps/desktop/src/main/media-access.ts
@@ -1,18 +1,20 @@
+import type { BackendRestartBoundary, MediaAccessResult } from '../shared/backend'
+
 export type MediaAccessPane = 'camera' | 'microphone'
 
-export interface MediaAccessResult {
-  granted: boolean
-  /** True when the grant transitioned and the capture backend was restarted.
-   * Callers that probe a device right after (the mic meter sample) must wait
-   * for the backend to reconnect first — sampling mid-restart is the FX1 race
-   * that left the permissions-dialog chip stuck on "Checked on first use". */
+export type MediaAccessRestartResult = {
+  /** True when the grant transitioned and the capture backend was restarted. */
   restarted: boolean
+  /** The process whose capture state predates the grant, without its renderer token. */
+  staleBackend?: BackendRestartBoundary
 }
+
+export type { MediaAccessResult }
 
 export interface MediaAccessDeps {
   getStatus: (pane: MediaAccessPane) => string
   askForAccess: (pane: MediaAccessPane) => Promise<boolean>
-  restartBackend: (reason: string) => Promise<boolean | void>
+  restartBackend: (reason: string) => Promise<MediaAccessRestartResult>
   stopGrantWatcher: () => void
   log: (level: 'info' | 'warn', message: string) => void
 }
@@ -53,9 +55,8 @@ export async function requestMediaAccessWithRestart(
   }
 
   deps.stopGrantWatcher()
-  const restarted =
-    (await deps.restartBackend(
-      `Restarting capture backend after ${pane} permission became available.`
-    )) !== false
-  return { granted: true, restarted }
+  const restart = await deps.restartBackend(
+    `Restarting capture backend after ${pane} permission became available.`
+  )
+  return { granted: true, ...restart }
 }

--- a/apps/desktop/src/renderer/src/backendClient.ts
+++ b/apps/desktop/src/renderer/src/backendClient.ts
@@ -78,7 +78,7 @@ export class BackendClient {
   private handlers = new Map<string, Set<EventHandler>>()
   private requestCounter = 0
 
-  constructor(private readonly connection: BackendConnection) {}
+  constructor(readonly connection: BackendConnection) {}
 
   get pendingRequestCount(): number {
     return this.pending.size

--- a/apps/desktop/src/renderer/src/components/app-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/app-shell.tsx
@@ -3,7 +3,6 @@ import { lazy, Suspense, useCallback, useEffect, useRef, useState, type ReactEle
 
 import { CommandPalette } from '@/components/command-palette'
 import { FooterActionBar, FooterActionDivider } from '@/components/footer-action-bar'
-import { PermissionsOnboardingDialog } from '@/components/permissions-onboarding-dialog'
 import { Sidebar } from '@/components/sidebar'
 import { Button } from '@/components/ui/button'
 import { Kbd, KbdGroup } from '@/components/ui/kbd'
@@ -25,7 +24,11 @@ import { useWhatsNew } from '@/hooks/use-whats-new'
 import { ONBOARDING_DISMISSED_VALUE, STORAGE_KEYS } from '@/lib/capture'
 import { displayKeyGlyph } from '@/lib/platform'
 import { isActiveRecordingState } from '@/lib/format'
-import { shouldShowPermissionsOnboarding, systemAccessRows } from '@/lib/system-access'
+import {
+  isMediaAccessSnapshotReady,
+  shouldShowPermissionsOnboarding,
+  systemAccessRows
+} from '@/lib/system-access'
 import { cn } from '@/lib/utils'
 
 // Studio is the launch surface and stays eager. Every other workspace is loaded
@@ -56,6 +59,9 @@ const SourcesTab = lazy(async () => ({ default: (await loadSourcesTab()).Sources
 const StreamingTab = lazy(async () => ({
   default: (await import('@/components/tabs/streaming-tab')).StreamingTab
 }))
+const PermissionsOnboardingDialog = lazy(async () => ({
+  default: (await import('@/components/permissions-onboarding-dialog')).PermissionsOnboardingDialog
+}))
 
 function WorkspaceTabFallback(): ReactElement {
   return (
@@ -81,10 +87,16 @@ function PermissionsOnboardingGate({
   const { wsStatus, deviceList, mediaAccess, runtimeInfo } = useStudioCore()
   const { audioMeter } = useStudioAudio()
   const evaluatedRef = useRef(false)
+  const dialogMountedRef = useRef(open)
   const backendReady = wsStatus === 'connected' && deviceList.devices.length > 0
+  const mediaAccessReady = runtimeInfo !== null && isMediaAccessSnapshotReady(mediaAccess)
+
+  if (open) {
+    dialogMountedRef.current = true
+  }
 
   useEffect(() => {
-    if (evaluatedRef.current || !backendReady) {
+    if (evaluatedRef.current || !backendReady || !mediaAccessReady) {
       return
     }
     evaluatedRef.current = true
@@ -95,12 +107,26 @@ function PermissionsOnboardingGate({
       platform: runtimeInfo?.platform,
       mediaAccess
     })
-    if (shouldShowPermissionsOnboarding({ rows, dismissed, backendReady })) {
+    if (shouldShowPermissionsOnboarding({ rows, dismissed, backendReady, mediaAccessReady })) {
       onOpen()
     }
-  }, [audioMeter, backendReady, deviceList, mediaAccess, onOpen, runtimeInfo?.platform])
+  }, [
+    audioMeter,
+    backendReady,
+    deviceList,
+    mediaAccess,
+    mediaAccessReady,
+    onOpen,
+    runtimeInfo?.platform
+  ])
 
-  return <PermissionsOnboardingDialog open={open} onComplete={onComplete} />
+  return (
+    <Suspense fallback={null}>
+      {dialogMountedRef.current ? (
+        <PermissionsOnboardingDialog open={open} onComplete={onComplete} />
+      ) : null}
+    </Suspense>
+  )
 }
 
 export function AppShell(): ReactElement {

--- a/apps/desktop/src/renderer/src/components/permissions-onboarding-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/permissions-onboarding-dialog.tsx
@@ -1,5 +1,5 @@
 import { ArrowRight, CircleNotch } from '@phosphor-icons/react'
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useEffect, useState, type ReactElement } from 'react'
 
 import logoUrl from '@/assets/videorc-logo.png'
 import { StatusBadge } from '@/components/status-badge'
@@ -14,7 +14,12 @@ import {
 } from '@/components/ui/dialog'
 import { useStudioAudio, useStudioCore } from '@/hooks/use-studio'
 import { isWindowsPlatform, osSettingsName } from '@/lib/platform'
-import { systemAccessRows, type SystemAccessRow } from '@/lib/system-access'
+import {
+  systemAccessAction,
+  systemAccessRows,
+  type SystemAccessAction,
+  type SystemAccessRow
+} from '@/lib/system-access'
 
 // Permissions-only onboarding: the ONE thing a fresh install needs is macOS
 // grants, so this is the whole flow — three rows sharing the exact state
@@ -28,27 +33,10 @@ export function PermissionsOnboardingDialog({
   open: boolean
   onComplete: () => void
 }): ReactElement {
-  const {
-    deviceList,
-    wsStatus,
-    refreshBackend,
-    openSystemPermission,
-    sampleAudioMeter,
-    canSampleAudio,
-    runtimeInfo,
-    mediaAccess
-  } = useStudioCore()
+  const { deviceList, refreshBackend, handleSystemPermission, runtimeInfo, mediaAccess } =
+    useStudioCore()
   const { audioMeter } = useStudioAudio()
-  const [pending, setPending] = useState<'camera' | 'microphone' | null>(null)
-
-  // enableMedia awaits across renders (backend restart → reconnect), so it
-  // reads live state through refs — closure values would be stale by then.
-  const wsStatusRef = useRef(wsStatus)
-  const canSampleAudioRef = useRef(canSampleAudio)
-  useEffect(() => {
-    wsStatusRef.current = wsStatus
-    canSampleAudioRef.current = canSampleAudio
-  }, [canSampleAudio, wsStatus])
+  const [pending, setPending] = useState<SystemAccessRow['id'] | null>(null)
 
   // Grants flip in System Settings or the native prompt while we may be
   // backgrounded — re-enumerate on focus so the chips stay honest (same
@@ -68,32 +56,17 @@ export function PermissionsOnboardingDialog({
     platform: runtimeInfo?.platform,
     mediaAccess
   })
-  const allGranted = rows.every((row) => row.state === 'granted')
+  const allPermissionsResolved = rows.every(
+    (row) => row.state === 'granted' || row.state === 'device-issue'
+  )
   const isWindows = isWindowsPlatform(runtimeInfo?.platform)
   const deviceNoun = isWindows ? 'PC' : 'Mac'
   const settingsName = osSettingsName(runtimeInfo?.platform)
 
-  // Camera/microphone support a native in-place prompt on first use. The mic
-  // chip derives from the audio-meter probe, so a fresh grant is proven by
-  // sampling — user-initiated here, never run by the gate itself. When the
-  // grant transitioned, main restarted the backend: wait for the reconnect
-  // before sampling (FX1 — sampling mid-restart left the chip stuck).
-  const enableMedia = async (pane: 'camera' | 'microphone'): Promise<void> => {
+  const runPermissionAction = async (pane: SystemAccessRow['id']): Promise<void> => {
     setPending(pane)
     try {
-      const result = await window.videorc?.requestMediaAccess?.(pane)
-      if (result?.granted) {
-        if (result.restarted) {
-          await waitFor(() => wsStatusRef.current === 'connected')
-        }
-        if (pane === 'microphone') {
-          await waitFor(() => canSampleAudioRef.current)
-          if (canSampleAudioRef.current) {
-            await sampleAudioMeter()
-          }
-        }
-      }
-      await refreshBackend()
+      await handleSystemPermission(pane)
     } finally {
       setPending(null)
     }
@@ -120,11 +93,16 @@ export function PermissionsOnboardingDialog({
           {rows.map((row) => (
             <PermissionRow
               key={row.id}
-              isWindows={isWindows}
+              action={systemAccessAction({
+                pane: row.id,
+                state: row.state,
+                platform: runtimeInfo?.platform,
+                mediaAccessStatus:
+                  row.id === 'camera' || row.id === 'microphone' ? mediaAccess?.[row.id] : undefined
+              })}
               pending={pending === row.id}
               row={row}
-              onEnable={() => void enableMedia(row.id as 'camera' | 'microphone')}
-              onOpenSettings={() => void openSystemPermission(row.id)}
+              onAction={() => void runPermissionAction(row.id)}
             />
           ))}
         </div>
@@ -142,7 +120,7 @@ export function PermissionsOnboardingDialog({
             Recordings stay on this {deviceNoun}. Cloud AI only runs after you opt in.
           </span>
           <Button onClick={onComplete}>
-            {allGranted ? 'Continue' : 'Continue without granting'}
+            {allPermissionsResolved ? 'Continue' : 'Continue without granting'}
             <ArrowRight data-icon="inline-end" />
           </Button>
         </DialogFooter>
@@ -151,47 +129,28 @@ export function PermissionsOnboardingDialog({
   )
 }
 
-// Bounded poll (~10s) — resolves early when the condition holds; on timeout
-// the caller just proceeds and the honest derived state stays visible.
-async function waitFor(condition: () => boolean, timeoutMs = 10_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (!condition() && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 250))
-  }
-}
-
 function PermissionRow({
   row,
-  isWindows,
+  action,
   pending,
-  onEnable,
-  onOpenSettings
+  onAction
 }: {
   row: SystemAccessRow
-  isWindows: boolean
+  action: SystemAccessAction
   pending: boolean
-  onEnable: () => void
-  onOpenSettings: () => void
+  onAction: () => void
 }): ReactElement {
-  // Screen Recording has no native prompt API — System Settings is the only
-  // door. Camera/mic get the in-place prompt while undetermined; once macOS
-  // has said no, only System Settings can flip it (TCC never re-asks).
-  //
-  // Windows has NO in-place prompt at all (askForMediaAccess is macOS-only), so
-  // an "Enable" button there was a dead no-op (the tester's "clicking Enable
-  // does nothing") — every row opens Settings instead.
-  const canEnableInPlace = !isWindows && row.id !== 'screen-recording' && row.state === 'first-use'
-  const action =
-    row.state === 'granted' || row.state === 'device-issue' ? null : canEnableInPlace ? (
-      <Button disabled={pending} size="xs" variant="outline" onClick={onEnable}>
+  const actionButton =
+    action === 'request-media-access' ? (
+      <Button disabled={pending} size="xs" variant="outline" onClick={onAction}>
         {pending ? <CircleNotch className="animate-spin" data-icon="inline-start" /> : null}
         Enable
       </Button>
-    ) : (
-      <Button size="xs" variant="outline" onClick={onOpenSettings}>
+    ) : action === 'open-settings' ? (
+      <Button disabled={pending} size="xs" variant="outline" onClick={onAction}>
         Open settings
       </Button>
-    )
+    ) : null
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-row border bg-muted/30 px-3 py-2.5 text-sm">
@@ -217,7 +176,7 @@ function PermissionRow({
       <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground" title={row.detail}>
         {row.purpose}
       </span>
-      {action}
+      {actionButton}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/preview-stage.test.ts
+++ b/apps/desktop/src/renderer/src/components/preview-stage.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PreviewSupervisorState } from '@/lib/backend'
+
+import { previewPermissionPane, previewSupervisorDisplay } from './preview-stage'
+
+function supervisor(
+  permissionStatus: PreviewSupervisorState['permissionStatus'],
+  lifecycleState: PreviewSupervisorState['lifecycleState'] = 'permission-required'
+): PreviewSupervisorState {
+  return {
+    lifecycleState,
+    generation: 1,
+    windowOpen: true,
+    windowVisible: true,
+    surfaceRequested: true,
+    surfaceActive: false,
+    transport: 'none',
+    backing: 'none',
+    permissionStatus,
+    updatedAt: '2026-07-15T00:00:00.000Z'
+  }
+}
+
+describe('previewPermissionPane', () => {
+  it('keeps camera failures on the camera permission path', () => {
+    expect(previewPermissionPane(supervisor('camera-required'))).toBe('camera')
+  })
+
+  it('keeps screen failures on the Screen Recording path', () => {
+    expect(previewPermissionPane(supervisor('screen-recording-required'))).toBe('screen-recording')
+  })
+
+  it('uses the generic privacy pane only for an unknown permission diagnosis', () => {
+    expect(previewPermissionPane(supervisor('unknown'))).toBe('privacy')
+  })
+
+  it('does not invent a permission action without an explicit diagnosis', () => {
+    expect(previewPermissionPane(supervisor('camera-required', 'failed'))).toBeNull()
+    expect(previewPermissionPane(supervisor('ok'))).toBeNull()
+  })
+})
+
+describe('previewSupervisorDisplay', () => {
+  it('reports device recovery instead of a stale camera permission blocker after grant', () => {
+    expect(
+      previewSupervisorDisplay(true, supervisor('camera-required'), undefined, undefined, {
+        action: null,
+        row: {
+          id: 'camera',
+          label: 'Camera',
+          purpose: 'Camera overlay in your scenes.',
+          state: 'device-issue',
+          detail: 'Camera permission is granted, but no usable camera is currently available.'
+        }
+      })
+    ).toEqual({
+      title: 'Preview is recovering',
+      detail: 'Camera permission is granted, but no usable camera is currently available.',
+      tone: 'warn'
+    })
+  })
+
+  it('reports capture recovery for a granted screen route while preserving real blockers', () => {
+    expect(
+      previewSupervisorDisplay(
+        true,
+        supervisor('screen-recording-required'),
+        undefined,
+        undefined,
+        {
+          action: null,
+          row: {
+            id: 'screen-recording',
+            label: 'Screen Recording',
+            purpose: 'Capture displays and app windows.',
+            state: 'granted',
+            detail: 'Permission granted.'
+          }
+        }
+      )
+    ).toEqual({
+      title: 'Preview is recovering',
+      detail: 'Screen Recording permission is granted. Reconnecting capture.',
+      tone: 'warn'
+    })
+
+    expect(
+      previewSupervisorDisplay(
+        true,
+        supervisor('screen-recording-required'),
+        undefined,
+        undefined,
+        {
+          action: 'open-settings',
+          row: {
+            id: 'screen-recording',
+            label: 'Screen Recording',
+            purpose: 'Capture displays and app windows.',
+            state: 'not-granted',
+            detail: 'System Settings is blocking screen capture.'
+          }
+        }
+      ).title
+    ).toBe('Preview needs permission')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/preview-stage.tsx
+++ b/apps/desktop/src/renderer/src/components/preview-stage.tsx
@@ -10,8 +10,15 @@ import type {
   PreviewLiveStatus,
   PreviewSupervisorState,
   PreviewSurfaceStatus,
-  PreviewWindowState
+  PreviewWindowState,
+  SystemPermissionPane
 } from '@/lib/backend'
+import {
+  systemAccessAction,
+  systemAccessRows,
+  type SystemAccessAction,
+  type SystemAccessRow
+} from '@/lib/system-access'
 import { cn } from '@/lib/utils'
 
 type PreviewStageProps = {
@@ -23,8 +30,13 @@ type PreviewStageProps = {
    * that normally carries it. */
   dockedFooterStart?: ReactNode
   onRetry?: () => void
-  onOpenPermissions?: () => void
+  onOpenPermissions?: (pane: SystemPermissionPane) => void
   className?: string
+}
+
+type PreviewPermissionAccess = {
+  action: SystemAccessAction
+  row: SystemAccessRow | undefined
 }
 
 export function PreviewStage({
@@ -42,8 +54,33 @@ export function PreviewStage({
     closePreviewWindow,
     setPreviewWindowAlwaysOnTop,
     setPreviewWindowMode,
-    captureConfig
+    captureConfig,
+    deviceList,
+    mediaAccess,
+    runtimeInfo
   } = useStudioCore()
+  const accessRows = systemAccessRows({
+    deviceList,
+    audioMeter: null,
+    platform: runtimeInfo?.platform,
+    mediaAccess
+  })
+  const permissionPane = previewPermissionPane(previewWindow.supervisor)
+  const permissionRow = accessRows.find((candidate) => candidate.id === permissionPane)
+  const permissionAccess: PreviewPermissionAccess | null = permissionPane
+    ? {
+        row: permissionRow,
+        action: systemAccessAction({
+          pane: permissionPane,
+          state: permissionRow?.state,
+          platform: runtimeInfo?.platform,
+          mediaAccessStatus:
+            permissionPane === 'camera' || permissionPane === 'microphone'
+              ? mediaAccess?.[permissionPane]
+              : undefined
+        })
+      }
+    : null
 
   const docked =
     nativePreviewSurfaceEnabled && previewWindow.open && previewWindow.mode === 'docked'
@@ -62,6 +99,7 @@ export function PreviewStage({
         footerStart={dockedFooterStart}
         previewSurfaceStatus={previewSurfaceStatus}
         previewWindow={previewWindow}
+        permissionAccess={permissionAccess}
         slotRef={slotRef}
         onClose={() => void closePreviewWindow()}
         onOpenPermissions={onOpenPermissions}
@@ -80,6 +118,7 @@ export function PreviewStage({
       previewSupervisor={previewWindow.supervisor}
       previewSurfaceStatus={previewSurfaceStatus}
       previewWindowOpen={previewWindow.open}
+      permissionAccess={permissionAccess}
       onAlwaysOnTopChange={(alwaysOnTop) => void setPreviewWindowAlwaysOnTop(alwaysOnTop)}
       onClose={() => void closePreviewWindow()}
       onOpen={() => void openPreviewWindow()}
@@ -126,6 +165,7 @@ function DockedPreviewFrame({
   footerStart,
   onPopOut,
   onClose,
+  permissionAccess,
   onOpenPermissions,
   className
 }: {
@@ -136,16 +176,16 @@ function DockedPreviewFrame({
   footerStart?: ReactNode
   onPopOut: () => void
   onClose: () => void
-  onOpenPermissions?: () => void
+  permissionAccess: PreviewPermissionAccess | null
+  onOpenPermissions?: (pane: SystemPermissionPane) => void
   className?: string
 }): ReactElement {
   const supervisor = previewWindow.supervisor
   const hidden = dockHiddenDisplay(previewWindow.dockHiddenReason)
-  const status = hidden ?? {
-    title: previewSupervisorDisplay(true, supervisor, previewSurfaceStatus).title,
-    detail: previewSupervisorDisplay(true, supervisor, previewSurfaceStatus).detail
-  }
-  const showPermissionAction = supervisor.lifecycleState === 'permission-required'
+  const status =
+    hidden ??
+    previewSupervisorDisplay(true, supervisor, previewSurfaceStatus, undefined, permissionAccess)
+  const permissionPane = previewPermissionPane(supervisor)
   const footprintRatio = previewFootprintRatio(aspect)
   const slotRatio = previewSlotRatio(aspect)
 
@@ -187,9 +227,9 @@ function DockedPreviewFrame({
           with the video edges. */}
       <div className="flex items-center justify-end gap-1.5 pt-2">
         {footerStart ? <div className="mr-auto flex items-center">{footerStart}</div> : null}
-        {showPermissionAction && onOpenPermissions ? (
-          <Button size="sm" variant="outline" onClick={onOpenPermissions}>
-            Open permissions
+        {permissionPane && permissionAccess?.action && onOpenPermissions ? (
+          <Button size="sm" variant="outline" onClick={() => onOpenPermissions(permissionPane)}>
+            Resolve permission
           </Button>
         ) : null}
         <Button
@@ -253,6 +293,7 @@ function DetachedPreviewCard({
   onClose,
   onStick,
   onRetry,
+  permissionAccess,
   onOpenPermissions,
   className
 }: {
@@ -268,14 +309,16 @@ function DetachedPreviewCard({
   onClose: () => void
   onStick: () => void
   onRetry?: () => void
-  onOpenPermissions?: () => void
+  permissionAccess: PreviewPermissionAccess | null
+  onOpenPermissions?: (pane: SystemPermissionPane) => void
   className?: string
 }): ReactElement {
   const supervisorStatus = previewSupervisorDisplay(
     previewWindowOpen,
     previewSupervisor,
     previewSurfaceStatus,
-    previewLiveStatus
+    previewLiveStatus,
+    permissionAccess
   )
   const transportLabel = previewWindowOpen
     ? (supervisorStatus.transportLabel ??
@@ -288,8 +331,9 @@ function DetachedPreviewCard({
     previewLiveStatus?.message ??
     previewSurfaceStatus?.message ??
     'Native preview surface is disabled.'
+  const permissionPane = previewPermissionPane(previewSupervisor)
   const showPermissionAction =
-    previewWindowOpen && previewSupervisor.lifecycleState === 'permission-required'
+    previewWindowOpen && permissionPane !== null && Boolean(permissionAccess?.action)
 
   return (
     <div
@@ -328,9 +372,13 @@ function DetachedPreviewCard({
               <Button size="sm" variant="outline" onClick={onClose}>
                 Close preview
               </Button>
-              {showPermissionAction && onOpenPermissions ? (
-                <Button size="sm" variant="outline" onClick={onOpenPermissions}>
-                  Open permissions
+              {showPermissionAction && permissionPane && onOpenPermissions ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onOpenPermissions(permissionPane)}
+                >
+                  Resolve permission
                 </Button>
               ) : null}
             </div>
@@ -367,9 +415,9 @@ function DetachedPreviewCard({
                 Retry preview
               </Button>
             ) : null}
-            {onOpenPermissions ? (
-              <Button size="sm" variant="outline" onClick={onOpenPermissions}>
-                Open permissions
+            {permissionPane && permissionAccess?.action && onOpenPermissions ? (
+              <Button size="sm" variant="outline" onClick={() => onOpenPermissions(permissionPane)}>
+                Resolve permission
               </Button>
             ) : null}
           </div>
@@ -386,11 +434,12 @@ type PreviewSupervisorDisplay = {
   tone: 'normal' | 'warn'
 }
 
-function previewSupervisorDisplay(
+export function previewSupervisorDisplay(
   previewWindowOpen: boolean,
   supervisor: PreviewSupervisorState,
   previewSurfaceStatus?: PreviewSurfaceStatus,
-  previewLiveStatus?: PreviewLiveStatus
+  previewLiveStatus?: PreviewLiveStatus,
+  permissionAccess?: PreviewPermissionAccess | null
 ): PreviewSupervisorDisplay {
   if (!previewWindowOpen) {
     return {
@@ -416,6 +465,21 @@ function previewSupervisorDisplay(
         tone: 'warn'
       }
     case 'permission-required':
+      if (
+        permissionAccess?.action === null &&
+        (permissionAccess.row?.state === 'device-issue' ||
+          permissionAccess.row?.state === 'granted')
+      ) {
+        const row = permissionAccess.row
+        return {
+          title: 'Preview is recovering',
+          detail:
+            row.state === 'device-issue'
+              ? row.detail
+              : `${row.label} permission is granted. Reconnecting capture.`,
+          tone: 'warn'
+        }
+      }
       return {
         title: 'Preview needs permission',
         detail:
@@ -472,6 +536,24 @@ function previewPermissionMessage(
       return 'Camera permission is required for camera sources.'
     case 'unknown':
       return 'Permission is required before this source can preview.'
+    case 'ok':
+      return null
+  }
+}
+
+export function previewPermissionPane(
+  supervisor: PreviewSupervisorState
+): SystemPermissionPane | null {
+  if (supervisor.lifecycleState !== 'permission-required') {
+    return null
+  }
+  switch (supervisor.permissionStatus) {
+    case 'camera-required':
+      return 'camera'
+    case 'screen-recording-required':
+      return 'screen-recording'
+    case 'unknown':
+      return 'privacy'
     case 'ok':
       return null
   }

--- a/apps/desktop/src/renderer/src/components/studio/audio-mixer.test.ts
+++ b/apps/desktop/src/renderer/src/components/studio/audio-mixer.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { audioMixerNotice } from './audio-mixer'
+
+describe('audioMixerNotice', () => {
+  it.each(['silent', 'no-frames'] as const)(
+    'lets an exact permission action outrank stale %s meter evidence',
+    (meterStatus) => {
+      expect(audioMixerNotice('open-settings', meterStatus, true)).toBe('permission')
+    }
+  )
+
+  it('retains meter and device recovery copy when no permission action exists', () => {
+    expect(audioMixerNotice(null, 'no-frames', true)).toBe('no-frames')
+    expect(audioMixerNotice(null, 'unavailable', true)).toBe('device-issue')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
@@ -10,11 +10,23 @@ import { useDocumentVisible } from '@/hooks/use-document-visible'
 import { useMicLevelMeter } from '@/hooks/use-mic-level-meter'
 import { useMicStream } from '@/hooks/use-mic-stream'
 import { useStudioAudio, useStudioCore, useStudioDiagnostics } from '@/hooks/use-studio'
+import type { AudioMeterStatus } from '@/lib/backend'
 import { formatDb } from '@/lib/format'
 import { advanceClipHoldDeadline, fallbackBandLevels } from '@/lib/mic-meter'
+import { systemAccessAction, systemAccessRows, type SystemAccessAction } from '@/lib/system-access'
 import { cn } from '@/lib/utils'
 
 const MIXER_BAR_COUNT = 28
+
+export function audioMixerNotice(
+  permissionAction: SystemAccessAction,
+  meterStatus: AudioMeterStatus | undefined,
+  deviceIssue: boolean
+): 'permission' | 'silent' | 'no-frames' | 'device-issue' | null {
+  if (permissionAction) return 'permission'
+  if (meterStatus === 'silent' || meterStatus === 'no-frames') return meterStatus
+  return deviceIssue ? 'device-issue' : null
+}
 
 /**
  * Audio mixer (SD4 + post-0.9.4 fix F7 + 2026-07-10 live-meter fix + Studio
@@ -29,8 +41,16 @@ const MIXER_BAR_COUNT = 28
  * is Phase-2 (F3).
  */
 export function AudioMixer(): ReactElement {
-  const { captureConfig, setCaptureConfig, selectedMicrophone, sampleAudioMeter, deviceList } =
-    useStudioCore()
+  const {
+    captureConfig,
+    setCaptureConfig,
+    selectedMicrophone,
+    sampleAudioMeter,
+    deviceList,
+    handleSystemPermission,
+    mediaAccess,
+    runtimeInfo
+  } = useStudioCore()
   const { audioMeter, audioMeterLoading } = useStudioAudio()
   const { diagnosticStats } = useStudioDiagnostics()
   const { openStudioPanel } = useWorkspaceNav()
@@ -39,6 +59,7 @@ export function AudioMixer(): ReactElement {
   const documentVisible = useDocumentVisible()
   const micStream = useMicStream({
     deviceName: selectedMicrophone?.name,
+    permissionStatus: mediaAccess?.microphone,
     enabled: Boolean(selectedMicrophone) && documentVisible
   })
   const micMeter = useMicLevelMeter({ stream: micStream.stream, muted })
@@ -67,6 +88,23 @@ export function AudioMixer(): ReactElement {
   // - silent/no-frames: warning tone over whatever level path is active;
   // - no mic: flat dim bars.
   const meterStatus = micMeter.active || liveLevel !== null ? 'ready' : audioMeter?.status
+  const microphoneAccess = systemAccessRows({
+    deviceList,
+    audioMeter,
+    platform: runtimeInfo?.platform,
+    mediaAccess
+  }).find((row) => row.id === 'microphone')
+  const microphonePermissionAction = systemAccessAction({
+    pane: 'microphone',
+    state: microphoneAccess?.state,
+    platform: runtimeInfo?.platform,
+    mediaAccessStatus: mediaAccess?.microphone
+  })
+  const notice = audioMixerNotice(
+    microphonePermissionAction,
+    meterStatus,
+    microphoneAccess?.state === 'device-issue'
+  )
   const analyserDriven = micStream.active && !muted
   const visualLevels = analyserDriven
     ? undefined
@@ -160,16 +198,27 @@ export function AudioMixer(): ReactElement {
             </Button>
           )}
         </div>
-        {meterStatus === 'silent' || meterStatus === 'no-frames' ? (
+        {notice === 'permission' ? (
+          <div className="flex items-center justify-between gap-2 text-xs text-warning">
+            <span>Microphone permission is required before levels can be read.</span>
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => void handleSystemPermission('microphone')}
+            >
+              {microphonePermissionAction === 'request-media-access'
+                ? 'Enable microphone'
+                : 'Open settings'}
+            </Button>
+          </div>
+        ) : notice === 'silent' || notice === 'no-frames' ? (
           <span className="text-xs text-warning">
-            {meterStatus === 'silent'
+            {notice === 'silent'
               ? 'The mic delivered only silence on the last check.'
               : 'The mic opened but did not send audio frames.'}
           </span>
-        ) : meterStatus === 'permission-required' ? (
-          <span className="text-xs text-warning">
-            Microphone permission is required before levels can be read.
-          </span>
+        ) : notice === 'device-issue' ? (
+          <span className="text-xs text-warning">{microphoneAccess?.detail}</span>
         ) : null}
       </div>
 

--- a/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { LiveWaveform } from '@/components/ui/live-waveform'
 import { useDocumentVisible } from '@/hooks/use-document-visible'
 import { useMicStream } from '@/hooks/use-mic-stream'
+import type { MediaAccessStatus } from '@/lib/backend'
 
 /**
  * See-before-you-pick mic preview (Studio audio rework S4): a scrolling live
@@ -14,14 +15,17 @@ import { useMicStream } from '@/hooks/use-mic-stream'
  * an honest inline reason, never a fake wave and never a toast.
  */
 export function MicPickerPreview({
-  deviceName
+  deviceName,
+  permissionStatus
 }: {
   /** Backend name of the mic to preview; undefined renders the idle line. */
   deviceName: string | undefined
+  /** Exact OS access status; unresolved/non-granted states stay passive. */
+  permissionStatus: MediaAccessStatus | undefined
 }): ReactElement {
   const documentVisible = useDocumentVisible()
   const enabled = Boolean(deviceName) && documentVisible
-  const micStream = useMicStream({ deviceName, enabled })
+  const micStream = useMicStream({ deviceName, enabled, permissionStatus })
 
   return (
     <div className="flex flex-col gap-1" data-videorc-mic-preview>

--- a/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/quick-settings.tsx
@@ -130,6 +130,7 @@ export function QuickSettings(): ReactElement {
     entitlements,
     captionsStatus,
     captionsCommandPending,
+    mediaAccess,
     wsStatus
   } = useStudioCore()
   // Q6 (plan 022): before the backend reports devices, selects say "Finding
@@ -243,7 +244,10 @@ export function QuickSettings(): ReactElement {
                 popover is open. Mounted only with the popover, so the preview
                 stream releases the device on close. */}
             <Suspense fallback={<div className="h-[38px] rounded-row border bg-muted/20" />}>
-              <MicPickerPreview deviceName={selectedMicrophone?.name} />
+              <MicPickerPreview
+                deviceName={selectedMicrophone?.name}
+                permissionStatus={mediaAccess?.microphone}
+              />
             </Suspense>
             {selectedMicrophone ? (
               <Button

--- a/apps/desktop/src/renderer/src/components/studio/session-mic-sliver.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-mic-sliver.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { BarVisualizer } from '@/components/ui/bar-visualizer'
 import { useDocumentVisible } from '@/hooks/use-document-visible'
 import { useMicStream } from '@/hooks/use-mic-stream'
+import type { MediaAccessStatus } from '@/lib/backend'
 import { fallbackBandLevels } from '@/lib/mic-meter'
 import { cn } from '@/lib/utils'
 
@@ -20,15 +21,17 @@ const SLIVER_BAR_COUNT = 5
 export function SessionMicSliver({
   sessionActive,
   deviceName,
-  muted
+  muted,
+  permissionStatus
 }: {
   sessionActive: boolean
   deviceName: string | undefined
   muted: boolean
+  permissionStatus: MediaAccessStatus | undefined
 }): ReactElement | null {
   const documentVisible = useDocumentVisible()
   const enabled = sessionActive && Boolean(deviceName) && !muted && documentVisible
-  const micStream = useMicStream({ deviceName, enabled })
+  const micStream = useMicStream({ deviceName, enabled, permissionStatus })
 
   if (!sessionActive || !deviceName) {
     return null

--- a/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
+  useStudioAudio,
   useStudioCore,
   useStudioDiagnostics,
   useStudioPreview,
@@ -37,17 +38,22 @@ import type {
   WebSocketQueueDiagnosticStats
 } from '@/lib/backend'
 import { compactTime, formatDroppedFrames, formatMetric } from '@/lib/format'
+import { systemAccessAction, systemAccessRows } from '@/lib/system-access'
 
 export function DiagnosticsTab(): ReactElement {
   const {
-    openSystemPermission,
+    handleSystemPermission,
     sessions,
     streamTargets,
     nativePreviewSurfaceEnabled,
     captureConfig,
+    deviceList,
+    mediaAccess,
+    runtimeInfo,
     exportSupportBundle,
     supportBundleExportPending
   } = useStudioCore()
+  const { audioMeter } = useStudioAudio()
   const { recording } = useStudioRecording()
   const { previewLiveStatus, previewCameraStatus, previewScreenStatus } = useStudioPreview()
   const { diagnosticStats, healthEvents, logs, previewSurfaceStatus, streamHealth } =
@@ -55,8 +61,27 @@ export function DiagnosticsTab(): ReactElement {
   const [dismissed, setDismissed] = useState<Set<string>>(() => new Set())
   const activeSession =
     sessions.find((session) => session.id === recording.sessionId) ?? sessions[0] ?? null
+  const accessRows = systemAccessRows({
+    deviceList,
+    audioMeter,
+    platform: runtimeInfo?.platform,
+    mediaAccess
+  })
+  const permissionAction = (pane: SystemPermissionPane) => {
+    const row = accessRows.find((candidate) => candidate.id === pane)
+    return systemAccessAction({
+      pane,
+      state: row?.state,
+      platform: runtimeInfo?.platform,
+      mediaAccessStatus:
+        pane === 'camera' || pane === 'microphone' ? mediaAccess?.[pane] : undefined
+    })
+  }
   const actionableEvents = healthEvents.filter(
-    (event) => event.permissionPane && !dismissed.has(event.id)
+    (event) =>
+      event.permissionPane &&
+      !dismissed.has(event.id) &&
+      permissionAction(event.permissionPane) !== null
   )
   const sessionLogs = activeSession?.sessionLogs ?? []
 
@@ -579,7 +604,7 @@ export function DiagnosticsTab(): ReactElement {
                       return next
                     })
                   }
-                  onOpenPermission={openSystemPermission}
+                  onHandlePermission={handleSystemPermission}
                 />
               ))}
             </div>
@@ -649,11 +674,11 @@ function MetricGroup({ title, children }: { title: string; children: ReactNode }
 function ActionableWarning({
   event,
   onDismiss,
-  onOpenPermission
+  onHandlePermission
 }: {
   event: HealthEvent
   onDismiss: () => void
-  onOpenPermission: (pane: SystemPermissionPane) => Promise<void>
+  onHandlePermission: (pane: SystemPermissionPane) => Promise<void>
 }): ReactElement {
   return (
     <div className="flex items-start justify-between gap-3 rounded-row border bg-warning/10 px-3 py-2">
@@ -667,11 +692,11 @@ function ActionableWarning({
       <div className="flex shrink-0 items-center gap-1">
         {event.permissionPane ? (
           <Button
-            aria-label="Open permission settings"
+            aria-label="Resolve permission"
             size="icon"
-            title="Open permission settings"
+            title="Resolve permission"
             variant="ghost"
-            onClick={() => void onOpenPermission(event.permissionPane!)}
+            onClick={() => void onHandlePermission(event.permissionPane!)}
           >
             <ArrowSquareOut />
           </Button>

--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -36,7 +36,7 @@ import { isActiveRecordingState } from '@/lib/format'
 import { recordingQuality, streamingSummary } from '@/lib/studio-session-view'
 import { shortcutsByGroup } from '@/lib/shortcuts'
 import { displayKeyGlyphs, osSettingsName } from '@/lib/platform'
-import { systemAccessRows } from '@/lib/system-access'
+import { systemAccessAction, systemAccessRows } from '@/lib/system-access'
 import { isUpdateInstallable } from '@/lib/update-ui'
 
 // ST1 (UX rework): Settings holds app-level facts and tools only. Session
@@ -58,7 +58,8 @@ export function SettingsTab({
     deviceList,
     mediaAccess,
     refreshBackend,
-    openSystemPermission,
+    handleSystemPermission,
+    openSystemPermissionSettings,
     exportSupportBundle,
     supportBundleExportPending,
     runtimeInfo
@@ -249,47 +250,68 @@ export function SettingsTab({
           }
         >
           <div className="flex flex-col gap-1">
-            {accessRows.map((row) => (
-              <div
-                key={row.id}
-                className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-row px-2.5 py-2 text-sm"
-              >
-                <span className="w-32 shrink-0 font-medium">{row.label}</span>
-                <StatusBadge
-                  tone={
-                    row.state === 'granted'
-                      ? 'good'
-                      : row.state === 'not-granted'
-                        ? 'warn'
-                        : 'neutral'
-                  }
-                  value={
-                    row.state === 'granted'
-                      ? 'Granted'
-                      : row.state === 'not-granted'
-                        ? 'Not granted'
-                        : 'Checked on first use'
-                  }
-                />
-                {/* Q4 (plan 022): the permission TARGET is the actionable part —
-                    truncation clipped it to "Captur…"/"Voice a…". The row
-                    flex-wraps, so let the detail take a full line when tight
-                    instead of truncating; tooltip keeps the hover affordance. */}
-                <span
-                  className="min-w-0 flex-1 basis-56 text-xs text-muted-foreground"
-                  title={`${row.purpose} ${row.detail}`}
+            {accessRows.map((row) => {
+              const action = systemAccessAction({
+                pane: row.id,
+                state: row.state,
+                platform: runtimeInfo?.platform,
+                mediaAccessStatus:
+                  row.id === 'camera' || row.id === 'microphone' ? mediaAccess?.[row.id] : undefined
+              })
+              return (
+                <div
+                  key={row.id}
+                  className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-row px-2.5 py-2 text-sm"
                 >
-                  {row.purpose} {row.detail}
-                </span>
-                <Button
-                  size="xs"
-                  variant="outline"
-                  onClick={() => void openSystemPermission(row.id)}
-                >
-                  Open settings
-                </Button>
-              </div>
-            ))}
+                  <span className="w-32 shrink-0 font-medium">{row.label}</span>
+                  <StatusBadge
+                    tone={
+                      row.state === 'granted'
+                        ? 'good'
+                        : row.state === 'not-granted' || row.state === 'device-issue'
+                          ? 'warn'
+                          : 'neutral'
+                    }
+                    value={
+                      row.state === 'granted'
+                        ? 'Granted'
+                        : row.state === 'not-granted'
+                          ? 'Not granted'
+                          : row.state === 'device-issue'
+                            ? 'Device issue'
+                            : 'Checked on first use'
+                    }
+                  />
+                  {/* Q4 (plan 022): the permission TARGET is the actionable part —
+                      truncation clipped it to "Captur…"/"Voice a…". The row
+                      flex-wraps, so let the detail take a full line when tight
+                      instead of truncating; tooltip keeps the hover affordance. */}
+                  <span
+                    className="min-w-0 flex-1 basis-56 text-xs text-muted-foreground"
+                    title={`${row.purpose} ${row.detail}`}
+                  >
+                    {row.purpose} {row.detail}
+                  </span>
+                  {action ? (
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      onClick={() => void handleSystemPermission(row.id)}
+                    >
+                      {action === 'request-media-access' ? 'Enable' : 'Open settings'}
+                    </Button>
+                  ) : row.state === 'granted' ? (
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      onClick={() => void openSystemPermissionSettings(row.id)}
+                    >
+                      Manage settings
+                    </Button>
+                  ) : null}
+                </div>
+              )
+            })}
           </div>
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <Button size="sm" variant="outline" onClick={onOpenPermissionsSetup}>

--- a/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sources-tab.tsx
@@ -40,6 +40,7 @@ import {
   type AudioSyncRecommendationReport
 } from '@/lib/capture'
 import type { SourceSelection } from '@/lib/backend'
+import { systemAccessAction, systemAccessRows } from '@/lib/system-access'
 
 // Live chip for a capture source (UI rewrite V3): what the preview pipeline says
 // about the source RIGHT NOW. A live source whose newest frame is old is reported
@@ -109,10 +110,10 @@ export function SourcesTab(): ReactElement {
     layoutSwitchPending,
     sourceDeviceSwitchPending,
     switchSourceDeviceLive,
-    openSystemPermission,
-    openPreviewPermissions,
+    handleSystemPermission,
     revealPermissionTarget,
     runtimeInfo,
+    mediaAccess,
     wsStatus
   } = useStudioCore()
   const { previewCameraStatus, previewScreenStatus } = useStudioPreview()
@@ -129,11 +130,20 @@ export function SourcesTab(): ReactElement {
   const hasCapturePermissionRequired = captureDevices.some(
     (device) => device.status === 'permission-required'
   )
-  const selectedCamera = cameras.find((device) => device.id === captureConfig.sources.cameraId)
+  const cameraAccess = systemAccessRows({
+    deviceList,
+    audioMeter: null,
+    platform: runtimeInfo?.platform,
+    mediaAccess
+  }).find((row) => row.id === 'camera')
   const hasCameraPermissionRequired =
-    previewCameraStatus?.state === 'permission-needed' ||
-    selectedCamera?.status === 'permission-required' ||
-    cameras.some((device) => device.status === 'permission-required')
+    cameraAccess?.state === 'first-use' || cameraAccess?.state === 'not-granted'
+  const cameraPermissionAction = systemAccessAction({
+    pane: 'camera',
+    state: cameraAccess?.state,
+    platform: runtimeInfo?.platform,
+    mediaAccessStatus: mediaAccess?.camera
+  })
   const capturePermissionTargetName =
     runtimeInfo?.capturePermissionTargetName ?? runtimeInfo?.permissionTargetName ?? 'Videorc'
   const [syncRecommendation, setSyncRecommendation] =
@@ -236,7 +246,11 @@ export function SourcesTab(): ReactElement {
               Screen Recording permission is required for {capturePermissionTargetName}.
             </AlertTitle>
             <AlertDescription className="flex flex-wrap gap-2 pt-2">
-              <Button size="sm" variant="outline" onClick={() => void openPreviewPermissions()}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void handleSystemPermission('screen-recording')}
+              >
                 <Monitor data-icon="inline-start" />
                 Open Screen Recording
               </Button>
@@ -254,14 +268,18 @@ export function SourcesTab(): ReactElement {
               Camera permission is required for {capturePermissionTargetName}.
             </AlertTitle>
             <AlertDescription className="flex flex-wrap gap-2 pt-2">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => void openSystemPermission('camera')}
-              >
-                <VideoCamera data-icon="inline-start" />
-                Open Camera
-              </Button>
+              {cameraPermissionAction ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void handleSystemPermission('camera')}
+                >
+                  <VideoCamera data-icon="inline-start" />
+                  {cameraPermissionAction === 'request-media-access'
+                    ? 'Enable Camera'
+                    : 'Open Camera Settings'}
+                </Button>
+              ) : null}
               <Button size="sm" variant="ghost" onClick={() => void revealPermissionTarget()}>
                 <UploadSimple data-icon="inline-start" />
                 Show Capture Helper
@@ -391,7 +409,10 @@ export function SourcesTab(): ReactElement {
         />
         {/* See-before-you-pick: live waveform of the selected mic (shared with
             the Quick Settings popover). */}
-        <MicPickerPreview deviceName={selectedMicrophone?.name} />
+        <MicPickerPreview
+          deviceName={selectedMicrophone?.name}
+          permissionStatus={mediaAccess?.microphone}
+        />
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           {captureConfig.audio.microphoneMuted ? (
             <SpeakerSlash className="size-4" weight="duotone" />

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -199,7 +199,8 @@ function StudioPreviewPanel(): ReactElement {
   const {
     captureConfig,
     nativePreviewSurfaceEnabled,
-    openPreviewPermissions,
+    handleSystemPermission,
+    mediaAccess,
     openPreviewWindow,
     previewWindow,
     refreshPreview,
@@ -226,6 +227,7 @@ function StudioPreviewPanel(): ReactElement {
       <SessionMicSliver
         deviceName={selectedMicrophone?.name}
         muted={captureConfig.audio.microphoneMuted}
+        permissionStatus={mediaAccess?.microphone}
         sessionActive={active}
       />
       <span data-videorc-session-status>
@@ -251,7 +253,7 @@ function StudioPreviewPanel(): ReactElement {
       nativePreviewSurfaceEnabled={nativePreviewSurfaceEnabled}
       previewLiveStatus={previewLiveStatus}
       previewSurfaceStatus={previewSurfaceStatus}
-      onOpenPermissions={openPreviewPermissions}
+      onOpenPermissions={(pane) => void handleSystemPermission(pane)}
       onRetry={refreshPreview}
     />
   )

--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -13,7 +13,10 @@ vi.mock('sonner', () => ({ toast: toastSpies }))
 
 import type {
   AccountCallbackEnvelope,
+  AudioMeterResult,
+  BackendConnection,
   CompositorStatus,
+  DeviceList,
   LayoutSettings,
   NoiseCleanupJob,
   OAuthCallbackEnvelope,
@@ -27,6 +30,7 @@ import type {
 import { BackgroundAssetsProvider } from './use-background-assets'
 import {
   StudioProvider,
+  useStudioAudio,
   useStudioCore,
   useStudioRecording,
   type StudioCoreContextValue,
@@ -249,6 +253,24 @@ class StudioBackend {
   emitRecordingStatusBeforeStartResponse = false
   audioProcessingResponseDelayMs = 0
   audioProcessingReasonCode: 'session-ended' | null = null
+  deviceListFailuresRemaining = 0
+  audioMeterFailuresRemaining = 0
+  deviceList: DeviceList = {
+    devices: [
+      {
+        id: 'screen:dxgi:0000000000000001:1',
+        name: 'Display 1',
+        kind: 'screen',
+        status: 'available',
+        width: 2560,
+        height: 1440
+      },
+      { id: 'camera:1', name: 'Camera 1', kind: 'camera', status: 'available' },
+      { id: 'mic:1', name: 'Microphone 1', kind: 'microphone', status: 'available' }
+    ],
+    warnings: []
+  }
+  audioMeterResult: AudioMeterResult = { status: 'ready', level: 0.4 }
 
   invalidateCompletedNoiseCleanup(message: string): void {
     this.sourceMutationRevision += 1
@@ -303,21 +325,17 @@ class StudioBackend {
       case 'ai.quota.get':
         throw new Error('AI web dependency is intentionally offline in this lifecycle test.')
       case 'devices.list':
-        return {
-          devices: [
-            {
-              id: 'screen:dxgi:0000000000000001:1',
-              name: 'Display 1',
-              kind: 'screen',
-              status: 'available',
-              width: 2560,
-              height: 1440
-            },
-            { id: 'camera:1', name: 'Camera 1', kind: 'camera', status: 'available' },
-            { id: 'mic:1', name: 'Microphone 1', kind: 'microphone', status: 'available' }
-          ],
-          warnings: []
+        if (this.deviceListFailuresRemaining > 0) {
+          this.deviceListFailuresRemaining -= 1
+          throw new Error('Temporary devices.list failure.')
         }
+        return this.deviceList
+      case 'audio.meter.sample':
+        if (this.audioMeterFailuresRemaining > 0) {
+          this.audioMeterFailuresRemaining -= 1
+          throw new Error('Temporary audio.meter.sample failure.')
+        }
+        return this.audioMeterResult
       case 'recording.status':
         return { state: this.recordingState, message: 'Ready.' }
       case 'diagnostics.stats':
@@ -566,25 +584,30 @@ class TestWebSocket {
   static readonly OPEN = 1
   static readonly CLOSED = 3
   static backend: StudioBackend
+  static nextGeneration = 0
 
   readyState = TestWebSocket.OPEN
+  readonly backend: StudioBackend
+  readonly generation: number
   onopen: (() => void) | null = null
   onerror: (() => void) | null = null
   onmessage: ((event: { data: string }) => void) | null = null
   onclose: (() => void) | null = null
 
   constructor(readonly url: string) {
-    TestWebSocket.backend.sockets.push(this)
+    this.backend = TestWebSocket.backend
+    this.generation = ++TestWebSocket.nextGeneration
+    this.backend.sockets.push(this)
     queueMicrotask(() => this.onopen?.())
   }
 
   send(raw: string): void {
+    if (this.readyState !== TestWebSocket.OPEN) {
+      throw new Error(`Test WebSocket generation ${this.generation} is closed.`)
+    }
     const command = JSON.parse(raw) as BackendCommand
-    TestWebSocket.backend.sentCommands.push(command)
-    if (
-      command.method === 'session.start' &&
-      TestWebSocket.backend.emitRecordingStatusBeforeStartResponse
-    ) {
+    this.backend.sentCommands.push(command)
+    if (command.method === 'session.start' && this.backend.emitRecordingStatusBeforeStartResponse) {
       queueMicrotask(() => {
         this.onmessage?.({
           data: JSON.stringify({
@@ -600,12 +623,15 @@ class TestWebSocket {
       })
     }
     const respond = (): void => {
+      if (this.readyState !== TestWebSocket.OPEN) {
+        return
+      }
       try {
         this.onmessage?.({
           data: JSON.stringify({
             id: command.id,
             ok: true,
-            payload: TestWebSocket.backend.response(command)
+            payload: this.backend.response(command)
           })
         })
       } catch (error) {
@@ -628,11 +654,11 @@ class TestWebSocket {
       }
     }
     const responseDelayMs = command.method.startsWith('scene.layout.apply_')
-      ? TestWebSocket.backend.layoutResponseDelayMs
+      ? this.backend.layoutResponseDelayMs
       : command.method === 'session.start'
-        ? TestWebSocket.backend.sessionStartResponseDelayMs
+        ? this.backend.sessionStartResponseDelayMs
         : command.method === 'audio.processing.update'
-          ? TestWebSocket.backend.audioProcessingResponseDelayMs
+          ? this.backend.audioProcessingResponseDelayMs
           : 0
     if (responseDelayMs > 0) {
       setTimeout(respond, responseDelayMs)
@@ -649,14 +675,16 @@ class TestWebSocket {
 }
 
 type StudioObservation = {
+  audio: ReturnType<typeof useStudioAudio>
   core: StudioCoreContextValue
   recording: StudioRecordingContextValue
 }
 
 function Probe({ observe }: { observe: (value: StudioObservation) => void }): null {
+  const audio = useStudioAudio()
   const core = useStudioCore()
   const recording = useStudioRecording()
-  useEffect(() => observe({ core, recording }), [core, observe, recording])
+  useEffect(() => observe({ audio, core, recording }), [audio, core, observe, recording])
   return null
 }
 
@@ -674,6 +702,647 @@ describe('real StudioProvider lifecycle', () => {
     vi.unstubAllGlobals()
     vi.clearAllMocks()
     vi.useRealTimers()
+  })
+
+  it('requests fresh macOS camera access, then routes a denial to System Settings', async () => {
+    const backend = new StudioBackend()
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let cameraStatus: 'not-determined' | 'denied' = 'not-determined'
+    const requestMediaAccess = vi.fn(async () => {
+      cameraStatus = 'denied'
+      return { granted: false, restarted: false }
+    })
+    const openSystemPermissions = vi.fn(async () => undefined)
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      getMediaAccessStatus: async () => ({
+        camera: cameraStatus,
+        microphone: 'granted'
+      }),
+      requestMediaAccess,
+      openSystemPermissions
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.camera === 'not-determined'
+    )
+
+    await act(async () => {
+      await latest()?.core.handleSystemPermission('camera')
+    })
+    await waitForObservation(() => latest()?.core.mediaAccess?.camera === 'denied')
+    expect(requestMediaAccess).toHaveBeenCalledOnce()
+    expect(requestMediaAccess).toHaveBeenCalledWith('camera')
+    expect(openSystemPermissions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await latest()?.core.handleSystemPermission('camera')
+    })
+    expect(requestMediaAccess).toHaveBeenCalledOnce()
+    expect(openSystemPermissions).toHaveBeenCalledOnce()
+    expect(openSystemPermissions).toHaveBeenCalledWith('camera')
+  })
+
+  it('does not reuse a stale permission snapshot when the click-time status read fails', async () => {
+    const backend = new StudioBackend()
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let statusReadAvailable = true
+    const requestMediaAccess = vi.fn(async () => ({ granted: false, restarted: false }))
+    const openSystemPermissions = vi.fn(async () => undefined)
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      getMediaAccessStatus: async () => {
+        if (!statusReadAvailable) {
+          throw new Error('TCC status read failed')
+        }
+        return { camera: 'not-determined', microphone: 'granted' }
+      },
+      requestMediaAccess,
+      openSystemPermissions
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.camera === 'not-determined'
+    )
+
+    statusReadAvailable = false
+    await act(async () => {
+      await latest()?.core.handleSystemPermission('camera')
+    })
+
+    expect(requestMediaAccess).not.toHaveBeenCalled()
+    expect(openSystemPermissions).not.toHaveBeenCalled()
+    expect(toastSpies.error).toHaveBeenCalledWith('Could not check Camera permission.', {
+      description: 'Try again before changing access.'
+    })
+  })
+
+  it('clears stale microphone evidence before opening System Settings', async () => {
+    const backend = new StudioBackend()
+    backend.audioMeterResult = {
+      status: 'permission-required',
+      message: 'Microphone permission is required.'
+    }
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    const requestMediaAccess = vi.fn(async () => ({ granted: false, restarted: false }))
+    const openSystemPermissions = vi.fn(async () => undefined)
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      getMediaAccessStatus: async () => ({ camera: 'granted', microphone: 'denied' }),
+      requestMediaAccess,
+      openSystemPermissions
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.microphone === 'denied'
+    )
+    await act(async () => {
+      await latest()?.core.sampleAudioMeter()
+    })
+    await waitForObservation(() => latest()?.audio.audioMeter?.status === 'permission-required')
+
+    await act(async () => {
+      await latest()?.core.handleSystemPermission('microphone')
+    })
+
+    expect(latest()?.audio.audioMeter).toBeNull()
+    expect(openSystemPermissions).toHaveBeenCalledWith('microphone')
+    expect(requestMediaAccess).not.toHaveBeenCalled()
+  })
+
+  it('refreshes exact permission and devices through the reconnected backend after a grant', async () => {
+    const initialBackend = new StudioBackend()
+    const reconnectedBackend = new StudioBackend()
+    TestWebSocket.backend = initialBackend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let cameraStatus: 'not-determined' | 'granted' = 'not-determined'
+    let emit: ((name: string, value: unknown) => void) | undefined
+    const requestMediaAccess = vi.fn(async () => {
+      cameraStatus = 'granted'
+      TestWebSocket.backend = reconnectedBackend
+      queueMicrotask(() => {
+        emit?.('backend:connection', {
+          host: '127.0.0.1',
+          port: 9989,
+          token: 'restarted-test-token'
+        })
+      })
+      return { granted: true, restarted: true }
+    })
+    const openSystemPermissions = vi.fn(async () => undefined)
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      getMediaAccessStatus: async () => ({
+        camera: cameraStatus,
+        microphone: 'granted'
+      }),
+      requestMediaAccess,
+      openSystemPermissions,
+      registerEmitter: (nextEmit) => {
+        emit = nextEmit
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.camera === 'not-determined'
+    )
+    const devicesBefore = initialBackend.commands.filter(
+      (command) => command.method === 'devices.list'
+    ).length
+
+    let permissionAction: Promise<void> | undefined
+    act(() => {
+      permissionAction = latest()?.core.handleSystemPermission('camera')
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' && latest()?.core.mediaAccess?.camera === 'granted'
+    )
+    await act(async () => {
+      await permissionAction
+    })
+
+    expect(requestMediaAccess).toHaveBeenCalledOnce()
+    expect(openSystemPermissions).not.toHaveBeenCalled()
+    expect(
+      initialBackend.commands.filter((command) => command.method === 'devices.list').length
+    ).toBe(devicesBefore)
+    expect(
+      reconnectedBackend.commands.filter((command) => command.method === 'devices.list').length
+    ).toBeGreaterThan(0)
+    expect(
+      initialBackend.sockets.every((socket) => socket.readyState === TestWebSocket.CLOSED)
+    ).toBe(true)
+
+    await act(async () => {
+      await latest()?.core.handleSystemPermission('camera')
+    })
+    expect(requestMediaAccess).toHaveBeenCalledOnce()
+    expect(openSystemPermissions).not.toHaveBeenCalled()
+  })
+
+  it('waits past a prompt-time backend generation that the permission restart retires', async () => {
+    const initialBackend = new StudioBackend()
+    const promptBackend = new StudioBackend()
+    const restartedBackend = new StudioBackend()
+    TestWebSocket.backend = initialBackend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let cameraStatus: 'not-determined' | 'granted' = 'not-determined'
+    let emit: ((name: string, value: unknown) => void) | undefined
+    let resolveRequest:
+      | ((value: Awaited<ReturnType<NonNullable<VideorcApi['requestMediaAccess']>>>) => void)
+      | undefined
+    const requestMediaAccess = vi.fn(
+      () =>
+        new Promise<Awaited<ReturnType<NonNullable<VideorcApi['requestMediaAccess']>>>>(
+          (resolve) => {
+            resolveRequest = resolve
+          }
+        )
+    )
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      backendConnection: { host: '127.0.0.1', port: 9988, token: 'initial', pid: 101 },
+      getMediaAccessStatus: async () => ({
+        camera: cameraStatus,
+        microphone: 'granted'
+      }),
+      requestMediaAccess,
+      registerEmitter: (nextEmit) => {
+        emit = nextEmit
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.camera === 'not-determined'
+    )
+
+    let permissionAction: Promise<void> | undefined
+    act(() => {
+      permissionAction = latest()?.core.handleSystemPermission('camera')
+    })
+    await waitForObservation(() => requestMediaAccess.mock.calls.length === 1)
+
+    TestWebSocket.backend = promptBackend
+    await act(async () => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9989,
+        token: 'prompt-generation',
+        pid: 202
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        promptBackend.commands.some((command) => command.method === 'devices.list')
+    )
+
+    let actionSettled = false
+    void permissionAction?.then(() => {
+      actionSettled = true
+    })
+    cameraStatus = 'granted'
+    await act(async () => {
+      resolveRequest?.({
+        granted: true,
+        restarted: true,
+        staleBackend: { port: 9989, pid: 202 }
+      })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+    })
+    expect(actionSettled).toBe(false)
+
+    TestWebSocket.backend = restartedBackend
+    await act(async () => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9990,
+        token: 'post-grant-generation',
+        pid: 303
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        restartedBackend.commands.some((command) => command.method === 'devices.list')
+    )
+    await act(async () => {
+      await permissionAction
+    })
+
+    expect(restartedBackend.commands.some((command) => command.method === 'devices.list')).toBe(
+      true
+    )
+    expect(actionSettled).toBe(true)
+  })
+
+  it('samples the microphone only after a fresh grant has reconnected and refreshed devices', async () => {
+    const initialBackend = new StudioBackend()
+    const reconnectedBackend = new StudioBackend()
+    TestWebSocket.backend = initialBackend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let microphoneStatus: 'not-determined' | 'granted' = 'not-determined'
+    let emit: ((name: string, value: unknown) => void) | undefined
+    const requestMediaAccess = vi.fn(async () => {
+      microphoneStatus = 'granted'
+      TestWebSocket.backend = reconnectedBackend
+      queueMicrotask(() => {
+        emit?.('backend:connection', {
+          host: '127.0.0.1',
+          port: 9990,
+          token: 'microphone-restart-token'
+        })
+      })
+      return { granted: true, restarted: true }
+    })
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      getMediaAccessStatus: async () => ({
+        camera: 'granted',
+        microphone: microphoneStatus
+      }),
+      requestMediaAccess,
+      registerEmitter: (nextEmit) => {
+        emit = nextEmit
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.microphone === 'not-determined' &&
+        latest()?.core.canSampleAudio === true
+    )
+
+    let permissionAction: Promise<void> | undefined
+    act(() => {
+      permissionAction = latest()?.core.handleSystemPermission('microphone')
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.microphone === 'granted'
+    )
+    await act(async () => {
+      await permissionAction
+    })
+
+    const commandMethods = reconnectedBackend.commands.map((command) => command.method)
+    const deviceRefreshIndex = commandMethods.lastIndexOf('devices.list')
+    const meterSampleIndex = commandMethods.lastIndexOf('audio.meter.sample')
+    expect(requestMediaAccess).toHaveBeenCalledWith('microphone')
+    expect(deviceRefreshIndex).toBeGreaterThan(-1)
+    expect(meterSampleIndex).toBeGreaterThan(deviceRefreshIndex)
+    expect(initialBackend.commands.some((command) => command.method === 'audio.meter.sample')).toBe(
+      false
+    )
+    expect(
+      initialBackend.sockets.every((socket) => socket.readyState === TestWebSocket.CLOSED)
+    ).toBe(true)
+  })
+
+  it('invalidates stale microphone evidence and defers proof to the eventual backend generation', async () => {
+    const initialBackend = new StudioBackend()
+    initialBackend.deviceList = {
+      ...initialBackend.deviceList,
+      devices: initialBackend.deviceList.devices.map((device) =>
+        device.kind === 'microphone'
+          ? {
+              ...device,
+              status: 'permission-required',
+              detail: 'Microphone permission is required.'
+            }
+          : device
+      )
+    }
+    initialBackend.audioMeterResult = {
+      status: 'permission-required',
+      message: 'Microphone permission is required.'
+    }
+    TestWebSocket.backend = initialBackend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let microphoneStatus: 'not-determined' | 'granted' = 'not-determined'
+    let emit: ((name: string, value: unknown) => void) | undefined
+    const requestMediaAccess = vi.fn(async () => {
+      microphoneStatus = 'granted'
+      return {
+        granted: true,
+        restarted: false,
+        staleBackend: { port: 9988, pid: 401 }
+      }
+    })
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      backendConnection: { host: '127.0.0.1', port: 9988, token: 'initial', pid: 401 },
+      getMediaAccessStatus: async () => ({
+        camera: 'granted',
+        microphone: microphoneStatus
+      }),
+      requestMediaAccess,
+      registerEmitter: (nextEmit) => {
+        emit = nextEmit
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.microphone === 'not-determined'
+    )
+    await act(async () => {
+      await latest()?.core.sampleAudioMeter()
+    })
+    await waitForObservation(() => latest()?.audio.audioMeter?.status === 'permission-required')
+    const initialDeviceRefreshes = initialBackend.commands.filter(
+      (command) => command.method === 'devices.list'
+    ).length
+
+    await act(async () => {
+      await latest()?.core.handleSystemPermission('microphone')
+    })
+
+    expect(requestMediaAccess).toHaveBeenCalledWith('microphone')
+    expect(latest()?.core.mediaAccess?.microphone).toBe('granted')
+    expect(latest()?.audio.audioMeter).toBeNull()
+    expect(
+      initialBackend.commands.filter((command) => command.method === 'devices.list').length
+    ).toBe(initialDeviceRefreshes)
+
+    const reconnectedBackend = new StudioBackend()
+    reconnectedBackend.deviceListFailuresRemaining = 3
+    reconnectedBackend.audioMeterFailuresRemaining = 1
+    TestWebSocket.backend = reconnectedBackend
+    act(() => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9991,
+        token: 'deferred-microphone-restart-token'
+      })
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' && latest()?.audio.audioMeter?.status === 'ready'
+    )
+
+    const reconnectedMethods = reconnectedBackend.commands.map((command) => command.method)
+    expect(
+      reconnectedMethods.filter((method) => method === 'devices.list').length
+    ).toBeGreaterThanOrEqual(4)
+    expect(reconnectedMethods.lastIndexOf('audio.meter.sample')).toBeGreaterThan(
+      reconnectedMethods.lastIndexOf('devices.list')
+    )
+    expect(reconnectedMethods.filter((method) => method === 'audio.meter.sample').length).toBe(2)
+    expect(
+      initialBackend.sockets.every((socket) => socket.readyState === TestWebSocket.CLOSED)
+    ).toBe(true)
+    expect(
+      reconnectedBackend.sockets.every((socket) => socket.backend === reconnectedBackend)
+    ).toBe(true)
   })
 
   it('boots, commits a layout, records, stops, and acknowledges a bound account callback', async () => {
@@ -1989,6 +2658,12 @@ function createVideorcApi(options: {
     registerEmitter?: (emit: (name: string, value: unknown) => void) => void
   }
   windowsLiveAudioSmokeMode?: boolean
+  platform?: string
+  getMediaAccessStatus?: VideorcApi['getMediaAccessStatus']
+  requestMediaAccess?: VideorcApi['requestMediaAccess']
+  openSystemPermissions?: VideorcApi['openSystemPermissions']
+  backendConnection?: BackendConnection
+  registerEmitter?: (emit: (name: string, value: unknown) => void) => void
 }): VideorcApi {
   const listeners = new Map<string, Set<(value: unknown) => void>>()
   const subscribe = (name: string, callback: (value: unknown) => void): (() => void) => {
@@ -1997,8 +2672,12 @@ function createVideorcApi(options: {
     listeners.set(name, bucket)
     return () => bucket.delete(callback)
   }
-  options.nativePreview?.registerEmitter?.((name, value) => {
+  const emit = (name: string, value: unknown): void => {
     for (const callback of listeners.get(name) ?? []) callback(value)
+  }
+  options.registerEmitter?.(emit)
+  options.nativePreview?.registerEmitter?.((name, value) => {
+    emit(name, value)
   })
   const idleNotes = {
     open: false,
@@ -2018,11 +2697,12 @@ function createVideorcApi(options: {
   }
   const api = new Proxy<Record<string, unknown>>(
     {
-      getBackendConnection: async () => ({ host: '127.0.0.1', port: 9988, token: 'test-token' }),
+      getBackendConnection: async () =>
+        options.backendConnection ?? { host: '127.0.0.1', port: 9988, token: 'test-token' },
       getBackendLogs: async () => [],
       getRuntimeInfo: async () => ({
         version: 'test',
-        platform: 'win32',
+        platform: options.platform ?? 'win32',
         arch: 'x64',
         osRelease: 'test',
         gpuDevices: [],
@@ -2058,7 +2738,11 @@ function createVideorcApi(options: {
       getNotesWindowState: async () => idleNotes,
       getCommentsWindowState: async () => idleComments,
       getCaptionsWindowState: async () => idleCaptions,
-      getMediaAccessStatus: async () => ({ camera: 'granted', microphone: 'granted' }),
+      getMediaAccessStatus:
+        options.getMediaAccessStatus ??
+        (async () => ({ camera: 'granted', microphone: 'granted' })),
+      requestMediaAccess: options.requestMediaAccess,
+      openSystemPermissions: options.openSystemPermissions,
       getViewerSample: async () => null,
       getCommentsSnapshot: async () => null,
       getCommentHighlightState: async () => ({ generation: 0, phase: 'idle' }),

--- a/apps/desktop/src/renderer/src/hooks/use-mic-stream.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-mic-stream.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
-import { createMicStreamController } from '@/lib/mic-stream'
+import type { MediaAccessStatus } from '@/lib/backend'
+import { createMicStreamController, microphoneStreamAcquisitionEnabled } from '@/lib/mic-stream'
 
 export type MicStreamStatus = 'idle' | 'acquiring' | 'active' | 'unavailable'
 
@@ -23,14 +24,17 @@ export type MicStream = {
 export function useMicStream(input: {
   /** Backend name of the selected microphone; matched to WebAudio by label. */
   deviceName: string | undefined
+  /** Exact OS access status; only `granted` may start a Chromium stream. */
+  permissionStatus: MediaAccessStatus | undefined
   enabled: boolean
 }): MicStream {
-  const { deviceName, enabled } = input
+  const { deviceName, enabled, permissionStatus } = input
+  const acquisitionEnabled = microphoneStreamAcquisitionEnabled(enabled, permissionStatus)
   const [stream, setStream] = useState<MediaStream | null>(null)
   const [status, setStatus] = useState<MicStreamStatus>('idle')
 
   useEffect(() => {
-    if (!enabled) {
+    if (!acquisitionEnabled) {
       setStream(null)
       setStatus('idle')
       return
@@ -50,7 +54,7 @@ export function useMicStream(input: {
       controller.close()
       setStream(null)
     }
-  }, [deviceName, enabled])
+  }, [acquisitionEnabled, deviceName])
 
   return { stream, active: stream !== null, status }
 }

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -746,8 +746,8 @@ export type StudioContextValue = {
   commitCameraTransform: (sourceId: string, x: number, y: number) => Promise<void>
   setSceneSourceVisible: (sourceId: string, visible: boolean) => Promise<void>
   moveSceneSource: (sourceId: string, direction: -1 | 1) => Promise<void>
-  openSystemPermission: (pane: SystemPermissionPane) => Promise<void>
-  openPreviewPermissions: () => Promise<void>
+  handleSystemPermission: (pane: SystemPermissionPane) => Promise<void>
+  openSystemPermissionSettings: (pane: SystemPermissionPane) => Promise<void>
   revealPermissionTarget: () => Promise<void>
   exportSupportBundle: () => Promise<void>
   registerPreviewSurfaceResize: () => void
@@ -755,7 +755,7 @@ export type StudioContextValue = {
     bounds: PreviewSurfaceBounds,
     generation?: number
   ) => Promise<void>
-  sampleAudioMeter: () => Promise<void>
+  sampleAudioMeter: () => Promise<boolean>
   startSession: () => Promise<void>
   stopSession: () => Promise<void>
   remuxSession: (sessionId: string) => Promise<void>
@@ -2044,11 +2044,37 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const [sceneEditMode, setSceneEditMode] = useState(false)
   const [selectedSceneSourceId, setSelectedSceneSourceId] = useState<string | null>(null)
   const [audioMeter, setAudioMeter] = useState<AudioMeterResult | null>(null)
+  const audioMeterRef = useRef<AudioMeterResult | null>(null)
+  const audioMeterSampleGenerationRef = useRef(0)
+  // A fresh mic grant can defer its backend restart until capture becomes idle.
+  // Remember the pre-grant client so proof can run only on the replacement.
+  const [pendingMicrophonePermissionProof, setPendingMicrophonePermissionProof] = useState<
+    | (import('@/lib/system-permission-orchestration').MicrophonePermissionProof & {
+        retry: number
+      })
+    | null
+  >(null)
+  audioMeterRef.current = audioMeter
   const [audioMeterLoading, setAudioMeterLoading] = useState(false)
-  // The OS's real camera/mic access state (Electron getMediaAccessStatus).
-  // On Windows this is what makes the permission chips truthful — the audio
-  // meter has no capture backend there, so it can't report mic permission.
+  // The OS's exact camera/mic access state (Electron getMediaAccessStatus).
+  // This distinguishes never-asked from denied on macOS and is the only
+  // truthful privacy-toggle signal on Windows.
   const [mediaAccess, setMediaAccess] = useState<MediaAccessSnapshot | null>(null)
+  const refreshMediaAccess = useCallback(async (): Promise<MediaAccessSnapshot | null> => {
+    const bridge = window.videorc?.getMediaAccessStatus
+    if (!bridge) {
+      return null
+    }
+    try {
+      const snapshot = await bridge()
+      setMediaAccess(snapshot)
+      return snapshot
+    } catch {
+      // Non-fatal: callers retain the last exact snapshot and the rows fall
+      // back to backend device/meter evidence when none has ever loaded.
+      return null
+    }
+  }, [])
   // Cloud-AI consent is a durable preference, not a per-launch answer: it
   // silently resetting to off every launch was the top reason publish runs
   // "did nothing but extract audio" (2026-07-11 report).
@@ -3275,6 +3301,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   }, [recording.state])
 
   useEffect(() => {
+    audioMeterSampleGenerationRef.current += 1
+    setAudioMeterLoading(false)
     setAudioMeter(null)
   }, [captureConfig.sources.microphoneId])
 
@@ -4420,6 +4448,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   )
 
   const refreshBackend = useCallback(async () => {
+    await refreshMediaAccess()
     // S1 (plan 024): the two window `focus` listeners fire refreshBackend on
     // TCC-prompt focus-return, and at grant/restart time `client` is still the
     // OLD object (setClient(null) is deferred to effect cleanup), so a bare
@@ -4490,7 +4519,13 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     } catch (error) {
       reportError(error)
     }
-  }, [client, refreshAiReadinessForClient, refreshEntitlementsForClient, reportError])
+  }, [
+    client,
+    refreshAiReadinessForClient,
+    refreshEntitlementsForClient,
+    refreshMediaAccess,
+    reportError
+  ])
 
   const refreshEntitlements = useCallback(async (): Promise<void> => {
     if (!client || wsStatusRef.current !== 'connected') {
@@ -4525,32 +4560,17 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   // Real OS camera/mic access status (Electron getMediaAccessStatus, over IPC —
   // independent of the backend socket). Refresh on mount and whenever the window
-  // regains focus, since grants flip in the OS Settings while we're backgrounded
-  // — the same trigger the Settings/onboarding chips already use.
+  // regains focus, since grants flip in the OS Settings while we're backgrounded.
   useEffect(() => {
-    const bridge = window.videorc?.getMediaAccessStatus
-    if (!bridge) {
-      return
-    }
-    let cancelled = false
     const refresh = (): void => {
-      void bridge()
-        .then((snapshot) => {
-          if (!cancelled) {
-            setMediaAccess(snapshot)
-          }
-        })
-        .catch(() => {
-          // Non-fatal: the chips fall back to the meter/enumeration derivation.
-        })
+      void refreshMediaAccess()
     }
     refresh()
     window.addEventListener('focus', refresh)
     return () => {
-      cancelled = true
       window.removeEventListener('focus', refresh)
     }
-  }, [])
+  }, [refreshMediaAccess])
 
   useEffect(() => {
     if (
@@ -6022,7 +6042,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
   }, [client, refreshScreensForClient, reportError, wsStatus])
 
-  const openSystemPermission = useCallback(
+  const openSystemPermissionSettings = useCallback(
     async (pane: SystemPermissionPane) => {
       if (!window.videorc?.openSystemPermissions) {
         toast.error('Permission shortcut is unavailable outside Electron.')
@@ -6037,10 +6057,6 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     },
     [reportError]
   )
-
-  const openPreviewPermissions = useCallback(async () => {
-    await openSystemPermission('screen-recording')
-  }, [openSystemPermission])
 
   const revealPermissionTarget = useCallback(async () => {
     if (!window.videorc?.revealPermissionTarget) {
@@ -6097,9 +6113,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       toast.error('Microphone check', {
         description: 'Backend is not connected — try again in a moment.'
       })
-      return
+      return false
     }
 
+    const sampleGeneration = audioMeterSampleGenerationRef.current + 1
+    audioMeterSampleGenerationRef.current = sampleGeneration
     try {
       setLastError(null)
       setAudioMeterLoading(true)
@@ -6108,11 +6126,26 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         microphoneGainDb: captureConfig.audio.microphoneGainDb,
         microphoneMuted: captureConfig.audio.microphoneMuted
       })
-      setAudioMeter(result)
+      if (
+        audioMeterSampleGenerationRef.current === sampleGeneration &&
+        clientRef.current === client
+      ) {
+        setAudioMeter(result)
+        return true
+      }
+      return false
     } catch (error) {
-      reportError(error)
+      if (
+        audioMeterSampleGenerationRef.current === sampleGeneration &&
+        clientRef.current === client
+      ) {
+        reportError(error)
+      }
+      return false
     } finally {
-      setAudioMeterLoading(false)
+      if (audioMeterSampleGenerationRef.current === sampleGeneration) {
+        setAudioMeterLoading(false)
+      }
     }
   }, [
     captureConfig.audio.microphoneGainDb,
@@ -8832,6 +8865,92 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   )
   const meterLevel = Math.round((audioMeter?.level ?? 0) * 100)
   const canSampleAudio = Boolean(wsStatus === 'connected' && selectedMicrophone && !isSessionActive)
+  const canSampleAudioRef = useRef(canSampleAudio)
+  const sampleAudioMeterRef = useRef(sampleAudioMeter)
+  canSampleAudioRef.current = canSampleAudio
+  sampleAudioMeterRef.current = sampleAudioMeter
+
+  useEffect(() => {
+    const pendingProof = pendingMicrophonePermissionProof
+    if (!pendingProof || !client || wsStatus !== 'connected') {
+      return
+    }
+
+    let cancelled = false
+    let retryTimer: number | undefined
+    const scheduleRetry = (): boolean => {
+      if (cancelled || clientRef.current !== client || pendingProof.retry >= 2) return false
+      retryTimer = window.setTimeout(() => {
+        setPendingMicrophonePermissionProof((current) =>
+          current === pendingProof && current ? { ...current, retry: current.retry + 1 } : current
+        )
+      }, 250)
+      return true
+    }
+    void (async () => {
+      try {
+        const { runMicrophonePermissionProof } =
+          await import('@/lib/system-permission-orchestration')
+        const completed = await runMicrophonePermissionProof({
+          client,
+          proof: pendingProof,
+          isCurrent: () =>
+            !cancelled && clientRef.current === client && wsStatusRef.current === 'connected',
+          setDeviceList,
+          canSampleAudio: () => canSampleAudioRef.current,
+          sampleAudioMeter: () => sampleAudioMeterRef.current()
+        })
+        if (completed && !cancelled) {
+          setPendingMicrophonePermissionProof((current) =>
+            current === pendingProof ? null : current
+          )
+        } else {
+          scheduleRetry()
+        }
+      } catch (error) {
+        if (!scheduleRetry() && !cancelled && clientRef.current === client) {
+          reportError(error)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer)
+    }
+  }, [canSampleAudio, client, pendingMicrophonePermissionProof, reportError, wsStatus])
+
+  const handleSystemPermission = useCallback(
+    async (pane: SystemPermissionPane): Promise<void> => {
+      try {
+        const { runSystemPermissionAction } = await import('@/lib/system-permission-orchestration')
+        await runSystemPermissionAction({
+          pane,
+          platform: runtimeInfo?.platform,
+          refreshMediaAccess,
+          getDeviceList: () => deviceListRef.current,
+          getAudioMeter: () => audioMeterRef.current,
+          openSystemPermissionSettings,
+          getClient: () => clientRef.current,
+          getWsStatus: () => wsStatusRef.current,
+          clearMicrophoneEvidence: () => {
+            audioMeterSampleGenerationRef.current += 1
+            audioMeterRef.current = null
+            setAudioMeterLoading(false)
+            setAudioMeter(null)
+            setPendingMicrophonePermissionProof(null)
+          },
+          deferMicrophoneProof: (proof) =>
+            setPendingMicrophonePermissionProof({ ...proof, retry: 0 }),
+          setDeviceList,
+          reportError
+        })
+      } catch (error) {
+        reportError(error)
+      }
+    },
+    [openSystemPermissionSettings, refreshMediaAccess, reportError, runtimeInfo?.platform]
+  )
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -9095,8 +9214,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       switchSourceDeviceLive,
       setSceneSourceVisible,
       moveSceneSource,
-      openSystemPermission,
-      openPreviewPermissions,
+      handleSystemPermission,
+      openSystemPermissionSettings,
       revealPermissionTarget,
       exportSupportBundle,
       registerPreviewSurfaceResize,
@@ -9267,8 +9386,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       switchSourceDeviceLive,
       setSceneSourceVisible,
       moveSceneSource,
-      openSystemPermission,
-      openPreviewPermissions,
+      handleSystemPermission,
+      openSystemPermissionSettings,
       revealPermissionTarget,
       exportSupportBundle,
       registerPreviewSurfaceResize,

--- a/apps/desktop/src/renderer/src/lib/mic-stream.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-stream.test.ts
@@ -1,12 +1,33 @@
 import { describe, expect, it } from 'vitest'
 
-import { createMicStreamController, type MicStreamConstraints } from './mic-stream'
+import {
+  createMicStreamController,
+  microphoneStreamAcquisitionEnabled,
+  type MicStreamConstraints
+} from './mic-stream'
 
 function fakeStream(): { stopped: number[]; stream: { getTracks: () => { stop: () => void }[] } } {
   const stopped: number[] = []
   const tracks = [0, 1].map((index) => ({ stop: (): void => void stopped.push(index) }))
   return { stopped, stream: { getTracks: () => tracks } }
 }
+
+describe('microphoneStreamAcquisitionEnabled', () => {
+  it('allows acquisition only when requested and OS microphone access is exactly granted', () => {
+    expect(microphoneStreamAcquisitionEnabled(true, 'granted')).toBe(true)
+    expect(microphoneStreamAcquisitionEnabled(false, 'granted')).toBe(false)
+
+    for (const status of [
+      'not-determined',
+      'denied',
+      'restricted',
+      'unknown',
+      undefined
+    ] as const) {
+      expect(microphoneStreamAcquisitionEnabled(true, status)).toBe(false)
+    }
+  })
+})
 
 describe('createMicStreamController', () => {
   it('matches the backend device name and requests that exact deviceId', async () => {

--- a/apps/desktop/src/renderer/src/lib/mic-stream.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-stream.ts
@@ -6,6 +6,7 @@
 // ("a passive meter must never toast") in a single tested place. The backend
 // stays the capture/health authority; these streams are visual-only.
 
+import type { MediaAccessStatus } from './backend'
 import { matchMicrophoneDeviceId } from './mic-meter'
 
 type MicTrackLike = { stop: () => void }
@@ -32,6 +33,18 @@ export type MicStreamController<S extends MicMediaStreamLike> = {
   open: (deviceName: string | undefined) => Promise<S | null>
   /** Stop every open track; the controller cannot be reused afterwards. */
   close: () => void
+}
+
+/**
+ * Renderer microphone visuals must never become an implicit OS permission
+ * request. Only a user-resolved, exact `granted` status may reach
+ * getUserMedia; loading, denied, restricted, and unknown states remain idle.
+ */
+export function microphoneStreamAcquisitionEnabled(
+  requested: boolean,
+  permissionStatus: MediaAccessStatus | undefined
+): boolean {
+  return requested && permissionStatus === 'granted'
 }
 
 export function createMicStreamController<S extends MicMediaStreamLike>(

--- a/apps/desktop/src/renderer/src/lib/system-access.test.ts
+++ b/apps/desktop/src/renderer/src/lib/system-access.test.ts
@@ -4,10 +4,12 @@ import type { AudioMeterResult, DeviceList } from '@/lib/backend'
 
 import {
   cameraAccessState,
+  isMediaAccessSnapshotReady,
   mediaAccessToState,
   microphoneAccessState,
   screenAccessState,
   shouldShowPermissionsOnboarding,
+  systemAccessAction,
   systemAccessRows
 } from './system-access'
 
@@ -72,6 +74,14 @@ describe('microphoneAccessState', () => {
   })
 })
 
+describe('isMediaAccessSnapshotReady', () => {
+  it('does not let automatic onboarding decide from an unknown OS snapshot', () => {
+    expect(isMediaAccessSnapshotReady({ camera: 'unknown', microphone: 'not-determined' })).toBe(
+      false
+    )
+  })
+})
+
 describe('shouldShowPermissionsOnboarding', () => {
   const allGranted = systemAccessRows({
     deviceList: devices([
@@ -131,9 +141,134 @@ describe('shouldShowPermissionsOnboarding', () => {
       shouldShowPermissionsOnboarding({ rows: missingSome, dismissed: false, backendReady: false })
     ).toBe(false)
   })
+  it('never evaluates before the exact media-access snapshot has loaded', () => {
+    expect(
+      shouldShowPermissionsOnboarding({
+        rows: missingSome,
+        dismissed: false,
+        backendReady: true,
+        mediaAccessReady: false
+      })
+    ).toBe(false)
+  })
 })
 
 describe('systemAccessRows', () => {
+  it('keeps a fresh macOS camera requestable when the backend collapses TCC states', () => {
+    const rows = systemAccessRows({
+      deviceList: devices([{ kind: 'camera', status: 'permission-required' }]),
+      audioMeter: null,
+      platform: 'darwin',
+      mediaAccess: { camera: 'not-determined', microphone: 'not-determined' }
+    })
+
+    expect(rows.find((row) => row.id === 'camera')?.state).toBe('first-use')
+    expect(rows.find((row) => row.id === 'microphone')?.state).toBe('first-use')
+  })
+
+  it.each(['denied', 'restricted'] as const)(
+    'uses the exact macOS %s state instead of the lossy backend placeholder',
+    (status) => {
+      const rows = systemAccessRows({
+        deviceList: devices([{ kind: 'camera', status: 'permission-required' }]),
+        audioMeter: { status: 'permission-required' },
+        platform: 'darwin',
+        mediaAccess: { camera: status, microphone: status }
+      })
+
+      expect(rows.find((row) => row.id === 'camera')?.state).toBe('not-granted')
+      expect(rows.find((row) => row.id === 'microphone')?.state).toBe('not-granted')
+      if (status === 'restricted') {
+        expect(rows.find((row) => row.id === 'camera')?.detail).toMatch(/restricted/i)
+        expect(rows.find((row) => row.id === 'microphone')?.detail).toMatch(/restricted/i)
+      }
+    }
+  )
+
+  it('requires backend device health before a macOS grant is shown as healthy', () => {
+    const healthy = systemAccessRows({
+      deviceList: devices([{ kind: 'camera', status: 'available' }]),
+      audioMeter: { status: 'ready' },
+      platform: 'darwin',
+      mediaAccess: { camera: 'granted', microphone: 'granted' }
+    })
+    const unhealthy = systemAccessRows({
+      deviceList: devices([{ kind: 'camera', status: 'unavailable' }]),
+      audioMeter: { status: 'no-frames' },
+      platform: 'darwin',
+      mediaAccess: { camera: 'granted', microphone: 'granted' }
+    })
+
+    expect(healthy.find((row) => row.id === 'camera')?.state).toBe('granted')
+    expect(healthy.find((row) => row.id === 'microphone')?.state).toBe('granted')
+    expect(unhealthy.find((row) => row.id === 'camera')?.state).toBe('device-issue')
+    expect(unhealthy.find((row) => row.id === 'microphone')?.state).toBe('device-issue')
+    expect(unhealthy.find((row) => row.id === 'camera')?.detail).toMatch(
+      /permission is granted.*no usable camera/i
+    )
+  })
+
+  it('accepts an enumerated microphone as healthy before an optional meter check', () => {
+    const rows = systemAccessRows({
+      deviceList: devices([
+        { kind: 'camera', status: 'available' },
+        { kind: 'microphone', status: 'available' }
+      ]),
+      audioMeter: null,
+      platform: 'darwin',
+      mediaAccess: { camera: 'granted', microphone: 'granted' }
+    })
+
+    expect(rows.find((row) => row.id === 'microphone')?.state).toBe('granted')
+  })
+
+  it('keeps a proven microphone backend failure visible after permission is granted', () => {
+    const rows = systemAccessRows({
+      deviceList: devices([{ kind: 'microphone', status: 'available' }]),
+      audioMeter: { status: 'unavailable' },
+      platform: 'darwin',
+      mediaAccess: { camera: 'granted', microphone: 'granted' }
+    })
+
+    expect(rows.find((row) => row.id === 'microphone')?.state).toBe('device-issue')
+  })
+
+  it('does not repeat stale permission-required meter copy after an exact microphone grant', () => {
+    const rows = systemAccessRows({
+      deviceList: devices([{ kind: 'microphone', status: 'available' }]),
+      audioMeter: {
+        status: 'permission-required',
+        message: 'Microphone permission is required.'
+      },
+      platform: 'darwin',
+      mediaAccess: { camera: 'granted', microphone: 'granted' }
+    })
+
+    const microphone = rows.find((row) => row.id === 'microphone')
+    expect(microphone?.state).toBe('device-issue')
+    expect(microphone?.detail).toMatch(/permission is granted/i)
+    expect(microphone?.detail).not.toMatch(/permission is required/i)
+  })
+
+  it('falls back to backend evidence when the exact macOS status is unknown or missing', () => {
+    const unknown = systemAccessRows({
+      deviceList: devices([{ kind: 'camera', status: 'permission-required' }]),
+      audioMeter: { status: 'ready' },
+      platform: 'darwin',
+      mediaAccess: { camera: 'unknown', microphone: 'unknown' }
+    })
+    const missing = systemAccessRows({
+      deviceList: devices([{ kind: 'camera', status: 'available' }]),
+      audioMeter: { status: 'permission-required' },
+      platform: 'darwin'
+    })
+
+    expect(unknown.find((row) => row.id === 'camera')?.state).toBe('not-granted')
+    expect(unknown.find((row) => row.id === 'microphone')?.state).toBe('granted')
+    expect(missing.find((row) => row.id === 'camera')?.state).toBe('granted')
+    expect(missing.find((row) => row.id === 'microphone')?.state).toBe('not-granted')
+  })
+
   it('renders three rows with purposes and honest details', () => {
     const rows = systemAccessRows({
       deviceList: devices([
@@ -203,6 +338,18 @@ describe('systemAccessRows', () => {
     expect(mic?.detail).toMatch(/isn.t listed by name/)
   })
 
+  it('falls back to backend evidence when the exact Windows status is unknown', () => {
+    const rows = systemAccessRows({
+      deviceList: devices([{ kind: 'camera', status: 'available' }]),
+      audioMeter: { status: 'permission-required' },
+      platform: 'win32',
+      mediaAccess: { camera: 'unknown', microphone: 'unknown' }
+    })
+
+    expect(rows.find((row) => row.id === 'camera')?.state).toBe('granted')
+    expect(rows.find((row) => row.id === 'microphone')?.state).toBe('not-granted')
+  })
+
   it('mediaAccessToState maps OS statuses to chip states', () => {
     expect(mediaAccessToState('granted')).toBe('granted')
     expect(mediaAccessToState('denied')).toBe('not-granted')
@@ -210,5 +357,70 @@ describe('systemAccessRows', () => {
     expect(mediaAccessToState('not-determined')).toBe('first-use')
     expect(mediaAccessToState('unknown')).toBe('first-use')
     expect(mediaAccessToState(undefined)).toBe('first-use')
+  })
+})
+
+describe('systemAccessAction', () => {
+  it('requests native macOS camera and microphone access only on first use', () => {
+    expect(
+      systemAccessAction({
+        pane: 'camera',
+        state: 'first-use',
+        platform: 'darwin',
+        mediaAccessStatus: 'not-determined'
+      })
+    ).toBe('request-media-access')
+    expect(
+      systemAccessAction({
+        pane: 'microphone',
+        state: 'first-use',
+        platform: 'darwin',
+        mediaAccessStatus: 'not-determined'
+      })
+    ).toBe('request-media-access')
+  })
+
+  it('opens settings for denied media, screen recording, privacy, and Windows', () => {
+    expect(systemAccessAction({ pane: 'camera', state: 'not-granted', platform: 'darwin' })).toBe(
+      'open-settings'
+    )
+    expect(
+      systemAccessAction({ pane: 'screen-recording', state: 'first-use', platform: 'darwin' })
+    ).toBe('open-settings')
+    expect(systemAccessAction({ pane: 'privacy', state: 'first-use', platform: 'darwin' })).toBe(
+      'open-settings'
+    )
+    expect(systemAccessAction({ pane: 'camera', state: 'first-use', platform: 'win32' })).toBe(
+      'open-settings'
+    )
+  })
+
+  it('does not offer another permission action after a grant or for a device issue', () => {
+    expect(systemAccessAction({ pane: 'camera', state: 'granted', platform: 'darwin' })).toBeNull()
+    expect(
+      systemAccessAction({ pane: 'microphone', state: 'device-issue', platform: 'darwin' })
+    ).toBeNull()
+    expect(
+      systemAccessAction({
+        pane: 'microphone',
+        state: 'first-use',
+        platform: 'darwin',
+        mediaAccessStatus: 'granted'
+      })
+    ).toBeNull()
+  })
+
+  it('never invents a native prompt when the exact macOS status is missing or unknown', () => {
+    expect(systemAccessAction({ pane: 'camera', state: 'first-use', platform: 'darwin' })).toBe(
+      'open-settings'
+    )
+    expect(
+      systemAccessAction({
+        pane: 'microphone',
+        state: 'first-use',
+        platform: 'darwin',
+        mediaAccessStatus: 'unknown'
+      })
+    ).toBe('open-settings')
   })
 })

--- a/apps/desktop/src/renderer/src/lib/system-access.ts
+++ b/apps/desktop/src/renderer/src/lib/system-access.ts
@@ -1,4 +1,11 @@
-import type { AudioMeterResult, Device, DeviceList, MediaAccessStatus } from '@/lib/backend'
+import type {
+  AudioMeterResult,
+  Device,
+  DeviceList,
+  MediaAccessSnapshot,
+  MediaAccessStatus,
+  SystemPermissionPane
+} from '@/lib/backend'
 import { appPlatform, osSettingsName, type AppPlatform } from '@/lib/platform'
 
 // ST3 (Settings rework): live permission states for the System access rows.
@@ -7,10 +14,11 @@ import { appPlatform, osSettingsName, type AppPlatform } from '@/lib/platform'
 // the OS genuinely won't tell us until first use, we say so instead of faking
 // a green chip.
 //
-// Platform matters here: macOS TCC reports denied camera/mic as
-// permission-required, so "enumerated" implies "granted"; Windows exposes no
-// such per-device denial in the device list and has NO per-app screen
-// permission at all, so the derivation and the row set differ by platform.
+// Platform matters here: the macOS backend collapses never-asked, denied, and
+// restricted into permission-required, so Electron's exact TCC snapshot owns
+// permission truth there. Backend enumeration/meter results refine device
+// health after a grant. Windows has no per-app screen permission, so its row
+// set and recovery path differ.
 
 export type SystemAccessState = 'granted' | 'not-granted' | 'first-use' | 'device-issue'
 
@@ -21,6 +29,19 @@ export interface SystemAccessRow {
   purpose: string
   state: SystemAccessState
   detail: string
+}
+
+export type SystemAccessAction = 'request-media-access' | 'open-settings' | null
+
+export function isMediaAccessSnapshotReady(
+  mediaAccess: MediaAccessSnapshot | null | undefined
+): mediaAccess is MediaAccessSnapshot {
+  return (
+    mediaAccess !== null &&
+    mediaAccess !== undefined &&
+    mediaAccess.camera !== 'unknown' &&
+    mediaAccess.microphone !== 'unknown'
+  )
 }
 
 function screenDevices(devices: Device[]): Device[] {
@@ -92,6 +113,65 @@ export function mediaAccessToState(status: MediaAccessStatus | undefined): Syste
   }
 }
 
+function windowsMediaAccessState(
+  status: MediaAccessStatus | undefined,
+  backendState: SystemAccessState
+): SystemAccessState {
+  return status === undefined || status === 'unknown' ? backendState : mediaAccessToState(status)
+}
+
+// macOS exposes the permission decision separately from capture health. The
+// exact TCC value must decide never-asked vs denied; after a grant, backend
+// evidence still has to prove that the device can actually be used.
+export function macosMediaAccessState(
+  status: MediaAccessStatus | undefined,
+  backendState: SystemAccessState
+): SystemAccessState {
+  switch (status) {
+    case 'not-determined':
+      return 'first-use'
+    case 'denied':
+    case 'restricted':
+      return 'not-granted'
+    case 'granted':
+      return backendState === 'granted' ? 'granted' : 'device-issue'
+    case 'unknown':
+    default:
+      return backendState
+  }
+}
+
+export function systemAccessAction({
+  pane,
+  state,
+  platform,
+  mediaAccessStatus
+}: {
+  pane: SystemPermissionPane
+  state?: SystemAccessState
+  platform?: string
+  mediaAccessStatus?: MediaAccessStatus
+}): SystemAccessAction {
+  if (pane === 'privacy') {
+    return 'open-settings'
+  }
+  if ((pane === 'camera' || pane === 'microphone') && mediaAccessStatus === 'granted') {
+    return null
+  }
+  if (state === 'granted' || state === 'device-issue') {
+    return null
+  }
+  if (
+    appPlatform(platform) === 'darwin' &&
+    (pane === 'camera' || pane === 'microphone') &&
+    state === 'first-use' &&
+    mediaAccessStatus === 'not-determined'
+  ) {
+    return 'request-media-access'
+  }
+  return 'open-settings'
+}
+
 export function systemAccessRows({
   deviceList,
   audioMeter,
@@ -104,17 +184,28 @@ export function systemAccessRows({
   mediaAccess?: { camera: MediaAccessStatus; microphone: MediaAccessStatus } | null
 }): SystemAccessRow[] {
   const os = appPlatform(platform)
-  // On Windows the OS access status is the honest signal (see mediaAccessToState);
-  // macOS keeps its TCC-aware enumeration/meter derivation, which already
-  // distinguishes denied from first-use.
+  const backendCamera = cameraAccessState(deviceList)
+  const backendMicrophone = microphoneAccessState(audioMeter)
+  const macosMicrophoneHealth =
+    audioMeter === null &&
+    backendMicrophone === 'first-use' &&
+    deviceList.devices.some(
+      (device) => device.kind === 'microphone' && device.status === 'available'
+    )
+      ? 'granted'
+      : backendMicrophone
   const camera =
-    os === 'win32' && mediaAccess
-      ? mediaAccessToState(mediaAccess.camera)
-      : cameraAccessState(deviceList)
+    os === 'win32'
+      ? windowsMediaAccessState(mediaAccess?.camera, backendCamera)
+      : os === 'darwin'
+        ? macosMediaAccessState(mediaAccess?.camera, backendCamera)
+        : backendCamera
   const microphone =
-    os === 'win32' && mediaAccess
-      ? mediaAccessToState(mediaAccess.microphone)
-      : microphoneAccessState(audioMeter)
+    os === 'win32'
+      ? windowsMediaAccessState(mediaAccess?.microphone, backendMicrophone)
+      : os === 'darwin'
+        ? macosMediaAccessState(mediaAccess?.microphone, macosMicrophoneHealth)
+        : backendMicrophone
 
   const rows: SystemAccessRow[] = []
 
@@ -136,7 +227,12 @@ export function systemAccessRows({
     label: 'Camera',
     purpose: 'Camera overlay in your scenes.',
     state: camera,
-    detail: accessDetail(camera, 'the camera', os)
+    detail:
+      os === 'darwin' && mediaAccess?.camera === 'restricted'
+        ? 'Camera access is restricted by macOS policy and may not be changeable here.'
+        : camera === 'device-issue'
+          ? 'Camera permission is granted, but no usable camera is currently available.'
+          : accessDetail(camera, 'the camera', os)
   })
 
   rows.push({
@@ -145,12 +241,14 @@ export function systemAccessRows({
     purpose: 'Voice audio and live captions.',
     state: microphone,
     detail:
-      microphone === 'device-issue'
-        ? (audioMeter?.message ??
-          'The microphone opened but did not send frames. Try the fallback input or another mic.')
-        : microphone === 'first-use'
-          ? 'Checked when you run a mic check or start a session.'
-          : accessDetail(microphone, 'the microphone', os)
+      os === 'darwin' && mediaAccess?.microphone === 'restricted'
+        ? 'Microphone access is restricted by macOS policy and may not be changeable here.'
+        : microphone === 'device-issue'
+          ? ((audioMeter?.status === 'permission-required' ? undefined : audioMeter?.message) ??
+            'Microphone permission is granted, but no usable input is currently available.')
+          : microphone === 'first-use'
+            ? 'Checked when you run a mic check or start a session.'
+            : accessDetail(microphone, 'the microphone', os)
   })
 
   return rows
@@ -162,17 +260,19 @@ export function systemAccessRows({
 // is a snooze, not the trigger: once the user continues or skips, gaps go back
 // to the Sources alerts and Settings chips. `backendReady` guards the boot
 // window where device enumeration hasn't arrived and every state would read
-// first-use — unknown must never flash the dialog.
+// first-use — unknown backend or exact media state must never flash the dialog.
 export function shouldShowPermissionsOnboarding({
   rows,
   dismissed,
-  backendReady
+  backendReady,
+  mediaAccessReady = true
 }: {
   rows: SystemAccessRow[]
   dismissed: boolean
   backendReady: boolean
+  mediaAccessReady?: boolean
 }): boolean {
-  if (dismissed || !backendReady) {
+  if (dismissed || !backendReady || !mediaAccessReady) {
     return false
   }
   return rows.some((row) => row.state !== 'granted' && row.state !== 'device-issue')

--- a/apps/desktop/src/renderer/src/lib/system-permission-orchestration.test.ts
+++ b/apps/desktop/src/renderer/src/lib/system-permission-orchestration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { BackendClient } from '@/backendClient'
+
+import { isReplacementPermissionClient } from './system-permission-orchestration'
+
+function client(port: number, pid: number): BackendClient {
+  return new BackendClient({ host: '127.0.0.1', port, pid, token: `token-${pid}` })
+}
+
+describe('isReplacementPermissionClient', () => {
+  it('rejects both the renderer client from before the prompt and an unpublished stale backend', () => {
+    const beforePrompt = client(9988, 101)
+    const staleBackend = { port: 9989, pid: 202 }
+    const proof = { previousClient: beforePrompt, staleBackend }
+
+    expect(isReplacementPermissionClient(beforePrompt, proof)).toBe(false)
+    expect(isReplacementPermissionClient(client(9989, 202), proof)).toBe(false)
+    expect(isReplacementPermissionClient(client(9990, 303), proof)).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/system-permission-orchestration.ts
+++ b/apps/desktop/src/renderer/src/lib/system-permission-orchestration.ts
@@ -1,0 +1,199 @@
+import { toast } from 'sonner'
+
+import type { BackendClient } from '@/backendClient'
+import type { WsStatus } from '@/lib/capture'
+import type {
+  AudioMeterResult,
+  BackendRestartBoundary,
+  DeviceList,
+  MediaAccessSnapshot,
+  RuntimeInfo,
+  SystemPermissionPane
+} from '@/lib/backend'
+import { systemAccessAction, systemAccessRows } from '@/lib/system-access'
+
+type SystemPermissionOrchestration = {
+  pane: SystemPermissionPane
+  platform: RuntimeInfo['platform'] | undefined
+  refreshMediaAccess: () => Promise<MediaAccessSnapshot | null>
+  getDeviceList: () => DeviceList
+  getAudioMeter: () => AudioMeterResult | null
+  openSystemPermissionSettings: (pane: SystemPermissionPane) => Promise<void>
+  getClient: () => BackendClient | null
+  getWsStatus: () => WsStatus
+  clearMicrophoneEvidence: () => void
+  deferMicrophoneProof: (proof: MicrophonePermissionProof) => void
+  setDeviceList: (deviceList: DeviceList) => void
+  reportError: (error: unknown) => void
+}
+
+export type MicrophonePermissionProof = {
+  previousClient: BackendClient | null
+  staleBackend?: BackendRestartBoundary
+}
+
+function matchesStaleBackend(client: BackendClient, boundary: BackendRestartBoundary): boolean {
+  const { connection } = client
+  return (
+    connection.port === boundary.port &&
+    (boundary.pid === undefined || connection.pid === boundary.pid)
+  )
+}
+
+export function isReplacementPermissionClient(
+  client: BackendClient | null,
+  proof: MicrophonePermissionProof
+): client is BackendClient {
+  if (!client || client === proof.previousClient) return false
+  return !proof.staleBackend || !matchesStaleBackend(client, proof.staleBackend)
+}
+
+export async function waitForPermissionCondition(
+  condition: () => boolean,
+  timeoutMs = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!condition() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+}
+
+export async function runMicrophonePermissionProof({
+  client,
+  proof,
+  isCurrent,
+  setDeviceList,
+  canSampleAudio,
+  sampleAudioMeter
+}: {
+  client: BackendClient
+  proof: MicrophonePermissionProof
+  isCurrent: () => boolean
+  setDeviceList: (deviceList: DeviceList) => void
+  canSampleAudio: () => boolean
+  sampleAudioMeter: () => Promise<boolean>
+}): Promise<boolean> {
+  if (!isReplacementPermissionClient(client, proof)) return false
+
+  let nextDevices: DeviceList | undefined
+  for (let attempt = 0; attempt < 2 && isCurrent(); attempt += 1) {
+    try {
+      nextDevices = await client.request<DeviceList>('devices.list')
+      break
+    } catch (error) {
+      if (!isCurrent()) return false
+      if (attempt === 1) throw error
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+  }
+  if (!nextDevices || !isCurrent()) return false
+  setDeviceList(nextDevices)
+  await waitForPermissionCondition(() => isCurrent() && canSampleAudio())
+  if (!isCurrent() || !canSampleAudio()) return false
+  return (await sampleAudioMeter()) && isCurrent()
+}
+
+export async function runSystemPermissionAction({
+  pane,
+  platform,
+  refreshMediaAccess,
+  getDeviceList,
+  getAudioMeter,
+  openSystemPermissionSettings,
+  getClient,
+  getWsStatus,
+  clearMicrophoneEvidence,
+  deferMicrophoneProof,
+  setDeviceList,
+  reportError
+}: SystemPermissionOrchestration): Promise<void> {
+  const snapshot = await refreshMediaAccess()
+  if ((pane === 'camera' || pane === 'microphone') && !snapshot) {
+    const label = pane === 'camera' ? 'Camera' : 'Microphone'
+    toast.error(`Could not check ${label} permission.`, {
+      description: 'Try again before changing access.'
+    })
+    return
+  }
+  const row = systemAccessRows({
+    deviceList: getDeviceList(),
+    audioMeter: getAudioMeter(),
+    platform,
+    mediaAccess: snapshot
+  }).find((candidate) => candidate.id === pane)
+  const mediaAccessStatus =
+    pane === 'camera' || pane === 'microphone' ? snapshot?.[pane] : undefined
+  const action = systemAccessAction({
+    pane,
+    state: row?.state,
+    platform,
+    mediaAccessStatus
+  })
+
+  if (!action) {
+    return
+  }
+  if (action === 'open-settings') {
+    if (pane === 'microphone') {
+      clearMicrophoneEvidence()
+    }
+    await openSystemPermissionSettings(pane)
+    return
+  }
+
+  const requestMediaAccess = window.videorc?.requestMediaAccess
+  if (!requestMediaAccess || (pane !== 'camera' && pane !== 'microphone')) {
+    toast.error('Permission request is unavailable outside Electron.')
+    return
+  }
+
+  try {
+    const previousClient = getClient()
+    const result = await requestMediaAccess(pane)
+    await refreshMediaAccess()
+    if (!result.granted) {
+      return
+    }
+
+    if (pane === 'microphone') {
+      clearMicrophoneEvidence()
+      deferMicrophoneProof({
+        previousClient,
+        ...(result.staleBackend ? { staleBackend: result.staleBackend } : {})
+      })
+      return
+    }
+
+    if (!result.restarted) {
+      // The current backend was initialized before the new grant. Its
+      // device/meter evidence is stale, so wait for the deferred restart.
+      return
+    }
+
+    await waitForPermissionCondition(
+      () =>
+        getWsStatus() === 'connected' &&
+        isReplacementPermissionClient(getClient(), {
+          previousClient,
+          ...(result.staleBackend ? { staleBackend: result.staleBackend } : {})
+        })
+    )
+    const activeClient = getClient()
+    if (
+      getWsStatus() !== 'connected' ||
+      !isReplacementPermissionClient(activeClient, {
+        previousClient,
+        ...(result.staleBackend ? { staleBackend: result.staleBackend } : {})
+      })
+    ) {
+      return
+    }
+
+    const nextDevices = await activeClient.request<DeviceList>('devices.list')
+    if (getClient() === activeClient) {
+      setDeviceList(nextDevices)
+    }
+  } catch (error) {
+    reportError(error)
+  }
+}

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -9,6 +9,19 @@ export interface BackendConnection {
   parentPid?: number
 }
 
+/** Non-secret identity for a backend whose capture state predates a permission grant. */
+export interface BackendRestartBoundary {
+  port: number
+  pid?: number
+}
+
+export interface MediaAccessResult {
+  granted: boolean
+  restarted: boolean
+  /** Backend whose capture state predates this grant. */
+  staleBackend?: BackendRestartBoundary
+}
+
 export interface BackendHealth {
   status: string
   version: string
@@ -2911,9 +2924,7 @@ export interface VideorcApi {
   /** Fire the native macOS grant prompt in place (no System Settings jump).
    * `restarted` is true only when a fresh grant restarted the capture backend
    * — callers probing a device right after must wait for reconnect first. */
-  requestMediaAccess: (
-    pane: 'camera' | 'microphone'
-  ) => Promise<{ granted: boolean; restarted: boolean }>
+  requestMediaAccess: (pane: 'camera' | 'microphone') => Promise<MediaAccessResult>
   revealPermissionTarget: () => Promise<void>
   revealSelectedResource: (capabilityId: string) => Promise<void>
   revealSession: (sessionId: string) => Promise<void>

--- a/docs/acceptance/2026-07-15-issue-125-camera-permission-registration.md
+++ b/docs/acceptance/2026-07-15-issue-125-camera-permission-registration.md
@@ -1,0 +1,117 @@
+# Issue 125 Camera Permission Registration Acceptance
+
+Date: 2026-07-15
+
+Issue: https://github.com/TheOrcDev/videorc/issues/125
+
+Branch: `codex/issue-125-camera-permissions`
+
+Status: implementation accepted by deterministic and real-device gates. Final
+macOS 27 clean-TCC release-candidate acceptance is BLOCKED because the available
+host is macOS 26.5.1 (25F80), arm64.
+
+## Accepted implementation
+
+- macOS camera and microphone state uses Electron's exact media-access status,
+  preserving `not-determined` versus `denied`/`restricted` instead of trusting
+  the backend's lossy `permission-required` value.
+- A shared renderer action makes first-use **Enable** call the native TCC request,
+  then makes denial/restriction use **Open settings**. Settings, onboarding,
+  Sources, Diagnostics, preview warnings, and the audio mixer share that policy.
+- Prompts remain user-initiated. Passive Chromium microphone visualizers require
+  exact `granted` status before reaching `getUserMedia`.
+- Grant recovery refreshes the exact status and the replacement backend's device
+  list. A non-secret stale-backend boundary rejects both the renderer's
+  pre-prompt client and any unpublished intermediate backend. Deferred microphone
+  grants retain and retry proof until a later generation refreshes devices and
+  successfully samples the meter.
+- Windows `unknown` snapshots fall back to backend evidence and cannot consume
+  the automatic-onboarding one-shot.
+- The packaged-app validator now requires the exact bundle identifier
+  `dev.theorcdev.videorc` and non-empty Camera and Microphone usage descriptions.
+
+## Deterministic gates
+
+| Gate | Result |
+| --- | --- |
+| Focused permission, media IPC, mic-stream, preview routing, and provider tests | PASS — 79/79 |
+| `pnpm typecheck` | PASS |
+| `pnpm lint` | PASS |
+| `pnpm format:check` | PASS |
+| `pnpm --filter @videorc/desktop test` | PASS — 1,111 passed, 1 skipped |
+| `pnpm test:scripts` | PASS — 640/640 |
+| `pnpm build` | PASS |
+| `pnpm check:renderer-assets` | PASS — 369,926 gzip bytes (370,000 budget) |
+| `cargo fmt --check --all` | PASS |
+| `cargo clippy -p videorc-backend -- -D warnings` | PASS |
+| `cargo test -p videorc-backend` | PASS on final rerun — 1,291 passed, 8 ignored; wire test passed |
+| `pnpm audit:deps` | PASS |
+
+An earlier full Rust run exposed two compositor timing failures. The
+auxiliary-output failure passed when isolated; the concurrent-compositor handoff
+test reproduced once when isolated. The final full rerun was green. This branch
+changes no Rust.
+
+`pnpm smoke:local-gates` passed text integrity, typecheck, build, the renderer
+asset budget, the final full Rust suite, OAuth, and OAuth guards before stopping
+at the existing `smoke:sources` temporary-module resolution error for
+`../../../shared/backend`.
+
+## Recording and native-preview evidence
+
+- `pnpm smoke:recording-studio` and
+  `pnpm smoke:recording-studio:devices` both passed their focused desktop,
+  script/A-V, backend layout/scene/recording/audio, captions, noise cleanup,
+  all-layout artifact, imported-screen, first-frame, liveness, and active-layout
+  rows. Both aggregates then stopped at the existing split record+stream
+  comment-highlight artifact failure; the stream-only row passed.
+- `pnpm smoke:preview-interaction-stress:devices`: PASS. A 59.266-second,
+  9,585,487-byte real-device recording passed final artifact analysis. Native
+  CAMetal preview stayed live, aligned, front-most, and scene-current through
+  491 interactions with no reported drops.
+- `pnpm smoke:live-layout-switch-recording:devices`: PASS for real
+  ScreenCaptureKit record-only and record+stream artifacts.
+- Source-complete `pnpm smoke:recording-native-preview`: PASS with 10 ms A/V
+  skew, zero CPU fallback frames, zero copied Metal frames, and four live layout
+  updates.
+- Preview scene commit, main-pump diagnostics, click/focus continuity, window
+  placement/docking, and native-surface reattach smokes: PASS.
+- The 100-cycle lifecycle behavior and clean teardown passed. The lifecycle
+  command exited 2 because its separate process-memory classifier counted four
+  Electron-main processes against a maximum of one.
+- The real-source screen and Notes-window baselines reached the existing
+  `preview.surface.create` admin-only authorization failure. The same blocker is
+  recorded in `docs/acceptance/2026-07-14-windows-pending-delete-live-mic-regression.md`.
+
+## Signed artifact validation
+
+The existing signed 0.9.41 app passed codesign, Gatekeeper, stapling, the exact
+bundle identifier check, both usage-description checks, capture entitlements,
+and native-preview-addon signing. The 0.9.41 DMG passed its checks.
+
+The full `pnpm release:validate:macos` command is BLOCKED locally because the X
+OAuth1 release consumer environment pair is not installed. No secret values were
+recorded.
+
+## macOS 27 clean-TCC acceptance — BLOCKED
+
+The issue was reported on macOS 27 beta. The available machine is macOS 26.5.1
+(25F80), and its existing grants must not be reset as a substitute for a
+disposable clean-TCC environment.
+
+Run the following against a signed candidate on a dedicated macOS 27 account,
+VM, or device:
+
+- [ ] Fresh Camera state renders **Checked on first use** and **Enable** in
+      Settings and Sources without prompting on mount.
+- [ ] Clicking **Enable** produces a native prompt naming Videorc.
+- [ ] Allow registers Videorc in System Settings, refreshes exact status,
+      reconnects the backend, enumerates the camera, and reaches live preview
+      frames. Relaunch does not re-prompt.
+- [ ] Deny registers Videorc disabled, changes the app to **Not granted** and
+      **Open settings**, and Settings recovery refreshes enumeration/preview.
+- [ ] Restricted, no-camera, and stale-backend cases retain truthful state and
+      never offer a dead permission action.
+
+Overall verdict: code and macOS 26 real-device acceptance PASS; macOS 27
+clean-TCC release acceptance BLOCKED.

--- a/scripts/lib/macos-release-artifact-validation.mjs
+++ b/scripts/lib/macos-release-artifact-validation.mjs
@@ -20,6 +20,8 @@ export const REQUIRED_CAPTURE_ENTITLEMENTS = [
   'com.apple.security.device.audio-input'
 ]
 
+export const EXPECTED_MACOS_BUNDLE_IDENTIFIER = 'dev.theorcdev.videorc'
+
 // One shared entitlements plist signs the app and every bundled tool, so all of
 // them must carry the device entitlements (paths mirror
 // scripts/sign-macos-local-app.mjs and electron-builder extraResources).
@@ -95,6 +97,22 @@ export function evaluateBinaryContainsEnvSecretCheck(
       }
 }
 
+export function stdoutExpectationFailures(check, stdout) {
+  const value = String(stdout ?? '')
+  const failures = []
+
+  if (check.expectStdoutEquals !== undefined && value !== check.expectStdoutEquals) {
+    failures.push(
+      `expected stdout exactly ${JSON.stringify(check.expectStdoutEquals)}, got ${JSON.stringify(value)}`
+    )
+  }
+  if (check.expectStdoutNonEmpty === true && value.trim().length === 0) {
+    failures.push('expected non-empty stdout')
+  }
+
+  return failures
+}
+
 export function buildMacosReleaseArtifactChecks(path) {
   const kind = artifactKindFromPath(path)
   if (!kind) {
@@ -102,6 +120,7 @@ export function buildMacosReleaseArtifactChecks(path) {
   }
 
   if (kind === 'app') {
+    const infoPlist = `${path}/Contents/Info.plist`
     return [
       {
         id: 'codesign-verify',
@@ -126,6 +145,57 @@ export function buildMacosReleaseArtifactChecks(path) {
         label: 'stapler validate',
         command: 'xcrun',
         args: ['stapler', 'validate', path]
+      },
+      {
+        id: 'info-plist-bundle-identifier',
+        label: 'Info.plist bundle identifier',
+        command: 'plutil',
+        args: [
+          '-extract',
+          'CFBundleIdentifier',
+          'raw',
+          '-expect',
+          'string',
+          '-n',
+          '-o',
+          '-',
+          infoPlist
+        ],
+        expectStdoutEquals: EXPECTED_MACOS_BUNDLE_IDENTIFIER
+      },
+      {
+        id: 'info-plist-camera-usage-description',
+        label: 'Info.plist camera usage description',
+        command: 'plutil',
+        args: [
+          '-extract',
+          'NSCameraUsageDescription',
+          'raw',
+          '-expect',
+          'string',
+          '-n',
+          '-o',
+          '-',
+          infoPlist
+        ],
+        expectStdoutNonEmpty: true
+      },
+      {
+        id: 'info-plist-microphone-usage-description',
+        label: 'Info.plist microphone usage description',
+        command: 'plutil',
+        args: [
+          '-extract',
+          'NSMicrophoneUsageDescription',
+          'raw',
+          '-expect',
+          'string',
+          '-n',
+          '-o',
+          '-',
+          infoPlist
+        ],
+        expectStdoutNonEmpty: true
       },
       ...captureEntitlementCheckTargets(path).map((target) => ({
         id: `capture-entitlements-${target.id}`,

--- a/scripts/lib/macos-release-artifact-validation.test.mjs
+++ b/scripts/lib/macos-release-artifact-validation.test.mjs
@@ -8,11 +8,13 @@ import {
   bundledXOauth1ConsumerCheckTargets,
   captureEntitlementCheckTargets,
   evaluateBinaryContainsEnvSecretCheck,
+  EXPECTED_MACOS_BUNDLE_IDENTIFIER,
   formatArtifactPath,
   formatReleaseArtifactValidationReport,
   REQUIRED_CAPTURE_ENTITLEMENTS,
   sanitizeReleaseValidationOutput,
-  selectLatestReleaseArtifacts
+  selectLatestReleaseArtifacts,
+  stdoutExpectationFailures
 } from './macos-release-artifact-validation.mjs'
 
 // relative() emits platform separators, so repo-relative path assertions must
@@ -40,6 +42,9 @@ describe('buildMacosReleaseArtifactChecks', () => {
         'codesign display',
         'Gatekeeper assess',
         'stapler validate',
+        'Info.plist bundle identifier',
+        'Info.plist camera usage description',
+        'Info.plist microphone usage description',
         'capture entitlements (app)',
         'capture entitlements (videorc-backend)',
         'capture entitlements (native_preview_host_helper)',
@@ -89,6 +94,104 @@ describe('buildMacosReleaseArtifactChecks', () => {
       labels.some((label) => label.startsWith('capture entitlements')),
       false
     )
+  })
+
+  it('requires exact capture identity and non-empty usage descriptions in the app Info.plist', () => {
+    const checks = buildMacosReleaseArtifactChecks('/release/Videorc.app')
+    const infoPlist = '/release/Videorc.app/Contents/Info.plist'
+
+    assert.equal(EXPECTED_MACOS_BUNDLE_IDENTIFIER, 'dev.theorcdev.videorc')
+    assert.deepEqual(
+      checks.find((check) => check.id === 'info-plist-bundle-identifier'),
+      {
+        id: 'info-plist-bundle-identifier',
+        label: 'Info.plist bundle identifier',
+        command: 'plutil',
+        args: [
+          '-extract',
+          'CFBundleIdentifier',
+          'raw',
+          '-expect',
+          'string',
+          '-n',
+          '-o',
+          '-',
+          infoPlist
+        ],
+        expectStdoutEquals: EXPECTED_MACOS_BUNDLE_IDENTIFIER
+      }
+    )
+    assert.deepEqual(
+      checks.find((check) => check.id === 'info-plist-camera-usage-description'),
+      {
+        id: 'info-plist-camera-usage-description',
+        label: 'Info.plist camera usage description',
+        command: 'plutil',
+        args: [
+          '-extract',
+          'NSCameraUsageDescription',
+          'raw',
+          '-expect',
+          'string',
+          '-n',
+          '-o',
+          '-',
+          infoPlist
+        ],
+        expectStdoutNonEmpty: true
+      }
+    )
+    assert.deepEqual(
+      checks.find((check) => check.id === 'info-plist-microphone-usage-description'),
+      {
+        id: 'info-plist-microphone-usage-description',
+        label: 'Info.plist microphone usage description',
+        command: 'plutil',
+        args: [
+          '-extract',
+          'NSMicrophoneUsageDescription',
+          'raw',
+          '-expect',
+          'string',
+          '-n',
+          '-o',
+          '-',
+          infoPlist
+        ],
+        expectStdoutNonEmpty: true
+      }
+    )
+  })
+
+  it('does not apply inner-app Info.plist checks directly to a DMG', () => {
+    const checks = buildMacosReleaseArtifactChecks('/release/Videorc.dmg')
+    assert.equal(
+      checks.some((check) => check.id.startsWith('info-plist-')),
+      false
+    )
+  })
+})
+
+describe('stdout expectation gate', () => {
+  it('requires an exact bundle identifier rather than substring containment', () => {
+    const check = { expectStdoutEquals: EXPECTED_MACOS_BUNDLE_IDENTIFIER }
+    assert.deepEqual(stdoutExpectationFailures(check, EXPECTED_MACOS_BUNDLE_IDENTIFIER), [])
+    assert.equal(
+      stdoutExpectationFailures(check, `prefix.${EXPECTED_MACOS_BUNDLE_IDENTIFIER}`).length,
+      1
+    )
+    assert.equal(
+      stdoutExpectationFailures(check, `${EXPECTED_MACOS_BUNDLE_IDENTIFIER}.suffix`).length,
+      1
+    )
+  })
+
+  it('rejects empty or whitespace-only usage descriptions', () => {
+    const check = { expectStdoutNonEmpty: true }
+    assert.deepEqual(stdoutExpectationFailures(check, 'Videorc uses your camera for overlays.'), [])
+    for (const output of ['', '   ', '\n\t']) {
+      assert.deepEqual(stdoutExpectationFailures(check, output), ['expected non-empty stdout'])
+    }
   })
 })
 

--- a/scripts/validate-macos-release-artifact.mjs
+++ b/scripts/validate-macos-release-artifact.mjs
@@ -21,7 +21,8 @@ import {
   formatArtifactPath,
   formatReleaseArtifactValidationReport,
   sanitizeReleaseValidationOutput,
-  selectLatestReleaseArtifacts
+  selectLatestReleaseArtifacts,
+  stdoutExpectationFailures
 } from './lib/macos-release-artifact-validation.mjs'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -194,8 +195,13 @@ function runCheck(check) {
   // e.g. the capture-entitlement gate requires the device entitlements to appear
   // in `codesign -d --entitlements` output (a signed binary without them exits 0).
   const missing = (check.expectOutputIncludes ?? []).filter((needle) => !rawOutput.includes(needle))
+  const stdoutFailures = stdoutExpectationFailures(check, result.stdout)
   const output = sanitizeReleaseValidationOutput(
-    [rawOutput, ...missing.map((needle) => `missing required entitlement: ${needle}`)]
+    [
+      rawOutput,
+      ...missing.map((needle) => `missing required entitlement: ${needle}`),
+      ...stdoutFailures
+    ]
       .filter(Boolean)
       .join('\n'),
     context()
@@ -203,7 +209,7 @@ function runCheck(check) {
 
   return {
     label: check.label,
-    ok: result.status === 0 && missing.length === 0,
+    ok: result.status === 0 && missing.length === 0 && stdoutFailures.length === 0,
     output
   }
 }


### PR DESCRIPTION
## Summary

- use Electron's exact macOS TCC status so a fresh camera or microphone is shown as **Checked on first use** with an **Enable** action instead of the dead-end **Open settings** path
- route Settings, onboarding, Sources, Diagnostics, preview recovery, and the audio mixer through one user-initiated permission policy; passive microphone visuals cannot trigger a prompt
- make post-grant recovery generation-safe across prompt-time reconnects and deferred restarts, with bounded device/meter proof retries and stale-evidence invalidation
- fail packaged-app validation unless the bundle identifier is exactly `dev.theorcdev.videorc` and both camera/microphone usage descriptions are non-empty

Fixes #125

## Root cause

The Rust backend collapses AVFoundation `not-determined`, `denied`, and `restricted` states into `permission-required`. The renderer trusted that lossy value on macOS and therefore treated a never-asked camera as denied. Every visible action opened System Settings, but opening Settings cannot create the initial TCC registration; only the existing native `askForMediaAccess` bridge can do that.

## Verification

- [x] focused permission/provider/media tests: 79/79
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm --filter @videorc/desktop test`: 1,111 passed, 1 skipped
- [x] `pnpm test:scripts`: 640/640
- [x] `pnpm build`
- [x] `pnpm check:renderer-assets`: 369,926/370,000 gzip bytes
- [x] `pnpm audit:deps`
- [x] `cargo fmt --check --all`
- [x] `cargo clippy -p videorc-backend -- -D warnings`
- [x] final `cargo test -p videorc-backend` rerun: 1,291 passed, 8 ignored, plus wire test
- [x] real-device native-preview interaction recording, real ScreenCaptureKit layout switching, source-complete native preview, scene/pump/click-focus/placement/reattach/lifecycle behavior
- [x] signed 0.9.41 app: codesign, Gatekeeper, stapling, exact bundle identifier, usage descriptions, capture entitlements, and native addon signing; DMG checks passed
- [ ] signed clean-TCC allow/deny/recovery/relaunch acceptance on macOS 27 (current host is macOS 26.5.1)

Acceptance record: `docs/acceptance/2026-07-15-issue-125-camera-permission-registration.md`

## Existing gate blockers observed

- recording-studio aggregates reach the existing split record+stream comment-highlight artifact failure after their relevant permission/preview rows pass
- `smoke:local-gates` reaches the existing temporary `../../../shared/backend` module-resolution failure in `smoke:sources`
- two real-source preview rows reach the existing admin-only `preview.surface.create` authorization failure
- full macOS artifact validation additionally requires the local X OAuth1 release environment pair; all new metadata checks pass without recording secret values

This stays draft until the macOS 27 clean-TCC checklist is run on a disposable account, VM, or device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved camera, microphone, and screen-recording permission onboarding with clearer “Enable” and “Open settings” actions.
  * Preview and diagnostics now provide pane-specific permission resolution guidance.
  * Microphone previews remain inactive until access is granted, reducing misleading device errors.
  * Added recovery messaging for permissions that are granted while devices are still initializing.
* **Bug Fixes**
  * Improved handling of stale backend connections and delayed permission updates.
  * Prevented outdated audio and device information from overriding current permission state.
* **Chores**
  * Strengthened macOS release validation for bundle identifiers and required privacy descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->