### PR TITLE
Release 0.9.42-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.42-beta.1.md
+++ b/changelog/0.9.42-beta.1.md
@@ -1,0 +1,34 @@
+---
+version: 0.9.42-beta.1
+date: 2026-07-15
+channel: beta
+title: New cameras and mics enable on the first try
+summary: On a fresh install, a camera or microphone you have never used now shows an Enable button that actually asks for access — instead of a dead end that sent you to System Settings, where a first-time permission cannot be granted. Plus a Windows recording-finalization reliability fix.
+highlights:
+  - A camera or microphone you have never used now shows "Enable" and prompts for access directly, instead of dead-ending at a System Settings link that could not grant a first-time permission.
+  - Every permission entry point — onboarding, Sources, Settings, Diagnostics, and preview recovery — now runs through one consistent flow, and simply viewing the mic meter never triggers a prompt.
+  - Windows: recording finalization now retries transient file locks so your MP4 completes normally instead of falling back to MKV recovery.
+---
+
+## Camera and microphone access, fixed on first use
+
+On a fresh install, macOS has never asked whether Videorc can use your camera
+or microphone — the permission is simply undecided. Videorc was treating that
+"not yet asked" state as if you'd said no, so every button pointed at System
+Settings — and opening Settings can't create a permission that was never
+registered in the first place. New users could get stuck with no way to turn
+their camera on.
+
+Now an unused camera or mic reads honestly as "checked on first use" and
+offers an **Enable** button that triggers the real macOS prompt. Once you
+grant it, the preview and meters recover on their own. Every place that
+touches permissions — onboarding, Sources, Settings, Diagnostics, preview
+recovery — runs through that same user-initiated flow, and passive things
+like the mic meter can never spring a prompt on you.
+
+## Windows: recordings finish as MP4
+
+When Windows briefly holds a file lock as a recording finalizes, Videorc now
+retries instead of giving up and falling back to MKV recovery — so your
+recording completes as the MP4 you expect. Genuine, non-transient failures
+still fall back safely.


### PR DESCRIPTION
Version 0.9.41 → 0.9.42 and the changelog for #131 (macOS camera/mic first-use permission registration, fixes #125) + #130 (Windows locked-MP4 finalization retry). `pnpm changelog:check` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Enable** option for first-time camera and microphone permissions on macOS.
  * Standardized permission requests so prompts occur only after an intentional user action.

* **Bug Fixes**
  * Fixed Windows MP4 recordings failing to finalize because of temporary file locks.
  * Improved recovery reliability for recorded videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->