### PR TITLE
Record the 0.9.42 release (first-use camera permission + Windows MP4 retry)

### DIFF
--- a/docs/releases/0.9.42.md
+++ b/docs/releases/0.9.42.md
@@ -1,0 +1,54 @@
+# Videorc 0.9.42 Beta 1
+
+Videorc 0.9.42 ships the macOS camera/microphone first-use permission
+fix (#131, fixes #125) and a Windows recording-finalization reliability
+fix (#130).
+
+## Scope
+
+- **macOS camera/mic permission registration on first use** (PR #131,
+  fixes #125, plan: vault `2026-07-14 - Videorc Issue 125 Camera
+  Permission Registration Fix Plan`): the Rust backend collapsed
+  AVFoundation `not-determined`/`denied`/`restricted` into
+  `permission-required`; the renderer trusted that lossy value and
+  treated a never-asked device as denied, so every action opened System
+  Settings — which cannot create the initial TCC registration. Now a
+  fresh device reads as "checked on first use" with an Enable action
+  that drives the native `askForMediaAccess` prompt; onboarding,
+  Sources, Settings, Diagnostics, preview recovery, and the audio mixer
+  route through one user-initiated policy (passive mic visuals cannot
+  prompt); post-grant recovery is generation-safe with bounded proof
+  retries; packaged validation now fails unless the bundle id is exactly
+  `dev.theorcdev.videorc` with non-empty camera/mic usage descriptions.
+- **Windows locked-MP4 finalization retry** (PR #130): transient
+  Windows file-lock errors while syncing staged MP4 exports now retry,
+  keeping MP4 as the completed artifact instead of immediately falling
+  back to MKV recovery; non-transient failures still fall back safely.
+
+## Release status
+
+- [x] PRs merged: #130, #131; prep #132 (admin-merged — GitHub Actions
+      blocked by billing; #131 carries a full green local gate matrix
+      incl. signed-0.9.41 codesign/Gatekeeper/stapling checks; full Rust
+      suite skipped per owner directive).
+- [x] Signed + notarized arm64 build; staple verified by
+      release:validate:macos. (Note: release-profile build still warns
+      `is_ffmpeg_error_line` dead code — non-fatal, carried since
+      0.9.38.)
+- [x] Uploaded to R2; feed verified end-to-end
+      (`https://www.videorc.com/api/updates/latest-mac.yml` →
+      `version: 0.9.42`, artifact hashes present); `/api/changelog`
+      serves 0.9.42-beta.1.
+- [x] Discord announcement posted.
+- [ ] Owner acceptance (macOS): on a machine/profile that has never
+      granted Videorc camera access (or after resetting TCC), confirm a
+      fresh camera shows Enable and the native prompt appears and
+      recovers the preview; confirm the mic meter never prompts on its
+      own.
+- [ ] Owner: X post (draft provided in session; posted manually).
+
+## Rollback
+
+Standard: re-upload 0.9.41's artifacts/manifest per
+`docs/releases/release-runbook.md`; the feed is version-compared, so
+restoring the older manifest reverts updates.


### PR DESCRIPTION
Internal release record for 0.9.42-beta.1: macOS camera/mic first-use permission registration (#131, fixes #125) + Windows locked-MP4 finalization retry (#130). Build/upload/feed/announce verified; owner acceptance checklist inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)