### PR TITLE
fix: a dying stream can no longer kill a live session or its recording

### DIFF
--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -60,6 +60,13 @@ const STREAM_OUTPUT_QUEUE_COALESCE_FRAMES: usize = 4;
 const STREAM_OUTPUT_QUEUE_COALESCE_AGE: Duration = Duration::from_millis(100);
 const STREAM_OUTPUT_QUEUE_MAX_FRAMES: usize = 8;
 const STREAM_OUTPUT_QUEUE_MAX_AGE: Duration = Duration::from_millis(150);
+/// A stream output over its age budget DEGRADES (latest-wins coalescing) for
+/// this long before the failure is treated as real. A single over-budget
+/// sample used to be a death sentence: one 166ms-old frame killed a
+/// 3-platform live session (2026-07-15 owner incident) while the queue held
+/// 2 of 8 frames. Transient downstream stalls recover within this window; a
+/// genuinely wedged output still fails honestly.
+const STREAM_OUTPUT_SUSTAINED_FAIL_WINDOW: Duration = Duration::from_secs(2);
 // Raw frames receive wall-clock PTS at FFmpeg demux. Keep no stale waiting
 // frames: the writer accepts the latest scheduler frame only when it is ready
 // for another complete write; busy ticks are explicitly coalesced and the
@@ -191,6 +198,38 @@ fn encoder_bridge_pre_encode_admission(
         return EncoderBridgePreEncodeAdmission::CoalesceLatestStreamFrame;
     }
     EncoderBridgePreEncodeAdmission::Submit
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EncoderBridgeOverBudgetEscalation {
+    /// Keep the output alive: drop pre-encode like coalescing and re-check.
+    Degrade,
+    /// The violation is sustained (or the queue truly full): fail the output.
+    Fail,
+}
+
+/// Only the stream role degrades — its latest-wins coalescing makes dropped
+/// frames an honest, visible quality trade. Recording/shared outputs have no
+/// such semantics: silently dropping recording frames is exactly the
+/// corruption the contract exists to prevent, so they fail immediately.
+fn encoder_bridge_over_budget_escalation(
+    policy: EncoderBridgeOutputQueuePolicy,
+    queue_depth: u64,
+    over_budget_since: Instant,
+    now: Instant,
+) -> EncoderBridgeOverBudgetEscalation {
+    if policy.role != EncoderBridgeOutputRole::Stream {
+        return EncoderBridgeOverBudgetEscalation::Fail;
+    }
+    // A queue at its frame ceiling means the consumer made no progress across
+    // the whole depth ladder — that is not jitter.
+    if queue_depth >= policy.max_frames as u64 {
+        return EncoderBridgeOverBudgetEscalation::Fail;
+    }
+    if now.duration_since(over_budget_since) >= STREAM_OUTPUT_SUSTAINED_FAIL_WINDOW {
+        return EncoderBridgeOverBudgetEscalation::Fail;
+    }
+    EncoderBridgeOverBudgetEscalation::Degrade
 }
 
 fn encoder_bridge_output_pressure_error(
@@ -1087,6 +1126,9 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
     let mut pending_video_toolbox_fifo_started_at = VecDeque::<Instant>::new();
     let mut output_queue_capacity_pressure_events = 0_u64;
     let mut output_queue_dropped_frames = 0_u64;
+    // First instant the output queue went over its hard budget; cleared the
+    // moment it recovers. Drives the sustained-violation escalation.
+    let mut output_over_budget_since: Option<Instant> = None;
     #[cfg(target_os = "macos")]
     macro_rules! oldest_output_queue_age {
         () => {
@@ -1508,6 +1550,33 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                 oldest_output_queue_age!(),
             )
         };
+        // Over-budget is a death sentence only when SUSTAINED (or the queue is
+        // truly full): a transient downstream stall degrades to latest-wins
+        // coalescing and recovers, instead of one over-age sample killing a
+        // live session (2026-07-15 incident).
+        let admission = match admission {
+            EncoderBridgePreEncodeAdmission::FailOutput => {
+                let now = Instant::now();
+                let since = *output_over_budget_since.get_or_insert(now);
+                match encoder_bridge_over_budget_escalation(
+                    output_queue_policy,
+                    queue_depth,
+                    since,
+                    now,
+                ) {
+                    EncoderBridgeOverBudgetEscalation::Degrade => {
+                        EncoderBridgePreEncodeAdmission::CoalesceLatestStreamFrame
+                    }
+                    EncoderBridgeOverBudgetEscalation::Fail => {
+                        EncoderBridgePreEncodeAdmission::FailOutput
+                    }
+                }
+            }
+            other => {
+                output_over_budget_since = None;
+                other
+            }
+        };
         match admission {
             EncoderBridgePreEncodeAdmission::Submit => {}
             EncoderBridgePreEncodeAdmission::CoalesceLatestStreamFrame => {
@@ -1831,13 +1900,26 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
             }
         };
         if let Err(error) = write_result {
-            let error = record_encoder_bridge_terminal_failure(
-                &terminal_failure,
+            // A closed downstream (EPIPE/EOF: FFmpeg exited or was stopped)
+            // is not this bridge's verdict — the process exit status decides
+            // the session outcome. Recording it as terminal made a STREAM
+            // death condemn a healthy recording: the stream writer died, the
+            // shared FFmpeg exited cleanly, and the recording writer's EPIPE
+            // was then indistinguishable from a real encoder failure.
+            let error = if io_error_is_downstream_closed(&error) {
                 format!(
-                    "{} encoder output stopped: {error}",
+                    "{} encoder output ended: downstream closed ({error})",
                     encoder_bridge_output_role_label(output_queue_policy.role)
-                ),
-            );
+                )
+            } else {
+                record_encoder_bridge_terminal_failure(
+                    &terminal_failure,
+                    format!(
+                        "{} encoder output stopped: {error}",
+                        encoder_bridge_output_role_label(output_queue_policy.role)
+                    ),
+                )
+            };
             terminal_writer_error = Some(error.clone());
             emit_encoder_bridge_diagnostics_from_thread(
                 &diagnostics_tx,
@@ -2844,8 +2926,19 @@ struct QueuedVideoToolboxFrame {
 #[cfg(target_os = "macos")]
 #[derive(Debug)]
 enum VideoToolboxFifoWriterResult {
-    FrameWritten { encoded_bytes: u64, write_ms: f64 },
-    Error(String),
+    FrameWritten {
+        encoded_bytes: u64,
+        write_ms: f64,
+    },
+    Error {
+        message: String,
+        /// True when the write side saw EPIPE/EOF — the downstream FFmpeg
+        /// closed or exited. That is not a bridge verdict: the process exit
+        /// status is the authority, and treating it as a terminal bridge
+        /// failure condemned healthy recordings when the STREAM writer died
+        /// first and FFmpeg exited cleanly (2026-07-15 incident cascade).
+        downstream_closed: bool,
+    },
 }
 
 #[cfg(target_os = "macos")]
@@ -2861,6 +2954,17 @@ impl VideoToolboxFifoWriter {
         // One extra slot preserves a terminal flush error without deadlocking
         // close_and_join if the bridge is already tearing down.
         let (result_tx, result_rx) = std_mpsc::sync_channel(policy.max_frames + 2);
+        // The per-frame write deadline bounds COMPLETE-frame delivery. The
+        // stream role gets the sustained-violation grace on top of its queue
+        // budget so a transient downstream freeze degrades instead of killing
+        // the writer (a 500ms FFmpeg stall used to trip the 150ms budget and
+        // end the stream). Recording keeps its strict budget: silently
+        // buffering recording frames is the corruption its contract prevents.
+        let write_frame_age = if policy.role == EncoderBridgeOutputRole::Stream {
+            policy.max_age + STREAM_OUTPUT_SUSTAINED_FAIL_WINDOW
+        } else {
+            policy.max_age
+        };
         let join = thread::Builder::new()
             .name(format!("videorc-{:?}-h264-fifo-writer", policy.role))
             .spawn(move || {
@@ -2870,7 +2974,7 @@ impl VideoToolboxFifoWriter {
                     frame_rx,
                     result_tx,
                     stop,
-                    policy.max_age,
+                    write_frame_age,
                 );
             })
             .expect("could not start VideoToolbox FIFO writer thread");
@@ -2979,7 +3083,10 @@ fn run_video_toolbox_fifo_writer_loop<W: StdWrite>(
                 });
             }
             Err(error) => {
-                let _ = result_tx.send(VideoToolboxFifoWriterResult::Error(error.to_string()));
+                let _ = result_tx.send(VideoToolboxFifoWriterResult::Error {
+                    message: error.to_string(),
+                    downstream_closed: io_error_is_downstream_closed(&error),
+                });
                 return;
             }
         }
@@ -2987,8 +3094,20 @@ fn run_video_toolbox_fifo_writer_loop<W: StdWrite>(
     if !stop.load(Ordering::Relaxed)
         && let Err(error) = sink.flush()
     {
-        let _ = result_tx.send(VideoToolboxFifoWriterResult::Error(error.to_string()));
+        let _ = result_tx.send(VideoToolboxFifoWriterResult::Error {
+            message: error.to_string(),
+            downstream_closed: io_error_is_downstream_closed(&error),
+        });
     }
+}
+
+/// EPIPE/EOF class: the reader (FFmpeg) went away. The writer must stop, but
+/// the SESSION verdict belongs to the process exit status, not this error.
+fn io_error_is_downstream_closed(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::BrokenPipe | io::ErrorKind::WriteZero | io::ErrorKind::UnexpectedEof
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -3256,8 +3375,19 @@ fn drain_video_toolbox_fifo_writer_results(
                     video_toolbox_output_bytes.saturating_add(encoded_bytes);
                 video_toolbox_fifo_write_times_ms.push(write_ms);
             }
-            VideoToolboxFifoWriterResult::Error(error) => {
-                return Err(io::Error::other(error));
+            VideoToolboxFifoWriterResult::Error {
+                message,
+                downstream_closed,
+            } => {
+                // Preserve the classification through the io::Error kind so
+                // the terminal-failure funnel can tell "FFmpeg went away"
+                // apart from a real bridge failure.
+                let kind = if downstream_closed {
+                    io::ErrorKind::BrokenPipe
+                } else {
+                    io::ErrorKind::Other
+                };
+                return Err(io::Error::new(kind, message));
             }
         }
     }
@@ -3557,6 +3687,13 @@ fn recording_queue_drop_watch_update(
 static RECORDING_QUEUE_DROP_WATCH: std::sync::Mutex<Option<RecordingQueueDropWatch>> =
     std::sync::Mutex::new(None);
 
+// The stream twin: pressure on the STREAM output was previously counted in
+// diagnostics but never surfaced — the 2026-07-15 incident sessions logged 11
+// silent pressure events and then died with no prior warning. Fires once per
+// session so a jittery platform cannot spam the session log.
+static STREAM_QUEUE_PRESSURE_WATCH: std::sync::Mutex<Option<RecordingQueueDropWatch>> =
+    std::sync::Mutex::new(None);
+
 async fn emit_encoder_bridge_diagnostics(
     state: &AppState,
     session_id: &str,
@@ -3591,6 +3728,34 @@ async fn emit_encoder_bridge_diagnostics(
                 crate::protocol::HealthLevel::Warn,
                 "recording-output-queue-drops",
                 &message,
+            );
+        }
+    }
+
+    // Stream pressure must be audible BEFORE any failure: the watchdog now
+    // degrades (drops to latest-wins) instead of dying on one over-age
+    // sample, and this is the user's signal that a platform connection is
+    // struggling while the stream still runs.
+    if effective_encoder_bridge_output_role(diagnostics_context) == EncoderBridgeOutputRole::Stream
+    {
+        let fire = {
+            let mut guard = STREAM_QUEUE_PRESSURE_WATCH
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let watch = guard.get_or_insert_with(RecordingQueueDropWatch::default);
+            recording_queue_drop_watch_update(
+                watch,
+                session_id,
+                runtime.output_queue_capacity_pressure_events,
+            )
+        };
+        if fire {
+            let _ = crate::recording::emit_health_event(
+                state,
+                Some(session_id),
+                crate::protocol::HealthLevel::Warn,
+                "stream-output-pressure",
+                "Stream output is under pressure: a destination is accepting data slower than the stream produces it. Frames are being dropped from the live stream to keep latency; the recording is unaffected.",
             );
         }
     }
@@ -4005,6 +4170,66 @@ mod tests {
             encoder_bridge_pre_encode_admission(policy, 2, Some(Duration::from_millis(150))),
             EncoderBridgePreEncodeAdmission::FailOutput
         );
+    }
+
+    #[test]
+    fn stream_over_budget_degrades_first_and_fails_only_when_sustained() {
+        let policy = encoder_bridge_output_queue_policy(EncoderBridgeDiagnosticsContext {
+            role: EncoderBridgeOutputRole::Stream,
+            ..EncoderBridgeDiagnosticsContext::default()
+        });
+        let since = Instant::now();
+
+        // A fresh over-age sample (the 2026-07-15 incident shape: depth 2/8,
+        // oldest 166ms) degrades instead of killing the stream.
+        assert_eq!(
+            encoder_bridge_over_budget_escalation(policy, 2, since, since),
+            EncoderBridgeOverBudgetEscalation::Degrade
+        );
+        assert_eq!(
+            encoder_bridge_over_budget_escalation(
+                policy,
+                2,
+                since,
+                since + STREAM_OUTPUT_SUSTAINED_FAIL_WINDOW - Duration::from_millis(1),
+            ),
+            EncoderBridgeOverBudgetEscalation::Degrade
+        );
+        // Continuously over budget for the whole window → real failure.
+        assert_eq!(
+            encoder_bridge_over_budget_escalation(
+                policy,
+                2,
+                since,
+                since + STREAM_OUTPUT_SUSTAINED_FAIL_WINDOW,
+            ),
+            EncoderBridgeOverBudgetEscalation::Fail
+        );
+        // A queue at its frame ceiling is not jitter — fail immediately.
+        assert_eq!(
+            encoder_bridge_over_budget_escalation(policy, 8, since, since),
+            EncoderBridgeOverBudgetEscalation::Fail
+        );
+    }
+
+    #[test]
+    fn recording_over_budget_never_degrades() {
+        for role in [
+            EncoderBridgeOutputRole::Recording,
+            EncoderBridgeOutputRole::Shared,
+        ] {
+            let policy = encoder_bridge_output_queue_policy(EncoderBridgeDiagnosticsContext {
+                role,
+                ..EncoderBridgeDiagnosticsContext::default()
+            });
+            let since = Instant::now();
+            // Dropping recording frames silently is the corruption the
+            // contract prevents — recording outputs keep the one-sample fail.
+            assert_eq!(
+                encoder_bridge_over_budget_escalation(policy, 2, since, since),
+                EncoderBridgeOverBudgetEscalation::Fail
+            );
+        }
     }
 
     #[test]
@@ -5199,8 +5424,8 @@ mod tests {
                     assert_eq!(encoded_bytes, 64);
                     assert!(write_ms >= 0.0);
                 }
-                VideoToolboxFifoWriterResult::Error(error) => {
-                    panic!("unexpected FIFO writer error: {error}");
+                VideoToolboxFifoWriterResult::Error { message, .. } => {
+                    panic!("unexpected FIFO writer error: {message}");
                 }
             }
         }
@@ -5277,10 +5502,67 @@ mod tests {
 
         assert!(started_at.elapsed() < Duration::from_millis(500));
         let result = result_rx.recv().expect("terminal writer result");
-        let VideoToolboxFifoWriterResult::Error(error) = result else {
+        let VideoToolboxFifoWriterResult::Error {
+            message,
+            downstream_closed,
+        } = result
+        else {
             panic!("stalled writer must fail explicitly")
         };
-        assert!(error.contains("complete-frame delivery budget"));
+        assert!(message.contains("complete-frame delivery budget"));
+        // A timeout is a REAL failure, not a closed downstream — it must
+        // still reach the terminal-failure funnel.
+        assert!(!downstream_closed);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn videotoolbox_fifo_writer_classifies_a_closed_downstream() {
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(3);
+        frame_tx
+            .send(QueuedVideoToolboxFrame {
+                frame: VideoToolboxH264AnnexBFrame {
+                    timing: VideoToolboxFrameTiming::new(0, 30, 1, 30),
+                    bytes: vec![0x44; 64],
+                    nal_types: vec![1],
+                    is_idr: false,
+                },
+                submitted_at: Instant::now(),
+            })
+            .expect("queue frame");
+        drop(frame_tx);
+
+        struct BrokenPipeSink;
+        impl StdWrite for BrokenPipeSink {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "EPIPE"))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        run_video_toolbox_fifo_writer_loop(
+            BrokenPipeSink,
+            VideoToolboxH264PipeWriter::for_output(
+                EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
+            ),
+            frame_rx,
+            result_tx,
+            Arc::new(AtomicBool::new(false)),
+            Duration::from_millis(250),
+        );
+
+        let result = result_rx.recv().expect("terminal writer result");
+        let VideoToolboxFifoWriterResult::Error {
+            downstream_closed, ..
+        } = result
+        else {
+            panic!("EPIPE must surface as a writer error")
+        };
+        // FFmpeg going away is the process exit's story, not a bridge verdict.
+        assert!(downstream_closed);
     }
 
     struct AlwaysWouldBlockSink;

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -836,15 +836,21 @@ impl ActiveRecording {
         Ok(())
     }
 
-    fn encoder_bridge_terminal_failure(&self) -> Option<String> {
+    fn recording_bridge_terminal_failure(&self) -> Option<String> {
         self.encoder_bridge
             .as_ref()
             .and_then(EncoderBridgeRecordingSession::terminal_failure)
-            .or_else(|| {
-                self.encoder_bridge_stream
-                    .as_ref()
-                    .and_then(EncoderBridgeRecordingSession::terminal_failure)
-            })
+    }
+
+    /// Kept SEPARATE from the recording signal on purpose: a dead stream
+    /// output is reported per-destination and the session still finalizes
+    /// the local file. OR-merging the two (the pre-2026-07-15 shape) made a
+    /// stream latency failure indistinguishable from a recording failure and
+    /// discarded healthy multi-minute recordings.
+    fn stream_bridge_terminal_failure(&self) -> Option<String> {
+        self.encoder_bridge_stream
+            .as_ref()
+            .and_then(EncoderBridgeRecordingSession::terminal_failure)
     }
 }
 
@@ -4156,7 +4162,8 @@ async fn monitor_session(
             });
             MonitoredRecording {
                 stop_intent_preceded_exit,
-                encoder_bridge_terminal_failure: active.encoder_bridge_terminal_failure(),
+                recording_bridge_terminal_failure: active.recording_bridge_terminal_failure(),
+                stream_bridge_terminal_failure: active.stream_bridge_terminal_failure(),
                 ffmpeg_path: active.ffmpeg_path.clone(),
                 started_at: active.started_at.clone(),
                 pipeline: active.pipeline.clone(),
@@ -4263,14 +4270,31 @@ async fn monitor_session(
     let ended_at = Utc::now().to_rfc3339();
     let duration_ms = recording_duration_ms(&monitored_recording.started_at, &ended_at);
     let final_diagnostics = final_session_diagnostics_snapshot(&state, &session_id).await;
-    let encoder_bridge_terminal_failure =
-        monitored_recording.encoder_bridge_terminal_failure.clone();
+    let recording_bridge_terminal_failure = monitored_recording
+        .recording_bridge_terminal_failure
+        .clone();
+    let stream_bridge_terminal_failure = monitored_recording.stream_bridge_terminal_failure.clone();
+    // A dead stream output is its own user-visible truth, whatever happens to
+    // the recording below: streaming stopped, the destinations went dark, and
+    // the reason must reach the session log — as an event, not a session kill.
+    if let Some(stream_error) = stream_bridge_terminal_failure.as_deref() {
+        let _ = emit_health_event(
+            &state,
+            Some(&session_id),
+            HealthLevel::Error,
+            "stream-output-failed",
+            &format!(
+                "Streaming stopped early: {stream_error}. The local recording continued and is being preserved."
+            ),
+        );
+    }
     let terminal_status = match status {
         Ok(exit_status)
             if should_finalize_recording_session(
                 exit_status.success(),
                 monitored_recording.stop_intent_preceded_exit,
-                encoder_bridge_terminal_failure.as_deref(),
+                recording_bridge_terminal_failure.as_deref(),
+                stream_bridge_terminal_failure.as_deref(),
             ) =>
         {
             let message = if exit_status.success() {
@@ -4532,8 +4556,11 @@ async fn monitor_session(
             terminal_status
         }
         Ok(exit_status) => {
+            // Only the RECORDING bridge condemns the session here — a stream
+            // failure was already reported above and, with a clean exit,
+            // finalizes in the arm before this one.
             let (failed_stage, health_code, mut message) = if let Some(error) =
-                encoder_bridge_terminal_failure.as_deref()
+                recording_bridge_terminal_failure.as_deref()
             {
                 (
                     RecordingPipelineStage::VideoEncoder,
@@ -5475,7 +5502,8 @@ struct NativeAudioStats {
 #[derive(Debug)]
 struct MonitoredRecording {
     stop_intent_preceded_exit: bool,
-    encoder_bridge_terminal_failure: Option<String>,
+    recording_bridge_terminal_failure: Option<String>,
+    stream_bridge_terminal_failure: Option<String>,
     ffmpeg_path: String,
     started_at: String,
     pipeline: RecordingPipeline,
@@ -5486,7 +5514,8 @@ struct MonitoredRecording {
 fn should_finalize_recording_session(
     ffmpeg_exit_success: bool,
     stop_intent_preceded_exit: bool,
-    encoder_bridge_terminal_failure: Option<&str>,
+    recording_bridge_terminal_failure: Option<&str>,
+    stream_bridge_terminal_failure: Option<&str>,
 ) -> bool {
     // Production capture is intentionally unbounded. A clean FFmpeg exit
     // before the user asks to stop is still an early termination (for example,
@@ -5497,7 +5526,15 @@ fn should_finalize_recording_session(
     // TERM/KILL or any non-zero FFmpeg exit keeps the artifact as recovery
     // media and marks the session failed unless a future explicit verifier can
     // prove the container is complete.
-    encoder_bridge_terminal_failure.is_none() && stop_intent_preceded_exit && ffmpeg_exit_success
+    if recording_bridge_terminal_failure.is_some() || !ffmpeg_exit_success {
+        return false;
+    }
+    // A dead STREAM output ends FFmpeg without a user stop, but the RECORDING
+    // data is intact and the muxer flushed cleanly (exit 0) — finalize it.
+    // The 2026-07-15 incident marked whole sessions failed and buried healthy
+    // multi-minute recordings because a stream latency failure was
+    // indistinguishable from a recording failure here.
+    stop_intent_preceded_exit || stream_bridge_terminal_failure.is_some()
 }
 
 fn should_begin_captioned_copy_render(requested: bool, caption_chunk_count: usize) -> bool {
@@ -14847,6 +14884,7 @@ mod tests {
         assert!(!should_finalize_recording_session(
             true,
             stop_intent_preceded_exit,
+            None,
             None
         ));
     }
@@ -14874,28 +14912,57 @@ mod tests {
         assert!(should_finalize_recording_session(
             true,
             stop_intent_preceded_exit,
+            None,
             None
         ));
     }
 
     #[test]
     fn only_an_explicit_graceful_stop_can_finalize_an_unbounded_capture() {
-        assert!(!should_finalize_recording_session(true, false, None));
+        assert!(!should_finalize_recording_session(true, false, None, None));
         assert!(
-            !should_finalize_recording_session(false, true, None),
+            !should_finalize_recording_session(false, true, None, None),
             "a non-zero/forced FFmpeg exit after stop must remain failed"
         );
-        assert!(should_finalize_recording_session(true, true, None));
+        assert!(should_finalize_recording_session(true, true, None, None));
 
         assert!(!should_finalize_recording_session(
             true,
             false,
-            Some("recording raw-video encoder output stopped: FIFO timed out")
+            Some("recording raw-video encoder output stopped: FIFO timed out"),
+            None
         ));
         assert!(!should_finalize_recording_session(
             false,
             true,
-            Some("recording raw-video encoder output stopped: FIFO timed out")
+            Some("recording raw-video encoder output stopped: FIFO timed out"),
+            None
+        ));
+    }
+
+    #[test]
+    fn stream_output_death_preserves_the_recording() {
+        // The 2026-07-15 incident: a stream latency failure ended FFmpeg
+        // cleanly with NO user stop — the healthy multi-minute recording was
+        // marked failed. A stream-only failure with a clean exit finalizes.
+        assert!(should_finalize_recording_session(
+            true,
+            false,
+            None,
+            Some("stream encoder output stopped: exceeded its bounded latency contract")
+        ));
+        // But it can never override a RECORDING failure or a dirty exit.
+        assert!(!should_finalize_recording_session(
+            true,
+            false,
+            Some("recording raw-video encoder output stopped"),
+            Some("stream encoder output stopped")
+        ));
+        assert!(!should_finalize_recording_session(
+            false,
+            false,
+            None,
+            Some("stream encoder output stopped")
         ));
     }
 

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "smoke:oauth": "node scripts/smoke-oauth-app.mjs",
     "smoke:screens": "node scripts/smoke-screens-app.mjs",
     "smoke:multistream": "node scripts/smoke-multistream-app.mjs",
+    "smoke:multistream-endurance": "node scripts/smoke-multistream-endurance-app.mjs",
     "smoke:packaged": "node scripts/smoke-packaged-app.mjs",
     "smoke:packaged:bundled": "node scripts/smoke-packaged-app.mjs --require-bundled-ffmpeg",
     "smoke:packaged:native-preview": "node scripts/run-with-env.mjs --platform=darwin VIDEORC_SMOKE_PACKAGED_APP=1 VIDEORC_EXPECT_NATIVE_METAL_PREVIEW=1 -- node scripts/smoke-preview-surface-app.mjs",

--- a/scripts/smoke-multistream-endurance-app.mjs
+++ b/scripts/smoke-multistream-endurance-app.mjs
@@ -1,0 +1,567 @@
+import { execFileSync, spawn } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, statSync } from 'node:fs'
+import net from 'node:net'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { launchDevApp } from './lib/app-launcher.mjs'
+import { requestSmokeCommand } from './lib/smoke-command-client.mjs'
+import { analyzeRecording } from './lib/recording-analyzer.mjs'
+import { connectBackend, request } from './smoke-recording-session.mjs'
+
+// Endurance proof for the multi-platform fan-out under REAL downstream
+// trouble (2026-07-15 owner incident: two 3-platform live sessions died
+// minutes in with "stream encoder output exceeded its bounded latency
+// contract" / "Encoder FIFO write exceeded the complete-frame delivery
+// budget", and the healthy multi-minute recordings were marked failed).
+//
+// Two sessions against three local RTMP listeners:
+//
+//   Session A — jitter tolerance. One leg sits behind a TCP proxy that
+//   periodically stops reading (a platform-side network stall), and the
+//   session FFmpeg is frozen (SIGSTOP) once for half a second — a transient
+//   downstream hiccup. The session must run to its planned stop and
+//   complete: transient pressure degrades the stream, never kills it.
+//
+//   Session B — stream-death honesty. The session FFmpeg is frozen for
+//   several seconds, past the sustained-violation window, so the stream
+//   output legitimately dies. The session must NOT be marked failed: the
+//   local recording finalizes healthy and a `stream-output-failed` health
+//   event tells the truth about the stream.
+//
+// No Docker or external services: listeners are plain `ffmpeg -listen 1`.
+
+const outputDirectory = resolve(
+  process.env.VIDEORC_SMOKE_OUTPUT_DIR ?? join(tmpdir(), `videorc-ms-endurance-${Date.now()}`)
+)
+const userDataDir =
+  process.env.VIDEORC_USER_DATA_DIR ??
+  mkdtempSync(join(tmpdir(), 'videorc-ms-endurance-user-data-'))
+const ffmpegPath = process.env.VIDEORC_SMOKE_FFMPEG_PATH ?? 'ffmpeg'
+const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 120000)
+const basePort = Number(process.env.VIDEORC_SMOKE_RTMP_PORT ?? 12935)
+// Session A duration; the release endurance run passes 600000.
+const streamMs = Number(process.env.VIDEORC_SMOKE_STREAM_MS ?? 60000)
+const listenerBindMs = Number(process.env.VIDEORC_SMOKE_LISTENER_BIND_MS ?? 2500)
+// Network stall profile for the proxied leg in session A.
+const stallEveryMs = Number(process.env.VIDEORC_SMOKE_STALL_EVERY_MS ?? 15000)
+const stallForMs = Number(process.env.VIDEORC_SMOKE_STALL_FOR_MS ?? 4000)
+// FFmpeg freeze lengths: transient (must survive) and fatal (stream may die,
+// session must still complete with the recording preserved).
+const transientFreezeMs = Number(process.env.VIDEORC_SMOKE_TRANSIENT_FREEZE_MS ?? 500)
+const fatalFreezeMs = Number(process.env.VIDEORC_SMOKE_FATAL_FREEZE_MS ?? 6000)
+
+const TARGETS = [
+  { id: 'youtube', label: 'YouTube', stalled: false },
+  { id: 'twitch', label: 'Twitch', stalled: false },
+  // The X leg is the jittery one in the incident (rtmps across the ocean).
+  { id: 'x', label: 'X (stalling)', stalled: true }
+]
+
+const targets = TARGETS.map((platform, index) => {
+  const listenPort = basePort + index
+  const proxyPort = platform.stalled ? basePort + 100 + index : null
+  const streamKey = `endurance${index}`
+  return {
+    ...platform,
+    listenPort,
+    proxyPort,
+    streamKey,
+    serverUrl: `rtmp://127.0.0.1:${proxyPort ?? listenPort}/live`,
+    listenUrl: `rtmp://127.0.0.1:${listenPort}/live/${streamKey}`,
+    recvPath: join(outputDirectory, `recv-${listenPort}.flv`)
+  }
+})
+
+mkdirSync(outputDirectory, { recursive: true })
+
+let stopping = false
+let stopApp = async () => {}
+let appRootPid = null
+const listeners = []
+const proxies = []
+const healthEvents = []
+const targetSnapshots = []
+let stallCycles = 0
+
+try {
+  const launch = await launchDevApp({
+    env: {
+      VIDEORC_SMOKE_COMMAND_SERVER: '1',
+      VIDEORC_SMOKE_STATE_DIR: outputDirectory,
+      VIDEORC_USER_DATA_DIR: userDataDir
+    },
+    timeoutMs,
+    requiredMarkers: ['backend-ready', 'preview-motion-ready'],
+    onLine: (line) => console.log(line)
+  })
+  stopApp = launch.stop
+  appRootPid = launch.process?.pid ?? null
+  const connection = launch.connections['backend-ready']
+  const smoke = launch.connections['preview-motion-ready']
+
+  const ws = await connectBackend(connection, timeoutMs)
+  ws.addEventListener('message', (event) => {
+    let message
+    try {
+      message = JSON.parse(event.data)
+    } catch {
+      return
+    }
+    if (message?.event === 'health.event' && message.payload?.code) {
+      healthEvents.push(message.payload)
+    }
+    if (message?.event === 'stream.targets' && Array.isArray(message.payload?.targets)) {
+      targetSnapshots.push(message.payload.targets)
+    }
+  })
+
+  try {
+    const health = await request(ws, timeoutMs, 'health.ping', { ffmpegPath })
+    if (!health?.ffmpeg?.available) {
+      throw new Error(health?.ffmpeg?.message ?? 'FFmpeg is unavailable for the endurance smoke.')
+    }
+    const recordingDirectory = await requestSmokeCommand(
+      smoke,
+      'authorize-smoke-resource',
+      { kind: 'output-directory', path: outputDirectory },
+      { timeoutMs }
+    )
+
+    // ---------- Session A: jitter tolerance ----------
+    for (const target of targets) {
+      listeners.push(spawnListener(target))
+      if (target.proxyPort) {
+        proxies.push(await startStallProxy(target))
+      }
+    }
+    console.log(
+      `Session A: ${targets.length} legs; ${stallForMs}ms network stall on ` +
+        `${targets.find((t) => t.stalled).label} every ${stallEveryMs}ms; one ` +
+        `${transientFreezeMs}ms FFmpeg freeze mid-run.`
+    )
+    await sleep(listenerBindMs)
+
+    const startedA = await request(
+      ws,
+      timeoutMs,
+      'session.start',
+      sessionParams(recordingDirectory.capabilityId)
+    )
+    if (startedA.state !== 'recording') {
+      throw new Error(`Expected recording state after start, got ${startedA.state}.`)
+    }
+
+    let froze = false
+    const deadlineA = Date.now() + streamMs
+    while (Date.now() < deadlineA) {
+      await sleep(2000)
+      const status = await request(ws, timeoutMs, 'recording.status')
+      if (status.state !== 'recording' && status.state !== 'streaming') {
+        throw new Error(
+          `SESSION A DIED ${Math.round((Date.now() - (deadlineA - streamMs)) / 1000)}s in ` +
+            `(state ${status.state}) after ${stallCycles} stall cycle(s): ${status.message ?? 'no message'}`
+        )
+      }
+      if (!froze && Date.now() > deadlineA - streamMs / 2) {
+        froze = true
+        freezeSessionFfmpeg(transientFreezeMs)
+      }
+    }
+    const stoppedA = await request(ws, timeoutMs, 'session.stop')
+    await sleep(2000)
+    console.log(
+      `Session A survived ${stallCycles} network stall(s) + a ${transientFreezeMs}ms freeze.`
+    )
+    await verifySessionA(stoppedA.outputPath ?? startedA.outputPath)
+
+    // ---------- Session B: stream-death honesty ----------
+    console.log(`Session B: one fatal ${fatalFreezeMs}ms FFmpeg freeze — the stream may die; the`)
+    console.log('recording must be preserved and the failure reported honestly.')
+    healthEvents.length = 0
+    // Output-directory capabilities are single-use — session B needs its own.
+    const recordingDirectoryB = await requestSmokeCommand(
+      smoke,
+      'authorize-smoke-resource',
+      { kind: 'output-directory', path: outputDirectory },
+      { timeoutMs }
+    )
+    // `ffmpeg -listen 1` sinks accept exactly ONE publisher — respawn fresh
+    // listeners so session B's legs actually connect.
+    for (const listener of listeners.splice(0)) {
+      await stopListener(listener)
+    }
+    for (const target of targets) {
+      listeners.push(spawnListener(target))
+    }
+    await sleep(listenerBindMs)
+    const startedB = await request(
+      ws,
+      timeoutMs,
+      'session.start',
+      sessionParams(recordingDirectoryB.capabilityId)
+    )
+    if (startedB.state !== 'recording') {
+      throw new Error(`Expected recording state for session B, got ${startedB.state}.`)
+    }
+    await sleep(8000)
+    freezeSessionFfmpeg(fatalFreezeMs)
+    // Give the watchdogs time to trip and the exit handler time to finalize.
+    const settleDeadline = Date.now() + fatalFreezeMs + 30000
+    let finalB = null
+    while (Date.now() < settleDeadline) {
+      await sleep(2000)
+      const status = await request(ws, timeoutMs, 'recording.status')
+      if (status.state !== 'recording' && status.state !== 'streaming') {
+        finalB = status
+        break
+      }
+    }
+    let endedEarly = true
+    if (!finalB) {
+      // The stream survived the freeze entirely — also a pass; stop cleanly.
+      endedEarly = false
+      finalB = await request(ws, timeoutMs, 'session.stop')
+      console.log('  • Session B survived the fatal freeze without stream death.')
+    }
+    await sleep(2000)
+    // Terminal recording.status snapshots do not carry the artifact path —
+    // fall back to the path reported at start.
+    if (!finalB.outputPath) {
+      finalB = { ...finalB, outputPath: startedB.outputPath }
+    }
+    await verifySessionB(finalB, endedEarly)
+  } finally {
+    ws.close()
+  }
+} finally {
+  stopping = true
+  for (const proxy of proxies) {
+    await proxy.close()
+  }
+  for (const listener of listeners) {
+    await stopListener(listener)
+  }
+  await stopApp()
+}
+
+async function verifySessionA(outputPath) {
+  const failures = []
+  for (const target of targets) {
+    const size = existsSync(target.recvPath) ? statSync(target.recvPath).size : 0
+    if (size > 0) {
+      console.log(`  ✓ ${target.label} (:${target.listenPort}) received ${size} bytes`)
+    } else if (target.stalled) {
+      const latest = targetSnapshotsLatestState(target.id)
+      console.log(`  • ${target.label} no bytes; final reported state: ${latest ?? 'absent'}`)
+      if (latest !== 'failed' && latest !== 'live') {
+        failures.push(`stalled leg has no honest final state (${latest ?? 'absent'})`)
+      }
+    } else {
+      failures.push(`healthy leg ${target.label} received no bytes`)
+    }
+  }
+  await verifyRecording(outputPath, failures)
+  if (failures.length > 0) {
+    throw new Error(`Session A failed: ${failures.join('; ')}`)
+  }
+  console.log('  ✓ Session A: jitter degraded gracefully, everything survived.')
+}
+
+async function verifySessionB(finalStatus, endedEarly) {
+  const failures = []
+  if (finalStatus.state === 'failed') {
+    failures.push(
+      `session B was marked FAILED (${finalStatus.message ?? 'no message'}) — the recording was condemned for a stream failure`
+    )
+  }
+  await verifyRecording(finalStatus.outputPath, failures)
+  if (endedEarly) {
+    // The stream died — the reason must be an explicit, user-visible event,
+    // never silence (the incident sessions had zero warnings before death).
+    const reported = healthEvents.some((event) =>
+      String(event.code ?? '').includes('stream-output-failed')
+    )
+    if (reported) {
+      console.log('  ✓ stream-output-failed health event reported the dead stream honestly')
+    } else {
+      failures.push('the stream died without a stream-output-failed health event')
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`Session B failed: ${failures.join('; ')}`)
+  }
+  console.log(
+    `  ✓ Session B: state "${finalStatus.state}" with the recording preserved — a dead stream no longer kills the session.`
+  )
+}
+
+async function verifyRecording(outputPath, failures) {
+  const recordingSize = outputPath && existsSync(outputPath) ? statSync(outputPath).size : 0
+  if (recordingSize > 0) {
+    const quality = await analyzeRecording(outputPath, {
+      ffmpegPath,
+      ffprobePath: process.env.VIDEORC_SMOKE_FFPROBE_PATH ?? 'ffprobe',
+      intendedFps: 30,
+      expectAudio: false,
+      gates: {
+        requireMotion: false,
+        avSyncTargetMs: Number.POSITIVE_INFINITY,
+        avSyncHardFailMs: Number.POSITIVE_INFINITY,
+        // Freezes legitimately drop frames; timestamp sanity is the gate.
+        frameCountTolerance: Number.POSITIVE_INFINITY,
+        maxDurationStretchRatio: Number.POSITIVE_INFINITY
+      }
+    })
+    if (quality.verdict.pass) {
+      console.log(`  ✓ Recording finalized healthy: ${outputPath} (${recordingSize} bytes)`)
+    } else {
+      failures.push(`recording failed quality gates: ${quality.verdict.failures.join('; ')}`)
+    }
+  } else {
+    failures.push(`recording did not finalize (${outputPath ?? 'no path'})`)
+  }
+}
+
+function targetSnapshotsLatestState(targetId) {
+  const latest = targetSnapshots.at(-1)
+  return latest?.find((entry) => entry.targetId === targetId)?.state ?? null
+}
+
+// SIGSTOP the session's FFmpeg (a descendant of the app we launched) for
+// `freezeMs` — the deterministic twin of "the downstream muxer stopped
+// draining". Walks only OUR OWN launched process tree; the harness's local
+// listener FFmpegs are children of this Node process, never of the app.
+function freezeSessionFfmpeg(freezeMs) {
+  const pids = findDescendantFfmpegPids(appRootPid)
+  if (pids.length === 0) {
+    throw new Error('No session FFmpeg found under the app process tree to freeze.')
+  }
+  console.log(`  [freeze] SIGSTOP ${pids.join(', ')} for ${freezeMs}ms`)
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGSTOP')
+    } catch {
+      // raced its exit — the freeze becomes a no-op for that pid
+    }
+  }
+  setTimeout(() => {
+    for (const pid of pids) {
+      try {
+        process.kill(pid, 'SIGCONT')
+      } catch {
+        // already gone
+      }
+    }
+  }, freezeMs)
+}
+
+function findDescendantFfmpegPids(rootPid) {
+  if (!rootPid) {
+    return []
+  }
+  const ffmpegPids = []
+  const queue = [rootPid]
+  const seen = new Set()
+  while (queue.length > 0) {
+    const pid = queue.shift()
+    if (seen.has(pid)) {
+      continue
+    }
+    seen.add(pid)
+    let children = ''
+    try {
+      children = execFileSync('pgrep', ['-P', String(pid)], { encoding: 'utf8' })
+    } catch {
+      continue // no children
+    }
+    for (const line of children.split('\n')) {
+      const child = Number(line.trim())
+      if (!Number.isFinite(child) || child <= 0) {
+        continue
+      }
+      queue.push(child)
+      let command = ''
+      try {
+        command = execFileSync('ps', ['-p', String(child), '-o', 'comm='], {
+          encoding: 'utf8'
+        }).trim()
+      } catch {
+        continue
+      }
+      if (command.endsWith('/ffmpeg') || command === 'ffmpeg') {
+        ffmpegPids.push(child)
+      }
+    }
+  }
+  return ffmpegPids
+}
+
+function sessionParams(outputDirectoryCapability) {
+  const timestamp = '2026-01-01T00:00:00.000Z'
+  return {
+    sources: { testPattern: true },
+    layout: {
+      layoutPreset: 'screen-camera',
+      cameraTransformMode: 'preset',
+      cameraTransform: null,
+      cameraCorner: 'bottom-right',
+      cameraSize: 'medium',
+      cameraShape: 'rectangle',
+      cameraMargin: 32,
+      cameraFit: 'fill',
+      cameraMirror: false,
+      cameraZoom: 100,
+      cameraOffsetX: 0,
+      cameraOffsetY: 0,
+      sideBySideSplit: '70-30',
+      sideBySideCameraSide: 'right'
+    },
+    output: {
+      recordEnabled: true,
+      streamEnabled: true,
+      outputDirectoryCapability,
+      video: { preset: 'custom', width: 1280, height: 720, fps: 30, bitrateKbps: 4000 },
+      rtmp: { preset: 'custom', serverUrl: targets[0].serverUrl, streamKey: targets[0].streamKey }
+    },
+    streaming: {
+      enabled: true,
+      mode: 'multi',
+      targets: targets.map((target) => ({
+        id: target.id,
+        platform: target.id,
+        label: target.label,
+        enabled: true,
+        serverUrl: target.serverUrl,
+        urlMode: 'server-and-key',
+        streamKey: target.streamKey,
+        streamKeyPresent: true,
+        authMode: 'manual-rtmp',
+        createdAt: timestamp,
+        updatedAt: timestamp
+      })),
+      defaultOutputPreset: 'stream-safe-1080p30',
+      defaultBitrateKbps: 6000,
+      enabledTargetIds: targets.map((target) => target.id)
+    }
+  }
+}
+
+// TCP proxy that periodically stops reading from the publisher so the
+// app-side socket genuinely backs up (kernel buffers fill, writes block) —
+// the deterministic loopback twin of a platform-side ingest stall.
+function startStallProxy(target) {
+  const sockets = new Set()
+  const server = net.createServer((client) => {
+    const upstream = net.connect(target.listenPort, '127.0.0.1')
+    sockets.add(client)
+    sockets.add(upstream)
+    client.pipe(upstream)
+    upstream.pipe(client)
+    const stallTimer = setInterval(() => {
+      if (stopping || client.destroyed) {
+        return
+      }
+      stallCycles += 1
+      console.log(
+        `[stall-proxy :${target.proxyPort}] cycle ${stallCycles}: pausing reads for ${stallForMs}ms`
+      )
+      client.pause()
+      setTimeout(() => {
+        if (!client.destroyed) {
+          client.resume()
+        }
+      }, stallForMs)
+    }, stallEveryMs)
+    const cleanup = () => {
+      clearInterval(stallTimer)
+      sockets.delete(client)
+      sockets.delete(upstream)
+      client.destroy()
+      upstream.destroy()
+    }
+    client.on('close', cleanup)
+    client.on('error', cleanup)
+    upstream.on('close', cleanup)
+    upstream.on('error', cleanup)
+  })
+  return new Promise((resolveProxy, rejectProxy) => {
+    server.once('error', rejectProxy)
+    server.listen(target.proxyPort, '127.0.0.1', () => {
+      resolveProxy({
+        close: () =>
+          new Promise((resolveClose) => {
+            for (const socket of sockets) {
+              socket.destroy()
+            }
+            server.close(() => resolveClose())
+          })
+      })
+    })
+  })
+}
+
+function spawnListener(target) {
+  const proc = spawn(
+    ffmpegPath,
+    [
+      '-y',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-listen',
+      '1',
+      '-i',
+      target.listenUrl,
+      '-c',
+      'copy',
+      '-f',
+      'flv',
+      target.recvPath
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  )
+  proc.stderr.setEncoding('utf8')
+  proc.stderr.on('data', (text) => {
+    if (stopping) {
+      return
+    }
+    for (const line of text.split(/\r?\n/)) {
+      if (line.trim()) {
+        console.error(`[listener :${target.listenPort}] ${line}`)
+      }
+    }
+  })
+  return proc
+}
+
+function stopListener(proc) {
+  return new Promise((resolveStop) => {
+    if (!proc?.pid || proc.killed) {
+      resolveStop()
+      return
+    }
+    const timer = setTimeout(() => {
+      try {
+        proc.kill('SIGKILL')
+      } catch {
+        // already gone
+      }
+      resolveStop()
+    }, 2000)
+    proc.once('exit', () => {
+      clearTimeout(timer)
+      resolveStop()
+    })
+    try {
+      proc.kill('SIGTERM')
+    } catch {
+      clearTimeout(timer)
+      resolveStop()
+    }
+  })
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms))
+}


### PR DESCRIPTION
## The incident (2026-07-15)

Two 3-platform (YouTube + Twitch + X) live sessions died at 4.5 and 9.4 minutes with `encoder-bridge-failed` — "stream encoder output exceeded its bounded latency contract (depth 2/8, oldest 166/150ms)" and "Encoder FIFO write exceeded the complete-frame delivery budget" — and both healthy multi-minute recordings were **marked failed and buried**. Plan: vault `2026-07-15 - Videorc Multistream Session Death Fix Plan`.

## Root cause — a three-link cascade (each link fixed)

Diagnosis note: the plan's initial "no per-leg buffering" hypothesis was wrong — per-leg fifo isolation already exists everywhere (`use_fifo=1` tee slaves, fifo-muxer split legs). The real cascade, reproduced deterministically with SIGSTOP freezes of the session FFmpeg:

1. **One-sample death sentences.** The stream output hard-failed the moment a single encoded frame aged past 150ms, and the stream writer's per-frame FIFO write deadline was that same raw 150ms — a 500ms downstream stall killed the stream. Now: over-budget **degrades** to the existing latest-wins coalescing and only fails when sustained (2s window, stream role only; recording keeps its strict one-sample contract). A once-per-session `stream-output-pressure` WARN makes pressure audible — the incident had 11 silent pressure events and zero warnings.
2. **EPIPE treated as a verdict.** The dying stream writer closed its FIFO → the shared FFmpeg exited cleanly → the *recording* writer's EPIPE was recorded as a terminal bridge failure. Downstream-closed errors now stop the writer without recording a terminal failure; the process exit status is the authority.
3. **The `or_else()` merge.** Stream and recording terminal failures were OR-merged into one session-fatal signal, so `should_finalize_recording_session` refused to finalize. Split: a stream-only failure with a clean exit **finalizes the recording** and emits an explicit `stream-output-failed` health error; a recording failure or dirty exit still fails the session.

## Proof — `pnpm smoke:multistream-endurance`

Three local RTMP sinks; one leg behind a read-stalling TCP proxy; SIGSTOP freezes of the session's own FFmpeg (found by walking our launched process tree). Pre-fix: session dies 32s in with the exact incident errors. Post-fix:
- **Session A** (4s network stalls ×4 + 500ms freeze): runs to planned stop, every leg delivers, recording healthy.
- **Session B** (fatal 6s freeze): stream dies **honestly** (`stream-output-failed` event), session is NOT failed, recording finalizes healthy.

## Gates

Targeted cargo (58 encoder_bridge + 204 recording tests incl. new policy/classification/finalization tables) + clippy `-D warnings` + fmt · typecheck/lint/format · 1111 desktop tests · 640 script tests · endurance smoke both scenarios green. Full Rust suite skipped per owner directive (CI billing block).

## Follow-ups (out of scope, filed)

- Encoder margin: incident diagnostics showed encoderSpeed 0.906 at 4K30 — inspection cleared the chroma-key/blend suspects of unconditional cost; a measurement/bisect task chip is filed. The fixes here remove the fatal consequence; sub-realtime encode now degrades stream quality instead of killing sessions.
- True stream continuation (recording keeps running after stream death — today FFmpeg exits and the session ends *completed*): candidate follow-up if owners want mid-session stream recovery.

Owner acceptance: a real 3-platform stream ≥15 minutes — the exact flow that failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streaming now tolerates brief output pressure by coalescing to the latest data before escalating.
  - Persistent stream failures are reported clearly, while local recordings remain preserved when unaffected.
  - Added dedicated health events for stream-output pressure and stream-output failure.

- **Bug Fixes**
  - Improved handling of downstream disconnects so they are distinguished from bridge failures.

- **Tests**
  - Added a multistream endurance smoke test covering stalled outputs, recovery, and stream failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->