### PR TITLE
Release 0.9.43-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.42",
+  "version": "0.9.43",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.43-beta.1.md
+++ b/changelog/0.9.43-beta.1.md
@@ -1,0 +1,36 @@
+---
+version: 0.9.43-beta.1
+date: 2026-07-15
+channel: beta
+title: Multistream stays up — a struggling platform can't end your session anymore
+summary: Going live to multiple platforms no longer dies when one connection hiccups. A brief stall now just drops a few stream frames and recovers, you get a warning when a destination is struggling — and if streaming genuinely fails, your local recording is finished and saved instead of being thrown away.
+highlights:
+  - A brief network stall on any streaming platform no longer ends your session — the stream drops a few frames, recovers, and keeps going.
+  - When a destination is accepting data slower than your stream produces it, a warning tells you — before anything worse happens, not after.
+  - If streaming genuinely dies mid-session, your local recording is finalized and saved with an honest message about what happened — previously the whole session was marked failed and the recording was buried.
+  - Recordings themselves keep their strict quality guarantees — nothing about local recording reliability was loosened.
+---
+
+## One bad connection is not a dead session
+
+Going live to YouTube, Twitch, and X at once means three network paths, and
+over a long stream one of them will hiccup. Videorc treated a single brief
+stall — one frame arriving 16 milliseconds late past its budget — as fatal:
+the whole session ended, and the recording you'd been making alongside was
+marked failed and hidden.
+
+Now transient trouble degrades instead of killing: the live stream drops a
+few frames to stay current and recovers when the connection does. If a
+destination stays slow, you'll see a clear warning in your session log while
+everything keeps running.
+
+## Your recording survives, no matter what the stream does
+
+Recording and streaming are separate promises. If streaming genuinely fails
+mid-session — a platform dies and stays dead — the failure is reported for
+what it is, and your local recording is finished, saved, and lands in the
+Library like any other. The multi-minute recordings that used to disappear
+with a failed session now survive.
+
+None of this loosens recording quality: the strict guarantees that catch a
+genuinely broken recording are unchanged.


### PR DESCRIPTION
Version 0.9.42 → 0.9.43 and the changelog for #134 (multistream session-death fix: sustained-violation watchdogs, stream-pressure warnings, recording survival). `pnpm changelog:check` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming resilience during temporary connection stalls and slow destinations.
  * Added warnings for slow streaming destinations without stopping the stream.
  * Local recordings are now finalized and saved when streaming fails mid-session.

* **Documentation**
  * Added release notes for version 0.9.43-beta.1.
  * Confirmed that local recording quality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->