### PR TITLE
Record the 0.9.43 release (multistream session-death fix)

### DIFF
--- a/docs/releases/0.9.43.md
+++ b/docs/releases/0.9.43.md
@@ -1,0 +1,61 @@
+# Videorc 0.9.43 Beta 1
+
+Videorc 0.9.43 ships the multistream session-death fix (#134): transient
+stream pressure degrades instead of killing the session, pressure is
+surfaced early, and a genuine stream death preserves and finalizes the
+local recording.
+
+## Scope
+
+- **Multistream resilience** (PR #134, plan: vault `2026-07-15 -
+  Videorc Multistream Session Death Fix Plan`, incident sessions
+  `50eb6d94`/`aef2f841` of 2026-07-15): the three-link cascade fixed —
+  (1) one-sample stream watchdogs (150ms age budget + raw write
+  deadline) now DEGRADE via latest-wins coalescing and fail only on a
+  sustained 2s violation, with a once-per-session
+  `stream-output-pressure` WARN when coalescing engages; (2) EPIPE/EOF
+  from a departed FFmpeg is classified "downstream closed" and never
+  recorded as a terminal bridge verdict; (3) stream and recording
+  terminal failures are split — a stream-only failure with a clean exit
+  finalizes the recording and emits `stream-output-failed`, instead of
+  marking the session failed and burying the file. Recording outputs
+  keep their strict one-sample contract.
+- **New maintained gate**: `pnpm smoke:multistream-endurance` — three
+  local RTMP sinks, one behind a read-stalling TCP proxy, plus SIGSTOP
+  freezes of the session FFmpeg. Session A (jitter) must fully survive;
+  Session B (fatal 6s freeze) must preserve the recording and report
+  the stream death. Both were red pre-fix (exact incident errors),
+  green post-fix. Release endurance profile:
+  `VIDEORC_SMOKE_STREAM_MS=600000`.
+
+## Release status
+
+- [x] PR merged: #134; prep #135 (admin-merged — GitHub Actions blocked
+      by billing; local gates: 58 encoder_bridge + 204 recording
+      targeted tests, clippy -D warnings, fmt, typecheck/lint/format,
+      1111 desktop tests, 640 script tests, endurance smoke green; full
+      Rust suite skipped per owner directive).
+- [x] Signed + notarized arm64 build; staple verified by
+      release:validate:macos. (Known: `is_ffmpeg_error_line` dead-code
+      warning, carried since 0.9.38.)
+- [x] Uploaded to R2; feed verified end-to-end
+      (`https://www.videorc.com/api/updates/latest-mac.yml` →
+      `version: 0.9.43`, artifact hashes present); `/api/changelog`
+      serves 0.9.43-beta.1.
+- [x] Discord announcement posted.
+- [ ] Owner acceptance: a REAL 3-platform (YouTube + Twitch + X) live
+      stream ≥15 minutes — the exact flow that failed on 0.9.42. Expect:
+      session survives; any pressure shows as a warn event, not a death;
+      if a platform genuinely dies, the recording still lands in the
+      Library.
+- [ ] Follow-up open: encoder margin at 4K (encoderSpeed 0.906 in the
+      incident) — measurement/bisect task chip filed; mid-session
+      stream continuation (session currently ends completed when the
+      stream dies) — candidate future work.
+- [ ] Owner: X post (draft provided in session; posted manually).
+
+## Rollback
+
+Standard: re-upload 0.9.42's artifacts/manifest per
+`docs/releases/release-runbook.md`; the feed is version-compared, so
+restoring the older manifest reverts updates.


### PR DESCRIPTION
Internal release record for 0.9.43-beta.1 (#134 multistream resilience). Build/upload/feed/announce verified; owner acceptance = a real 3-platform stream ≥15 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)