### PR TITLE
fix: green screen keys real screens — chroma-direction keyer

### DIFF
--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -2166,19 +2166,21 @@ fn scene_mask_into_metal(mask: SceneMask) -> crate::metal_compositor::SourceMask
 }
 
 /// f32 projection of the shared keyer spec for the shader. The spec from
-/// `camera_chroma_key` stays the single source of truth.
+/// `camera_chroma_key` stays the single source of truth. A grey key color has
+/// no chroma direction — returns None so the quad renders unkeyed.
 #[cfg(target_os = "macos")]
 fn scene_chroma_key_into_metal(
     spec: &crate::scene_geometry::ChromaKeySpec,
-) -> crate::metal_compositor::GpuChromaKey {
-    crate::metal_compositor::GpuChromaKey {
-        key_cb: spec.key_cb() as f32,
-        key_cr: spec.key_cr() as f32,
-        threshold: spec.threshold as f32,
-        band: spec.band as f32,
+) -> Option<crate::metal_compositor::GpuChromaKey> {
+    let (dir_cb, dir_cr) = spec.key_direction()?;
+    Some(crate::metal_compositor::GpuChromaKey {
+        key_dir_cb: dir_cb as f32,
+        key_dir_cr: dir_cr as f32,
+        max_angle_rad: spec.max_angle_deg.to_radians() as f32,
+        band_rad: spec.band_deg.to_radians() as f32,
         spill: spec.spill as f32,
         spill_is_blue: spec.spill_is_blue(),
-    }
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -2626,10 +2628,13 @@ fn try_gpu_compose(
                         // The keyed camera is the one capture source that
                         // blends: its alpha comes from the shader's keyer,
                         // not the (untrustworthy) capture alpha channel.
-                        blend: camera_chroma_key(layout).is_some(),
+                        blend: camera_chroma_key(layout)
+                            .as_ref()
+                            .and_then(scene_chroma_key_into_metal)
+                            .is_some(),
                         chroma_key: camera_chroma_key(layout)
                             .as_ref()
-                            .map(scene_chroma_key_into_metal),
+                            .and_then(scene_chroma_key_into_metal),
                     });
                 } else {
                     let placeholder =
@@ -5155,12 +5160,14 @@ mod tests {
             eprintln!("skipping: no Metal device available in this environment");
             return;
         };
-        // Key green (out), red (kept), a mid green-grey (partial alpha), and
-        // grey (kept + despill-neutral), over a blue background. RGBA order.
+        // A REALISTIC shadowed screen tone (out — the 0.9.39 model failed
+        // here), red (kept), a low-saturation screen tone inside the
+        // saturation-floor ramp (partial alpha), and grey (kept), over a
+        // blue background. RGBA order.
         let pixels: [[u8; 4]; 4] = [
-            [0, 255, 0, 255],
+            [30, 100, 40, 255],
             [255, 0, 0, 255],
-            [74, 181, 74, 255],
+            [100, 135, 100, 255],
             [128, 128, 128, 255],
         ];
         let spec = chroma_key_test_spec();
@@ -5213,7 +5220,7 @@ mod tests {
                     mirror: false,
                     mask: SourceMask::None,
                     blend: true,
-                    chroma_key: Some(scene_chroma_key_into_metal(&spec)),
+                    chroma_key: scene_chroma_key_into_metal(&spec),
                 }],
             )
             .expect("metal compose");
@@ -5238,7 +5245,7 @@ mod tests {
         assert!(gpu_pixels[1] <= 2 && gpu_pixels[2] <= 2);
         // The partial pixel genuinely blended on both paths (neither the
         // background nor the despilled source survives verbatim).
-        let partial_alpha = chroma_key_alpha(&spec, 74, 181, 74);
+        let partial_alpha = chroma_key_alpha(&spec, 100, 135, 100);
         assert!(
             partial_alpha > 0 && partial_alpha < 255,
             "fixture pixel must ramp, got {partial_alpha}"

--- a/crates/videorc-backend/src/metal_compositor.rs
+++ b/crates/videorc-backend/src/metal_compositor.rs
@@ -54,11 +54,11 @@ struct FragParams {
     float circle;
     float aspect;
     float radius;
-    // Chroma key, mirroring scene_geometry's f64 reference keyer:
-    // chroma_key = (enabled, key_cb, key_cr, threshold); chroma_key2 =
-    // (band, spill, spill_is_blue, reserved). CbCr and distances are in
-    // 0..255 units with the SAME -43/-85/128 and 128/-107/-21 coefficient
-    // family as color.rs — if these drift, the CPU and GPU keyers disagree.
+    // Chroma key, mirroring scene_geometry's f64 reference keyer (ANGLE
+    // model): chroma_key = (enabled, key_dir_cb, key_dir_cr, max_angle_rad);
+    // chroma_key2 = (band_rad, spill, spill_is_blue, saturation_floor).
+    // CbCr uses the SAME -43/-85/128 and 128/-107/-21 coefficient family as
+    // color.rs — if these drift, the CPU and GPU keyers disagree.
     float4 chroma_key;
     float4 chroma_key2;
 };
@@ -117,20 +117,30 @@ fragment float4 f_main(VOut in [[stage_in]],
     float2 src = float2(cl + u * (1.0 - cl - cr), ct + uv.y * (1.0 - ct - cb));
     float4 color = tex.sample(samp, src);
     // Chroma key (scene_geometry::chroma_key_alpha / chroma_key_despill in
-    // f32): CbCr distance from the key ramps alpha 0->1 across the band, and
-    // spill pulls the dominant key channel down toward the other channels'
-    // max. The quad must be drawn on the blending pipeline for the computed
-    // alpha to matter.
+    // f32, ANGLE model): the angle between the pixel's CbCr vector and the
+    // key direction ramps alpha 0->1 across the band; a saturation floor
+    // (ramp width 6.0, mirroring CHROMA_KEY_SATURATION_RAMP) pulls greys
+    // back to opaque. Spill pulls the dominant key channel down toward the
+    // other channels' max. The quad must be drawn on the blending pipeline
+    // for the computed alpha to matter.
     if (params.chroma_key.x > 0.5) {
         float r = color.r * 255.0, g = color.g * 255.0, b = color.b * 255.0;
-        float dcb = 128.0 + (-43.0 * r - 85.0 * g + 128.0 * b) / 256.0 - params.chroma_key.y;
-        float dcr = 128.0 + (128.0 * r - 107.0 * g - 21.0 * b) / 256.0 - params.chroma_key.z;
-        float dist = sqrt(dcb * dcb + dcr * dcr);
-        float threshold = params.chroma_key.w;
-        float band = params.chroma_key2.x;
-        float alpha = (band > 0.0)
-            ? clamp((dist - threshold) / band, 0.0, 1.0)
-            : (dist <= threshold ? 0.0 : 1.0);
+        float vcb = (-43.0 * r - 85.0 * g + 128.0 * b) / 256.0;
+        float vcr = (128.0 * r - 107.0 * g - 21.0 * b) / 256.0;
+        float saturation = sqrt(vcb * vcb + vcr * vcr);
+        float angle_alpha = 1.0;
+        if (saturation > 1e-4) {
+            float cos_theta = clamp(
+                (vcb * params.chroma_key.y + vcr * params.chroma_key.z) / saturation, -1.0, 1.0);
+            float theta = acos(cos_theta);
+            float max_angle = params.chroma_key.w;
+            float band = params.chroma_key2.x;
+            angle_alpha = (band > 0.0)
+                ? clamp((theta - max_angle) / band, 0.0, 1.0)
+                : (theta <= max_angle ? 0.0 : 1.0);
+        }
+        float eligibility = clamp((saturation - params.chroma_key2.w) / 6.0, 0.0, 1.0);
+        float alpha = 1.0 - eligibility * (1.0 - angle_alpha);
         float spill = params.chroma_key2.y;
         if (spill > 0.0) {
             if (params.chroma_key2.z > 0.5) {
@@ -168,27 +178,33 @@ struct FragParams {
 
 /// Per-quad chroma key in shader units, converted once from
 /// `scene_geometry::ChromaKeySpec` at the compositor bridge (the spec stays
-/// the single source; this is just its f32 projection).
+/// the single source; this is just its f32 projection). Angle model: the key
+/// is a unit CbCr DIRECTION plus a max angle and ramp band in radians.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GpuChromaKey {
-    pub key_cb: f32,
-    pub key_cr: f32,
-    pub threshold: f32,
-    pub band: f32,
+    pub key_dir_cb: f32,
+    pub key_dir_cr: f32,
+    pub max_angle_rad: f32,
+    pub band_rad: f32,
     pub spill: f32,
     pub spill_is_blue: bool,
 }
+
+/// Mirrors scene_geometry::CHROMA_KEY_SATURATION_FLOOR / _RAMP — if these
+/// drift the CPU and GPU keyers disagree about which greys survive.
+const CHROMA_KEY_SATURATION_FLOOR: f32 = 14.0;
+const CHROMA_KEY_SATURATION_RAMP: f32 = 6.0;
 
 impl GpuChromaKey {
     fn frag_params(source: Option<&GpuChromaKey>) -> ([f32; 4], [f32; 4]) {
         match source {
             Some(key) => (
-                [1.0, key.key_cb, key.key_cr, key.threshold],
+                [1.0, key.key_dir_cb, key.key_dir_cr, key.max_angle_rad],
                 [
-                    key.band,
+                    key.band_rad,
                     key.spill,
                     if key.spill_is_blue { 1.0 } else { 0.0 },
-                    0.0,
+                    CHROMA_KEY_SATURATION_FLOOR,
                 ],
             ),
             None => ([0.0; 4], [0.0; 4]),
@@ -1896,14 +1912,17 @@ mod tests {
         assert_eq!(pixel(&px, 1, 0, 0)[..3], [0, 0, 0]);
     }
 
-    /// Green key in the shader's CbCr units — the same -85/-107 coefficient
-    /// family the Rust reference keyer uses.
-    fn green_key(threshold: f32, band: f32, spill: f32) -> GpuChromaKey {
+    /// Pure-green key DIRECTION (unit CbCr vector) with angles in radians —
+    /// the same -85/-107 coefficient family the Rust reference keyer uses.
+    fn green_key(max_angle_deg: f32, band_deg: f32, spill: f32) -> GpuChromaKey {
+        let cb = -85.0_f32 * 255.0 / 256.0;
+        let cr = -107.0_f32 * 255.0 / 256.0;
+        let length = (cb * cb + cr * cr).sqrt();
         GpuChromaKey {
-            key_cb: 128.0 + (-85.0 * 255.0) / 256.0,
-            key_cr: 128.0 + (-107.0 * 255.0) / 256.0,
-            threshold,
-            band,
+            key_dir_cb: cb / length,
+            key_dir_cr: cr / length,
+            max_angle_rad: max_angle_deg.to_radians(),
+            band_rad: band_deg.to_radians(),
             spill,
             spill_is_blue: false,
         }
@@ -1915,30 +1934,33 @@ mod tests {
             eprintln!("skipping: no Metal device available in this environment");
             return;
         };
-        // BGRA texels: key green (keys out), red (kept), a green-grey mix
-        // (partial alpha), grey (kept). Composed over a BLUE background.
+        // BGRA texels: a REALISTIC shadowed screen tone (the 0.9.39 model
+        // failed exactly here), red (kept), a desaturated screen tone in the
+        // saturation-floor ramp (partial), grey (kept). Over a BLUE frame.
         let camera = [
-            0u8, 255, 0, 255, // green
+            40u8, 100, 30, 255, // shadowed screen green (rgb 30,100,40)
             0, 0, 255, 255, // red
-            74, 181, 74, 255, // partial
+            100, 135, 100, 255, // low-saturation screen tone (partial)
             128, 128, 128, 255, // grey
         ];
         let mut source = full_frame(&camera, 4, 1, false, SourceMask::None, [0.0; 4]);
         source.blend = true;
-        source.chroma_key = Some(green_key(72.0, 14.4, 0.0));
+        source.chroma_key = Some(green_key(24.0, 4.8, 0.0));
         let px = compositor
             .compose_bgra(4, 1, [0.0, 0.0, 1.0, 1.0], &[source])
             .unwrap();
         assert_eq!(
             pixel(&px, 4, 0, 0)[..3],
             [255, 0, 0],
-            "key green shows the blue frame"
+            "shadowed REAL screen tone keys with defaults (the 0.9.39 bug)"
         );
         assert_eq!(pixel(&px, 4, 1, 0)[..3], [0, 0, 255], "red survives");
+        // Reference alpha for (100,135,100) is ~55/255 (saturation 18.7 in
+        // the 14..20 ramp): out ≈ src*0.22 + blue*0.78 → BGRA ≈ (221, 30, 22).
         let partial = pixel(&px, 4, 2, 0);
         assert!(
-            partial[1] > 30 && partial[1] < 165 && partial[0] > 60 && partial[0] < 220,
-            "green-grey mix blends fractionally over blue, got {partial:?}"
+            partial[0] > 190 && partial[0] < 245 && partial[1] > 15 && partial[1] < 60,
+            "saturation-ramp tone blends fractionally over blue, got {partial:?}"
         );
         assert_eq!(
             pixel(&px, 4, 3, 0)[..3],
@@ -1958,7 +1980,9 @@ mod tests {
         let camera = [80u8, 200, 100, 255]; // BGRA: r=100 g=200 b=80
         let mut source = full_frame(&camera, 1, 1, false, SourceMask::None, [0.0; 4]);
         source.blend = true;
-        source.chroma_key = Some(green_key(40.0, 0.0, 1.0));
+        // Narrow 5-degree cone: this green-dominant tone sits ~8.5 degrees
+        // off the key direction, so it is KEPT — and only despilled.
+        source.chroma_key = Some(green_key(5.0, 0.0, 1.0));
         let px = compositor
             .compose_bgra(1, 1, [0.0, 0.0, 0.0, 1.0], &[source])
             .unwrap();
@@ -1983,7 +2007,7 @@ mod tests {
         let red = [0u8, 0, 255, 255].repeat(2 * 2);
         let mut source = full_frame(&red, 2, 2, false, SourceMask::Circle, [0.0; 4]);
         source.blend = true;
-        source.chroma_key = Some(green_key(72.0, 14.4, 0.1));
+        source.chroma_key = Some(green_key(24.0, 4.8, 0.1));
         let px = compositor
             .compose_bgra(out, out, [0.0, 0.0, 1.0, 1.0], &[source])
             .unwrap();

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -8429,21 +8429,31 @@ fn scene_source_layer_filter(
     )
 }
 
-/// FFmpeg mirror of the shared keyer (`scene_geometry::camera_chroma_key`):
-/// `chromakey` computes the same CbCr-plane distance normalized to the plane's
-/// diagonal (255·√2), so `similarity`/`blend` are exactly the spec's
-/// threshold/band divided by that constant, and `despill`'s `mix` is the spill
-/// strength. Empty when keying is off. Trailing comma composes into chains.
+/// Chroma saturation of a typical studio-lit screen — the anchor for the
+/// FFmpeg leg's calibrated approximation of the angle keyer (real screens
+/// measured at 35–62 units; see the realistic-palette test).
+const FFMPEG_CHROMA_KEY_REFERENCE_SATURATION: f64 = 55.0;
+
+/// FFmpeg approximation of the shared ANGLE keyer. `chromakey` can only
+/// express absolute CbCr distance, and a per-pixel `geq` keyer is too slow at
+/// full frame — so this leg anchors an EFFECTIVE key color at the spec's
+/// chroma direction scaled to a realistic screen saturation (not the pure
+/// preset color, whose saturation ~136 put real screens 75+ units away — the
+/// 0.9.39 bug), with a similarity radius that covers the screen cluster at
+/// the spec's angle. The Metal/CPU paths key by true angle; this bounded
+/// divergence is pinned by `ffmpeg_chroma_mapping_keys_the_realistic_palette`.
 fn camera_chroma_key_filter(layout: &LayoutSettings) -> String {
     let Some(spec) = camera_chroma_key(layout) else {
         return String::new();
     };
-    let [r, g, b] = spec.key_rgb;
+    let Some((effective_rgb, similarity_units)) = ffmpeg_chroma_key_mapping(&spec) else {
+        return String::new();
+    };
+    let [r, g, b] = effective_rgb;
     let normalize = 255.0 * std::f64::consts::SQRT_2;
-    // chromakey rejects similarity 0; the floor keeps a zero threshold keying
-    // only exact key pixels, matching the reference's hard edge.
-    let similarity = (spec.threshold / normalize).clamp(0.0001, 1.0);
-    let blend = (spec.band / normalize).clamp(0.0, 1.0);
+    let similarity = (similarity_units / normalize).clamp(0.01, 1.0);
+    let blend = (spec.band_deg.to_radians() * FFMPEG_CHROMA_KEY_REFERENCE_SATURATION / normalize)
+        .clamp(0.0, 1.0);
     let despill = if spec.spill > 0.0 {
         let kind = if spec.spill_is_blue() {
             "blue"
@@ -8457,6 +8467,32 @@ fn camera_chroma_key_filter(layout: &LayoutSettings) -> String {
     format!(
         "chromakey=color=0x{r:02X}{g:02X}{b:02X}:similarity={similarity:.4}:blend={blend:.4}{despill},"
     )
+}
+
+/// Effective key color + similarity radius (CbCr units) for the chromakey
+/// approximation: the key DIRECTION at reference saturation, with a radius
+/// covering saturation spread (±20 units around the reference) plus the
+/// angular cone at that saturation.
+fn ffmpeg_chroma_key_mapping(
+    spec: &crate::scene_geometry::ChromaKeySpec,
+) -> Option<([u8; 3], f64)> {
+    let (dir_cb, dir_cr) = spec.key_direction()?;
+    let cb = 128.0 + dir_cb * FFMPEG_CHROMA_KEY_REFERENCE_SATURATION;
+    let cr = 128.0 + dir_cr * FFMPEG_CHROMA_KEY_REFERENCE_SATURATION;
+    // Full-range BT.601 inverse at mid luma; chromakey compares CbCr only,
+    // so the Y channel of the encoded color is irrelevant.
+    let y = 128.0;
+    let red = (y + 1.402 * (cr - 128.0)).clamp(0.0, 255.0).round() as u8;
+    let green = (y - 0.344136 * (cb - 128.0) - 0.714136 * (cr - 128.0))
+        .clamp(0.0, 255.0)
+        .round() as u8;
+    let blue = (y + 1.772 * (cb - 128.0)).clamp(0.0, 255.0).round() as u8;
+    // Radius: saturation spread of a real screen around the reference plus
+    // the chord of the angle cone at reference saturation.
+    let angular_reach =
+        FFMPEG_CHROMA_KEY_REFERENCE_SATURATION * spec.max_angle_deg.to_radians().sin();
+    let similarity_units = 20.0 + angular_reach;
+    Some(([red, green, blue], similarity_units))
 }
 
 fn normalized_crop_filter(transform: &crate::protocol::SceneTransform) -> String {
@@ -13628,10 +13664,11 @@ mod tests {
         assert!(clamped.contains("2500.000"), "{clamped}");
     }
 
-    // Chroma key (2026-07-13 plan): the FFmpeg leg maps the ONE keyer spec to
-    // chromakey/despill — similarity and blend are the spec's threshold/band
-    // normalized to the CbCr diagonal (255·√2). Pin the string so the mapping
-    // cannot silently drift from the CPU/Metal keyers.
+    // Chroma key (real-screen fix, 2026-07-14): the FFmpeg leg approximates
+    // the angle keyer with chromakey anchored at an EFFECTIVE key color — the
+    // spec's chroma direction at realistic screen saturation (NOT the pure
+    // preset color, whose saturation put real screens outside any usable
+    // radius — the 0.9.39 bug). Pin the mapping so it cannot drift.
     #[test]
     fn camera_chroma_key_filter_pins_the_chromakey_despill_mapping() {
         let mut layout = crate::protocol::default_layout_settings();
@@ -13640,7 +13677,7 @@ mod tests {
         layout.camera_chroma_key_enabled = true;
         assert_eq!(
             camera_chroma_key_filter(&layout),
-            "chromakey=color=0x00FF00:similarity=0.1997:blend=0.0399,despill=type=green:mix=0.1000,"
+            "chromakey=color=0x44AB43:similarity=0.1175:blend=0.0128,despill=type=green:mix=0.1000,"
         );
 
         layout.camera_chroma_key_color = "#0000FF".to_string();
@@ -13648,17 +13685,69 @@ mod tests {
         layout.camera_chroma_key_spill_pct = 0;
         assert_eq!(
             camera_chroma_key_filter(&layout),
-            "chromakey=color=0x0000FF:similarity=0.1997:blend=0.0000,",
+            "chromakey=color=0x7474E0:similarity=0.1175:blend=0.0000,",
             "zero band is a hard cut and zero spill drops despill"
         );
 
-        // A zero similarity floors at chromakey's minimum instead of erroring.
+        // Zero similarity keeps the base saturation-spread radius (a real
+        // screen still keys) instead of collapsing to an exact-color match.
         layout.camera_chroma_key_similarity_pct = 0;
         assert!(
-            camera_chroma_key_filter(&layout).contains("similarity=0.0001"),
+            camera_chroma_key_filter(&layout).contains("similarity=0.0555"),
             "{}",
             camera_chroma_key_filter(&layout)
         );
+    }
+
+    /// The FFmpeg-leg twin of scene_geometry's realistic-palette pin: under
+    /// chromakey's absolute-CbCr-distance model, the DEFAULT mapping must key
+    /// every real screen tone and keep the subject. (Pure synthetic green
+    /// falls outside the effective disc — real footage is the contract.)
+    #[test]
+    fn ffmpeg_chroma_mapping_keys_the_realistic_palette() {
+        let mut layout = crate::protocol::default_layout_settings();
+        layout.camera_chroma_key_enabled = true;
+        let spec = camera_chroma_key(&layout).expect("keying enabled");
+        let (effective_rgb, similarity_units) =
+            ffmpeg_chroma_key_mapping(&spec).expect("green key has a direction");
+        // Same coefficient family as color.rs / scene_geometry, local to the
+        // test because the spec helpers work on the key color only.
+        let cbcr = |rgb: [u8; 3]| {
+            let [r, g, b] = rgb.map(f64::from);
+            (
+                128.0 + (-43.0 * r - 85.0 * g + 128.0 * b) / 256.0,
+                128.0 + (128.0 * r - 107.0 * g - 21.0 * b) / 256.0,
+            )
+        };
+        let (key_cb, key_cr) = cbcr(effective_rgb);
+        let distance = |rgb: [u8; 3]| {
+            let (cb, cr) = cbcr(rgb);
+            ((cb - key_cb).powi(2) + (cr - key_cr).powi(2)).sqrt()
+        };
+        for (label, rgb) in [
+            ("bright lit screen", [80u8, 200, 90]),
+            ("well-lit screen", [60, 180, 70]),
+            ("mid screen", [40, 140, 55]),
+            ("shadowed screen", [30, 100, 40]),
+            ("overexposed edge", [110, 190, 120]),
+        ] {
+            assert!(
+                distance(rgb) <= similarity_units,
+                "{label} must be inside the chromakey disc ({:.1} > {similarity_units:.1})",
+                distance(rgb)
+            );
+        }
+        for (label, rgb) in [
+            ("skin", [200u8, 160, 140]),
+            ("dark hair", [40, 30, 25]),
+            ("white shirt", [230, 230, 230]),
+        ] {
+            assert!(
+                distance(rgb) > similarity_units + 10.0,
+                "{label} must stay clearly outside the disc ({:.1})",
+                distance(rgb)
+            );
+        }
     }
 
     #[test]

--- a/crates/videorc-backend/src/scene_geometry.rs
+++ b/crates/videorc-backend/src/scene_geometry.rs
@@ -243,23 +243,41 @@ pub fn camera_mask(layout: &LayoutSettings) -> SceneMask {
 }
 
 /// Chroma key spec for the camera layer — THE single source every render path
-/// (CPU, Metal shader, FFmpeg filter) derives its keying from. Distances are
-/// in full-range BT.601 CbCr units (0..=255 per axis), matching
-/// `crate::color::rgb_to_yuv_full_range_bt601`'s coefficient family.
+/// (CPU, Metal shader, FFmpeg filter) derives its keying from.
+///
+/// The keyer works on chroma DIRECTION, not absolute CbCr distance: a pixel
+/// keys when the ANGLE between its CbCr vector and the key color's CbCr
+/// direction is small, gated by a saturation floor so near-grey pixels never
+/// key. The 0.9.39 absolute-distance model could not key real screens: pure
+/// `#00FF00` sits at CbCr saturation ~136 while studio-lit screens sit at
+/// 35–62, putting their DISTANCE at 75–101 units regardless of hue — above
+/// any usable threshold (owner report + numeric repro, 2026-07-14). Angle is
+/// lighting-invariant: bright and shadowed screen tones cluster within ~8° of
+/// the key direction while subjects sit 90°+ away.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ChromaKeySpec {
     pub key_rgb: [u8; 3],
-    /// CbCr distance at/below which a pixel is fully transparent.
-    pub threshold: f64,
-    /// Ramp width above `threshold` over which alpha rises 0→255 (0 = hard cut).
-    pub band: f64,
+    /// Angle (degrees) from the key's chroma direction at/below which a
+    /// pixel is fully transparent.
+    pub max_angle_deg: f64,
+    /// Ramp band (degrees) beyond `max_angle_deg` over which alpha rises
+    /// 0→255 (0 = hard cut).
+    pub band_deg: f64,
     /// Spill suppression strength, 0..=1.
     pub spill: f64,
 }
 
-/// Similarity/smoothness percent → CbCr distance. 100% maps to 180 units —
-/// half the CbCr plane's diagonal, past which everything keys out.
-const CHROMA_KEY_PCT_TO_DISTANCE: f64 = 1.8;
+/// Similarity/smoothness percent → degrees. 100% maps to 60°; the default
+/// similarity of 40% is a 24° cone — real screen tones cluster within ~8° of
+/// the key direction, subjects sit 90°+ away, so defaults key with margin.
+const CHROMA_KEY_PCT_TO_DEGREES: f64 = 0.6;
+
+/// Chroma saturation (|CbCr vector|) below which a pixel can never key —
+/// greys, whites, and blacks have no meaningful hue direction. Ramps to fully
+/// keyable over `CHROMA_KEY_SATURATION_RAMP` units. The Metal shader mirrors
+/// both constants.
+pub const CHROMA_KEY_SATURATION_FLOOR: f64 = 14.0;
+pub const CHROMA_KEY_SATURATION_RAMP: f64 = 6.0;
 
 impl ChromaKeySpec {
     pub fn key_cb(&self) -> f64 {
@@ -268,6 +286,18 @@ impl ChromaKeySpec {
 
     pub fn key_cr(&self) -> f64 {
         rgb_cr_f64(self.key_rgb)
+    }
+
+    /// Unit vector of the key color's chroma direction. `None` when the key
+    /// color is (near-)grey — no direction exists and nothing may key.
+    pub fn key_direction(&self) -> Option<(f64, f64)> {
+        let cb = self.key_cb() - 128.0;
+        let cr = self.key_cr() - 128.0;
+        let length = (cb * cb + cr * cr).sqrt();
+        if length < 1.0 {
+            return None;
+        }
+        Some((cb / length, cr / length))
     }
 
     /// Which channel spills: blue screens contaminate blue, everything else
@@ -316,28 +346,42 @@ pub fn camera_chroma_key(layout: &LayoutSettings) -> Option<ChromaKeySpec> {
     });
     Some(ChromaKeySpec {
         key_rgb,
-        threshold: f64::from(layout.camera_chroma_key_similarity_pct.min(100))
-            * CHROMA_KEY_PCT_TO_DISTANCE,
-        band: f64::from(layout.camera_chroma_key_smoothness_pct.min(100))
-            * CHROMA_KEY_PCT_TO_DISTANCE,
+        max_angle_deg: f64::from(layout.camera_chroma_key_similarity_pct.min(100))
+            * CHROMA_KEY_PCT_TO_DEGREES,
+        band_deg: f64::from(layout.camera_chroma_key_smoothness_pct.min(100))
+            * CHROMA_KEY_PCT_TO_DEGREES,
         spill: f64::from(layout.camera_chroma_key_spill_pct.min(100)) / 100.0,
     })
 }
 
-/// Alpha for one source pixel: 0 at/below `threshold` CbCr distance from the
-/// key, 255 at/above `threshold + band`, linear ramp between. This f64 form is
-/// the reference the CPU path calls directly and the Metal shader mirrors.
+/// Alpha for one source pixel. Angle model: θ = angle between the pixel's
+/// CbCr vector and the key direction; 0 at/below `max_angle_deg`, 255 at/above
+/// `max_angle_deg + band_deg`, linear ramp between. The saturation floor then
+/// pulls low-chroma pixels back toward opaque (greys never key). This f64
+/// form is the reference the CPU path calls directly and the Metal shader
+/// mirrors in f32.
 pub fn chroma_key_alpha(spec: &ChromaKeySpec, r: u8, g: u8, b: u8) -> u8 {
-    let cb = rgb_cb_f64([r, g, b]) - spec.key_cb();
-    let cr = rgb_cr_f64([r, g, b]) - spec.key_cr();
-    let distance = (cb * cb + cr * cr).sqrt();
-    if distance <= spec.threshold {
-        return 0;
-    }
-    if spec.band <= 0.0 || distance >= spec.threshold + spec.band {
+    let Some((dir_cb, dir_cr)) = spec.key_direction() else {
+        return 255;
+    };
+    let cb = rgb_cb_f64([r, g, b]) - 128.0;
+    let cr = rgb_cr_f64([r, g, b]) - 128.0;
+    let saturation = (cb * cb + cr * cr).sqrt();
+    if saturation <= CHROMA_KEY_SATURATION_FLOOR {
         return 255;
     }
-    ((distance - spec.threshold) / spec.band * 255.0).round() as u8
+    let cos_theta = ((cb * dir_cb + cr * dir_cr) / saturation).clamp(-1.0, 1.0);
+    let theta_deg = cos_theta.acos().to_degrees();
+    let angle_alpha = if theta_deg <= spec.max_angle_deg {
+        0.0
+    } else if spec.band_deg <= 0.0 || theta_deg >= spec.max_angle_deg + spec.band_deg {
+        255.0
+    } else {
+        (theta_deg - spec.max_angle_deg) / spec.band_deg * 255.0
+    };
+    let eligibility =
+        ((saturation - CHROMA_KEY_SATURATION_FLOOR) / CHROMA_KEY_SATURATION_RAMP).clamp(0.0, 1.0);
+    (255.0 - eligibility * (255.0 - angle_alpha)).round() as u8
 }
 
 /// Spill suppression on kept pixels: pull the key channel down toward the
@@ -710,8 +754,8 @@ mod tests {
             layout.camera_chroma_key_enabled = true;
             let spec = camera_chroma_key(&layout).expect("keying enabled");
             assert_eq!(spec.key_rgb, [0, 255, 0]);
-            assert_eq!(spec.threshold, 40.0 * 1.8);
-            assert_eq!(spec.band, 8.0 * 1.8);
+            assert_eq!(spec.max_angle_deg, 40.0 * 0.6);
+            assert_eq!(spec.band_deg, 8.0 * 0.6);
             assert_eq!(spec.spill, 0.10);
         }
     }
@@ -726,8 +770,8 @@ mod tests {
         layout.camera_chroma_key_spill_pct = 900;
         let spec = camera_chroma_key(&layout).expect("keying enabled");
         assert_eq!(spec.key_rgb, [0, 255, 0], "unparseable color keys green");
-        assert_eq!(spec.threshold, 180.0);
-        assert_eq!(spec.band, 180.0);
+        assert_eq!(spec.max_angle_deg, 60.0);
+        assert_eq!(spec.band_deg, 60.0);
         assert_eq!(spec.spill, 1.0);
     }
 
@@ -749,55 +793,111 @@ mod tests {
         }
     }
 
-    #[test]
-    fn chroma_key_alpha_ramps_from_key_to_far_colors() {
-        let spec = ChromaKeySpec {
+    fn default_green_spec() -> ChromaKeySpec {
+        ChromaKeySpec {
             key_rgb: [0, 255, 0],
-            threshold: 72.0,
-            band: 14.4,
+            max_angle_deg: 24.0,
+            band_deg: 4.8,
             spill: 0.0,
-        };
-        assert_eq!(chroma_key_alpha(&spec, 0, 255, 0), 0, "exact key");
-        assert_eq!(chroma_key_alpha(&spec, 30, 200, 40), 0, "screen variance");
-        assert_eq!(chroma_key_alpha(&spec, 255, 0, 0), 255, "red survives");
-        assert_eq!(chroma_key_alpha(&spec, 128, 128, 128), 255, "grey survives");
-        // Alpha never decreases as a pixel moves away from the key color.
-        let mut previous = 0;
-        for step in 0..=8 {
-            let toward_grey = |key: u8, grey: u8| {
-                (f64::from(key) + (f64::from(grey) - f64::from(key)) * f64::from(step) / 8.0)
-                    .round() as u8
-            };
-            let alpha = chroma_key_alpha(
-                &spec,
-                toward_grey(0, 128),
-                toward_grey(255, 128),
-                toward_grey(0, 128),
-            );
-            assert!(alpha >= previous, "ramp not monotonic at step {step}");
-            previous = alpha;
         }
-        assert_eq!(previous, 255);
+    }
+
+    /// THE calibration pin (2026-07-14 owner report): the keyer must key a
+    /// REALISTIC studio-lit screen with the SHIPPED DEFAULTS, not just pure
+    /// fixture colors. The 0.9.39 absolute-distance model passed every
+    /// pure-color test and keyed nothing real; this table is the regression
+    /// guard against that class of miscalibration.
+    #[test]
+    fn chroma_key_keys_a_realistic_screen_palette_with_defaults() {
+        let spec = default_green_spec();
+        // Real screen tones across lighting — ALL must key fully.
+        for (label, rgb) in [
+            ("pure green", [0u8, 255, 0]),
+            ("bright lit screen", [80, 200, 90]),
+            ("well-lit screen", [60, 180, 70]),
+            ("mid screen", [40, 140, 55]),
+            ("shadowed screen", [30, 100, 40]),
+            ("overexposed edge", [110, 190, 120]),
+        ] {
+            assert_eq!(
+                chroma_key_alpha(&spec, rgb[0], rgb[1], rgb[2]),
+                0,
+                "{label} must key with defaults"
+            );
+        }
+        // The subject must survive untouched.
+        for (label, rgb) in [
+            ("skin", [200u8, 160, 140]),
+            ("dark hair", [40, 30, 25]),
+            ("white shirt", [230, 230, 230]),
+            ("red", [255, 0, 0]),
+            ("grey", [128, 128, 128]),
+        ] {
+            assert_eq!(
+                chroma_key_alpha(&spec, rgb[0], rgb[1], rgb[2]),
+                255,
+                "{label} must survive with defaults"
+            );
+        }
+        // Documented physics (true of every chroma keyer): a saturated green
+        // GARMENT keys too — the saturation floor cannot save a green shirt.
+        assert_eq!(chroma_key_alpha(&spec, 90, 140, 95), 0);
     }
 
     #[test]
-    fn chroma_key_alpha_zero_band_is_a_hard_cut() {
+    fn chroma_key_alpha_ramps_by_angle_and_saturation() {
+        let spec = default_green_spec();
+        // Alpha never decreases as hue rotates away from the key direction:
+        // blend green toward red through yellow.
+        let mut previous = 0;
+        for step in 0..=10 {
+            let t = f64::from(step) / 10.0;
+            let r = (255.0 * t).round() as u8;
+            let g = (255.0 * (1.0 - t) + 100.0 * t).round() as u8;
+            let alpha = chroma_key_alpha(&spec, r, g, 0);
+            assert!(
+                alpha >= previous,
+                "hue ramp not monotonic at step {step}: {alpha} < {previous}"
+            );
+            previous = alpha;
+        }
+        assert_eq!(previous, 255);
+        // The saturation floor ramps: a key-direction color fades to opaque
+        // as it desaturates toward grey.
+        // (100,135,100): saturation ~18.7 → partially eligible → mid alpha.
+        let partial = chroma_key_alpha(&spec, 100, 135, 100);
+        assert!(
+            partial > 0 && partial < 255,
+            "low-saturation screen tone should partially key, got {partial}"
+        );
+        // (110,130,110): saturation ~10.7, below the floor → fully opaque.
+        assert_eq!(chroma_key_alpha(&spec, 110, 130, 110), 255);
+    }
+
+    #[test]
+    fn chroma_key_alpha_zero_band_is_a_hard_cut_and_grey_key_never_keys() {
         let spec = ChromaKeySpec {
-            key_rgb: [0, 255, 0],
-            threshold: 72.0,
-            band: 0.0,
-            spill: 0.0,
+            band_deg: 0.0,
+            ..default_green_spec()
         };
         assert_eq!(chroma_key_alpha(&spec, 0, 255, 0), 0);
         assert_eq!(chroma_key_alpha(&spec, 128, 128, 128), 255);
+        assert_eq!(chroma_key_alpha(&spec, 255, 0, 0), 255);
+        // A grey key color has no chroma direction — nothing may key.
+        let grey_key = ChromaKeySpec {
+            key_rgb: [128, 128, 128],
+            ..default_green_spec()
+        };
+        assert_eq!(chroma_key_alpha(&grey_key, 0, 255, 0), 255);
+        assert!(grey_key.key_direction().is_none());
     }
 
     #[test]
     fn chroma_key_despill_clamps_only_the_dominant_key_channel() {
         let green = ChromaKeySpec {
             key_rgb: [0, 255, 0],
-            threshold: 72.0,
-            band: 14.4,
+            max_angle_deg: 24.0,
+            band_deg: 4.8,
             spill: 1.0,
         };
         assert_eq!(chroma_key_despill(&green, 100, 200, 80), (100, 100, 80));


### PR DESCRIPTION
## Problem

Owner report on shipped 0.9.39: the green screen feature doesn't work — flipping the switch keys essentially nothing on a real screen.

## Diagnosis (numeric reproduction)

The keyer measured **absolute CbCr distance from pure `#00FF00`** (saturation ~136). Real studio-lit screens sit at saturation 35–62, so their chroma distance is 75–101 units regardless of hue — above the default threshold (similarity 40% → 72) and unrescuable by tuning: keying a shadowed screen needs ≥56% similarity while skin starts keying at 81%. Every pipeline test passed because every fixture was a pure color; the pipeline was correct, the **model** was miscalibrated for reality.

Full diagnosis + plan: vault `2026-07-14 - Videorc Green Screen Real Screen Keying Fix Plan`.

## Fix

**Chroma-direction (angle) keying with a saturation floor.** The angle between a pixel's CbCr vector and the key direction is lighting-invariant: bright, mid, shadowed, and overexposed screen tones all cluster within ~8° of the key while the subject sits 90°+ away (or below the floor, for greys). The unchanged defaults (similarity 40 → a 24° cone) now key the whole screen with 4× margin.

- **Zero wire/protocol change** — the five `LayoutSettings` fields keep their names, ranges, and persisted values; only the interpretation is recalibrated (% → degrees ×0.6). No renderer changes at all.
- **Metal shader + CPU blit** mirror the reference formula exactly (constants comment-pinned both ways); the CPU↔Metal parity fixture now keys a shadowed-screen pixel and a saturation-ramp partial.
- **FFmpeg leg**: `chromakey` can't express angles and per-pixel `geq` is too slow at full frame, so the leg anchors an **effective key color** — the key direction at realistic screen saturation (55, ≈ `0x44AB43` for green) — with a similarity radius covering the screen cluster. Bounded, documented divergence, pinned by its own palette test. Honest quirk: pure *synthetic* green now falls outside that leg's disc at defaults — real footage is the contract.

## Verification

- **The calibration pin that was missing**: `chroma_key_keys_a_realistic_screen_palette_with_defaults` asserts bright/mid/shadowed/overexposed screen tones key to 0 and skin/hair/white survive at 255 — **with shipped defaults**. Its FFmpeg twin pins the chromakey mapping on the same palette. This test class not existing is how 0.9.39 shipped.
- Angle-ramp monotonicity, zero-band hard cut, saturation-floor ramp, grey-key-never-keys; despill unchanged and untouched.
- On-device Metal pixel tests re-fixtured to realistic tones (shadowed screen keys, ramp tone blends at the reference-computed alpha, spill clamps, key+circle-mask composes).
- Bundled-ffmpeg end-to-end: realistic screen green over a blue base composites to pure blue (keyed); a skin-tone layer survives.
- Module suites (scene_geometry/compositor/metal/recording): 332 green; `clippy -D warnings`, fmt clean.

## Pending

Owner by-eye with the real screen — this time the defaults have real margin; if hair edges want it, nudge smoothness. Ships as 0.9.41 when accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved chroma-key accuracy using angle- and saturation-based color detection.
  * Updated camera rendering and recording paths for more consistent keying across platforms.
  * Added calibrated handling for realistic screen colors and improved spill suppression.
  * Neutral or low-saturation key colors are now handled safely without enabling chroma keying.

* **Bug Fixes**
  * Improved transparency results around key-color boundaries and partial-alpha areas.
  * Reduced incorrect removal of non-screen colors during chroma keying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->