### PR TITLE
Release 0.9.44-beta.1: version bump + changelog

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.44-beta.1.md
+++ b/changelog/0.9.44-beta.1.md
@@ -1,0 +1,53 @@
+---
+version: 0.9.44-beta.1
+date: 2026-07-16
+channel: beta
+title: Recordings leveled up — true 60fps, correct color everywhere, and green screen that keys real screens
+summary: Recording quality got a ground-up pass. 60fps recordings now use the same high-quality pipeline as 30fps and end perfectly in sync, every file carries proper color information so it looks the same in every player, exported audio is higher quality with an option to keep the lossless original — and the green screen keyer now removes real, imperfectly-lit screens, not just ideal colors.
+highlights:
+  - 60fps recordings (1080p and 1440p) now run through the same pipeline as 30fps — what you see in the preview is what gets recorded, and audio/video stay in sync to the last frame.
+  - Every recording is now tagged with standard BT.709 color, so your footage shows the same colors in QuickTime, on YouTube, and in every editor — no more player guesswork.
+  - Green screen now actually keys real screens — the first release keyed only ideal colors; the new keyer handles unevenly lit, real-world green screens with room to spare.
+  - Exported MP4 audio jumped from 160 to 256 kbps, and a new setting can keep the original lossless-audio recording file next to the MP4.
+---
+
+## 60fps is a first-class citizen now
+
+Recording at 60fps used to take a different, lesser path through the app:
+the file could end with audio and video out of step by a fraction of a
+second, and the file's technical labeling was out of spec — strict players
+and upload validators could reject it. Now 1080p60 and 1440p60 recordings
+ride the exact same pipeline as 30fps: the preview you watch is the file you
+get, sync is tight at the stop, and every file declares the correct H.264
+level for its resolution and frame rate. 4K60 (experimental) got the same
+sync and labeling fixes.
+
+## Colors that survive the trip
+
+Recordings never said what color standard they used, so every player had to
+guess — and different players guessed differently. Every recording is now
+produced and tagged as standard BT.709 video, end to end. What you saw while
+recording is what you see in QuickTime, in your editor, and after upload.
+
+## Green screen, take two — now it works on real screens
+
+The first green screen release keyed ideal, pure-green pixels beautifully —
+and real, unevenly lit screens barely at all. The keyer was rebuilt around
+how real screens actually behave: every part of a real screen, from bright
+to shadowed, now disappears with the default settings, while skin, hair,
+and clothing stay untouched.
+
+## Better sound in your exports
+
+The MP4 you get after recording now carries 256 kbps audio (up from 160).
+If you want the untouched original — the recording is captured with
+lossless audio before export — turn on "Keep original recording" in
+Settings and the original file stays right next to the MP4.
+
+## For the meticulous
+
+Recordings made without streaming now tell the encoder to favor quality
+over speed (streaming keeps its low-latency tuning), and a new internal
+quality gate records every supported resolution and frame rate on every
+release — 1080p to 4K, horizontal and vertical, 24 to 60fps — and fails the
+release if any file is less than right.


### PR DESCRIPTION
Version 0.9.43 → 0.9.44 + user-facing changelog entry for the recording-quality overhaul (#138) and the green-screen real-screen keyer fix (#137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved 60fps and experimental 4K60 recording with better audio/video synchronization.
  - Standardized BT.709 color handling for more consistent results across players, editors, and uploads.
  - Enhanced green screen processing for unevenly lit screens.
  - Increased exported MP4 audio quality to 256 kbps.
  - Added an option to retain the original lossless recording alongside the MP4.
  - Improved quality prioritization for recordings made without streaming.

- **Documentation**
  - Added release notes for version 0.9.44-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->