### PR TITLE
Record the 0.9.44 release

### DIFF
--- a/docs/releases/0.9.44.md
+++ b/docs/releases/0.9.44.md
@@ -1,0 +1,65 @@
+# Videorc 0.9.44 Beta 1
+
+Videorc 0.9.44 ships the recording quality perfection batch (#138) and the
+green-screen real-screen keyer fix (#137): every recording is BT.709-tagged
+end-to-end, 60fps recordings ride the first-class encoder-bridge pipeline
+with spec-valid H.264 levels and bounded stop tails, export audio moves to
+256k with a keep-lossless-MKV option, and green screen now keys real,
+unevenly lit screens.
+
+## Scope
+
+- **Recording quality perfection** (PR #138, plan: vault `2026-07-15 -
+  Videorc Recording Quality Perfection Plan`, audit of 2026-07-15): (Q1)
+  BT.709 video-range colorimetry produced AND tagged on every path —
+  VideoToolbox session color properties, `color.rs` CPU/Metal-readback
+  conversion moved from full-range BT.601 to video-range BT.709, ffmpeg
+  color flags, explicit `scale`+`setparams` conversion on the legacy
+  graph; (Q2) record-only 60fps up to 1440p rides the encoder bridge
+  (WYSIWYG compositor + VT + epoch trim); A/V stop tails bounded for all
+  paths by trimming the MP4 export to the shorter stream (was 159–273ms
+  at 60fps, now ≤17ms); (Q3) spec-correct High profile/level from real
+  macroblock rate (new `h264_profile` module; 1080p60→4.2, 4K60→5.2) on
+  VT and ffmpeg legs; record-only sessions drop the speed-over-quality
+  posture; (Q4) MP4 export audio 160k→256k AAC + "Keep original
+  recording" Settings toggle (lossless-PCM MKV preserved); (Q6) the 4K60
+  preset error no longer dead-ends into the custom preset.
+- **Green screen keys real screens** (PR #137, merged 2026-07-15,
+  unreleased until now): chroma-DIRECTION keyer with saturation floor
+  replaces the absolute-CbCr-distance model that only keyed ideal pure
+  green; realistic-screen palette pinned as a regression test across all
+  three render paths (CPU / Metal / calibrated ffmpeg `chromakey`).
+- **New maintained gate**: `pnpm smoke:recording-matrix` (in
+  `smoke:local-gates`) — records all 10 shipping profiles (1080p/1440p/4K
+  × 30/60 incl. the pinned 4K60 experimental preset, vertical twins,
+  640×360 floor) through the real app; hard-fails on missing color tags,
+  under-spec levels, keyframe cadence >2.5s, wrong dims/fps, or A/V tail
+  >100ms. Result on this release: **10/10 PASS** (7/10 with 3 hard fails
+  before the fixes).
+
+## Release status
+
+- [x] PRs merged: #138 (admin-merged — GitHub Actions blocked by
+      billing; local gates: full cargo suite 1305 tests, clippy -D
+      warnings, fmt, typecheck/lint/format, 1111 desktop tests, 647
+      script tests, build, smoke:dev, smoke:recording-matrix 10/10);
+      prep #139 (admin-merged).
+- [x] Signed + notarized arm64 build; staple verified by
+      release:validate:macos.
+- [x] Uploaded to R2; feed verified end-to-end
+      (`https://www.videorc.com/api/updates/latest-mac.yml` →
+      `version: 0.9.44`, artifact hashes present); `/api/changelog`
+      serves 0.9.44-beta.1.
+- [x] Discord announcement posted.
+- [ ] Owner acceptance: real-screen 1080p60 + 4K30 recording by eye
+      (QuickTime + a YouTube upload — its validator is the de-facto
+      level/colorimetry check), A/V sync by ear at stop; green-screen
+      by-eye with a real screen (defaults 40/8/10).
+
+## Notes
+
+- Windows: MF encoder arms get the colorimetry tags, but h264_mf exposes
+  no profile/level options — Windows levels stay encoder-default; spot
+  check at the next Windows pass.
+- Streaming >30fps and 4K60 keep the legacy capture path (unchanged
+  posture); their stop tails are bounded by the export trim regardless.


### PR DESCRIPTION
Release record for 0.9.44-beta.1: build/upload/verify/announce all done; owner acceptance items listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)