### PR TITLE
fix: cloud-AI consent never silently revoked — readiness errors become visible

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -773,6 +773,62 @@ describe('real StudioProvider lifecycle', () => {
     expect(openSystemPermissions).toHaveBeenCalledWith('camera')
   })
 
+  it('never revokes persisted cloud-AI consent when readiness is not ready', async () => {
+    // 2026-07-16 owner incident: an effect silently flipped the consent
+    // toggle off whenever cloud AI readiness was not ready (signed-out,
+    // server unconfigured, ...), which also made the run-time readiness
+    // error toast unreachable — every AI run downgraded to local-only with
+    // no visible reason. Consent is the user's durable intent: readiness
+    // gates the RUN, never the stored preference.
+    const backend = new StudioBackend()
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      getMediaAccessStatus: async () => ({
+        camera: 'not-determined',
+        microphone: 'granted'
+      }),
+      requestMediaAccess: vi.fn(async () => ({ granted: false, restarted: false })),
+      openSystemPermissions: vi.fn(async () => undefined)
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    localStorage.setItem('videorc.aiConsent', '1')
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(() => latest()?.core.wsStatus === 'connected')
+
+    // No account is signed in on this fake backend, so cloud AI readiness is
+    // NOT ready — and the persisted consent must survive untouched. (The
+    // removed auto-revoke effect flipped it to '0' on mount.)
+    expect(localStorage.getItem('videorc.aiConsent')).toBe('1')
+  })
+
   it('does not reuse a stale permission snapshot when the click-time status read fails', async () => {
     const backend = new StudioBackend()
     TestWebSocket.backend = backend

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -6456,11 +6456,14 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
   }, [isSessionActive, suppressCaptionsForSession])
 
-  useEffect(() => {
-    if (aiConsent && !currentCloudAiReadiness.ready) {
-      setAiConsent(false)
-    }
-  }, [aiConsent, currentCloudAiReadiness.ready, setAiConsent])
+  // Consent is the USER'S durable intent — no code path may revoke it. An
+  // earlier effect here silently flipped the toggle off whenever cloud AI
+  // readiness was not ready, which also made runAiWorkflow's readiness error
+  // toast unreachable (it checks consent first): every run silently downgraded
+  // to local-only and "nothing worked" with no visible reason (2026-07-16
+  // owner incident — the server had never been configured, and the app never
+  // said so). Readiness gates the RUN and the switch's enabled state, never
+  // the stored consent.
 
   // Burn-in driver: a serial latest-wins scheduler replaces the old boolean
   // busy gate, which could permanently drop a final/style update that arrived


### PR DESCRIPTION
Companion to videorc-web#8 (cloud AI production enablement). Desktop side of the "AI features, nothing is working" incident.

**The bug:** an effect force-flipped the persisted cloud-AI consent toggle off whenever `cloudAiReadiness` was not ready — silently. Because `runAiWorkflow` checks `aiConsent && !ready` to show the readiness error toast, the revoke made that toast unreachable: every run silently downgraded to local-only (audio extract + pending-consent transcript) and the user saw "nothing happened" — on every attempt since the feature shipped (app DB shows identical dead-ends Jul 6/10/16).

**The fix:** remove the auto-revoke. Consent is the user's durable intent; readiness already gates the switch's enabled state and the run itself, and with the revoke gone the existing toast now names the real reason at Generate time ("AI worker not configured" / "requires Premium" / "session expired").

**Test:** integration regression — persisted consent survives a provider mount whose readiness is not ready.

Gates: 1112 desktop tests, typecheck, lint, format.

Plan: vault "2026-07-16 - Videorc Cloud AI Production Enablement Plan" (W3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved users’ saved cloud AI consent when cloud AI is temporarily unavailable or no account is signed in.
  * Cloud AI readiness now controls availability without automatically revoking the user’s stored consent.
* **Tests**
  * Added coverage to verify that persisted consent remains unchanged when cloud AI is not ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->