### PR TITLE
Record the 0.9.45 release

### DIFF
--- a/docs/releases/0.9.45.md
+++ b/docs/releases/0.9.45.md
@@ -1,0 +1,52 @@
+# Videorc 0.9.45 Beta 1
+
+Stability hotfix for the 0.9.44 recording-crash/preview-starvation regression,
+plus the cloud-AI consent visibility fix — shipped the same day the regression
+was reported, alongside the production enablement of cloud AI itself.
+
+## Scope
+
+- **Recording crash + preview starvation fix** (PR #144, plan: vault
+  `2026-07-16 - Videorc 0.9.44 Recording Crash And Preview Starvation Fix
+  Plan`): VideoToolbox frame-delay cap restored for every session (1 live /
+  2 record-only = ring−1) — it is the compositor target ring's correctness
+  guard; quality encoding posture limited to the proven ≤1440p envelope;
+  Recording/Shared outputs submit under age pressure and fail only on a
+  sustained 2s breach or a truly full queue (was: single-sample 250ms kill);
+  ring slots carry in-flight guards so no encoder behavior can scribble
+  frames; read-only RPCs (preview.surface.status et al.) answer on an
+  overlap lane so session start/stop can't starve them; hard-content smoke
+  pass (1080p60 strict + 4K30 survival) added to smoke:recording-matrix.
+- **Cloud AI consent visibility** (PR #145, plan: vault `2026-07-16 -
+  Videorc Cloud AI Production Enablement Plan` W3): the consent toggle is
+  never silently revoked; readiness errors ("AI worker not configured",
+  "requires Premium", "session expired") surface at Generate time.
+- **Cloud AI production enablement** (videorc-web PR #8 + live env, same
+  plan W1/W2/W5): Vercel production now carries the full AI env (worker
+  secret, CRON_SECRET, default model openai/gpt-5.5 + fallback,
+  transcription provider openai + key); `/api/ai/jobs/drain` gained a
+  cron-authenticated GET and jobs kick a drain inline after creation;
+  per-minute Vercel cron registered and verified; production enablement
+  checklist added to docs/ai-gateway.md.
+- Release prep #146 (version bump + changelog).
+
+## Release status
+
+- [x] PRs merged: #144, #145, #146 (admin-merged; local gates: 1308 backend
+      tests, clippy -D warnings, fmt, 1112 desktop tests, 647 script tests,
+      typecheck/lint/format, smoke:recording-matrix 12/12 incl. hard pass);
+      videorc-web #8 (tests + tsc, deployed to production, cron registered).
+- [x] Signed + notarized arm64 build; staple + Gatekeeper verified.
+- [x] Uploaded to R2, all objects verified; feed serves `version: 0.9.45`.
+- [x] Discord announcement posted.
+- [ ] Owner acceptance: the exact 0.9.44 repro workflow (4K30 camera-only
+      circle, rapid start/stop + layout switches with green screen panel,
+      ≥10 min) survives with live preview; one real cloud-AI run
+      (transcript + title/description) on the signed-in account; verify
+      `AI_GATEWAY_API_KEY` in production is a durable dashboard key.
+
+## Notes
+
+- The full fake-gateway desktop AI smoke (enablement plan W4) is deferred —
+  needs a signed-in Better-Auth harness; cron-auth unit tests cover the new
+  server wiring.


### PR DESCRIPTION
Release record for 0.9.45-beta.1: #144 + #145 + #146 shipped; cloud AI production enablement live (videorc-web#8, cron verified). Owner acceptance items listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)