### PR TITLE
fix: no success toasts on routine scene/layout/source changes

### DIFF
--- a/.claude/skills/videorc-design/SKILL.md
+++ b/.claude/skills/videorc-design/SKILL.md
@@ -54,6 +54,23 @@ Icons
 Motion
 - Fast and subtle: 100–150ms ease-out. Panels fade+scale from 0.98; rows highlight instantly (no transition on selection). Nothing bounces.
 
+## Toast discipline
+
+Toasts are for NEWS the interface does not already show — never for
+confirming a routine interaction the user just watched succeed.
+
+- **Never toast success for scene/layout/source changes.** The stage/preview
+  IS the confirmation (owner call, 2026-07-16 — "no green popups on every
+  small thing"). This includes live layout applies, preset clicks, and
+  source device switches.
+- Success toasts are reserved for: async work finishing out of view
+  (recording saved, import complete, publish pack generated), destructive
+  confirmations (deleted), and account-level side effects (connected,
+  authorized).
+- Warnings/errors always surface — silence is only for the expected outcome.
+- When in doubt, don't toast. A user mid-flow reads every popup as an
+  interruption.
+
 ## Core patterns
 
 **Glass panel** — the universal container (windows, dialogs, palettes): translucent blurred black glass, hairline ring, big radius, floating shadow. Content sits directly on it; no nested cards-on-cards.

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -5042,9 +5042,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             )
             return
           }
-          if (status.mode === 'warm' && status.message) {
-            toast.success(status.message)
-          }
+          // A successful layout commit is the EXPECTED outcome — the stage
+          // already shows it (owner call, 2026-07-16: no green popups for
+          // routine scene changes). Only lag/failure states surface above.
         } catch (error) {
           // Superseded requests are expected and must not overwrite the newer
           // selection or flash an error. The latest request still reports exact
@@ -5204,9 +5204,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         await rememberLiveLayoutCommit(status)
         applyScene(status.scene)
         setCaptureConfig((current) => ({ ...current, sources }))
-        if (status.message) {
-          toast.success(status.message)
-        }
+        // Success is visible in the preview itself — no confirmation popup
+        // for a routine source switch (errors still report below).
       } catch (error) {
         reportError(error)
       } finally {


### PR DESCRIPTION
Owner call: green popups on every scene change are noise — the stage/preview already shows the result.

- Live layout applies (`mode: 'warm'`) and source device switches no longer fire `toast.success`; warnings and errors are untouched.
- New **Toast discipline** section in the videorc-design skill: success toasts only for async out-of-view outcomes (recording saved, import finished), destructive confirmations, and account side effects — never for routine interactions the user just watched succeed.

Gates: 1112 desktop tests, typecheck, lint, format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)