### PR TITLE
fix: Windows-only encoder test pin missed in #151 (SoftwareOpenH264)

### DIFF
--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -13006,7 +13006,8 @@ mod tests {
                 assert_eq!(arg_value(args, "-realtime"), None);
                 assert_eq!(arg_value(args, "-prio_speed"), None);
                 assert_eq!(arg_value(args, "-hw_encoding"), None);
-                assert_eq!(encoder.backend, EncodeBackend::SoftwareMediaFoundation);
+                // libopenh264 fallback since #151 (issue #149).
+                assert_eq!(encoder.backend, EncodeBackend::SoftwareOpenH264);
             }
             FfmpegH264Platform::Other => {
                 assert_eq!(arg_value(args, "-allow_sw"), None);


### PR DESCRIPTION
The Windows gates job on main has failed since #151 landed: `assert_current_h264_encoder_args` asserts against the **current** platform's encoder, and its `WindowsSoftware` arm still pinned `EncodeBackend::SoftwareMediaFoundation` from before the libopenh264 switch. The arm is dead code on macOS, so the 1314-test local suite stayed green while `bridge_recording_args_use_raw_yuv_video_and_existing_audio` and `shared_pipeline_uses_tee_for_dual_output` failed on every Windows runner.

One-line pin update (+ comment). Local gates: full cargo suite green, clippy `-D warnings`, fmt. The real proof is this PR's own Windows CI run — the gates job should go green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows H.264 encoding validation to correctly recognize the OpenH264 software encoder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->