### PR TITLE
release: freeze 0.9.46-alpha.1 Windows Alpha candidate source

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.46-alpha.1.md
+++ b/changelog/0.9.46-alpha.1.md
@@ -1,0 +1,25 @@
+---
+version: 0.9.46-alpha.1
+date: 2026-07-18
+channel: alpha
+platforms:
+  - windows
+title: The first signed Windows Alpha
+summary: Windows recording is reliable end to end — signed installer, working screen, camera, and microphone capture, and stable recording startup.
+highlights:
+  - Recordings no longer fail moments after starting; encoder stalls are tolerated instead of killing the session.
+  - A reliable software encoder fallback keeps recording working on machines where hardware encoding is unavailable.
+  - Faster, more stable recording startup.
+  - The installer is Authenticode-signed — no more "Unknown publisher" warning.
+---
+
+This is the first signed Windows Alpha of Videorc.
+
+What this build proves on real Windows 11 x64 hardware: screen, camera, and
+microphone recording produce correct finished files; recording keeps running
+through encoder pressure instead of dying about a second in; and startup is
+stable across the hardware and fallback GPU paths we test.
+
+Known limitations while Windows is in Alpha: livestreaming workflows are still
+being validated per platform, and auto-update arrives with the next accepted
+Alpha. Report issues via the Windows Alpha bug template on GitHub.


### PR DESCRIPTION
Step 1 of docs/releases/windows-alpha-runbook.md: bump `apps/desktop/package.json` to **0.9.46** and add `changelog/0.9.46-alpha.1.md` (`channel: alpha`, `platforms: [windows]`). `pnpm changelog:check`: 47 entries valid, latest 0.9.46-alpha.1.

After merge, the candidate identity is this merge commit on `main`; dispatch **Build Windows Alpha Candidate** with `release_id: 0.9.46-alpha.1` once the `windows-alpha-release` environment (created, reviewer-gated) has the Azure Trusted Signing variables and R2 candidate secrets from docs/windows-signing.md.

macOS is untouched: the 0.9.45 macOS feed only moves when a macOS release is uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the first signed Windows Alpha release.
  * Added a software encoding fallback when hardware encoding is unavailable.
  * Improved startup speed and stability, including better handling of encoder stalls.
  * Added an Authenticode-signed installer to reduce “Unknown publisher” warnings.

* **Documentation**
  * Documented current Alpha limitations, livestreaming validation status, and upcoming auto-update support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->