### PR TITLE
perf(windows): bound proof-surface transport and presentation work (Plan 036)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -211,9 +211,11 @@ import {
 import { NATIVE_PREVIEW_PROOF_POLLER_RUNTIME_SCRIPT } from './native-preview-proof-poller-runtime'
 import { NATIVE_PREVIEW_PROOF_MEASUREMENT_RUNTIME_SCRIPT } from './native-preview-proof-measurement-runtime'
 import {
+  type NativePreviewProofPollingProfile,
   nativePreviewProofFrameUrl,
   nativePreviewProofPollingProfile,
-  nativePreviewProofPollingProfileKey
+  nativePreviewProofPollingProfileKey,
+  nativePreviewProofPresentStatus
 } from '../shared/native-preview-proof-polling'
 import {
   DEFAULT_MAIN_PUMP_FRAME_STALL_TIMEOUT_MS,
@@ -4120,6 +4122,7 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
         let frames = 0;
         let blankFrames = 0;
         let liveLayerCount = 0;
+        let proofTransportRateBaseline = null;
         let proofMeasurementEpoch = createNativePreviewProofMeasurementEpoch(
           performance.now(),
           blankFrames,
@@ -4303,6 +4306,7 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
             const abortController = new AbortController();
             poller.abortController = abortController;
             try {
+              markProofPollerRequestStarted(poller);
               const response = await fetch(frameRequestUrl(url, poller), {
                 cache: 'no-store',
                 signal: abortController.signal
@@ -4313,6 +4317,7 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
               const cursor = responseFrameCursor(response);
               if (response.status === 204) {
                 markProofPollerTransportSuccess(poller, performance.now());
+                markProofPollerNotModified(poller);
                 if (cursor) {
                   poller.generation = cursor.generation;
                   poller.sequence = cursor.sequence;
@@ -4352,6 +4357,13 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
                 throw new Error('Preview frame decoded without any visible pixels.');
               }
               presentProofPollerFrame(poller, objectUrl);
+              markProofPollerFrameDecoded(
+                poller,
+                blob.size,
+                next.naturalWidth,
+                next.naturalHeight,
+                performance.now()
+              );
               if (cursor) {
                 poller.generation = cursor.generation;
                 poller.sequence = cursor.sequence;
@@ -4609,6 +4621,16 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
             const healthySourceTransportCount = [...pollers.values()].filter((poller) =>
               proofPollerTransportIsFresh(poller, measuredAt, sourceFreshnessBudgetMs)
             ).length;
+            const transportTotals = proofPollerTransportTotals(pollers);
+            const transportBaseline = proofTransportRateBaseline;
+            proofTransportRateBaseline = { at: measuredAt, ...transportTotals };
+            const transportElapsedMs = transportBaseline
+              ? Math.max(1, measuredAt - transportBaseline.at)
+              : null;
+            const transportRate = (current, previous) =>
+              transportElapsedMs === null
+                ? null
+                : Math.max(0, current - previous) / transportElapsedMs * 1000;
             return {
               frames,
               measuredFps: measurement.measuredFps,
@@ -4642,6 +4664,20 @@ function nativePreviewSurfaceHtml(initialScene: PreviewSurfaceSceneState | null)
               framePollingSuppressed,
               framePollingIntervalMs,
               framePollingMaxWidth,
+              proofTransportRequestCount: transportTotals.requestCount,
+              proofTransportNotModifiedCount: transportTotals.notModifiedCount,
+              proofTransportBytesReceived: transportTotals.bytesReceived,
+              proofTransportDecodedFrames: transportTotals.decodedFrames,
+              proofTransportRequestsPerSecond: transportBaseline
+                ? transportRate(transportTotals.requestCount, transportBaseline.requestCount)
+                : null,
+              proofTransportBytesPerSecond: transportBaseline
+                ? transportRate(transportTotals.bytesReceived, transportBaseline.bytesReceived)
+                : null,
+              proofTransportDecodedFramesPerSecond: transportBaseline
+                ? transportRate(transportTotals.decodedFrames, transportBaseline.decodedFrames)
+                : null,
+              proofSourceDimensions: transportTotals.sourceDimensions,
               proofSurfaceSuspended,
               sourcePixelsPresent: liveLayerCount > 0,
               blankFrames: measurement.blankFrames,
@@ -4720,6 +4756,10 @@ async function createNativePreviewSurfaceWindow(generation: number): Promise<voi
     })
     nativePreviewSurfaceWindow = surfaceWindow
     surfaceWindow.setIgnoreMouseEvents(true)
+    // Geometry changes re-derive the DPR-aware frame width cap; moving across
+    // displays changes the scale factor even at constant logical size.
+    surfaceWindow.on('resize', scheduleNativePreviewProofPollingProfileResync)
+    surfaceWindow.on('move', scheduleNativePreviewProofPollingProfileResync)
     surfaceWindow.on('closed', () => {
       if (nativePreviewSurfaceWindow === surfaceWindow) {
         nativePreviewSurfaceWindow = null
@@ -5455,13 +5495,16 @@ async function presentNativePreviewSurfaceCompositor(
       compositorScene && compositorSceneIsCurrent
         ? `window.__videorcSetPreviewScene?.(${jsonForInlineScript(compositorScene)});`
         : ''
-    const statusJson = jsonForInlineScript(effectiveStatus)
+    // Compact present DTO (issue #157): only the fields the proof script
+    // consumes ride the per-present hot path; full diagnostics stay on the
+    // status channel. Present + metrics happen in ONE script round trip.
+    const statusJson = jsonForInlineScript(nativePreviewProofPresentStatus(effectiveStatus))
     if (nativePreviewSurfaceWindow === surfaceWindow && !surfaceWindow.isDestroyed()) {
-      await surfaceWindow.webContents.executeJavaScript(
-        `${sceneScript}window.__videorcSetCompositorStatus?.(${statusJson})`,
+      metrics = await surfaceWindow.webContents.executeJavaScript(
+        `${sceneScript}window.__videorcSetCompositorStatus?.(${statusJson});` +
+          `window.__videorcPresentNativePreviewNow?.() ?? new Promise((resolve) => requestAnimationFrame(() => resolve(window.__videorcNativePreviewMetrics?.() ?? null)))`,
         true
       )
-      metrics = await readNativePreviewSurfaceMetricsAfterPaint()
     }
   }
   if (!nativePreviewPresentationAllowedForGeneration(generation)) {
@@ -5486,6 +5529,12 @@ async function presentNativePreviewSurfaceCompositor(
   const freshSourceLayerCount = finiteMetric(metrics?.freshSourceLayerCount) ?? 0
   const sourcePollerCount = finiteMetric(metrics?.sourcePollerCount) ?? 0
   const sourceFrameAgeMs = finiteMetric(metrics?.sourceFrameAgeMs)
+  const proofTransportRequestsPerSecond = finiteMetric(metrics?.proofTransportRequestsPerSecond)
+  const proofTransportBytesPerSecond = finiteMetric(metrics?.proofTransportBytesPerSecond)
+  const proofTransportDecodedFramesPerSecond = finiteMetric(
+    metrics?.proofTransportDecodedFramesPerSecond
+  )
+  const proofSourceDimensions = proofSourceDimensionMetrics(metrics?.proofSourceDimensions)
   nativePreviewSurfaceStatus = {
     ...nativePreviewSurfaceStatus,
     ...nativePreviewRendererTimingStatusFields(effectiveStatus),
@@ -5507,6 +5556,10 @@ async function presentNativePreviewSurfaceCompositor(
     presentFps,
     intervalP95Ms,
     intervalP99Ms,
+    proofTransportRequestsPerSecond,
+    proofTransportBytesPerSecond,
+    proofTransportDecodedFramesPerSecond,
+    proofSourceDimensions,
     framePollingSuppressed: nativePreviewProofPollingIsSuppressed(),
     sourcePixelsPresent: freshSourceLayerCount > 0,
     nativePreviewHostKind: 'proof-surface',
@@ -5910,13 +5963,50 @@ async function setNativePreviewSurfaceFramePollingSuppressed(
   return nativePreviewSurfaceStatus
 }
 
+// DPR-aware cap input (issue #157): the proof surface can never display more
+// source pixels than its own content width × display scale, so that is the
+// width the frame requests are bounded by (quantized + floored in shared
+// nativePreviewProofPollingMaxWidth).
+function nativePreviewProofSurfacePixelWidth(surfaceWindow: BrowserWindow): number | undefined {
+  try {
+    const contentWidth = surfaceWindow.getContentBounds().width
+    if (!Number.isFinite(contentWidth) || contentWidth <= 0) {
+      return undefined
+    }
+    const scaleFactor = screen.getDisplayMatching(surfaceWindow.getBounds()).scaleFactor
+    return contentWidth * (Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : 1)
+  } catch {
+    return undefined
+  }
+}
+
+let nativePreviewProofPollingResyncTimer: NodeJS.Timeout | null = null
+
+// Trailing debounce: bounds changes arrive in bursts (drag-resize, slot
+// follow); the profile key dedupes identical results, this just keeps the
+// script round trips off the resize hot path.
+function scheduleNativePreviewProofPollingProfileResync(): void {
+  if (nativePreviewProofPollingResyncTimer) {
+    return
+  }
+  nativePreviewProofPollingResyncTimer = setTimeout(() => {
+    nativePreviewProofPollingResyncTimer = null
+    void syncNativePreviewProofPollingProfile()
+  }, 150)
+}
+
 async function syncNativePreviewProofPollingProfile(): Promise<void> {
-  const profile = nativePreviewProofPollingProfile(nativePreviewProofPollingRecordingActive)
   const surfaceWindow = nativePreviewSurfaceWindow
   if (!surfaceWindow || surfaceWindow.isDestroyed()) {
     nativePreviewAppliedProofPollingProfile = null
     return
   }
+  const currentProfile = (): NativePreviewProofPollingProfile =>
+    nativePreviewProofPollingProfile(
+      nativePreviewProofPollingRecordingActive,
+      nativePreviewProofSurfacePixelWidth(surfaceWindow)
+    )
+  const profile = currentProfile()
   const profileKey = nativePreviewProofPollingProfileKey(surfaceWindow.id, profile)
   if (nativePreviewAppliedProofPollingProfile === profileKey) {
     return
@@ -5925,11 +6015,7 @@ async function syncNativePreviewProofPollingProfile(): Promise<void> {
   await waitForNativePreviewSurfaceScript(surfaceWindow)
   if (
     requestSerial !== nativePreviewProofPollingProfileSerial ||
-    profileKey !==
-      nativePreviewProofPollingProfileKey(
-        surfaceWindow.id,
-        nativePreviewProofPollingProfile(nativePreviewProofPollingRecordingActive)
-      ) ||
+    profileKey !== nativePreviewProofPollingProfileKey(surfaceWindow.id, currentProfile()) ||
     surfaceWindow.isDestroyed() ||
     nativePreviewSurfaceWindow !== surfaceWindow
   ) {
@@ -5942,11 +6028,7 @@ async function syncNativePreviewProofPollingProfile(): Promise<void> {
   )
   if (
     requestSerial === nativePreviewProofPollingProfileSerial &&
-    profileKey ===
-      nativePreviewProofPollingProfileKey(
-        surfaceWindow.id,
-        nativePreviewProofPollingProfile(nativePreviewProofPollingRecordingActive)
-      ) &&
+    profileKey === nativePreviewProofPollingProfileKey(surfaceWindow.id, currentProfile()) &&
     !surfaceWindow.isDestroyed() &&
     nativePreviewSurfaceWindow === surfaceWindow
   ) {
@@ -6039,6 +6121,23 @@ async function readNativePreviewSurfaceMetricsAfterPaint(
 
 function finiteMetric(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function proofSourceDimensionMetrics(
+  value: unknown
+): Record<string, { width: number; height: number }> | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const dimensions: Record<string, { width: number; height: number }> = {}
+  for (const [id, entry] of Object.entries(value as Record<string, unknown>)) {
+    const width = finiteMetric((entry as { width?: unknown })?.width)
+    const height = finiteMetric((entry as { height?: unknown })?.height)
+    if (width !== undefined && height !== undefined) {
+      dimensions[id] = { width, height }
+    }
+  }
+  return Object.keys(dimensions).length > 0 ? dimensions : undefined
 }
 
 function proofSourceFrameTotal(metrics: unknown): number {
@@ -8115,7 +8214,7 @@ async function runSmokePreviewMotionCommand(
     const sceneScript = finalScene
       ? `window.__videorcSetPreviewScene?.(${jsonForInlineScript(finalScene)});`
       : ''
-    const statusScript = `window.__videorcSetCompositorStatus?.(${jsonForInlineScript(finalStatus)});`
+    const statusScript = `window.__videorcSetCompositorStatus?.(${jsonForInlineScript(nativePreviewProofPresentStatus(finalStatus))});`
     const result = await nativePreviewSurfaceWindow.webContents.executeJavaScript(
       `${sceneScript}${statusScript}window.__videorcPresentNativePreviewNow?.();(() => {
         const layer = document.querySelector('[data-layer-id="source:camera"]');
@@ -8148,7 +8247,7 @@ async function runSmokePreviewMotionCommand(
     const finalStatus = smokeCompositorStatusFromSceneParams(params)
     const status = await updateNativePreviewSurfaceCompositor(finalStatus)
     const result = await nativePreviewSurfaceWindow.webContents.executeJavaScript(
-      `window.__videorcSetCompositorStatus?.(${jsonForInlineScript(finalStatus)});window.__videorcPresentNativePreviewNow?.();(() => {
+      `window.__videorcSetCompositorStatus?.(${jsonForInlineScript(nativePreviewProofPresentStatus(finalStatus))});window.__videorcPresentNativePreviewNow?.();(() => {
         const background = document.querySelector('[data-layer-id="background:builtin-bg-01"]');
         const screen = document.querySelector('[data-layer-id="source:test-pattern"]');
         const image = background?.querySelector('img');
@@ -8200,7 +8299,7 @@ async function runSmokePreviewMotionCommand(
       const sceneScript = finalScene
         ? `window.__videorcSetPreviewScene?.(${jsonForInlineScript(finalScene)});`
         : ''
-      const statusScript = `window.__videorcSetCompositorStatus?.(${jsonForInlineScript(finalStatus)});`
+      const statusScript = `window.__videorcSetCompositorStatus?.(${jsonForInlineScript(nativePreviewProofPresentStatus(finalStatus))});`
       metrics = await surfaceWindow.webContents.executeJavaScript(
         `${sceneScript}${statusScript}window.__videorcPresentNativePreviewNow?.();window.__videorcNativePreviewMetrics?.() ?? null`,
         true

--- a/apps/desktop/src/main/native-preview-proof-poller-runtime.test.ts
+++ b/apps/desktop/src/main/native-preview-proof-poller-runtime.test.ts
@@ -37,6 +37,22 @@ type ProofPollerRuntime = {
     freshnessBudgetMs: number
   ) => boolean
   proofPollersHaveCompleteFrameHistory: (pollers: Map<string, RuntimePoller>) => boolean
+  markProofPollerRequestStarted: (poller: RuntimePoller) => void
+  markProofPollerNotModified: (poller: RuntimePoller) => void
+  markProofPollerFrameDecoded: (
+    poller: RuntimePoller,
+    byteLength: number,
+    width: number,
+    height: number,
+    now: number
+  ) => void
+  proofPollerTransportTotals: (pollers: Map<string, RuntimePoller>) => {
+    requestCount: number
+    notModifiedCount: number
+    bytesReceived: number
+    decodedFrames: number
+    sourceDimensions: Record<string, { width: number; height: number }>
+  }
 }
 
 function loadRuntime(
@@ -57,7 +73,11 @@ function loadRuntime(
       proofPollerTransportAgeMs,
       proofPollerFrameIsFresh,
       proofPollerTransportIsFresh,
-      proofPollersHaveCompleteFrameHistory
+      proofPollersHaveCompleteFrameHistory,
+      markProofPollerRequestStarted,
+      markProofPollerNotModified,
+      markProofPollerFrameDecoded,
+      proofPollerTransportTotals
     };`
   )
   const pixels = new Uint8ClampedArray(8 * 8 * 4)
@@ -180,5 +200,63 @@ describe('Windows proof poller runtime', () => {
     expect(visible.proofImageIsBlank({ naturalWidth: 640, naturalHeight: 360 })).toBe(false)
     expect(transparent.proofImageIsBlank({ naturalWidth: 640, naturalHeight: 360 })).toBe(true)
     expect(visible.proofImageIsBlank({ naturalWidth: 0, naturalHeight: 0 })).toBe(true)
+  })
+})
+
+describe('proof poller transport accounting', () => {
+  function poller(): RuntimePoller {
+    return {
+      image: { src: '', dataset: { live: '0' }, removeAttribute: vi.fn() },
+      cancelled: false,
+      abortController: { abort: vi.fn() },
+      objectUrl: null,
+      startedAt: 0,
+      lastFrameAdvanceAt: null,
+      lastTransportSuccessAt: null
+    }
+  }
+
+  it('aggregates request, not-modified, byte, and decode totals per surface', () => {
+    const pollers = new Map<string, RuntimePoller>()
+    const runtime = loadRuntime(pollers, () => {})
+    const screen = poller()
+    const camera = poller()
+    pollers.set('screen', screen)
+    pollers.set('camera', camera)
+
+    runtime.markProofPollerRequestStarted(screen)
+    runtime.markProofPollerRequestStarted(screen)
+    runtime.markProofPollerRequestStarted(camera)
+    runtime.markProofPollerNotModified(screen)
+    runtime.markProofPollerFrameDecoded(screen, 8_294_454, 1920, 1080, 1000)
+    runtime.markProofPollerFrameDecoded(camera, 3_686_454, 1280, 720, 1001)
+
+    expect(runtime.proofPollerTransportTotals(pollers)).toEqual({
+      requestCount: 3,
+      notModifiedCount: 1,
+      bytesReceived: 8_294_454 + 3_686_454,
+      decodedFrames: 2,
+      sourceDimensions: {
+        screen: { width: 1920, height: 1080 },
+        camera: { width: 1280, height: 720 }
+      }
+    })
+  })
+
+  it('ignores invalid byte lengths and dimensions without losing the decode count', () => {
+    const pollers = new Map<string, RuntimePoller>()
+    const runtime = loadRuntime(pollers, () => {})
+    const layer = poller()
+    pollers.set('layer', layer)
+
+    runtime.markProofPollerFrameDecoded(layer, Number.NaN, 0, -1, 5)
+
+    expect(runtime.proofPollerTransportTotals(pollers)).toEqual({
+      requestCount: 0,
+      notModifiedCount: 0,
+      bytesReceived: 0,
+      decodedFrames: 1,
+      sourceDimensions: {}
+    })
   })
 })

--- a/apps/desktop/src/main/native-preview-proof-poller-runtime.ts
+++ b/apps/desktop/src/main/native-preview-proof-poller-runtime.ts
@@ -44,6 +44,49 @@ function markProofPollerFrameAdvance(poller, now) {
   poller.lastFrameAdvanceAt = now;
 }
 
+// Transport accounting (issue #157): the proof surface is a production
+// preview transport on Windows, so its request rate, payload bytes, and
+// decoded source dimensions must be observable instead of inferred.
+function markProofPollerRequestStarted(poller) {
+  poller.requestCount = (poller.requestCount ?? 0) + 1;
+}
+
+function markProofPollerNotModified(poller) {
+  poller.notModifiedCount = (poller.notModifiedCount ?? 0) + 1;
+}
+
+function markProofPollerFrameDecoded(poller, byteLength, width, height, now) {
+  poller.bytesReceived = (poller.bytesReceived ?? 0) +
+    (Number.isFinite(byteLength) && byteLength > 0 ? byteLength : 0);
+  poller.decodedFrames = (poller.decodedFrames ?? 0) + 1;
+  if (Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0) {
+    poller.lastFrameWidth = width;
+    poller.lastFrameHeight = height;
+  }
+  poller.lastDecodeAt = now;
+}
+
+function proofPollerTransportTotals(activePollers) {
+  let requestCount = 0;
+  let notModifiedCount = 0;
+  let bytesReceived = 0;
+  let decodedFrames = 0;
+  const sourceDimensions = {};
+  for (const [id, poller] of activePollers) {
+    requestCount += poller.requestCount ?? 0;
+    notModifiedCount += poller.notModifiedCount ?? 0;
+    bytesReceived += poller.bytesReceived ?? 0;
+    decodedFrames += poller.decodedFrames ?? 0;
+    if (poller.lastFrameWidth != null && poller.lastFrameHeight != null) {
+      sourceDimensions[id] = {
+        width: poller.lastFrameWidth,
+        height: poller.lastFrameHeight
+      };
+    }
+  }
+  return { requestCount, notModifiedCount, bytesReceived, decodedFrames, sourceDimensions };
+}
+
 function presentProofPollerFrame(poller, objectUrl) {
   const previousObjectUrl = poller.objectUrl;
   poller.image.src = objectUrl;

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -434,6 +434,11 @@ function streamingWithTargetPatch(
   }
 }
 const NATIVE_PREVIEW_COMPOSITOR_POLL_INTERVAL_MS = 1000 / 60
+// Fallback-pump dedupe (issue #157): an unchanged compositor status carries no
+// new pixels, so resubmitting it at 60Hz only burns main-process present work.
+// A bounded refresh still goes through so main's staleness/liveness gates keep
+// seeing a heartbeat while the compositor is genuinely idle.
+const NATIVE_PREVIEW_FALLBACK_LIVENESS_REFRESH_MS = 1000
 const NATIVE_PREVIEW_COMPOSITOR_TIMING_SAMPLE_LIMIT = 900
 const NATIVE_PREVIEW_SCENE_FRAME_WAIT_TIMEOUT_MS = 750
 const NATIVE_PREVIEW_SCENE_FRAME_WAIT_INTERVAL_MS = 33
@@ -2301,6 +2306,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const nativePreviewCompositorLastEventAtRef = useRef(0)
   const nativePreviewCompositorPollInFlightRef = useRef(false)
   const nativePreviewCompositorPumpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const nativePreviewFallbackLastPresentRef = useRef<{ key: string; at: number } | null>(null)
   const nativePreviewCompositorPollIntervalSamplesRef = useRef<number[]>([])
   const nativePreviewCompositorPollRoundTripSamplesRef = useRef<number[]>([])
   const nativePreviewCompositorPresentRoundTripSamplesRef = useRef<number[]>([])
@@ -2909,7 +2915,19 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         }
         nativePreviewCompositorLastPollStartedAtRef.current = pollStartedAt
         if (latestStatus) {
-          queueNativePreviewCompositorPresent(client, latestStatus)
+          // A new frame, run, or scene presents immediately (its key differs);
+          // an unchanged status is only re-presented as a bounded liveness
+          // refresh instead of 60 times per second.
+          const presentKey = `${latestStatus.runId ?? ''}:${latestStatus.framesRendered}:${latestStatus.sceneRevision ?? ''}`
+          const lastPresent = nativePreviewFallbackLastPresentRef.current
+          if (
+            !lastPresent ||
+            lastPresent.key !== presentKey ||
+            pollStartedAt - lastPresent.at >= NATIVE_PREVIEW_FALLBACK_LIVENESS_REFRESH_MS
+          ) {
+            nativePreviewFallbackLastPresentRef.current = { key: presentKey, at: pollStartedAt }
+            queueNativePreviewCompositorPresent(client, latestStatus)
+          }
         }
       }
       nativePreviewCompositorPumpTimerRef.current = setTimeout(
@@ -2925,6 +2943,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     return () => {
       cancelled = true
       nativePreviewCompositorPollInFlightRef.current = false
+      nativePreviewFallbackLastPresentRef.current = null
       if (nativePreviewCompositorPumpTimerRef.current) {
         clearTimeout(nativePreviewCompositorPumpTimerRef.current)
         nativePreviewCompositorPumpTimerRef.current = null

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1470,6 +1470,13 @@ export interface PreviewSurfaceStatus {
   framesRendered: number
   presentedFrameId?: number
   compositorFrameLag?: number
+  /** Windows proof-surface transport metrics (issue #157): observed frame
+   * request rate, payload bandwidth, decode cadence, and decoded per-layer
+   * source dimensions. Absent on native CAMetalLayer transports. */
+  proofTransportRequestsPerSecond?: number
+  proofTransportBytesPerSecond?: number
+  proofTransportDecodedFramesPerSecond?: number
+  proofSourceDimensions?: Record<string, { width: number; height: number }>
   droppedFrames: number
   inputToPresentLatencyMs?: number
   inputToPresentLatencyP50Ms?: number

--- a/apps/desktop/src/shared/native-preview-proof-polling.test.ts
+++ b/apps/desktop/src/shared/native-preview-proof-polling.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  PROOF_POLLING_MIN_MAX_WIDTH,
+  PROOF_POLLING_WIDTH_STEP,
   nativePreviewProofFrameUrl,
+  nativePreviewProofPollingMaxWidth,
   nativePreviewProofPollingProfile,
-  nativePreviewProofPollingProfileKey
+  nativePreviewProofPollingProfileKey,
+  nativePreviewProofPresentStatus
 } from './native-preview-proof-polling'
 
 describe('nativePreviewProofPollingProfile', () => {
@@ -29,6 +33,42 @@ describe('nativePreviewProofPollingProfile', () => {
     )
   })
 
+  it('caps the requested width at the DPR-aware surface width, quantized up', () => {
+    // A 1280px-wide proof window at 1.25 DPR displays 1600 physical pixels —
+    // fetching 1920px sources would be wasted decode + resize work.
+    expect(nativePreviewProofPollingProfile(false, 1600)).toEqual({
+      intervalMs: 40,
+      maxWidth: 1600
+    })
+    // Mid-bucket widths round UP so the surface is never undersupplied.
+    expect(nativePreviewProofPollingProfile(false, 1444).maxWidth).toBe(
+      Math.ceil(1444 / PROOF_POLLING_WIDTH_STEP) * PROOF_POLLING_WIDTH_STEP
+    )
+  })
+
+  it('never exceeds the profile ceiling for oversized surfaces', () => {
+    expect(nativePreviewProofPollingProfile(false, 5120).maxWidth).toBe(1920)
+    expect(nativePreviewProofPollingProfile(true, 5120).maxWidth).toBe(960)
+  })
+
+  it('holds the documented quality floor for tiny proof windows', () => {
+    expect(nativePreviewProofPollingProfile(false, 180).maxWidth).toBe(PROOF_POLLING_MIN_MAX_WIDTH)
+    expect(nativePreviewProofPollingProfile(true, 1).maxWidth).toBe(PROOF_POLLING_MIN_MAX_WIDTH)
+  })
+
+  it('fails open to the full profile cap when geometry is unknown or invalid', () => {
+    expect(nativePreviewProofPollingMaxWidth(1920, undefined)).toBe(1920)
+    expect(nativePreviewProofPollingMaxWidth(1920, Number.NaN)).toBe(1920)
+    expect(nativePreviewProofPollingMaxWidth(1920, 0)).toBe(1920)
+    expect(nativePreviewProofPollingMaxWidth(1920, -400)).toBe(1920)
+  })
+
+  it('quantizes so live resizes only change the profile across width buckets', () => {
+    const inBucketA = nativePreviewProofPollingMaxWidth(1920, 1441)
+    const inBucketB = nativePreviewProofPollingMaxWidth(1920, 1599)
+    expect(inBucketA).toBe(inBucketB)
+  })
+
   it('uses the backend camelCase maxWidth query contract', () => {
     const url = nativePreviewProofFrameUrl(
       'http://127.0.0.1:4312/preview/screen/latest.bmp?token=test',
@@ -38,5 +78,41 @@ describe('nativePreviewProofPollingProfile', () => {
 
     expect(parsed.searchParams.get('maxWidth')).toBe('960')
     expect(parsed.searchParams.has('max_width')).toBe(false)
+  })
+})
+
+describe('nativePreviewProofPresentStatus', () => {
+  it('carries exactly the fields the proof script consumes', () => {
+    const compact = nativePreviewProofPresentStatus({
+      state: 'live',
+      framesRendered: 812,
+      frameAgeMs: 21,
+      width: 1920,
+      sceneRevision: 14,
+      sources: [
+        { kind: 'screen', state: 'live', frames: 999, lastError: 'noise' } as never,
+        { kind: 'camera', state: 'starting' }
+      ]
+    })
+
+    expect(compact).toEqual({
+      state: 'live',
+      framesRendered: 812,
+      frameAgeMs: 21,
+      width: 1920,
+      sceneRevision: 14,
+      sources: [
+        { kind: 'screen', state: 'live' },
+        { kind: 'camera', state: 'starting' }
+      ]
+    })
+    // The full diagnostics payload must never leak onto the present hot path.
+    expect(JSON.stringify(compact)).not.toContain('lastError')
+  })
+
+  it('omits absent optionals and defaults sources to an empty list', () => {
+    expect(
+      nativePreviewProofPresentStatus({ state: 'starting', framesRendered: 0, width: 1280 })
+    ).toEqual({ state: 'starting', framesRendered: 0, width: 1280, sources: [] })
   })
 })

--- a/apps/desktop/src/shared/native-preview-proof-polling.ts
+++ b/apps/desktop/src/shared/native-preview-proof-polling.ts
@@ -3,8 +3,23 @@ export interface NativePreviewProofPollingProfile {
   maxWidth: number
 }
 
+/**
+ * Documented quality floor: even a tiny proof window keeps at least this many
+ * source pixels of width so text in a screen share stays legible when the
+ * window is enlarged again before the next profile push lands.
+ */
+export const PROOF_POLLING_MIN_MAX_WIDTH = 640
+
+/**
+ * Geometry quantization for the DPR-aware cap. Widths round UP to this step so
+ * live resizes only re-push a profile when they cross a bucket, not per pixel,
+ * and a mid-bucket surface is never undersupplied.
+ */
+export const PROOF_POLLING_WIDTH_STEP = 160
+
 const IDLE_PROOF_POLLING_PROFILE: NativePreviewProofPollingProfile = {
   intervalMs: 40,
+  // Absolute ceiling — a 4K proof window still never asks for more than this.
   maxWidth: 1920
 }
 
@@ -14,6 +29,30 @@ const RECORDING_PROOF_POLLING_PROFILE: NativePreviewProofPollingProfile = {
   // 25 full-resolution channel swaps, Lanczos resizes, and PNG encodes/sec.
   intervalMs: 125,
   maxWidth: 960
+}
+
+/**
+ * DPR-aware image cap (issue #157): the surface never needs more source
+ * pixels than it can physically display, so the requested width follows the
+ * proof-window content width × devicePixelRatio, quantized up to
+ * {@link PROOF_POLLING_WIDTH_STEP}, floored at
+ * {@link PROOF_POLLING_MIN_MAX_WIDTH}, and ceilinged by the profile's own
+ * cap. An unknown geometry keeps the full profile cap (fail open on quality).
+ */
+export function nativePreviewProofPollingMaxWidth(
+  profileCap: number,
+  surfacePixelWidth: number | undefined
+): number {
+  if (
+    typeof surfacePixelWidth !== 'number' ||
+    !Number.isFinite(surfacePixelWidth) ||
+    surfacePixelWidth <= 0
+  ) {
+    return profileCap
+  }
+  const quantized =
+    Math.ceil(surfacePixelWidth / PROOF_POLLING_WIDTH_STEP) * PROOF_POLLING_WIDTH_STEP
+  return Math.min(profileCap, Math.max(PROOF_POLLING_MIN_MAX_WIDTH, quantized))
 }
 
 export function nativePreviewProofFrameUrl(url: string, maxWidth?: number): string {
@@ -30,11 +69,14 @@ export function nativePreviewProofFrameUrl(url: string, maxWidth?: number): stri
 }
 
 export function nativePreviewProofPollingProfile(
-  recordingActive: boolean
+  recordingActive: boolean,
+  surfacePixelWidth?: number
 ): NativePreviewProofPollingProfile {
-  return recordingActive
-    ? { ...RECORDING_PROOF_POLLING_PROFILE }
-    : { ...IDLE_PROOF_POLLING_PROFILE }
+  const base = recordingActive ? RECORDING_PROOF_POLLING_PROFILE : IDLE_PROOF_POLLING_PROFILE
+  return {
+    intervalMs: base.intervalMs,
+    maxWidth: nativePreviewProofPollingMaxWidth(base.maxWidth, surfacePixelWidth)
+  }
 }
 
 export function nativePreviewProofPollingProfileKey(
@@ -42,4 +84,40 @@ export function nativePreviewProofPollingProfileKey(
   profile: NativePreviewProofPollingProfile
 ): string {
   return `${surfaceWindowId}:${profile.intervalMs}:${profile.maxWidth}`
+}
+
+/**
+ * The compact proof-present payload (issue #157). The proof surface script
+ * consumes exactly these fields per accepted update; the full compositor
+ * status — scene sources, image cache, frame pipeline, layouts — stays on the
+ * normal status/diagnostics channel and must not ride the present hot path.
+ */
+export interface NativePreviewProofPresentStatus {
+  state: string
+  framesRendered: number
+  frameAgeMs?: number
+  width: number
+  sceneRevision?: number
+  sources: Array<{ kind: string; state: string }>
+}
+
+export function nativePreviewProofPresentStatus(status: {
+  state: string
+  framesRendered: number
+  frameAgeMs?: number
+  width: number
+  sceneRevision?: number
+  sources?: Array<{ kind: string; state: string }>
+}): NativePreviewProofPresentStatus {
+  return {
+    state: status.state,
+    framesRendered: status.framesRendered,
+    ...(typeof status.frameAgeMs === 'number' ? { frameAgeMs: status.frameAgeMs } : {}),
+    width: status.width,
+    ...(typeof status.sceneRevision === 'number' ? { sceneRevision: status.sceneRevision } : {}),
+    sources: (status.sources ?? []).map((source) => ({
+      kind: source.kind,
+      state: source.state
+    }))
+  }
 }

--- a/crates/videorc-backend/src/preview_bmp.rs
+++ b/crates/videorc-backend/src/preview_bmp.rs
@@ -117,7 +117,11 @@ fn bounded_bgra_pixels(
     let target_height = ((u64::from(height) * u64::from(max_width)) / u64::from(width))
         .max(1)
         .min(u64::from(u32::MAX)) as u32;
-    let image = image::RgbaImage::from_raw(width, height, bytes.to_vec())?;
+    // Borrow the retained capture bytes for the downscale source (issue #157):
+    // cloning them first cost a second full-source allocation — ~33 MB per 4K
+    // response — before any resampling had happened. Only the small resized
+    // target is allocated now.
+    let image = image::ImageBuffer::<image::Rgba<u8>, &[u8]>::from_raw(width, height, bytes)?;
     let resized = image::imageops::resize(&image, max_width, target_height, FilterType::Triangle);
     Some((Cow::Owned(resized.into_raw()), max_width, target_height))
 }


### PR DESCRIPTION
Closes #157. Implements all five Plan 036 steps.

## What changed

**1. Proof transport metrics** (`native-preview-proof-poller-runtime.ts`, proof script): per-poller request / not-modified / bytes / decoded-frame counters plus decoded per-layer source dimensions, aggregated in `__videorcNativePreviewMetrics` with inter-snapshot rates, folded into `PreviewSurfaceStatus` as `proofTransportRequestsPerSecond`, `proofTransportBytesPerSecond`, `proofTransportDecodedFramesPerSecond`, `proofSourceDimensions`. Request rate/bytes/latency/cadence/dimensions are now observable instead of inferred.

**2. DPR-aware image cap** (`native-preview-proof-polling.ts`, main): `maxWidth` follows the proof window's content width × display `scaleFactor`, quantized **up** in 160px buckets (`PROOF_POLLING_WIDTH_STEP`) with a documented 640px quality floor (`PROOF_POLLING_MIN_MAX_WIDTH`), ceilinged by the existing profile caps (1920 idle / 960 recording — the lower recording profile is retained). `resize`/`move` (cross-display DPR changes) re-derive it through a 150ms trailing debounce; the profile key dedupes unchanged results so nothing is re-pushed per pixel. Unknown geometry fails open to the full cap.

**3. No full-source allocation on downscale** (`preview_bmp.rs`): the resize path built an owned `RgbaImage` from `bytes.to_vec()` — a second full-source copy (~33 MB per 4K response) before any resampling. It now borrows the retained capture bytes via `ImageBuffer<Rgba<u8>, &[u8]>`; only the resized target is allocated. Duplicate-sequence suppression stays ahead of all expensive work (existing test pins it).

**4. Compact proof-present DTO + one round trip** (`nativePreviewProofPresentStatus`): the per-present `executeJavaScript` payload now carries exactly the fields the proof script consumes — `state, framesRendered, frameAgeMs, width, sceneRevision, sources[{kind,state}]` — instead of the full compositor scene/source/cache diagnostics (which stay on the status/diagnostics channel). The separate post-paint metrics read is merged into the same script evaluation, halving present round trips. A test pins that diagnostics fields cannot leak into the compact payload. All smoke-command injection sites use the same builder, so there is one contract.

**5. Renderer fallback dedupe** (`use-studio.tsx`): the 60Hz fallback pump re-presents only when `{runId, framesRendered, sceneRevision}` changes, with a bounded 1s liveness refresh (main's staleness gates keep their heartbeat) and immediate delivery for any new frame/run/scene (its key differs). Dedupe state resets when the pump restarts.

## STOP conditions checked

- Geometry caps: quantization rounds **up** and unknown geometry keeps the full profile cap — a large surface can't be underfilled; floor documented.
- Compact payload: field set derived from reading every consumer in the proof script (`applyCompositorStatus`, `presentLatestCompositorStatus`, `__videorcNativePreviewMetrics`); liveness fields (`state`, `frameAgeMs`, `sources[].state`) all retained.
- Dedupe: keyed exactly on `{runId, framesRendered, sceneRevision}` — any changed scene/run/frame presents immediately.

## Verification

- `cargo test -p videorc-backend`: 1323 green (8 new/updated preview_bmp assertions included); clippy `-D warnings`; fmt.
- `pnpm --filter @videorc/desktop test`: 1198 green (new shared profile-geometry/DTO tests + poller transport-accounting tests).
- `pnpm typecheck` / `lint` / `format:check` / `test:scripts` (759) green.
- `pnpm smoke:windows-native-screen` / `smoke:recording-native-preview` need a Windows box — not runnable on this macOS machine; the closest focused gates (runtime-script unit tests that execute the same injected code, plus the full suites above) are green. Requesting a Windows-side run before merge if available.

The proof surface still identifies as `electron-proof-surface` / `electron-browser-window`, and no macOS native-presentation code path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more detailed Windows native preview diagnostics, including transport rates, decoded frame rates, bandwidth, and source dimensions.
  - Native preview polling now adapts quality and width to display size and pixel density.
  - Preview updates are presented more efficiently with compact status data and reduced redundant refreshes.

- **Bug Fixes**
  - Improved preview responsiveness during window moves and resizing.
  - Reduced unnecessary memory allocation during preview frame resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->