### PR TITLE
perf(windows): tee-backed MF hardware probe + capability-keyed encoder selection (Plan 035, step 3)

### DIFF
--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -6288,19 +6288,111 @@ enum FfmpegH264Platform {
 
 #[cfg(target_os = "windows")]
 static WINDOWS_MEDIA_FOUNDATION_HARDWARE_SELECTED: AtomicBool = AtomicBool::new(false);
-#[cfg(target_os = "windows")]
+#[cfg(any(test, target_os = "windows"))]
 static WINDOWS_MEDIA_FOUNDATION_PROBE_CACHE: std::sync::OnceLock<
-    StdMutex<std::collections::HashMap<WindowsMediaFoundationProbeKey, bool>>,
+    StdMutex<
+        std::collections::HashMap<
+            WindowsMediaFoundationProbeKey,
+            WindowsMediaFoundationProbeOutcome,
+        >,
+    >,
 > = std::sync::OnceLock::new();
+
+/// Cached hardware verdict for one capability key, if any. Failures are
+/// cached exactly like successes: a rejected probe must not re-run FFmpeg on
+/// every session start with the same binary + profile.
+#[cfg(any(test, target_os = "windows"))]
+fn windows_media_foundation_cached_outcome(
+    key: &WindowsMediaFoundationProbeKey,
+) -> Option<WindowsMediaFoundationProbeOutcome> {
+    WINDOWS_MEDIA_FOUNDATION_PROBE_CACHE
+        .get_or_init(|| StdMutex::new(std::collections::HashMap::new()))
+        .lock()
+        .ok()
+        .and_then(|cache| cache.get(key).cloned())
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_media_foundation_store_outcome(
+    key: WindowsMediaFoundationProbeKey,
+    outcome: WindowsMediaFoundationProbeOutcome,
+) {
+    if let Ok(mut cache) = WINDOWS_MEDIA_FOUNDATION_PROBE_CACHE
+        .get_or_init(|| StdMutex::new(std::collections::HashMap::new()))
+        .lock()
+    {
+        cache.insert(key, outcome);
+    }
+}
 
 #[cfg(any(test, target_os = "windows"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct WindowsMediaFoundationProbeKey {
     ffmpeg_path: PathBuf,
+    /// Byte length + mtime of the FFmpeg binary: app updates replace the
+    /// bundled ffmpeg IN PLACE, so the path alone would let a stale hardware
+    /// verdict outlive the binary that produced it (Plan 035 maintenance
+    /// note: the capability key must include the bundled FFmpeg version).
+    ffmpeg_len: Option<u64>,
+    ffmpeg_modified_ms: Option<u128>,
     width: u32,
     height: u32,
     fps: u32,
     bitrate_kbps: u32,
+}
+
+/// One cached hardware-capability verdict for a probe key. `reason` carries
+/// the EXACT failure evidence (exit status + stderr tail) so every session
+/// that falls back logs why, not just that it did.
+#[cfg(any(test, target_os = "windows"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WindowsMediaFoundationProbeOutcome {
+    accepted: bool,
+    reason: Option<String>,
+}
+
+/// The exact fallback reason recorded when the tee-backed probe rejects the
+/// hardware encoder. Bounded: only the stderr tail rides along, and control
+/// characters are stripped so the reason stays one loggable line.
+#[cfg(any(test, target_os = "windows"))]
+fn windows_media_foundation_fallback_reason(
+    exit_code: Option<i32>,
+    stderr: &str,
+    timed_out: bool,
+) -> String {
+    const STDERR_TAIL_MAX: usize = 400;
+    if timed_out {
+        return "tee-backed hardware probe timed out".to_string();
+    }
+    let cleaned: String = stderr
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect();
+    let cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    let tail = if cleaned.len() > STDERR_TAIL_MAX {
+        let start = cleaned.len() - STDERR_TAIL_MAX;
+        let boundary = (start..cleaned.len())
+            .find(|index| cleaned.is_char_boundary(*index))
+            .unwrap_or(cleaned.len());
+        format!("…{}", &cleaned[boundary..])
+    } else {
+        cleaned
+    };
+    let status = match exit_code {
+        Some(code) => format!("exit code {code}"),
+        None => "terminated by signal".to_string(),
+    };
+    if tail.is_empty() {
+        format!("tee-backed hardware probe failed ({status})")
+    } else {
+        format!("tee-backed hardware probe failed ({status}): {tail}")
+    }
 }
 
 #[cfg(any(test, target_os = "windows"))]
@@ -6309,8 +6401,18 @@ fn windows_media_foundation_probe_key(
     video: &VideoSettings,
 ) -> WindowsMediaFoundationProbeKey {
     let path = PathBuf::from(ffmpeg_path);
+    let metadata = std::fs::metadata(&path).ok();
     WindowsMediaFoundationProbeKey {
         ffmpeg_path: std::fs::canonicalize(&path).unwrap_or(path),
+        ffmpeg_len: metadata.as_ref().map(std::fs::Metadata::len),
+        ffmpeg_modified_ms: metadata.and_then(|metadata| {
+            metadata
+                .modified()
+                .ok()?
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()
+                .map(|duration| duration.as_millis())
+        }),
         width: video.width,
         height: video.height,
         fps: video.fps,
@@ -6404,23 +6506,122 @@ fn windows_media_foundation_hardware_probe_args(video: &VideoSettings) -> Vec<St
         FfmpegH264Platform::WindowsHardware,
         true,
     );
-    args.extend(["-f".to_string(), "null".to_string(), "-".to_string()]);
+    // Plan 035 / issue #156: h264_mf has PASSED a null-output probe and then
+    // failed during TEE header creation in production. Exercise the exact
+    // record+stream tee topology — same fifo isolation, same matroska and
+    // FLV slave shapes — against the null device, so a probe pass proves the
+    // headers, codec tags, and rate control the real session will use.
+    let null_device = if cfg!(target_os = "windows") {
+        "NUL"
+    } else {
+        "/dev/null"
+    };
+    args.extend(tee_output_args(format!(
+        "[f=matroska:onfail=abort]{null_device}|[f=flv:onfail=ignore:flvflags=no_duration_filesize]{null_device}"
+    )));
     args
 }
 #[cfg(target_os = "windows")]
+const WINDOWS_MEDIA_FOUNDATION_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Per-session, capability-keyed hardware selection (Plan 035 / issue #156).
+/// The hardware Media Foundation encoder is chosen only after the tee-backed
+/// probe proved the production headers, rate control, and output topology on
+/// this exact FFmpeg binary and output profile; anything else selects the
+/// OpenH264 fallback and logs the exact reason. Verdicts are cached by
+/// capability key, so one probe covers every later session with the same
+/// binary + profile and a changed binary or profile re-proves itself.
+#[cfg(target_os = "windows")]
 async fn select_windows_media_foundation_encoder(
     state: &AppState,
-    _ffmpeg_path: &str,
-    _video: &VideoSettings,
+    ffmpeg_path: &str,
+    video: &VideoSettings,
 ) {
-    // FFmpeg's h264_mf hardware probe can pass while its real tee output fails
-    // during header creation. Prefer the Media Foundation software MFT until a
-    // tee-backed hardware probe is available.
-    WINDOWS_MEDIA_FOUNDATION_HARDWARE_SELECTED.store(false, Ordering::Relaxed);
-    state.emit_log(
-        "warn",
-        "Using the Media Foundation software H.264 fallback: the hardware encoder is not reliable with this recording output.",
-    );
+    let key = windows_media_foundation_probe_key(ffmpeg_path, video);
+    let (outcome, freshly_probed) = match windows_media_foundation_cached_outcome(&key) {
+        Some(outcome) => (outcome, false),
+        None => {
+            let outcome = run_windows_media_foundation_hardware_probe(ffmpeg_path, video).await;
+            windows_media_foundation_store_outcome(key, outcome.clone());
+            (outcome, true)
+        }
+    };
+    WINDOWS_MEDIA_FOUNDATION_HARDWARE_SELECTED.store(outcome.accepted, Ordering::Relaxed);
+    if outcome.accepted {
+        if freshly_probed {
+            state.emit_log(
+                "info",
+                "Hardware Media Foundation H.264 selected: the tee-backed probe proved production headers, rate control, and tee topology.",
+            );
+        }
+    } else {
+        let reason = outcome
+            .reason
+            .as_deref()
+            .unwrap_or("tee-backed hardware probe was rejected");
+        state.emit_log(
+            "warn",
+            &format!("Using the OpenH264 software H.264 fallback: {reason}"),
+        );
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn run_windows_media_foundation_hardware_probe(
+    ffmpeg_path: &str,
+    video: &VideoSettings,
+) -> WindowsMediaFoundationProbeOutcome {
+    let args = windows_media_foundation_hardware_probe_args(video);
+    let mut command = Command::new(ffmpeg_path);
+    command
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    command.kill_on_drop(true);
+    let spawned = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return WindowsMediaFoundationProbeOutcome {
+                accepted: false,
+                reason: Some(format!(
+                    "tee-backed hardware probe could not start FFmpeg: {error}"
+                )),
+            };
+        }
+    };
+    match timeout(
+        WINDOWS_MEDIA_FOUNDATION_PROBE_TIMEOUT,
+        spawned.wait_with_output(),
+    )
+    .await
+    {
+        Ok(Ok(output)) => {
+            if output.status.success() {
+                WindowsMediaFoundationProbeOutcome {
+                    accepted: true,
+                    reason: None,
+                }
+            } else {
+                WindowsMediaFoundationProbeOutcome {
+                    accepted: false,
+                    reason: Some(windows_media_foundation_fallback_reason(
+                        output.status.code(),
+                        &String::from_utf8_lossy(&output.stderr),
+                        false,
+                    )),
+                }
+            }
+        }
+        Ok(Err(error)) => WindowsMediaFoundationProbeOutcome {
+            accepted: false,
+            reason: Some(format!("tee-backed hardware probe failed to run: {error}")),
+        },
+        Err(_) => WindowsMediaFoundationProbeOutcome {
+            accepted: false,
+            reason: Some(windows_media_foundation_fallback_reason(None, "", true)),
+        },
+    }
 }
 #[cfg(not(target_os = "windows"))]
 async fn select_windows_media_foundation_encoder(
@@ -11093,6 +11294,39 @@ mod tests {
         );
         assert_eq!(arg_value(&args, "-frames:v"), Some("3"));
 
+        // Plan 035: the probe must exercise the REAL record+stream tee — the
+        // hardware encoder has passed null-output probes and then failed
+        // during tee header creation in production.
+        let output_format = args
+            .windows(2)
+            .filter(|pair| pair[0] == "-f")
+            .map(|pair| pair[1].as_str())
+            .next_back();
+        assert_eq!(
+            output_format,
+            Some("tee"),
+            "probe output must be the tee muxer"
+        );
+        assert!(
+            !args.contains(&"null".to_string()),
+            "null-output probes prove nothing"
+        );
+        assert_eq!(arg_value(&args, "-use_fifo"), Some("1"));
+        assert_eq!(
+            arg_value(&args, "-fifo_options"),
+            Some("queue_size=512:drop_pkts_on_overflow=1"),
+            "probe tee must use the production fifo isolation"
+        );
+        let tee_spec = args.last().unwrap();
+        assert!(
+            tee_spec.contains("[f=matroska:onfail=abort]"),
+            "recording leg shape missing"
+        );
+        assert!(
+            tee_spec.contains("[f=flv:onfail=ignore:flvflags=no_duration_filesize]"),
+            "stream leg shape missing"
+        );
+
         let key = windows_media_foundation_probe_key("ffmpeg", &video);
         let mut higher_fps = video.clone();
         higher_fps.fps = 60;
@@ -11105,6 +11339,106 @@ mod tests {
             key,
             windows_media_foundation_probe_key("alternate-ffmpeg", &video),
             "hardware results must not leak across FFmpeg binaries"
+        );
+    }
+
+    #[test]
+    fn media_foundation_probe_key_tracks_the_ffmpeg_binary_bytes_not_only_its_path() {
+        // App updates replace the bundled ffmpeg IN PLACE: same path, new
+        // binary. The capability key must change with it or a stale hardware
+        // verdict outlives the encoder build that produced it.
+        let video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            bitrate_kbps: 6_000,
+        };
+        let binary =
+            std::env::temp_dir().join(format!("videorc-mf-probe-key-{}.bin", Uuid::new_v4()));
+        std::fs::write(&binary, b"build-one").unwrap();
+        let first = windows_media_foundation_probe_key(binary.to_str().unwrap(), &video);
+        assert_eq!(
+            first,
+            windows_media_foundation_probe_key(binary.to_str().unwrap(), &video)
+        );
+        assert_eq!(first.ffmpeg_len, Some(9));
+
+        std::fs::write(&binary, b"build-two-with-longer-bytes").unwrap();
+        let second = windows_media_foundation_probe_key(binary.to_str().unwrap(), &video);
+        let _ = std::fs::remove_file(&binary);
+        assert_ne!(
+            first, second,
+            "an in-place FFmpeg replacement must invalidate the cached verdict"
+        );
+    }
+
+    #[test]
+    fn media_foundation_probe_cache_replays_verdicts_including_failures() {
+        let video = VideoSettings {
+            preset: VideoPreset::Custom,
+            width: 1234,
+            height: 770,
+            fps: 24,
+            bitrate_kbps: 4_321,
+        };
+        let key = windows_media_foundation_probe_key("cache-test-ffmpeg", &video);
+        assert_eq!(windows_media_foundation_cached_outcome(&key), None);
+
+        let rejected = WindowsMediaFoundationProbeOutcome {
+            accepted: false,
+            reason: Some(
+                "tee-backed hardware probe failed (exit code 1): header error".to_string(),
+            ),
+        };
+        windows_media_foundation_store_outcome(key.clone(), rejected.clone());
+        // A cached failure must replay without re-running FFmpeg, keeping its
+        // exact fallback reason for every later session's diagnostics.
+        assert_eq!(
+            windows_media_foundation_cached_outcome(&key),
+            Some(rejected)
+        );
+
+        // A different profile is a different capability; it must not inherit
+        // the verdict.
+        let mut wider = video.clone();
+        wider.width = 3840;
+        wider.height = 2160;
+        let wider_key = windows_media_foundation_probe_key("cache-test-ffmpeg", &wider);
+        assert_eq!(windows_media_foundation_cached_outcome(&wider_key), None);
+    }
+
+    #[test]
+    fn media_foundation_fallback_reason_is_exact_and_bounded() {
+        assert_eq!(
+            windows_media_foundation_fallback_reason(None, "", true),
+            "tee-backed hardware probe timed out"
+        );
+        assert_eq!(
+            windows_media_foundation_fallback_reason(Some(1), "", false),
+            "tee-backed hardware probe failed (exit code 1)"
+        );
+        assert_eq!(
+            windows_media_foundation_fallback_reason(None, "killed", false),
+            "tee-backed hardware probe failed (terminated by signal): killed"
+        );
+        let reason = windows_media_foundation_fallback_reason(
+            Some(1),
+            "line one\nCould not create tee output header\u{7}",
+            false,
+        );
+        assert_eq!(
+            reason,
+            "tee-backed hardware probe failed (exit code 1): line one Could not create tee output header"
+        );
+        let long = "x".repeat(2000) + " Error creating output header";
+        let bounded = windows_media_foundation_fallback_reason(Some(187), &long, false);
+        assert!(bounded.len() < 500, "reason must stay one loggable line");
+        assert!(bounded.contains("exit code 187"));
+        assert!(bounded.ends_with("Error creating output header"));
+        assert!(
+            bounded.contains('…'),
+            "a trimmed tail must be visibly truncated"
         );
     }
 


### PR DESCRIPTION
Part of #156 (Plan 035). This lands the implementable-off-hardware core — step 3 plus step 4's Rust regression tests — and re-enables hardware Media Foundation H.264 behind exactly the proof the plan demands.

## What was wrong

`select_windows_media_foundation_encoder` stored `false` unconditionally: the old capability probe encoded 3 frames to `-f null -`, which h264_mf can pass while its real tee output fails during header creation. Result: every Windows session paid for software encoding (OpenH264) even on capable hardware.

## What changed

**Tee-backed probe** — the probe keeps the full production encode args (same rate control, GOP, headers) and now outputs through the **real tee topology**: `-f tee -use_fifo 1 -fifo_options queue_size=512:drop_pkts_on_overflow=1` with the production slave shapes `[f=matroska:onfail=abort]` + `[f=flv:onfail=ignore:flvflags=no_duration_filesize]`, written to the null device. A pass now proves header creation, codec tags, and rate control for the actual record+stream tee — the precise failure mode the old probe missed. Hardware is selected **only** on a probe pass, per the plan's STOP condition.

**Capability-keyed, per-session selection with a cache** — the verdict cache is keyed by canonical FFmpeg path **+ binary byte length + mtime** (app updates replace the bundled ffmpeg in place — path alone would let a stale verdict outlive the binary; this implements the maintenance note) + width/height/fps/bitrate. Failures are cached like successes, so a rejected probe never re-runs FFmpeg each session; any binary or profile change re-proves itself.

**Exact fallback diagnostics** — a rejected probe records exit status + a bounded, control-character-stripped stderr tail, and every fallback session logs it: `Using the OpenH264 software H.264 fallback: tee-backed hardware probe failed (exit code 1): …`. A 15s timeout fails closed with its own reason.

## Regression tests

- Probe args pin the tee muxer, fifo isolation, both slave shapes, and the **absence** of any null-output format.
- Key invalidation: same path + rewritten binary bytes ⇒ different key; profile changes ⇒ different key (existing pins retained).
- Cache replays verdicts including failures with their exact reason; different profiles don't inherit verdicts.
- Fallback-reason formatting: timeout, exit code, signal, control-char stripping, bounded tail with visible truncation.

## Explicitly deferred (needs the physical Windows host + Plan 034 instrumentation)

- Step 1 characterization at 1080p30/60, 4K30/60.
- Step 2 encoded bridge output (removing the ~356 MiB/s raw FIFO itself).
- Step 4's packaged physical smokes (encoder backend, realtime cadence, artifact quality, clean fallback on-device).

Keeping #156 open for those; this PR removes the CPU-bound software-encode half of the bottleneck wherever hardware proves itself.

## Verification

- `cargo test -p videorc-backend`: **1326 green** (4 new tests + hardened probe pins); `cargo clippy -- -D warnings`; `cargo fmt --check`.
- `pnpm check:windows` (cargo xwin, `x86_64-pc-windows-msvc`): the Windows-only selection/probe/timeout code compiles for the real target.
- Zero non-Windows runtime code changed (diff is confined to `#[cfg(windows)]` / `#[cfg(any(test, windows))]` paths + tests), so macOS recording behavior — including `smoke:recording-matrix` coverage — is untouched by construction.
- On-device proof requested: @petercr, a run on your box would show either the hardware-selected log line or the exact fallback reason — both outcomes are useful data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows hardware H.264 detection for recording and streaming.
  * Hardware capability checks now reflect the actual recording and streaming setup.
  * Updated FFmpeg changes are detected automatically, preventing outdated hardware-selection results.
  * When hardware encoding is unavailable, the app now consistently falls back to software encoding and provides a clearer reason in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->