### PR TITLE
Release: bump desktop to 0.9.47 + fix Windows clippy needless_borrow

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.47-beta.1.md
+++ b/changelog/0.9.47-beta.1.md
@@ -1,0 +1,41 @@
+---
+version: 0.9.47-beta.1
+date: 2026-07-20
+channel: beta
+platforms:
+  - macos
+title: Videorc now tells you when your camera's frame rate will make a recording stutter
+summary: If your camera feeds a different frame rate than your session is set to — like a mirrorless outputting 24p over HDMI into a 30fps session — Videorc now warns you the moment you start recording, before viewers ever see the stutter. The automatic quality check also stops flagging a person simply holding still as a "frozen" recording.
+highlights:
+  - New warning at recording start when your camera delivers a different frame rate than the session is set to (for example a 24p HDMI feed into a 30fps session), including exactly how it will look and how to fix it.
+  - The automatic quality check now only reports a freeze when frames were genuinely repeated — sitting still on camera no longer marks a perfectly good recording "not 100%".
+  - Clean recordings are never re-encoded anymore by the automatic repair when nothing is actually wrong with them.
+  - Remote control from 0.9.46 is included in this macOS release — Stream Deck support, global shortcuts, and a token-gated local API.
+---
+
+## Know about frame-rate stutter before your viewers do
+
+Cameras connected through HDMI capture cards deliver whatever frame rate the
+camera's movie output is set to. If that's 24p while your Videorc session is
+set to 30fps, roughly six frames every second have to repeat — and hand
+movement visibly stutters in the recording, even though everything looks fine
+while you record. Nothing anywhere used to tell you this was happening.
+
+Now, the moment a recording starts, Videorc compares the frame rate your
+camera is actually delivering against your session setting. If they don't
+match, you get a clear warning with the measured rate, what it will look like,
+and the fix: set the camera or HDMI output to the session's rate, or match the
+session to the camera.
+
+## An honest quality check
+
+The automatic post-recording quality check used to detect "freezes" by looking
+for stretches of near-identical frames. A person holding still against a plain
+wall looks exactly like that — so good recordings were regularly flagged
+"could not be brought to 100%" and sometimes re-encoded by the automatic
+repair for no reason.
+
+The check now demands real evidence: a freeze only counts when the recording
+contains genuinely repeated frames, which live cameras never produce on their
+own. Still moments are reported as just that — still moments — and clean
+recordings are left untouched.

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -6610,7 +6610,7 @@ async fn select_windows_media_foundation_encoder(
             .unwrap_or("tee-backed hardware probe was rejected");
         state.emit_log(
             "warn",
-            &format!("Using the OpenH264 software H.264 fallback: {reason}"),
+            format!("Using the OpenH264 software H.264 fallback: {reason}"),
         );
     }
 }


### PR DESCRIPTION
- 0.9.47-beta.1 changelog entry: camera frame-rate mismatch warning + honest quality-check freeze verdicts (from #164), plus the 0.9.46 remote-control work shipping to macOS for the first time.
- `recording.rs`: drop the needless `&format!` borrow in the `cfg(windows)` OpenH264 fallback log — it has been failing the Windows clippy gate on main since #151.
- `pnpm changelog:check` passes (48 entries, latest 0.9.47-beta.1); macOS clippy/fmt/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning at recording start when the camera or HDMI frame rate differs from the configured session rate, with measured details and guidance.
  * Added macOS support for remote-control features, including Stream Deck integration, global shortcuts, and a token-protected local API.

* **Bug Fixes**
  * Improved post-recording quality checks to flag freezes only when frames are genuinely repeated, reducing false positives for still scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->