### PR TITLE
Record the 0.9.47 release (camera cadence truth + honest quality verdicts)

### DIFF
--- a/docs/releases/0.9.47.md
+++ b/docs/releases/0.9.47.md
@@ -1,0 +1,58 @@
+# Videorc 0.9.47 Beta 1
+
+Camera cadence truth + honest quality-check verdicts, born from the 2026-07-20
+"4K feels laggy" investigation. Also the first macOS Beta carrying the 0.9.46
+remote-control work (Stream Deck, global shortcuts, token-gated local API),
+since 0.9.46 shipped only as a Windows Alpha source freeze.
+
+## Scope
+
+- **Camera cadence mismatch warning** (PR #164): the pre-record cadence gate
+  compares the camera's measured delivery rate (500ms windows) against the
+  session fps; >2% deviation (NTSC offsets tolerated) emits warn-level
+  `camera-cadence-mismatch` with the expected repeat/drop count and the fix,
+  and the renderer toasts it at record start. Non-blocking.
+- **Honest freeze verdicts** (PR #164): freezedetect similarity hits only
+  count as `FrozenSegments` when exact decoded-frame repeats (framemd5
+  bursts) overlap them; uncorroborated hits are the new informational
+  `LowMotionSegments` (still content) — never flagged "not 100%", never
+  auto-repaired. Kills the false-positive class that flagged ~25% of
+  recordings historically.
+- **Artifact analyzer cadence + corroboration** (PR #164):
+  `scripts/lib/frame-cadence.mjs` (standard-rate classification,
+  cadence-vs-intent mismatch, freeze corroboration) wired into
+  `analyze-recording`; explicit `--fps` mismatch now fails with an
+  actionable "check camera HDMI/movie output settings" message.
+- **Windows clippy unblock** (PR #165): the `cfg(windows)` OpenH264 fallback
+  log's needless `&format!` borrow had been failing the Windows clippy gate
+  on main since #151.
+- **Plan 034** recorded for the 4K perf headroom work (async GPU completion,
+  O(retain) camera callback, tick phase-keeping, evidence-gated 4K quality
+  posture).
+
+## Verification & caveats
+
+- Rust tests (1,334), Node script tests (793), typecheck, eslint, prettier,
+  `cargo fmt`, macOS clippy `-D warnings`: all green locally.
+- `smoke:recording-studio` passed through the native preview real-launch
+  contract, then stopped at the layout/source liveness stage with "No camera
+  device available to select" — **identical failure on untouched main** (no
+  camera connected on the build host; the owner's Cam Link was unplugged).
+  The real-device gates (`smoke:recording-studio:devices`,
+  `smoke:screen-recording-real`) were therefore NOT run for this candidate
+  and should be run when a camera is reconnected.
+- `release:validate:macos`: codesign verify/display, stapler validate, all
+  bundle + baked-secret checks PASS; notarytool status **Accepted**
+  (submission 2bf7e44b-8734-44ac-8367-e1bdc3f43ef4). The local **Gatekeeper
+  assess step could not run**: `spctl` failed machine-wide with "Too many
+  open files" (reproduced against Discord.app — degraded syspolicyd on the
+  build host, needs a sudo restart). Owner accepted upload on the strength
+  of the notarization + staple evidence.
+- CI on main: Rust + CodeRabbit green; the JS gate stays red on the
+  pre-existing renderer asset budget overage introduced by #150 (owner
+  chose admin-merge over recalibrating the budget); Windows clippy is fixed
+  by #165, remaining Windows gate status pending its next main run.
+- Upload: `release:upload:macos` PASS (dmg + sha256 + release.json +
+  latest-mac.yml + zip + blockmap + changelog.json all verified); live feed
+  `https://www.videorc.com/api/updates/latest-mac.yml` serves 0.9.47 and the
+  zip resolves.


### PR DESCRIPTION
Internal release record for 0.9.47-beta.1: scope, verification evidence, and the two build-host caveats (device gates not run — no camera connected; local Gatekeeper assess blocked by a degraded syspolicyd, notarization Accepted + staple validated instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)