### PR TITLE
Release: prepare 0.9.47-alpha.1 Windows Alpha candidate

### DIFF
--- a/changelog/0.9.47-alpha.1.md
+++ b/changelog/0.9.47-alpha.1.md
@@ -1,0 +1,23 @@
+---
+version: 0.9.47-alpha.1
+date: 2026-07-28
+channel: alpha
+platforms:
+  - windows
+title: A steadier Windows Alpha with faster startup and smoother live preview
+summary: The Windows Alpha now starts recording more reliably, keeps preview work bounded under pressure, and handles more hardware paths cleanly.
+highlights:
+  - Windows recording startup is more reliable across hardware-accelerated and software fallback paths.
+  - The live preview stays responsive under sustained capture and encoding pressure.
+  - GPU and capture capability detection now choose safer paths on more Windows systems.
+  - The signed Alpha installer remains identifiable as Videorc instead of an unknown publisher.
+---
+
+This Windows Alpha builds on the first signed candidate with a steadier capture
+pipeline and a more predictable packaged runtime. Recording startup now has
+safer hardware and fallback selection, while the preview keeps its work bounded
+when capture and encoding are busy.
+
+Windows is still in Alpha. Livestreaming workflows and broader hardware
+coverage remain under validation; report issues through the Windows Alpha bug
+template on GitHub.


### PR DESCRIPTION
Prepare the Windows Alpha changelog for the exact 0.9.47 protected-main candidate.\n\n- validates with pnpm changelog:check\n- keeps claims limited to packaged Windows stability and preview behavior\n- does not publish or alter macOS release artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Windows Alpha release notes for version 0.9.47-alpha.1.
  - Improved recording startup reliability across supported hardware and fallback modes.
  - Kept live preview responsive during sustained recording and encoding.
  - Improved GPU and capture capability selection across more systems.
  - Updated the signed installer to display “Videorc” as the publisher.

- **Documentation**
  - Noted that Windows Alpha and broader livestreaming and hardware coverage remain under validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->