### PR TITLE
fix(auth): guard global shortcut cleanup before app ready

### DIFF
--- a/apps/desktop/src/main/global-shortcut-lifecycle.test.ts
+++ b/apps/desktop/src/main/global-shortcut-lifecycle.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { unregisterGlobalShortcutsWhenReady } from './global-shortcut-lifecycle'
+
+describe('global shortcut lifecycle', () => {
+  it('does not touch the registry before Electron is ready', () => {
+    const registry = { unregisterAll: vi.fn() }
+
+    unregisterGlobalShortcutsWhenReady(registry, () => false)
+
+    expect(registry.unregisterAll).not.toHaveBeenCalled()
+  })
+
+  it('clears the registry when Electron is ready', () => {
+    const registry = { unregisterAll: vi.fn() }
+
+    unregisterGlobalShortcutsWhenReady(registry, () => true)
+
+    expect(registry.unregisterAll).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/main/global-shortcut-lifecycle.ts
+++ b/apps/desktop/src/main/global-shortcut-lifecycle.ts
@@ -1,0 +1,18 @@
+export interface GlobalShortcutRegistry {
+  unregisterAll(): void
+}
+
+/**
+ * Electron rejects globalShortcut calls before app readiness. A second
+ * protocol-launch process can reach will-quit before its ready event, and it
+ * has no shortcuts of its own to clean up in that case.
+ */
+export function unregisterGlobalShortcutsWhenReady(
+  registry: GlobalShortcutRegistry,
+  isReady: () => boolean
+): void {
+  if (!isReady()) {
+    return
+  }
+  registry.unregisterAll()
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -66,6 +66,7 @@ import {
 import { runBackendInterruptingAction } from './interruption-actions'
 import { AccountSignInTransactions } from './account-sign-in-transactions'
 import { ProviderOAuthCallbacks } from './provider-oauth-callbacks'
+import { unregisterGlobalShortcutsWhenReady } from './global-shortcut-lifecycle'
 import {
   createSafeStoragePersistenceCodec,
   type SecurePersistenceCodec
@@ -420,7 +421,7 @@ function setGlobalShortcuts(shortcuts: {
 }
 
 app.on('will-quit', () => {
-  globalShortcut.unregisterAll()
+  unregisterGlobalShortcutsWhenReady(globalShortcut, () => app.isReady())
 })
 let nativePreviewSurfaceWindow: BrowserWindow | null = null
 let notesWindow: BrowserWindow | null = null


### PR DESCRIPTION
## Summary

- Guard global shortcut cleanup until Electron reports that the app is ready.
- Add regression coverage for pre-ready and ready shutdown paths.

## Root cause

When the OAuth custom-protocol redirect launches a duplicate Electron process, that process exits before `app.ready`. Its `will-quit` handler previously called `globalShortcut.unregisterAll()`, which Electron rejects before readiness and showed the main-process JavaScript error dialog.

## Validation

- `pnpm --filter @videorc/desktop typecheck`
- `pnpm --filter @videorc/desktop test` (148 files, 1,324 passed, 2 skipped)
- `pnpm format:check`
- `pnpm --filter @videorc/desktop build`
- Confirmed website login redirect now returns to the app successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved global keyboard shortcut cleanup during application shutdown.
  - Prevented shortcut cleanup from running before the desktop app is ready.
  - Ensured shortcuts are cleared exactly once when the app is ready.

- **Tests**
  - Added coverage for shortcut behavior before and after application readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->