### PR TITLE
fix(windows): finalize recordings and harden release dependencies

### DIFF
--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -3885,7 +3885,7 @@ fn mp4_export_args(input: &Path, output: &Path, trim_seconds: Option<f64>) -> Ve
         "-loglevel".to_string(),
         "warning".to_string(),
         "-i".to_string(),
-        input.display().to_string(),
+        ffmpeg_file_path(input),
         "-map".to_string(),
         "0".to_string(),
         "-c:v".to_string(),
@@ -3904,7 +3904,7 @@ fn mp4_export_args(input: &Path, output: &Path, trim_seconds: Option<f64>) -> Ve
         // Bound the stop tail: end the delivered file at the shorter stream.
         args.extend(["-t".to_string(), format!("{trim_seconds:.3}")]);
     }
-    args.push(output.display().to_string());
+    args.push(ffmpeg_file_path(output));
     args
 }
 
@@ -6613,12 +6613,15 @@ fn should_finalize_recording_session(
     // before the user asks to stop is still an early termination (for example,
     // a source/pipe that silently ended) and must never publish a shortened
     // artifact as successful.
-    // Stop intent must win the monitor's exit-ready race, but that alone is not
-    // proof that muxer flush completed. A forced
-    // TERM/KILL or any non-zero FFmpeg exit keeps the artifact as recovery
-    // media and marks the session failed unless a future explicit verifier can
-    // prove the container is complete.
-    if recording_bridge_terminal_failure.is_some() || !ffmpeg_exit_success {
+    // Stop intent must win the monitor's exit-ready race. Windows FFmpeg can
+    // report a non-zero status while closing a stopped graph even though the
+    // local MKV is still exportable; let the MP4 exporter validate that output
+    // instead of unconditionally marooning it as recovery media. A recording
+    // bridge failure remains terminal because it means the video producer did
+    // not finish its contract.
+    if recording_bridge_terminal_failure.is_some()
+        || (!ffmpeg_exit_success && !stop_intent_preceded_exit)
+    {
         return false;
     }
     // A dead STREAM output ends FFmpeg without a user stop, but the RECORDING
@@ -20504,8 +20507,8 @@ mod tests {
     fn only_an_explicit_graceful_stop_can_finalize_an_unbounded_capture() {
         assert!(!should_finalize_recording_session(true, false, None, None));
         assert!(
-            !should_finalize_recording_session(false, true, None, None),
-            "a non-zero/forced FFmpeg exit after stop must remain failed"
+            should_finalize_recording_session(false, true, None, None),
+            "a stopped Windows graph may have a non-zero exit while its MKV remains exportable"
         );
         assert!(should_finalize_recording_session(true, true, None, None));
 
@@ -21329,6 +21332,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn mp4_export_normalizes_windows_verbatim_paths() {
+        #[cfg(target_os = "windows")]
+        {
+            let args = mp4_export_args(
+                Path::new(r"\\?\C:\recordings\capture.mkv"),
+                Path::new(r"\\?\C:\recordings\.videorc-export.partial\export.mp4"),
+                None,
+            );
+            assert_eq!(arg_value(&args, "-i"), Some(r"C:\recordings\capture.mkv"));
+            assert_eq!(
+                args.last().map(String::as_str),
+                Some(r"C:\recordings\.videorc-export.partial\export.mp4")
+            );
+        }
+    }
     #[test]
     fn mp4_export_uses_no_overwrite_with_an_absent_child_in_an_owned_directory() {
         let directory = std::env::temp_dir().join(format!(

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "@eslint/js": "^10.0.1",
     "eslint": "^10.4.1",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "prettier": "^3.8.4",
     "typescript-eslint": "^8.61.0",
     "ws": "^8.21.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
 
 patchedDependencies:
   app-builder-lib@26.8.1: 62b157949e11699c0fdc5983b00c70bf99d8e4defc5d8ecc2c55ddf3c8aa0656
@@ -24,8 +24,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -2711,8 +2711,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5358,7 +5358,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -5465,7 +5465,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -5640,7 +5640,7 @@ snapshots:
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -5719,7 +5719,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -6245,7 +6245,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 packages:
   - apps/*
 overrides:
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
 patchedDependencies:
   app-builder-lib@26.8.1: patches/app-builder-lib@26.8.1.patch
 allowBuilds:

--- a/vendor/ffmpeg/windows-pin.json
+++ b/vendor/ffmpeg/windows-pin.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-23-14-16/ffmpeg-n8.1.2-30-g45f1910444-win64-lgpl-8.1.zip",
-  "sha256": "0c6dc759eb1c70804ca04e11d83c583a6b03ae0630474f862e97400c715c6376"
+  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-06-13-39/ffmpeg-n8.1.2-34-g9b6c8969e0-win64-lgpl-8.1.zip",
+  "sha256": "2e24a342be74a2676fbfbbd9148a8853c36746a5fa237406d4ddfac2aacbffce"
 }


### PR DESCRIPTION
## What changed

- Finalize a stopped Windows recording when FFmpeg returns a non-zero close status but the staged MKV remains exportable.
- Normalize Windows verbatim paths before passing recording inputs and outputs to FFmpeg.
- Refresh the pinned Windows FFmpeg build used by packaging.
- Pin `js-yaml` to 4.3.1 in the package manifest, workspace override, and pnpm lockfile.

## Why

Windows can report a non-zero FFmpeg status while closing a stopped capture graph. Treating that status as an unconditional failure strands an otherwise valid recording as recovery media. Separately, upstream still resolved vulnerable `js-yaml` 4.3.0 and the previous Windows FFmpeg build is no longer downloadable.

## Validation

- `git diff --check`
- Existing Rust unit coverage in `crates/videorc-backend/src/recording.rs`
- Lockfile, workspace override, and package manifest updated together.
- Full recording-studio/device validation remains for GitHub Actions or the appropriate native host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recording finalization after an explicit stop, even when FFmpeg exits unsuccessfully.
  - Preserved error handling for recording bridge failures and unexpected FFmpeg failures.
  - Improved Windows MP4 export path handling.

- **Maintenance**
  - Updated the Windows FFmpeg build.
  - Updated the YAML parsing package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->