### PR TITLE
fix(oauth): send client_secret in the YouTube token exchange

### DIFF
--- a/crates/videorc-backend/src/oauth.rs
+++ b/crates/videorc-backend/src/oauth.rs
@@ -22,6 +22,13 @@ const OAUTH_PROVIDER_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration:
 const OAUTH_PROVIDER_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const BUNDLED_TWITCH_CLIENT_ID: Option<&str> = option_env!("VIDEORC_BUNDLED_TWITCH_CLIENT_ID");
 const BUNDLED_YOUTUBE_CLIENT_ID: Option<&str> = option_env!("VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID");
+// Google's "Desktop app" client type REQUIRES client_secret in the token
+// exchange even with PKCE — omitting it fails the exchange with
+// `invalid_request: client_secret is missing.` AFTER the user has already
+// granted consent. For an installed app this value is not a true secret
+// (it ships in the binary); PKCE is what actually protects the exchange.
+const BUNDLED_YOUTUBE_CLIENT_SECRET: Option<&str> =
+    option_env!("VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET");
 // The Videorc X OAuth app (public Native App client, PKCE — no secret involved).
 // Client IDs are public identifiers; build-time/runtime env still override.
 const BUNDLED_X_CLIENT_ID: Option<&str> = match option_env!("VIDEORC_BUNDLED_X_CLIENT_ID") {
@@ -2324,10 +2331,13 @@ fn provider_config(platform: StreamPlatform) -> Result<OAuthProviderConfig> {
             if let Some(message) = provider_oauth_unavailable_message(platform) {
                 anyhow::bail!("{message}");
             }
-            Ok(youtube_provider_config(required_credential(
-                "VIDEORC_YOUTUBE_CLIENT_ID",
-                BUNDLED_YOUTUBE_CLIENT_ID,
-            )?))
+            Ok(youtube_provider_config(
+                required_credential("VIDEORC_YOUTUBE_CLIENT_ID", BUNDLED_YOUTUBE_CLIENT_ID)?,
+                required_credential(
+                    "VIDEORC_YOUTUBE_CLIENT_SECRET",
+                    BUNDLED_YOUTUBE_CLIENT_SECRET,
+                )?,
+            ))
         }
         StreamPlatform::Twitch => Ok(OAuthProviderConfig {
             authorization_url: "https://id.twitch.tv/oauth2/authorize".to_string(),
@@ -2365,14 +2375,14 @@ fn provider_config(platform: StreamPlatform) -> Result<OAuthProviderConfig> {
     }
 }
 
-fn youtube_provider_config(client_id: String) -> OAuthProviderConfig {
+fn youtube_provider_config(client_id: String, client_secret: String) -> OAuthProviderConfig {
     OAuthProviderConfig {
         authorization_url: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
         token_url: "https://oauth2.googleapis.com/token".to_string(),
         profile_url: "https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true"
             .to_string(),
         client_id,
-        client_secret: None,
+        client_secret: Some(client_secret),
         scopes: vec!["https://www.googleapis.com/auth/youtube.force-ssl".to_string()],
         extra_params: HashMap::from([
             ("access_type".to_string(), "offline".to_string()),
@@ -4681,10 +4691,15 @@ mod tests {
 
     #[test]
     fn youtube_verification_config_uses_pkce_and_the_minimum_scope() {
-        let config = youtube_provider_config("public-client-id".to_string());
+        let config =
+            youtube_provider_config("public-client-id".to_string(), "client-secret".to_string());
 
         assert!(config.pkce);
-        assert_eq!(config.client_secret, None);
+        // Google's Desktop client type rejects a PKCE-only token exchange with
+        // `client_secret is missing` AFTER consent, so the secret rides along
+        // WITH PKCE. Asserting None here previously enshrined a flow that
+        // could never complete against Google.
+        assert_eq!(config.client_secret.as_deref(), Some("client-secret"));
         assert_eq!(
             config.scopes,
             vec!["https://www.googleapis.com/auth/youtube.force-ssl"]

--- a/scripts/lib/provider-readiness.mjs
+++ b/scripts/lib/provider-readiness.mjs
@@ -21,8 +21,12 @@ export const PROVIDERS = [
     pauseReason: YOUTUBE_OAUTH_PAUSED_REASON,
     enableVars: ['VIDEORC_ENABLE_YOUTUBE_OAUTH', 'VIDEORC_BUNDLED_YOUTUBE_OAUTH_ENABLED'],
     clientIdVars: ['VIDEORC_YOUTUBE_CLIENT_ID', 'VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID'],
-    secretVars: ['VIDEORC_YOUTUBE_CLIENT_SECRET'],
-    secretRequired: false,
+    // Google's Desktop client type REQUIRES client_secret in the token
+    // exchange even with PKCE: omitting it fails AFTER consent with
+    // `invalid_request: client_secret is missing.` The bundled build-time
+    // value is the shipping source, so it counts toward readiness.
+    secretVars: ['VIDEORC_YOUTUBE_CLIENT_SECRET', 'VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET'],
+    secretRequired: true,
     accountChecks: [
       {
         label: 'verified Live-enabled channel available',

--- a/scripts/lib/provider-readiness.test.mjs
+++ b/scripts/lib/provider-readiness.test.mjs
@@ -12,7 +12,10 @@ import {
 function completeEnv(overrides = {}) {
   return {
     VIDEORC_ENABLE_YOUTUBE_OAUTH: '1',
-    VIDEORC_YOUTUBE_CLIENT_ID: 'youtube-client-secret-value',
+    VIDEORC_YOUTUBE_CLIENT_ID: 'youtube-client-id-value',
+    // Google's Desktop client rejects a secretless token exchange, so a
+    // complete YouTube setup now carries the secret too.
+    VIDEORC_YOUTUBE_CLIENT_SECRET: 'youtube-client-secret-value',
     VIDEORC_SMOKE_YOUTUBE_CHANNEL_READY: '1',
     VIDEORC_BUNDLED_TWITCH_CLIENT_ID: 'twitch-bundled-client-value',
     VIDEORC_TWITCH_CLIENT_SECRET: 'twitch-secret-value',


### PR DESCRIPTION
Connecting YouTube could **never** succeed. The consent screen appears, the user grants access, and the token exchange then fails silently — no account row, no error surfaced.

## Root cause

Google's **Desktop app** client type requires `client_secret` in the token exchange *even with PKCE*. But [`youtube_provider_config`](crates/videorc-backend/src/oauth.rs) hardcoded `client_secret: None`, and `provider_config()` only ever read `VIDEORC_YOUTUBE_CLIENT_ID` — the secret env var was never consulted.

Verified directly against Google's token endpoint with our own client:

```
POST https://oauth2.googleapis.com/token   (client_id + code + PKCE verifier, no secret)
→ {"error":"invalid_request","error_description":"client_secret is missing."}
```

The authorization request only needs the client ID, which is why the consent screen rendered fine and the failure landed *after* the user granted — the worst place for it.

## Why it went unnoticed

1. YouTube OAuth is switched off in public builds (paused pending Google verification), so no user could reach it.
2. `VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET` is baked into every release build but was referenced **nowhere in the Rust source** — the flow had drifted to PKCE-only while the pipeline kept shipping the secret.
3. The test `youtube_verification_config_uses_pkce_and_the_minimum_scope` **asserted `client_secret == None`**, so the suite actively enshrined a configuration that cannot complete against Google.

## The fix

- Resolve the secret like every other credential: runtime `VIDEORC_YOUTUBE_CLIENT_SECRET` → build-time `VIDEORC_BUNDLED_YOUTUBE_CLIENT_SECRET`, passed into the config with **PKCE still on** (Google accepts both together). For an installed app this value isn't a true secret — it ships in the binary — and PKCE is what actually protects the exchange.
- Test now asserts the secret is **present** alongside PKCE, with a comment explaining why the old assertion was wrong.
- **Release-gate hole closed:** `provider-readiness` listed only the runtime secret var and marked the YouTube secret optional, so a bundled build with OAuth enabled and no secret reported "ready". It now accepts the bundled var and requires it — this combination can no longer pass a gate.

## Why this matters now

Found while proving the 0.9.12 client-secret rotation end to end. Without it, flipping `VIDEORC_BUNDLED_YOUTUBE_OAUTH_ENABLED` after Google approves verification would have shipped an **approved but non-functional** YouTube integration to every user.

Related gap for the same flip (not in this PR, worth tracking): `VIDEORC_BUNDLED_YOUTUBE_CLIENT_ID` is also absent from the release env, so the client ID needs adding there before enabling.

## Verification

- `cargo test -p videorc-backend`: **1466 green**; clippy `-D warnings`; fmt.
- `pnpm test:scripts`: **1014 green** (includes the updated readiness fixture).
- `pnpm format:check` green.
- Real-world proof is the connect flow itself, which the author will re-run against the live client once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube sign-in reliability by supporting the required client secret during OAuth authorization and token exchange.
  * Updated provider readiness checks to recognize bundled YouTube credentials.
  * Added validation covering secure OAuth flows that combine PKCE with the client secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->