### PR TITLE
fix(gates): reject placeholder credentials instead of reporting them ready

### DIFF
--- a/scripts/lib/provider-readiness.mjs
+++ b/scripts/lib/provider-readiness.mjs
@@ -296,6 +296,9 @@ function readinessForProvider(provider, env, callbackCoverage) {
   if (clientId.source === 'missing') {
     missing.push(`one of ${provider.clientIdVars.join(', ')}`)
   }
+  if (clientId.source === 'placeholder') {
+    missing.push(`${clientId.envVar} still holds template text, not a real client ID`)
+  }
   if (clientSecret.required && clientSecret.source === 'missing') {
     missing.push(provider.secretVars.join(' or '))
   }
@@ -330,12 +333,41 @@ function evaluateCallbackCoverage(env) {
   }
 }
 
+// A credential file can be filled with template text and still look
+// "configured": Videorc shipped every build with
+// VIDEORC_BUNDLED_TWITCH_CLIENT_ID=paste-your-client-id-here, so Twitch OAuth
+// answered "invalid client" for every user while readiness reported ready.
+// Non-empty is not the same as real.
+const PLACEHOLDER_CREDENTIAL_PATTERNS = [
+  /paste/i,
+  /your[-_ ]?(client|api|app)/i,
+  /(client|api|app)[-_ ]?id[-_ ]?here/i,
+  /^(changeme|change[-_ ]me|todo|tbd|xxx+|placeholder|example|dummy|fake|test)$/i,
+  /<[^>]+>/,
+  /\.\.\./
+]
+
+export function isPlaceholderCredential(value) {
+  const trimmed = stringValue(value)
+  if (!trimmed) {
+    return false
+  }
+  return PLACEHOLDER_CREDENTIAL_PATTERNS.some((pattern) => pattern.test(trimmed))
+}
+
 function credentialPresence(names, env) {
   const present = names.find((name) => stringValue(env[name]))
   if (!present) {
     return {
       source: 'missing',
       envVar: null,
+      envVars: names
+    }
+  }
+  if (isPlaceholderCredential(env[present])) {
+    return {
+      source: 'placeholder',
+      envVar: present,
       envVars: names
     }
   }
@@ -370,6 +402,9 @@ function credentialSourceLabel(credential) {
   }
   if (credential.source === 'missing') {
     return `missing (expected ${credential.envVars.join(' or ')})`
+  }
+  if (credential.source === 'placeholder') {
+    return `PLACEHOLDER in ${credential.envVar} — replace with the real client ID`
   }
   return `${credential.source} (${credential.envVar})`
 }

--- a/scripts/lib/provider-readiness.test.mjs
+++ b/scripts/lib/provider-readiness.test.mjs
@@ -102,4 +102,37 @@ describe('provider readiness evidence', () => {
     assert.match(markdown, /VIDEORC_SMOKE_X_LIVESTREAM_OAUTH1_READY=1/)
     assert.match(markdown, /VIDEORC_SMOKE_X_NATIVE_LIVE_ACCESS=1/)
   })
+
+  it('rejects template text in a credential instead of reading it as configured', () => {
+    // Videorc shipped every build with
+    // VIDEORC_BUNDLED_TWITCH_CLIENT_ID=paste-your-client-id-here; Twitch
+    // answered "invalid client" for every user while readiness said ready.
+    const result = evaluateProviderReadiness({
+      env: completeEnv({ VIDEORC_BUNDLED_TWITCH_CLIENT_ID: 'paste-your-client-id-here' }),
+      generatedAt: '2026-06-13T00:00:00Z',
+      commit: 'abc123'
+    })
+
+    const twitch = result.providers.find((provider) => provider.label === 'Twitch')
+    assert.equal(twitch.ready, false)
+    assert.equal(twitch.clientId.source, 'placeholder')
+    assert.match(twitch.missing.join(' '), /template text/)
+    assert.equal(result.ready, false)
+
+    const consoleReport = formatProviderReadinessConsole(result)
+    assert.match(consoleReport, /PLACEHOLDER/)
+    // Never echo the value itself, only the variable name.
+    assert.doesNotMatch(consoleReport, /paste-your-client-id-here/)
+  })
+
+  it('accepts a real-looking client ID', () => {
+    const result = evaluateProviderReadiness({
+      env: completeEnv({ VIDEORC_BUNDLED_TWITCH_CLIENT_ID: 'h0bkly86iw8hc6zrljio6ay86ccv3d' }),
+      generatedAt: '2026-06-13T00:00:00Z',
+      commit: 'abc123'
+    })
+    const twitch = result.providers.find((provider) => provider.label === 'Twitch')
+    assert.equal(twitch.clientId.source, 'bundled')
+    assert.equal(twitch.ready, true)
+  })
 })


### PR DESCRIPTION
Every Videorc release has shipped with this in the release env:

```
VIDEORC_BUNDLED_TWITCH_CLIENT_ID=paste-your-client-id-here
```

The template was never filled in, so every build was compiled with that literal string as its Twitch client ID. Twitch answers `{"status":400,"message":"invalid client"}` for every user who tries to connect — **Twitch OAuth has been live and non-functional in shipped builds since it was written**, which matches the long-standing "Twitch connect = blocking owner action" note and the fact that no Twitch account has ever appeared in a local DB.

## Why no gate caught it

`credentialPresence()` asked only whether the variable was **non-empty**. Template text is non-empty, so readiness reported Twitch as `bundled` and `ready`.

That's the same failure family as the YouTube credential gap closed in #182: a gate that reports "ready" for a configuration that cannot possibly work. Fixing the one credential without fixing the gate would leave the next placeholder free to ship.

## The fix

- `credentialPresence()` classifies template-looking values as a distinct **`placeholder`** source.
- Readiness **fails** with a message naming the offending variable — never its value.
- The console report prints `PLACEHOLDER in VIDEORC_BUNDLED_… — replace with the real client ID` instead of a reassuring `bundled (…)`.
- Patterns cover `paste…`, `your-client…`, `…-id-here`, `changeme` / `todo` / `tbd` / `xxx` / `placeholder` / `example` / `dummy` / `fake` / `test`, `<angle brackets>`, and `...`.

Two tests: a placeholder fails readiness and prints `PLACEHOLDER` **without echoing the value**; a real-looking client ID still reads as `bundled` and ready.

## Not a code bug in Twitch OAuth

The Twitch app is registered correctly — dev.twitch.tv shows **Client Type: Public** with redirect URLs `localhost:{17995,27995,37995}/oauth/callback`, so the existing `client_secret: None` + `pkce: false` config matches the registration. The credential was simply never set. The real client ID has been put into the release env locally; a rebuild plus a by-eye connect confirms the flow.

## Verification

`pnpm test:scripts` **1016 green**, `pnpm format:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider readiness checks to recognize placeholder client IDs as unconfigured credentials.
  - Providers using template values are now correctly reported as unavailable.
  - Console output now clearly explains that placeholder credentials must be replaced.
  - Valid, properly configured client IDs continue to be accepted.
- **Tests**
  - Added coverage for placeholder detection, readiness failures, credential classification, and successful validation of real client IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->