### PR TITLE
release: 0.9.48-beta.1 — Twitch connect fixed, placeholder-credential gate

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.48-beta.1.md
+++ b/changelog/0.9.48-beta.1.md
@@ -1,0 +1,26 @@
+---
+version: 0.9.48-beta.1
+date: 2026-08-09
+channel: beta
+platforms:
+  - macos
+title: Connecting Twitch works again
+summary: Connecting a Twitch account failed for everyone because Videorc was built with a placeholder credential instead of the real one — that is fixed, and a new release check makes it impossible to ship that mistake again.
+highlights:
+  - Connecting Twitch works again — every previous build was compiled with a placeholder credential, so Twitch always answered "invalid client".
+  - Releases now refuse to build when a credential is still template text, so a provider can never ship looking configured but broken.
+  - Groundwork for native YouTube connection: the sign-in exchange with Google was missing a required field and could never complete.
+---
+
+Connecting a Twitch account has never actually worked in a released build.
+Videorc was compiled with placeholder text where the real Twitch credential
+should have been, so Twitch rejected every sign-in attempt. The credential is
+now correct, and the release process refuses to build if any provider
+credential is still template text — the check that would have caught this on
+day one.
+
+While tracking that down we found the same class of problem waiting in the
+YouTube sign-in: the token exchange with Google was missing a field it
+requires, so it could never have completed. That is fixed too. Native YouTube
+connection stays switched off until Google finishes verifying the app; use
+Manual RTMP for YouTube in the meantime.


### PR DESCRIPTION
Version bump + changelog for 0.9.48-beta.1.

Ships the two credential fixes from this session:
- **#183** — Twitch connect works again (every prior build compiled with `paste-your-client-id-here`), plus the readiness gate that rejects template text.
- **#182** — the YouTube token exchange was missing `client_secret` and could never complete. YouTube OAuth stays off pending Google verification, so this is groundwork.

`pnpm changelog:check`: 50 entries valid, latest 0.9.48-beta.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored Twitch connections using the correct credential.
  * Fixed YouTube sign-in token exchange.
  * Added validation to reject template credentials during release checks.

* **Documentation**
  * Added macOS beta release notes for version 0.9.48.
  * Noted that native YouTube connections remain unavailable pending app verification; Manual RTMP is available as an interim option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->