### PR TITLE
release: 0.9.49-beta.1 — Twitch device code flow + 0.9.48 correction

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.48",
+  "version": "0.9.49",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.49-beta.1.md
+++ b/changelog/0.9.49-beta.1.md
@@ -1,0 +1,28 @@
+---
+version: 0.9.49-beta.1
+date: 2026-08-09
+channel: beta
+platforms:
+  - macos
+title: Twitch sign-in rebuilt on the flow Twitch actually supports
+summary: Connecting Twitch was still failing after 0.9.48 — the credential fix was real but incomplete, because Twitch rejects the sign-in method Videorc was using. Sign-in is rebuilt on Twitch's device authorization flow.
+highlights:
+  - Twitch sign-in now uses Twitch's device authorization flow, the method Twitch supports for desktop apps that hold no secret.
+  - Correction to 0.9.48 — that release said Twitch connect was fixed. It was not; the credential it fixed was necessary but not sufficient.
+  - When a sign-in does fail, the browser page now tells you why instead of showing a bare failure.
+---
+
+**Correction to 0.9.48.** That release said "Connecting Twitch works again".
+It did not. The credential it fixed was genuinely broken — Videorc had been
+built with placeholder text instead of a real Twitch credential — but fixing
+it only moved the failure later: sign-in still failed right after you
+approved it on Twitch.
+
+The reason is that Videorc's Twitch app holds no secret, which is correct for
+a desktop app, and Twitch refuses that kind of app for the sign-in method
+Videorc was using. Sign-in is now rebuilt on Twitch's device authorization
+flow, which is the method Twitch supports for exactly this case. What you see
+is unchanged: click Connect, approve in the browser, come back.
+
+If a sign-in does fail, the browser page now states the reason instead of
+just saying it failed.


### PR DESCRIPTION
Version bump + changelog for 0.9.49-beta.1.

Ships **#185** — Twitch sign-in rebuilt on Twitch's device authorization flow, the method Twitch supports for desktop apps that hold no client secret.

The changelog **explicitly corrects 0.9.48**, which claimed "Connecting Twitch works again". The credential 0.9.48 fixed was genuinely broken (placeholder text), but fixing it only moved the failure later — sign-in still failed immediately after the user approved.

`pnpm changelog:check`: 51 entries valid, latest 0.9.49-beta.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Twitch sign-in reliability using an updated authorization flow.
  * Sign-in failures now display a clear explanation of what went wrong.

* **Changelog**
  * Added release notes for version 0.9.49-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->