### PR TITLE
fix(oauth): let a Twitch device grant complete without an authorization code

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -4515,6 +4515,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         setActiveScreen(payload as StreamScreen | null)
       }),
       nextClient.on('platformAccounts.changed', (payload) => {
+        // The authorization link toast is persistent; retire it as soon
+        // as the connection resolves.
+        toast.dismiss('oauth-authorization-link')
         bootstrapGuard.mark('platformAccounts')
         setPlatformAccounts(payload as PlatformAccount[])
       }),
@@ -7757,10 +7760,28 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           params
         )
         await window.videorc.openOAuthUrl(result.authUrl)
+        // Auto-open uses the DEFAULT browser, which is often NOT the browser
+        // the user is signed into the platform with. Keep the link copyable so
+        // it can be pasted into the right one. Stays until dismissed: device
+        // authorizations (Twitch) can take a while, and a 4-second toast is
+        // gone long before the user has switched browsers and signed in.
         // Callback-URL registration hints live in docs/distribution.md — they
         // are developer-portal instructions, not something an end user can act
         // on, so the toast stays quiet.
-        toast.success('OAuth browser opened.')
+        toast.success('Approve the connection in your browser', {
+          id: 'oauth-authorization-link',
+          description: 'Signed in on a different browser? Copy the link and open it there instead.',
+          duration: Number.POSITIVE_INFINITY,
+          action: {
+            label: 'Copy link',
+            onClick: () => {
+              void navigator.clipboard
+                .writeText(result.authUrl)
+                .then(() => toast.success('Authorization link copied.'))
+                .catch(() => toast.error('Could not copy the link.'))
+            }
+          }
+        })
       } catch (error) {
         reportError(error)
       }

--- a/crates/videorc-backend/src/oauth.rs
+++ b/crates/videorc-backend/src/oauth.rs
@@ -217,10 +217,18 @@ enum PendingOAuthWork {
 
 impl PendingOAuthWork {
     fn is_code_less_resumable(&self) -> bool {
-        matches!(
-            self,
-            Self::ProviderExchangeStarted(_) | Self::ProviderToken(_) | Self::AccountStorage { .. }
-        )
+        match self {
+            Self::ProviderExchangeStarted(_)
+            | Self::ProviderToken(_)
+            | Self::AccountStorage { .. } => true,
+            // A device grant (Twitch) NEVER has an authorization code: the
+            // poller trades the device code for tokens instead. Without this,
+            // completion is rejected as "no code" before it ever polls — which
+            // is exactly how the flow silently did nothing after the user
+            // approved in the browser.
+            Self::ProviderExchange(exchange) => exchange.is_device_grant(),
+            Self::Generic => false,
+        }
     }
 
     fn is_unadvanced(&self) -> bool {
@@ -5011,6 +5019,25 @@ mod tests {
             device_code: device_code.map(str::to_string),
             device_interval_seconds: Some(5),
         }
+    }
+
+    #[test]
+    fn a_device_grant_completes_without_an_authorization_code() {
+        // The bug this pins: completion computed
+        //   failed = !code_less_resume && (error || !code_present)
+        // and a device grant has NO code by design, so the flow was rejected
+        // before it ever polled — the user approved in the browser and the app
+        // did nothing. A device grant must be code-less resumable.
+        let device = PendingOAuthWork::ProviderExchange(device_exchange_fixture(Some("dc")));
+        assert!(
+            device.is_code_less_resumable(),
+            "a device grant has no authorization code and must still complete"
+        );
+
+        // Redirect providers must keep requiring their code.
+        let redirect = PendingOAuthWork::ProviderExchange(device_exchange_fixture(None));
+        assert!(!redirect.is_code_less_resumable());
+        assert!(!PendingOAuthWork::Generic.is_code_less_resumable());
     }
 
     #[test]


### PR DESCRIPTION
0.9.49 shipped the device code flow and **connecting Twitch still did nothing** — the browser reached Twitch, the user approved, and the app never picked it up. Reported from real use, which is exactly what the by-eye step exists for.

## Cause

One predicate in `complete_with_pending`:

```rust
let failed = !code_less_resume && (params.error.is_some() || !code_present);
```

A device grant has **no authorization code by design** — the poller trades the *device* code for tokens instead. But `is_code_less_resumable()` only allowed already-advanced work (`ProviderExchangeStarted` / `ProviderToken` / `AccountStorage`). A fresh `ProviderExchange` carrying a device code was rejected as "no code" **before it ever polled**, so the spawned completion task failed instantly and silently.

`ProviderExchange` is now code-less resumable exactly when it's a device grant. Redirect providers still require their code; `Generic` still doesn't resume.

## Also: copy the authorization link

From real use — connect auto-opens the **default** browser, which is often not where the user is signed in (Zen as default, Twitch session in Chrome). The authorization toast now has a **Copy link** action and **stays until dismissed**: a device authorization can take a while, and a few-second toast is long gone by the time someone has switched browsers and signed in. It's retired automatically when the connection resolves.

This helps **every** provider, not just Twitch.

## Note on where this landed

Built in a clean worktree off `origin/main`. A concurrent session had taken the shared checkout onto another branch and swept an earlier copy of this fix into its own commit (`36a15d9a` on `codex/fix-deep-audit`), which is not on `main` — so this PR is the one that gets it there. If that branch also lands, the duplicate is trivially reconciled.

## Verification

- New tests: a device grant is code-less resumable; a redirect exchange is not
- cargo **1475** green, clippy `-D warnings`, fmt
- desktop **1325**, scripts **1016**, typecheck, format:check

Still needs the by-eye connect (account row, stream key, chat read, chat **send**, disconnect) before the next release claims Twitch works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth connection notifications now remain visible until the connection is completed.
  * Authorization URLs can be copied directly from the notification, with clear success or failure feedback.
  * Notifications automatically close once the account connection is detected.

* **Bug Fixes**
  * Improved Twitch device-based authorization recovery, helping connections resume correctly without requiring an authorization code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->