### PR TITLE
release: 0.9.50-beta.1 — Twitch connect completes after approval

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.49",
+  "version": "0.9.50",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.50-beta.1.md
+++ b/changelog/0.9.50-beta.1.md
@@ -1,0 +1,25 @@
+---
+version: 0.9.50-beta.1
+date: 2026-08-09
+channel: beta
+platforms:
+  - macos
+title: Twitch connect now finishes after you approve it
+summary: In 0.9.49 the Twitch sign-in reached Twitch and then stopped — approving it in the browser did nothing. The app now completes the connection, and you can copy the authorization link to open it in whichever browser you are signed in on.
+highlights:
+  - Approving the Twitch connection in your browser now actually completes it — 0.9.49 stopped one step short.
+  - New Copy link button on the sign-in prompt, for when your default browser is not the one you are signed into the platform with.
+  - The sign-in prompt now stays until the connection finishes instead of disappearing after a few seconds.
+---
+
+0.9.49 rebuilt Twitch sign-in on Twitch's device authorization flow, but it
+stopped one step short: the browser opened, you approved, and nothing came
+back. The app was waiting for a piece of information this kind of sign-in
+never produces, so it gave up before asking Twitch for your tokens. It now
+completes the connection.
+
+Sign-in also opens in your default browser, which is often not the browser
+you are actually signed into Twitch, YouTube or X on. The prompt now has a
+Copy link button so you can open it wherever you are signed in, and it stays
+on screen until the connection finishes rather than vanishing while you are
+still switching browsers.


### PR DESCRIPTION
Version bump + changelog for 0.9.50-beta.1.

Ships **#187**: 0.9.49 shipped the device code flow but completion was rejected as "no code" before it ever polled, so approving in the browser did nothing. Also adds the **Copy link** action for users whose default browser isn't where they're signed in.

`pnpm changelog:check`: 52 entries valid, latest 0.9.50-beta.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Copy link** action for easier sharing.
  * Improved sign-in flow with a prompt that remains visible until the connection is complete.

* **Bug Fixes**
  * Fixed Twitch device authorization on macOS.

* **Release**
  * Updated the desktop app to version **0.9.50**.
  * Added release notes for the **0.9.50 beta**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->