### PR TITLE
fix(windows): re-pin FFmpeg to a build upstream keeps

### DIFF
--- a/scripts/fetch-ffmpeg-windows.mjs
+++ b/scripts/fetch-ffmpeg-windows.mjs
@@ -21,6 +21,8 @@ import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
 
+import { assessFfmpegWindowsPin, autobuildDurability } from './lib/ffmpeg-windows-pin.mjs'
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const pinPath = join(repoRoot, 'vendor', 'ffmpeg', 'windows-pin.json')
 const downloadPath = join(repoRoot, 'vendor', 'ffmpeg', '_build', 'windows-download.zip')
@@ -49,11 +51,9 @@ async function sha256Of(path) {
 }
 
 const pin = JSON.parse(await readFile(pinPath, 'utf8'))
-if (!pin.url || !pin.sha256) {
-  fail(`${pinPath} must contain { url, sha256 }`)
-}
-if (!/lgpl/.test(pin.url)) {
-  fail(`pinned URL is not an LGPL build: ${pin.url} (LGPL-only is the repo's ffmpeg policy)`)
+const assessment = assessFfmpegWindowsPin(pin)
+if (!assessment.ok) {
+  fail(`${pinPath} is unusable:\n  - ${assessment.problems.join('\n  - ')}`)
 }
 
 const ffmpegExe = join(outputDir, 'bin', 'ffmpeg.exe')
@@ -84,7 +84,13 @@ if (!haveZip) {
   await mkdir(dirname(downloadPath), { recursive: true })
   const response = await fetch(pin.url, { redirect: 'follow' })
   if (!response.ok || !response.body) {
-    fail(`download failed: HTTP ${response.status} for ${pin.url}`)
+    // A 404 on a BtbN autobuild almost always means upstream pruned the
+    // release. Say so, rather than leaving the next reader to rediscover it.
+    const pruned =
+      response.status === 404 && autobuildDurability(pin.url)
+        ? '\nThis release looks pruned upstream. Re-pin the last autobuild of a recent month and update the sha256.'
+        : ''
+    fail(`download failed: HTTP ${response.status} for ${pin.url}${pruned}`)
   }
   await pipeline(Readable.fromWeb(response.body), createWriteStream(downloadPath))
 }

--- a/scripts/lib/ffmpeg-windows-pin.mjs
+++ b/scripts/lib/ffmpeg-windows-pin.mjs
@@ -1,0 +1,69 @@
+// Validity rules for vendor/ffmpeg/windows-pin.json, the committed pin the
+// Windows bundle's FFmpeg is fetched from.
+//
+// BtbN/FFmpeg-Builds PRUNES its autobuild releases. Roughly the last two weeks
+// of daily builds survive, plus the last build of each month, which is kept for
+// years. A mid-month daily therefore works fine until it silently starts
+// 404ing — which is exactly how every Windows installer build broke in August
+// 2026, four minutes into each run, once the pinned 2026-07-23 build aged out.
+// Pin month-end autobuilds only; they are the durable ones.
+//
+// A pin that points somewhere other than a BtbN autobuild (a mirror we host) is
+// durable by construction, so the month-end rule does not apply to it. The
+// LGPL-only rule always does: it mirrors scripts/build-ffmpeg-macos.sh, and the
+// checksum is what actually authenticates the bytes.
+
+const AUTOBUILD_DOWNLOAD =
+  /^https:\/\/github\.com\/BtbN\/FFmpeg-Builds\/releases\/download\/autobuild-(\d{4})-(\d{2})-(\d{2})-\d{2}-\d{2}\//
+
+const SHA256 = /^[0-9a-f]{64}$/
+
+/** Last calendar day of the given 1-indexed month (UTC, leap-year aware). */
+export function lastDayOfMonth(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
+}
+
+/**
+ * True when the URL is a BtbN autobuild that upstream retains long-term.
+ * Non-BtbN URLs are not subject to the rule and report `null`.
+ */
+export function autobuildDurability(url) {
+  const match = AUTOBUILD_DOWNLOAD.exec(String(url ?? ''))
+  if (!match) {
+    return null
+  }
+  const [, year, month, day] = match.map(Number)
+  return {
+    tagDate: `${match[1]}-${match[2]}-${match[3]}`,
+    durable: day === lastDayOfMonth(year, month)
+  }
+}
+
+/** Collect every reason the pin is unusable. Empty problems means it is fine. */
+export function assessFfmpegWindowsPin(pin) {
+  const problems = []
+  const url = pin?.url
+  const sha256 = pin?.sha256
+
+  if (!url || typeof url !== 'string') {
+    problems.push('missing "url"')
+  }
+  if (!sha256 || typeof sha256 !== 'string') {
+    problems.push('missing "sha256"')
+  } else if (!SHA256.test(sha256)) {
+    problems.push(`"sha256" must be 64 lowercase hex characters, got "${sha256}"`)
+  }
+  if (typeof url === 'string' && url && !/lgpl/.test(url)) {
+    problems.push(`not an LGPL build: ${url} (LGPL-only is the repo's ffmpeg policy)`)
+  }
+
+  const durability = autobuildDurability(url)
+  if (durability && !durability.durable) {
+    problems.push(
+      `autobuild-${durability.tagDate} is a mid-month daily build, which BtbN deletes after ~2 weeks. ` +
+        'Pin the last autobuild of a month instead — those are retained for years.'
+    )
+  }
+
+  return { ok: problems.length === 0, problems }
+}

--- a/scripts/lib/ffmpeg-windows-pin.test.mjs
+++ b/scripts/lib/ffmpeg-windows-pin.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  assessFfmpegWindowsPin,
+  autobuildDurability,
+  lastDayOfMonth
+} from './ffmpeg-windows-pin.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+const DURABLE_URL =
+  'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-31-14-10/ffmpeg-n8.1.2-34-g9b6c8969e0-win64-lgpl-8.1.zip'
+const SHA = '089e4169e93b2b3f3acbfced3c0704d24276a225641bdda04d796d28b07a2a38'
+
+describe('lastDayOfMonth', () => {
+  it('handles 30/31-day months and leap Februaries', () => {
+    assert.equal(lastDayOfMonth(2026, 7), 31)
+    assert.equal(lastDayOfMonth(2026, 6), 30)
+    assert.equal(lastDayOfMonth(2026, 2), 28)
+    assert.equal(lastDayOfMonth(2028, 2), 29)
+  })
+})
+
+describe('autobuildDurability', () => {
+  it('accepts a month-end autobuild', () => {
+    assert.deepEqual(autobuildDurability(DURABLE_URL), {
+      tagDate: '2026-07-31',
+      durable: true
+    })
+  })
+
+  it('rejects the mid-month daily that broke the August 2026 Windows build', () => {
+    assert.deepEqual(
+      autobuildDurability(
+        'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-23-14-16/ffmpeg-n8.1.2-30-g45f1910444-win64-lgpl-8.1.zip'
+      ),
+      { tagDate: '2026-07-23', durable: false }
+    )
+  })
+
+  it('does not apply the rule to a non-BtbN URL', () => {
+    assert.equal(autobuildDurability('https://mirror.example.com/ffmpeg-win64-lgpl.zip'), null)
+  })
+})
+
+describe('assessFfmpegWindowsPin', () => {
+  it('passes a well-formed durable pin', () => {
+    assert.deepEqual(assessFfmpegWindowsPin({ url: DURABLE_URL, sha256: SHA }), {
+      ok: true,
+      problems: []
+    })
+  })
+
+  it('reports a prunable pin with the fix in the message', () => {
+    const { ok, problems } = assessFfmpegWindowsPin({
+      url: DURABLE_URL.replace('autobuild-2026-07-31-14-10', 'autobuild-2026-07-23-14-16'),
+      sha256: SHA
+    })
+    assert.equal(ok, false)
+    assert.match(problems.join('\n'), /mid-month daily build/)
+    assert.match(problems.join('\n'), /last autobuild of a month/)
+  })
+
+  it('rejects a non-LGPL build, keeping the repo ffmpeg licence policy', () => {
+    const { ok, problems } = assessFfmpegWindowsPin({
+      url: DURABLE_URL.replace('lgpl', 'gpl'),
+      sha256: SHA
+    })
+    assert.equal(ok, false)
+    assert.match(problems.join('\n'), /LGPL-only/)
+  })
+
+  it('rejects missing and malformed checksums', () => {
+    assert.match(assessFfmpegWindowsPin({ url: DURABLE_URL }).problems.join(), /missing "sha256"/)
+    assert.match(
+      assessFfmpegWindowsPin({ url: DURABLE_URL, sha256: 'ABC123' }).problems.join(),
+      /64 lowercase hex/
+    )
+    assert.match(assessFfmpegWindowsPin({ sha256: SHA }).problems.join(), /missing "url"/)
+  })
+})
+
+describe('the committed pin', () => {
+  it('is durable, so a Windows release cannot be blocked by upstream pruning', async () => {
+    const pin = JSON.parse(
+      await readFile(join(repoRoot, 'vendor', 'ffmpeg', 'windows-pin.json'), 'utf8')
+    )
+    const { ok, problems } = assessFfmpegWindowsPin(pin)
+    assert.equal(ok, true, problems.join('\n'))
+  })
+})

--- a/vendor/ffmpeg/windows-pin.json
+++ b/vendor/ffmpeg/windows-pin.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-23-14-16/ffmpeg-n8.1.2-30-g45f1910444-win64-lgpl-8.1.zip",
-  "sha256": "0c6dc759eb1c70804ca04e11d83c583a6b03ae0630474f862e97400c715c6376"
+  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-31-14-10/ffmpeg-n8.1.2-34-g9b6c8969e0-win64-lgpl-8.1.zip",
+  "sha256": "089e4169e93b2b3f3acbfced3c0704d24276a225641bdda04d796d28b07a2a38"
 }


### PR DESCRIPTION
## What broke

Every Windows build has failed since at least 2026-08-09 — including `windows.yml`'s installer job and, critically, the Windows Alpha candidate. It is not runner flakiness:

```
fetch-ffmpeg-windows: download failed: HTTP 404 for .../autobuild-2026-07-23-14-16/...
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
[ELIFECYCLE] Command failed with exit code 3221226505
```

The libuv assertion is just how Node dies on Windows after the failed download. The real cause is that BtbN **pruned the pinned release**.

## Why it will happen again without the guard

BtbN/FFmpeg-Builds keeps ~2 weeks of daily autobuilds, **plus the last build of every month** — those persist for years (verified: `autobuild-2026-06-30` → 200, `autobuild-2026-07-23` → 404). The old pin was a mid-month daily, so it had a two-week shelf life from the day it was chosen.

## Changes

- Re-pin to `autobuild-2026-07-31` (month-end, same `n8.1.2` line, `-34` vs `-30`), checksum recomputed from the downloaded bytes.
- New `scripts/lib/ffmpeg-windows-pin.mjs` holds the pin rules — LGPL-only, well-formed sha256, and month-end-if-BtbN. A self-hosted mirror URL is exempt from the retention rule since it is durable by construction.
- `fetch-ffmpeg-windows.mjs` uses the shared assessor instead of its own inline checks, and a 404 on an autobuild URL now names pruning as the likely cause.
- A test asserts the **committed** pin is durable, so `pnpm test:scripts` fails the PR — and the Alpha workflow's gate job — before a fragile pin can reach a release build.

## Verification

- `pnpm test:scripts` — 1025 pass, 0 fail (+9)
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- `node scripts/fetch-ffmpeg-windows.mjs --force` installs ffmpeg.exe/ffprobe.exe from the new pin
- Reverting the pin to the pruned URL fails with the fix in the message

Windows CI on this PR is the real end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows FFmpeg download validation and error messages.
  * Downloads now provide guidance when a release is no longer available or requires updating.
  * Enforced supported LGPL builds and valid checksums.

* **Maintenance**
  * Updated the bundled Windows FFmpeg release to a durable July 2026 build.
  * Added coverage for release durability, URL compatibility, licensing, and checksum validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->