### PR TITLE
fix(deps): take the js-yaml patch for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
 
 patchedDependencies:
   app-builder-lib@26.8.1: 62b157949e11699c0fdc5983b00c70bf99d8e4defc5d8ecc2c55ddf3c8aa0656
@@ -24,8 +24,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -2711,8 +2711,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5358,7 +5358,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -5465,7 +5465,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -5640,7 +5640,7 @@ snapshots:
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -5719,7 +5719,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -6245,7 +6245,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,9 @@
 packages:
   - apps/*
 overrides:
-  js-yaml: 4.3.0
+  # electron-builder's toolchain pulls js-yaml transitively; 4.3.0 is affected by
+  # GHSA-5p4m-2wfm-xmqj (>=4.0.0 <4.3.1), so hold the whole tree at the patch.
+  js-yaml: 4.3.1
 patchedDependencies:
   app-builder-lib@26.8.1: patches/app-builder-lib@26.8.1.patch
 allowBuilds:


### PR DESCRIPTION
`pnpm audit:js` fails on **main** and therefore on every open PR:

```
js-yaml  >=4.0.0 <4.3.1  (patched: >=4.3.1)
Paths: apps__desktop>electron-updater>js-yaml
1 vulnerabilities found — Severity: 1 high
```

`pnpm-workspace.yaml` already overrode js-yaml to `4.3.0` to hold electron-builder's transitive copy at one version. That pinned version is exactly the affected one, so the override was keeping the tree on the vulnerable release. Bumped to the `4.3.1` patch.

Verified: `pnpm audit:js` → "No known vulnerabilities found"; every resolved copy is `js-yaml@4.3.1`; scripts 1016 pass, typecheck/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a dependency to address a known security vulnerability.
  * Pinned the dependency tree to the patched version for improved security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->