### PR TITLE
release: add the 0.9.50-alpha.1 Windows changelog entry

### DIFF
--- a/changelog/0.9.50-alpha.1.md
+++ b/changelog/0.9.50-alpha.1.md
@@ -1,0 +1,23 @@
+---
+version: 0.9.50-alpha.1
+date: 2026-08-10
+channel: alpha
+platforms:
+  - windows
+title: The Windows Alpha is now signed with Videorc's own certificate
+summary: This Alpha installer carries a real Videorc code signature, so Windows names the publisher instead of warning about an unknown one. It is built from the same source as the 0.9.50 macOS release.
+highlights:
+  - The installer and the app are signed, so Windows shows Videorc as the publisher rather than an unknown one.
+  - Built from the same source as the 0.9.50 macOS release, so Windows picks up the recent connection and reliability work.
+  - Recording startup, capture device handling and packaged-runtime cleanup carry the fixes from earlier Alphas.
+---
+
+Until now the Windows Alpha was unsigned, which is why Windows treated the
+installer as coming from an unknown publisher. This build is signed with
+Videorc's own certificate and timestamped, so the publisher shows as Videorc
+and the signature stays valid over time.
+
+Windows is still in Alpha. Livestreaming workflows and broader hardware
+coverage remain under validation, and SmartScreen may still show a warning
+until this new certificate builds reputation. Report issues through the
+Windows Alpha bug template on GitHub.


### PR DESCRIPTION
Windows Alpha changelog entry for the signed candidate. **No package version change** — 0.9.50 is already published for macOS as `0.9.50-beta.1`; this is the Windows track of the same numeric version.

Azure and GitHub configuration is now complete:
- Certificate profile `videorc-windows-alpha` (Public Trust) — **Active**
- **Artifact Signing Certificate Profile Signer** assigned to the OIDC service principal, scoped to that profile (Microsoft renamed this role from *Trusted Signing…*)
- All 10 environment variables set, including `VIDEORC_WINDOWS_PUBLISHER_NAME = Uros Miric` (the certificate's SimpleName)
- All 6 R2 credentials set at environment scope

Claims are held to what the physical acceptance pass can prove — signature, publisher and timestamp. No streaming or Stream Deck claims, and no YouTube claim since that flow is still gated behind Google approval.

`pnpm changelog:check`: 53 entries valid.

⚠️ Once this merges, **no macOS upload may run** until Windows is publicly promoted — the macOS uploader publishes every committed changelog entry and would disclose the held Windows release early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for the Windows 0.9.50-alpha.1 release.
  * Documented signed and timestamped installer and application binaries.
  * Included known validation and SmartScreen limitations.
  * Recorded inherited recording and runtime fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->