### PR TITLE
fix(windows): let the release Clippy gate match the CI Clippy gate

### DIFF
--- a/.github/workflows/release-windows-alpha.yml
+++ b/.github/workflows/release-windows-alpha.yml
@@ -103,7 +103,13 @@ jobs:
           Invoke-NativeGate 'desktop tests' { pnpm --filter @videorc/desktop test }
           Invoke-NativeGate 'Rustfmt' { cargo fmt --check --all }
           Invoke-NativeGate 'Rust tests' { cargo test -p videorc-backend }
-          Invoke-NativeGate 'Clippy' { cargo clippy -p videorc-backend -- -D warnings }
+          # Same allow list as the windows.yml Clippy gate, and for the same
+          # reason: macOS-only helpers are dead code under cfg(windows), the
+          # known cross-check warning wall (docs/windows-port-plan.md). Without
+          # the allows this gate fails on 92 pre-existing dead-code findings and
+          # no Windows candidate can ever be cut. Burn the wall down, then drop
+          # the allows from BOTH gates together — they must not drift again.
+          Invoke-NativeGate 'Clippy' { cargo clippy -p videorc-backend -- -D warnings -A dead_code -A unused_imports -A unused_variables -A unused_mut }
 
       - name: Build exact unsigned staging payload
         env:


### PR DESCRIPTION
## What happened

The first-ever Windows Alpha candidate dispatch ([run 31397986797](https://github.com/TheOrcDev/videorc/actions/runs/31397986797)) failed in its unprivileged gate job, before signing was attempted:

```
error: could not compile `videorc-backend` (bin "videorc-backend") due to 92 previous errors
Clippy failed with exit code 101.
```

## Why

The two Windows Clippy gates disagreed:

| Workflow | Invocation |
|---|---|
| `windows.yml` (CI, passing on main) | `-D warnings -A dead_code -A unused_imports -A unused_variables -A unused_mut` |
| `release-windows-alpha.yml` (candidate) | `-D warnings` |

`windows.yml` carries a comment explaining the allows: macOS-only helpers are dead code under `cfg(windows)` — the known cross-check warning wall tracked in `docs/windows-port-plan.md`. The release workflow was never updated to match, and the mismatch stayed invisible because candidate dispatch was blocked on Azure signing until today.

**All 92 findings are in the dead-code/unused family** — 137 "never used", 26 "never constructed", 12 "does not need to be mutable", 8 "never read", 4 unused variables, 2 unused imports. Nothing outside what the four allows cover, so no genuine lint is being suppressed.

This is pre-existing: as written, **no Windows candidate could ever be cut**.

## Change

Align the release gate with the CI gate, carrying the same explanation plus a note that the two must be un-allowed together so they cannot drift again.

The alternative — deleting the 92 items — is the real fix the comment calls for, but it is cross-platform surgery with real risk of removing something live on macOS. Worth doing as its own change, not on the day of the first signed Windows release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows alpha release validation to allow select non-critical code warnings while continuing to enforce other warning checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->