### PR TITLE
fix(windows): one shared Authenticode reader for release tooling

### DIFF
--- a/scripts/lib/windows-authenticode.mjs
+++ b/scripts/lib/windows-authenticode.mjs
@@ -1,0 +1,68 @@
+// The one Authenticode signature reader for release tooling.
+//
+// History that mandates a single shared copy: two scripts carried their own
+// powershell.exe-based readers, and BOTH failed the same way on real Azure
+// Trusted Signing artifacts — Get-AuthenticodeSignature errors are
+// non-terminating by default, so a failure left $sig null, the script still
+// exited 0, stderr was discarded, and the operator saw
+// "status must be Valid, got ." with no cause. The release validator was fixed
+// first (#195); the candidate verifier then failed identically during the
+// first pilot promotion because it still had the old copy. Import this;
+// do not write another reader.
+
+import { spawnSync } from 'node:child_process'
+
+// Prefer pwsh: it is what the signing job itself uses to verify publisher and
+// timestamp, so it is the interpreter this repo has actually proven against
+// Azure Trusted Signing signatures. powershell.exe stays as a fallback for
+// hosts without PowerShell 7.
+const SIGNATURE_SHELLS = ['pwsh', 'powershell.exe']
+
+/**
+ * Read { status, publisher, timestampPresent } for a signed PE file.
+ * Throws with per-shell reasons (exit codes and stderr) when no shell can
+ * produce a non-empty status.
+ */
+export function readAuthenticodeSignature(target) {
+  // ErrorActionPreference=Stop matters: without it a failing
+  // Get-AuthenticodeSignature is non-terminating, $sig stays null, the script
+  // still exits 0, and the caller sees an empty status with no reason.
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    '$sig = Get-AuthenticodeSignature -LiteralPath $env:VIDEORC_SIGNATURE_TARGET',
+    'if ($null -eq $sig) { throw "Get-AuthenticodeSignature returned nothing for $env:VIDEORC_SIGNATURE_TARGET" }',
+    '$publisher = if ($sig.SignerCertificate) { $sig.SignerCertificate.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false) } else { $null }',
+    '[pscustomobject]@{ status = [string]$sig.Status; publisher = $publisher; timestampPresent = ($null -ne $sig.TimeStamperCertificate) } | ConvertTo-Json -Compress'
+  ].join('; ')
+
+  const failures = []
+  for (const shell of SIGNATURE_SHELLS) {
+    const result = spawnSync(
+      shell,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, VIDEORC_SIGNATURE_TARGET: target }
+      }
+    )
+    if (result.error?.code === 'ENOENT') {
+      failures.push(`${shell}: not installed`)
+      continue
+    }
+    const stdout = result.stdout?.trim() ?? ''
+    if (result.status === 0 && stdout) {
+      const parsed = JSON.parse(stdout)
+      if (parsed.status) {
+        return parsed
+      }
+      failures.push(`${shell}: empty signature status`)
+      continue
+    }
+    // Surface the real reason instead of swallowing it.
+    const stderr = result.stderr?.trim() ?? ''
+    failures.push(`${shell}: exit ${result.status}${stderr ? ` — ${stderr}` : ''}`)
+  }
+  throw new Error(
+    `Unable to read the Authenticode signature of ${target}:\n  ${failures.join('\n  ')}`
+  )
+}

--- a/scripts/validate-windows-release-artifact.mjs
+++ b/scripts/validate-windows-release-artifact.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process'
+
+import { readAuthenticodeSignature } from './lib/windows-authenticode.mjs'
 import { existsSync } from 'node:fs'
 import { readFile, stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
@@ -56,57 +58,6 @@ async function main() {
   console.log(formatWindowsReleaseValidationReport(result))
 }
 
-// Prefer pwsh: it is what the signing job itself uses to verify publisher and
-// timestamp, so it is the interpreter this repo has actually proven against
-// Azure Trusted Signing signatures. powershell.exe stays as a fallback for
-// hosts without PowerShell 7.
-const SIGNATURE_SHELLS = ['pwsh', 'powershell.exe']
-
-function readAuthenticodeSignature(target) {
-  // ErrorActionPreference=Stop matters: without it a failing
-  // Get-AuthenticodeSignature is non-terminating, $sig stays null, the script
-  // still exits 0, and the caller sees an empty status with no reason — which
-  // is exactly how this validator once reported `status must be Valid, got .`
-  // after a successful sign.
-  const script = [
-    "$ErrorActionPreference = 'Stop'",
-    '$sig = Get-AuthenticodeSignature -LiteralPath $env:VIDEORC_SIGNATURE_TARGET',
-    'if ($null -eq $sig) { throw "Get-AuthenticodeSignature returned nothing for $env:VIDEORC_SIGNATURE_TARGET" }',
-    '$publisher = if ($sig.SignerCertificate) { $sig.SignerCertificate.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false) } else { $null }',
-    '[pscustomobject]@{ status = [string]$sig.Status; publisher = $publisher; timestampPresent = ($null -ne $sig.TimeStamperCertificate) } | ConvertTo-Json -Compress'
-  ].join('; ')
-
-  const failures = []
-  for (const shell of SIGNATURE_SHELLS) {
-    const result = spawnSync(
-      shell,
-      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
-      {
-        encoding: 'utf8',
-        env: { ...process.env, VIDEORC_SIGNATURE_TARGET: target }
-      }
-    )
-    if (result.error?.code === 'ENOENT') {
-      failures.push(`${shell}: not installed`)
-      continue
-    }
-    const stdout = result.stdout?.trim() ?? ''
-    if (result.status === 0 && stdout) {
-      const parsed = JSON.parse(stdout)
-      if (parsed.status) {
-        return parsed
-      }
-      failures.push(`${shell}: empty signature status`)
-      continue
-    }
-    // Surface the real reason instead of swallowing it.
-    const stderr = result.stderr?.trim() ?? ''
-    failures.push(`${shell}: exit ${result.status}${stderr ? ` — ${stderr}` : ''}`)
-  }
-  throw new Error(
-    `Unable to read the Authenticode signature of ${target}:\n  ${failures.join('\n  ')}`
-  )
-}
 
 function currentCommit() {
   const result = spawnSync('git', ['rev-parse', 'HEAD'], {

--- a/scripts/windows-release-candidate-verify.mjs
+++ b/scripts/windows-release-candidate-verify.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process'
+import { readAuthenticodeSignature } from './lib/windows-authenticode.mjs'
 import { readFile, stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -67,25 +68,6 @@ async function main() {
   console.log(`windows-release-candidate-verify: PASS (${result.candidateIdentity})`)
 }
 
-function readAuthenticodeSignature(installerPath) {
-  const script = [
-    '$sig = Get-AuthenticodeSignature -LiteralPath $env:VIDEORC_SIGNATURE_TARGET',
-    '$publisher = if ($sig.SignerCertificate) { $sig.SignerCertificate.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false) } else { $null }',
-    '[pscustomobject]@{ status = [string]$sig.Status; publisher = $publisher; timestampPresent = ($null -ne $sig.TimeStamperCertificate) } | ConvertTo-Json -Compress'
-  ].join('; ')
-  const result = spawnSync(
-    'powershell.exe',
-    ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
-    {
-      encoding: 'utf8',
-      env: { ...process.env, VIDEORC_SIGNATURE_TARGET: installerPath }
-    }
-  )
-  if (result.status !== 0 || !result.stdout?.trim()) {
-    throw new Error('Get-AuthenticodeSignature failed for the downloaded candidate.')
-  }
-  return JSON.parse(result.stdout.trim())
-}
 
 async function requiredSize(path) {
   const size = (await stat(path)).size


### PR DESCRIPTION
## What failed

The first pilot promotion. The candidate **download worked** (the #198 compression fix held — every artifact, text ones included, came down and hash-verified). Then:

```
windows-release-candidate-verify: FAIL (Candidate Authenticode status must be Valid, got .)
```

That is the exact failure #195 fixed in `validate-windows-release-artifact.mjs` — except `windows-release-candidate-verify.mjs` had its **own copy** of the old `powershell.exe` reader: non-terminating `Get-AuthenticodeSignature` errors, exit 0, stderr discarded, empty status returned as data.

## Change

Extract the proven pwsh-first reader into `scripts/lib/windows-authenticode.mjs` and import it from both release-path scripts. The lib's header documents why a private copy is banned.

Two more inline readers exist in smoke/local tooling (`smoke-windows-obs-side-by-side.mjs`, `lib/windows-local-gates.mjs`) — not on the release path, left for a follow-up rather than expanding this change.

`pnpm test:scripts` 1039 pass 0 fail; typecheck, lint, format clean. Behavior-identical extraction of already-proven code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Windows app-update configuration generation for unsigned builds.
  * Added Windows installer prewarming to improve packaging consistency.
  * Added shared validation for Authenticode signatures and release metadata.

* **Bug Fixes**
  * Improved handling of compressed downloads and missing size headers during release verification.
  * Strengthened credential validation without exposing sensitive values.
  * Improved cleanup and packaging of Windows release candidates.

* **Tests**
  * Expanded coverage for credentials, update configuration, signatures, and release verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->