### PR TITLE
fix: make live monitor switches tolerate slow ScreenCaptureKit starts

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -515,6 +515,18 @@ class StudioBackend {
           compositorStatus: compositorFor(this.currentScene, this.currentLayout, this.revision)
         }
       }
+      case 'scene.source.device.switch': {
+        this.revision += 1
+        return {
+          applied: true,
+          mode: 'warm',
+          intentId: this.revision,
+          sceneRevision: this.revision,
+          presentationProven: true,
+          scene: this.currentScene,
+          compositorStatus: compositorFor(this.currentScene, this.currentLayout, this.revision)
+        }
+      }
       case 'screens.list':
         return []
       case 'screens.active':
@@ -815,6 +827,65 @@ describe('real StudioProvider lifecycle', () => {
     vi.clearAllMocks()
     vi.useRealTimers()
   })
+
+  it('keeps a committed live source selection when output proof catches up late', async () => {
+    const backend = new StudioBackend()
+    backend.recordingState = 'recording'
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => []
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.recording.recording.state === 'recording'
+    )
+    vi.clearAllMocks()
+
+    const sources = {
+      ...latest()!.core.captureConfig.sources,
+      screenId: 'screen:screencapturekit:2',
+      windowId: undefined
+    }
+    await act(async () => {
+      await latest()!.core.switchSourceDeviceLive('capture', sources)
+    })
+
+    expect(latest()?.core.captureConfig.sources).toEqual(sources)
+    expect(toastSpies.error).not.toHaveBeenCalled()
+    expect(toastSpies.warning).toHaveBeenCalledWith(
+      'Switch committed — output catching up.',
+      expect.objectContaining({ id: 'live-source-switch-output-catching-up' })
+    )
+  }, 10_000)
 
   it('builds the exact secret-free shared and split output topology shapes', () => {
     const streamVideo = {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -5918,9 +5918,25 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           background: activeSceneBackground,
           protectedOverlayWindowIds
         })
-        await rememberLiveLayoutCommit(status)
+        let proofError: unknown = null
+        try {
+          await rememberLiveLayoutCommit(status)
+        } catch (error) {
+          proofError = error
+        }
         applyScene(status.scene)
         setCaptureConfig((current) => ({ ...current, sources }))
+        if (proofError) {
+          const detail = proofError instanceof Error ? proofError.message : String(proofError)
+          console.warn(
+            `Source switch committed at revision ${status.sceneRevision}; output proof was not observed. ${detail}`
+          )
+          toast.warning('Switch committed — output catching up.', {
+            id: 'live-source-switch-output-catching-up',
+            description:
+              'The source selection was applied. Videorc will reconcile the output status as it catches up.'
+          })
+        }
         // Success is visible in the preview itself — no confirmation popup
         // for a routine source switch (errors still report below).
       } catch (error) {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -5919,14 +5919,16 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           protectedOverlayWindowIds
         })
         let proofError: unknown = null
+        let proofFailed = false
         try {
           await rememberLiveLayoutCommit(status)
         } catch (error) {
+          proofFailed = true
           proofError = error
         }
         applyScene(status.scene)
         setCaptureConfig((current) => ({ ...current, sources }))
-        if (proofError) {
+        if (proofFailed) {
           const detail = proofError instanceof Error ? proofError.message : String(proofError)
           console.warn(
             `Source switch committed at revision ${status.sceneRevision}; output proof was not observed. ${detail}`

--- a/crates/videorc-backend/Cargo.toml
+++ b/crates/videorc-backend/Cargo.toml
@@ -53,3 +53,6 @@ objc2-video-toolbox = { version = "0.3.2", default-features = false, features = 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.2", features = ["Foundation", "Graphics_Capture", "Graphics_DirectX", "Graphics_DirectX_Direct3D11", "Win32_Foundation", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Direct3D_Fxc", "Win32_Graphics_DirectComposition", "Win32_Graphics_Dxgi", "Win32_Graphics_Dxgi_Common", "Win32_Graphics_Gdi", "Win32_Media_MediaFoundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_LibraryLoader", "Win32_System_Ole", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_WinRT", "Win32_System_WinRT_Direct3D11", "Win32_System_WinRT_Graphics_Capture", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
 windows-core = "0.62.2"
+
+[dev-dependencies]
+tokio = { version = "1.48", features = ["test-util"] }

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use anyhow::{Result, bail};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
 use tokio::time::{Instant, sleep};
 
 use crate::compositor::update_compositor_scene;
@@ -35,7 +36,7 @@ use crate::preview_camera::{
 use crate::preview_screen::{PreviewScreenFrameInfo, preview_screen_latest_frame_info};
 use crate::preview_screen::{
     begin_preview_screen_stop, finish_preview_screen_stop, preview_screen_status,
-    start_preview_screen,
+    start_preview_screen_for_live_switch,
 };
 use crate::protocol::default_layout_settings;
 use crate::protocol::{
@@ -51,13 +52,21 @@ use crate::screen_capture::{
 };
 use crate::state::AppState;
 
-const WARM_SOURCE_START_TIMEOUT: Duration = Duration::from_secs(5);
+const WARM_CAMERA_START_TIMEOUT: Duration = Duration::from_secs(5);
+const WARM_SCREEN_START_TIMEOUT: Duration = Duration::from_secs(15);
 const WARM_SOURCE_POLL: Duration = Duration::from_millis(100);
 const LAYOUT_INTENT_CANCEL_POLL: Duration = Duration::from_millis(25);
 const UNUSED_CAMERA_STOP_GRACE: Duration = Duration::from_secs(1);
 /// A source counts as live only when its newest frame is at most this old — a stalled
 /// capturer must not be swapped onto program output.
 const SOURCE_FRESH_FRAME_MAX_AGE_MS: u64 = 1_500;
+
+fn warm_source_start_timeout(source_label: &str) -> Duration {
+    match source_label {
+        "screen" => WARM_SCREEN_START_TIMEOUT,
+        _ => WARM_CAMERA_START_TIMEOUT,
+    }
+}
 
 fn fallback_video_settings() -> crate::protocol::VideoSettings {
     crate::protocol::VideoSettings {
@@ -438,9 +447,8 @@ async fn apply_scene_transaction(
         }
         ApplyMode::Warm => {
             let missing = missing_sources(needs, live);
-            let deadline = Instant::now() + WARM_SOURCE_START_TIMEOUT;
-            start_missing_sources(state, intent_id, deadline, &params, &missing, action_label)
-                .await?;
+            let deadline =
+                start_missing_sources(state, intent_id, &params, &missing, action_label).await?;
             ensure_layout_intent_current(state, intent_id).await?;
             wait_for_sources_ready(
                 state,
@@ -527,53 +535,98 @@ async fn wait_for_layout_intent_superseded(state: &AppState, intent_id: u64) -> 
 async fn await_layout_source_start<T: Send + 'static>(
     state: &AppState,
     intent_id: u64,
-    deadline: Instant,
+    timeout: Duration,
     source_label: &'static str,
+    restart_ready: Option<oneshot::Receiver<()>>,
     mut source_task: tokio::task::JoinHandle<T>,
-) -> Result<T> {
+) -> Result<(T, Instant)> {
+    if let Some(mut restart_ready) = restart_ready {
+        tokio::select! {
+            result = &mut source_task => {
+                let deadline = Instant::now() + timeout;
+                return result
+                    .map(|value| (value, deadline))
+                    .map_err(|error| anyhow::anyhow!("{source_label} source startup task failed: {error}"));
+            },
+            _ = wait_for_layout_intent_superseded(state, intent_id) => {
+                let latest = reconcile_superseded_source_start(state, source_label, &mut source_task).await;
+                bail!("Layout intent {intent_id} was superseded by newer intent {latest}.")
+            },
+            _ = &mut restart_ready => {}
+        }
+    }
+    let deadline = Instant::now() + timeout;
     tokio::select! {
-        result = &mut source_task => result.map_err(|error| {
-            anyhow::anyhow!("{source_label} source startup task failed: {error}")
-        }),
+        result = &mut source_task => result
+            .map(|value| (value, deadline))
+            .map_err(|error| anyhow::anyhow!("{source_label} source startup task failed: {error}")),
         _ = wait_for_layout_intent_superseded(state, intent_id) => {
-            let intents = state.layout_intents.lock().await;
-            let latest = intents.latest_intent_id;
-            let latest_needs_source = match source_label {
-                "camera" => intents.latest_needs_camera,
-                "screen" => intents.latest_needs_screen,
-                _ => false,
-            };
-            if !latest_needs_source {
-                // Do not detach a startup that can register after the winner's
-                // retirement edge has already run. Abort it while intent
-                // registration is blocked, then invalidate any lease it created
-                // before observing cancellation. A winner that still needs this
-                // source keeps the detached task and can join its lease instead.
-                source_task.abort();
-                let _ = (&mut source_task).await;
-                match source_label {
-                    "camera" if preview_camera_status(state).await.state == PreviewCameraState::Starting => {
-                        let stop = begin_preview_camera_stop(state).await;
-                        let _ = finish_preview_camera_stop(stop).await;
-                    }
-                    "screen" if preview_screen_status(state).await.state == PreviewScreenState::Starting => {
-                        let stop = begin_preview_screen_stop(state).await;
-                        let _ = finish_preview_screen_stop(stop).await;
-                    }
-                    _ => {}
-                }
-            }
+            let latest = reconcile_superseded_source_start(state, source_label, &mut source_task).await;
             bail!("Layout intent {intent_id} was superseded by newer intent {latest}.")
         }
         _ = tokio::time::sleep_until(deadline) => {
+            let failure_detail = source_start_failure_detail(state, source_label).await;
             source_task.abort();
             cancel_pending_source_start_for_intent(state, intent_id, source_label).await;
             bail!(
-                "Layout intent {intent_id} timed out while starting {source_label} within {}s.",
-                WARM_SOURCE_START_TIMEOUT.as_secs()
+                "Layout intent {intent_id} timed out while starting {source_label} within {}s.{failure_detail}",
+                timeout.as_secs(),
             );
         }
     }
+}
+
+async fn source_start_failure_detail(state: &AppState, source_label: &str) -> String {
+    if source_label != "screen" {
+        return String::new();
+    }
+    let status = preview_screen_status(state).await;
+    if status.state != PreviewScreenState::Failed {
+        return String::new();
+    }
+    status
+        .message
+        .as_deref()
+        .map(|message| format!(" Screen error: {message}"))
+        .unwrap_or_default()
+}
+
+async fn reconcile_superseded_source_start<T: Send + 'static>(
+    state: &AppState,
+    source_label: &'static str,
+    source_task: &mut tokio::task::JoinHandle<T>,
+) -> u64 {
+    let intents = state.layout_intents.lock().await;
+    let latest = intents.latest_intent_id;
+    let latest_needs_source = match source_label {
+        "camera" => intents.latest_needs_camera,
+        "screen" => intents.latest_needs_screen,
+        _ => false,
+    };
+    if !latest_needs_source {
+        // Do not detach a startup that can register after the winner's retirement
+        // edge has already run. Abort it while intent registration is blocked, then
+        // invalidate any lease it created before observing cancellation. A winner
+        // that still needs this source keeps the detached task and can join its lease.
+        source_task.abort();
+        let _ = source_task.await;
+        match source_label {
+            "camera"
+                if preview_camera_status(state).await.state == PreviewCameraState::Starting =>
+            {
+                let stop = begin_preview_camera_stop(state).await;
+                let _ = finish_preview_camera_stop(stop).await;
+            }
+            "screen"
+                if preview_screen_status(state).await.state == PreviewScreenState::Starting =>
+            {
+                let stop = begin_preview_screen_stop(state).await;
+                let _ = finish_preview_screen_stop(stop).await;
+            }
+            _ => {}
+        }
+    }
+    latest
 }
 
 async fn cancel_pending_source_start_for_intent(
@@ -665,12 +718,17 @@ fn layout_apply_status(
 async fn start_missing_sources(
     state: &AppState,
     intent_id: u64,
-    deadline: Instant,
     params: &SceneConfigParams,
     missing: &[&'static str],
     action_label: &'static str,
-) -> Result<()> {
+) -> Result<Instant> {
     let ffmpeg_path = active_recording_ffmpeg_path(state).await;
+    let mut readiness_deadline = Instant::now()
+        + missing
+            .iter()
+            .map(|source| warm_source_start_timeout(source))
+            .max()
+            .unwrap_or(WARM_CAMERA_START_TIMEOUT);
     for source in missing {
         ensure_layout_intent_current(state, intent_id).await?;
         match *source {
@@ -690,8 +748,16 @@ async fn start_missing_sources(
                         ffmpeg_path: ffmpeg_path.clone(),
                     },
                 ));
-                let status =
-                    await_layout_source_start(state, intent_id, deadline, "camera", start).await?;
+                let (status, deadline) = await_layout_source_start(
+                    state,
+                    intent_id,
+                    warm_source_start_timeout("camera"),
+                    "camera",
+                    None,
+                    start,
+                )
+                .await?;
+                readiness_deadline = readiness_deadline.max(deadline);
                 if matches!(
                     status.state,
                     PreviewCameraState::Failed
@@ -712,7 +778,8 @@ async fn start_missing_sources(
                 {
                     continue;
                 }
-                let start = tokio::spawn(start_preview_screen(
+                let (restart_ready_tx, restart_ready_rx) = oneshot::channel();
+                let start = tokio::spawn(start_preview_screen_for_live_switch(
                     state.clone(),
                     PreviewScreenStartParams {
                         sources: params.sources.clone(),
@@ -720,9 +787,18 @@ async fn start_missing_sources(
                         protected_overlay_window_ids: params.protected_overlay_window_ids.clone(),
                         ffmpeg_path: ffmpeg_path.clone(),
                     },
+                    restart_ready_tx,
                 ));
-                let status =
-                    await_layout_source_start(state, intent_id, deadline, "screen", start).await?;
+                let (status, deadline) = await_layout_source_start(
+                    state,
+                    intent_id,
+                    warm_source_start_timeout("screen"),
+                    "screen",
+                    Some(restart_ready_rx),
+                    start,
+                )
+                .await?;
+                readiness_deadline = readiness_deadline.max(deadline);
                 if matches!(
                     status.state,
                     PreviewScreenState::Failed
@@ -739,7 +815,7 @@ async fn start_missing_sources(
             other => bail!("Unknown source kind {other} for live layout switch."),
         }
     }
-    Ok(())
+    Ok(readiness_deadline)
 }
 
 async fn active_recording_ffmpeg_path(state: &AppState) -> Option<String> {
@@ -776,7 +852,7 @@ async fn wait_for_sources_ready(
             }
             bail!(
                 "Live {action_label} blocked: {still_missing} within {}s total source-start/readiness time. The previous layout is still live.",
-                WARM_SOURCE_START_TIMEOUT.as_secs()
+                warm_source_start_timeout(if needs.screen { "screen" } else { "camera" }).as_secs()
             );
         }
         sleep(WARM_SOURCE_POLL).await;
@@ -882,8 +958,17 @@ fn screen_readiness_detail(
         .screen_frame
         .map(|frame| frame.frame_age_ms)
         .or(status.frame_age_ms);
+    let failure = if status.state == PreviewScreenState::Failed {
+        status
+            .message
+            .as_deref()
+            .map(|message| format!(", error: {message}"))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
     format!(
-        "state: {}, target: {}, current: {}, frames captured: {}, latest sequence: {}, latest frame age: {}",
+        "state: {}, target: {}, current: {}, frames captured: {}, latest sequence: {}, latest frame age: {}{}",
         screen_state_label(&status.state),
         target_sources
             .and_then(selected_screen_source_id)
@@ -896,7 +981,8 @@ fn screen_readiness_detail(
                 .map(|frame| frame.sequence)
                 .or(status.sequence)
         ),
-        format_age_ms(frame_age_ms)
+        format_age_ms(frame_age_ms),
+        failure
     )
 }
 
@@ -1658,8 +1744,9 @@ mod tests {
             await_layout_source_start(
                 &waiter_state,
                 stale_intent,
-                Instant::now() + Duration::from_secs(5),
+                Duration::from_secs(5),
                 "screen",
+                None,
                 source_task,
             )
             .await
@@ -1727,8 +1814,9 @@ mod tests {
             await_layout_source_start(
                 &waiter_state,
                 stale_intent,
-                Instant::now() + Duration::from_secs(5),
+                Duration::from_secs(5),
                 "screen",
+                None,
                 source_task,
             )
             .await
@@ -1787,8 +1875,9 @@ mod tests {
             await_layout_source_start(
                 &state,
                 intent_id,
-                Instant::now() + Duration::from_millis(50),
+                Duration::from_millis(50),
                 "screen",
+                None,
                 source_task,
             ),
         )
@@ -1801,6 +1890,176 @@ mod tests {
             preview_screen_status(&state).await.state,
             PreviewScreenState::Starting,
             "timeout must invalidate the pending lease so it cannot install later"
+        );
+    }
+
+    #[test]
+    fn live_source_start_budgets_are_source_specific() {
+        assert_eq!(warm_source_start_timeout("camera"), Duration::from_secs(5));
+        assert_eq!(warm_source_start_timeout("screen"), Duration::from_secs(15));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn screen_source_start_budget_accepts_an_eight_second_start() {
+        let state = test_state();
+        let intent_id = begin_layout_intent(
+            &state,
+            Some(21),
+            SceneSourceNeeds {
+                camera: false,
+                screen: true,
+            },
+        )
+        .await
+        .expect("screen intent should register");
+        let source_task = tokio::spawn(async {
+            sleep(Duration::from_secs(8)).await;
+            42_u64
+        });
+
+        let result = await_layout_source_start(
+            &state,
+            intent_id,
+            warm_source_start_timeout("screen"),
+            "screen",
+            None,
+            source_task,
+        )
+        .await;
+
+        assert_eq!(
+            result
+                .expect("an eight-second screen start should fit its budget")
+                .0,
+            42
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn screen_source_start_budget_begins_after_old_stream_teardown() {
+        let state = test_state();
+        let intent_id = begin_layout_intent(
+            &state,
+            Some(22),
+            SceneSourceNeeds {
+                camera: false,
+                screen: true,
+            },
+        )
+        .await
+        .expect("screen intent should register");
+        let (restart_ready_tx, restart_ready_rx) = oneshot::channel();
+        let source_task = tokio::spawn(async move {
+            sleep(Duration::from_secs(8)).await;
+            let _ = restart_ready_tx.send(());
+            sleep(Duration::from_secs(8)).await;
+            42_u64
+        });
+
+        let result = await_layout_source_start(
+            &state,
+            intent_id,
+            warm_source_start_timeout("screen"),
+            "screen",
+            Some(restart_ready_rx),
+            source_task,
+        )
+        .await;
+
+        assert_eq!(
+            result
+                .expect("teardown time must not consume the screen startup budget")
+                .0,
+            42
+        );
+    }
+
+    #[tokio::test]
+    async fn screen_source_start_timeout_surfaces_the_native_start_error() {
+        let state = test_state();
+        let intent_id = begin_layout_intent(
+            &state,
+            Some(23),
+            SceneSourceNeeds {
+                camera: false,
+                screen: true,
+            },
+        )
+        .await
+        .expect("screen intent should register");
+        {
+            let mut screen = state.preview_screen.lock().await;
+            screen.status.state = PreviewScreenState::Failed;
+            screen.status.message = Some(
+                "ScreenCaptureKit stream failed to start: display was disconnected".to_string(),
+            );
+        }
+        let source_task = tokio::spawn(async { std::future::pending::<u64>().await });
+
+        let error = await_layout_source_start(
+            &state,
+            intent_id,
+            Duration::from_millis(1),
+            "screen",
+            None,
+            source_task,
+        )
+        .await
+        .expect_err("pending native startup must time out");
+
+        assert!(
+            error
+                .to_string()
+                .contains("ScreenCaptureKit stream failed to start: display was disconnected")
+        );
+    }
+
+    #[tokio::test]
+    async fn screen_readiness_timeout_surfaces_the_native_start_error() {
+        let state = test_state();
+        let target = sources(false, true);
+        let intent_id = begin_layout_intent(
+            &state,
+            Some(24),
+            SceneSourceNeeds {
+                camera: false,
+                screen: true,
+            },
+        )
+        .await
+        .expect("screen intent should register");
+        {
+            let mut screen = state.preview_screen.lock().await;
+            screen.status = live_screen_status(
+                target.screen_id.as_deref().expect("selected screen"),
+                None,
+                0,
+                None,
+            );
+            screen.status.state = PreviewScreenState::Failed;
+            screen.status.message = Some(
+                "ScreenCaptureKit stream failed to start: display was disconnected".to_string(),
+            );
+        }
+
+        let error = wait_for_sources_ready(
+            &state,
+            intent_id,
+            Instant::now(),
+            SceneSourceNeeds {
+                camera: false,
+                screen: true,
+            },
+            &target,
+            "source device switch",
+        )
+        .await
+        .expect_err("a failed screen start must block the switch");
+
+        assert!(
+            error
+                .to_string()
+                .contains("ScreenCaptureKit stream failed to start: display was disconnected")
         );
     }
 

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -61,6 +61,33 @@ const UNUSED_CAMERA_STOP_GRACE: Duration = Duration::from_secs(1);
 /// capturer must not be swapped onto program output.
 const SOURCE_FRESH_FRAME_MAX_AGE_MS: u64 = 1_500;
 
+#[derive(Debug, Clone, Copy)]
+struct SourceReadinessDeadlines {
+    camera: Option<Instant>,
+    screen: Option<Instant>,
+}
+
+#[derive(Debug, Clone)]
+struct SourceReadinessGuard {
+    source_label: &'static str,
+    deadline: Instant,
+    target_sources: SourceSelection,
+}
+
+impl SourceReadinessDeadlines {
+    fn starting_now(needs: SceneSourceNeeds) -> Self {
+        let now = Instant::now();
+        Self {
+            camera: needs
+                .camera
+                .then(|| now + warm_source_start_timeout("camera")),
+            screen: needs
+                .screen
+                .then(|| now + warm_source_start_timeout("screen")),
+        }
+    }
+}
+
 fn warm_source_start_timeout(source_label: &str) -> Duration {
     match source_label {
         "screen" => WARM_SCREEN_START_TIMEOUT,
@@ -447,13 +474,14 @@ async fn apply_scene_transaction(
         }
         ApplyMode::Warm => {
             let missing = missing_sources(needs, live);
-            let deadline =
-                start_missing_sources(state, intent_id, &params, &missing, action_label).await?;
+            let deadlines =
+                start_missing_sources(state, intent_id, &params, needs, &missing, action_label)
+                    .await?;
             ensure_layout_intent_current(state, intent_id).await?;
             wait_for_sources_ready(
                 state,
                 intent_id,
-                deadline,
+                deadlines,
                 needs,
                 target_sources,
                 action_label,
@@ -538,6 +566,7 @@ async fn await_layout_source_start<T: Send + 'static>(
     timeout: Duration,
     source_label: &'static str,
     restart_ready: Option<oneshot::Receiver<()>>,
+    readiness_guard: Option<SourceReadinessGuard>,
     mut source_task: tokio::task::JoinHandle<T>,
 ) -> Result<(T, Instant)> {
     if let Some(mut restart_ready) = restart_ready {
@@ -556,6 +585,14 @@ async fn await_layout_source_start<T: Send + 'static>(
         }
     }
     let deadline = Instant::now() + timeout;
+    let guarded_source_label = readiness_guard.as_ref().map(|guard| guard.source_label);
+    let guarded_readiness_failure = async {
+        match readiness_guard.as_ref() {
+            Some(guard) => wait_for_guarded_source_readiness_failure(state, guard).await,
+            None => std::future::pending::<String>().await,
+        }
+    };
+    tokio::pin!(guarded_readiness_failure);
     tokio::select! {
         result = &mut source_task => result
             .map(|value| (value, deadline))
@@ -573,7 +610,46 @@ async fn await_layout_source_start<T: Send + 'static>(
                 timeout.as_secs(),
             );
         }
+        failure = &mut guarded_readiness_failure => {
+            source_task.abort();
+            cancel_pending_source_start_for_intent(state, intent_id, source_label).await;
+            if let Some(guarded_source_label) = guarded_source_label
+                && guarded_source_label != source_label
+            {
+                cancel_pending_source_start_for_intent(state, intent_id, guarded_source_label).await;
+            }
+            bail!(failure)
+        }
     }
+}
+
+async fn wait_for_guarded_source_readiness_failure(
+    state: &AppState,
+    guard: &SourceReadinessGuard,
+) -> String {
+    tokio::time::sleep_until(guard.deadline).await;
+    let readiness = source_readiness(state, &guard.target_sources).await;
+    let needs = match guard.source_label {
+        "camera" => SceneSourceNeeds {
+            camera: true,
+            screen: false,
+        },
+        "screen" => SceneSourceNeeds {
+            camera: false,
+            screen: true,
+        },
+        _ => SceneSourceNeeds::default(),
+    };
+    if missing_sources(needs, readiness.live).is_empty() {
+        return std::future::pending::<String>().await;
+    }
+    let detail =
+        missing_readiness_messages(needs, &readiness, Some(&guard.target_sources)).join("; ");
+    format!(
+        "Live source device switch blocked after {} ({}s) exceeded its source-start/readiness budget: {detail}. The previous layout is still live.",
+        guard.source_label,
+        warm_source_start_timeout(guard.source_label).as_secs()
+    )
 }
 
 async fn source_start_failure_detail(state: &AppState, source_label: &str) -> String {
@@ -719,16 +795,12 @@ async fn start_missing_sources(
     state: &AppState,
     intent_id: u64,
     params: &SceneConfigParams,
+    needs: SceneSourceNeeds,
     missing: &[&'static str],
     action_label: &'static str,
-) -> Result<Instant> {
+) -> Result<SourceReadinessDeadlines> {
     let ffmpeg_path = active_recording_ffmpeg_path(state).await;
-    let mut readiness_deadline = Instant::now()
-        + missing
-            .iter()
-            .map(|source| warm_source_start_timeout(source))
-            .max()
-            .unwrap_or(WARM_CAMERA_START_TIMEOUT);
+    let mut readiness_deadlines = SourceReadinessDeadlines::starting_now(needs);
     for source in missing {
         ensure_layout_intent_current(state, intent_id).await?;
         match *source {
@@ -754,10 +826,17 @@ async fn start_missing_sources(
                     warm_source_start_timeout("camera"),
                     "camera",
                     None,
+                    missing.contains(&"screen").then(|| SourceReadinessGuard {
+                        source_label: "screen",
+                        deadline: readiness_deadlines
+                            .screen
+                            .expect("needed screen source must have a readiness deadline"),
+                        target_sources: params.sources.clone(),
+                    }),
                     start,
                 )
                 .await?;
-                readiness_deadline = readiness_deadline.max(deadline);
+                readiness_deadlines.camera = Some(deadline);
                 if matches!(
                     status.state,
                     PreviewCameraState::Failed
@@ -795,10 +874,11 @@ async fn start_missing_sources(
                     warm_source_start_timeout("screen"),
                     "screen",
                     Some(restart_ready_rx),
+                    None,
                     start,
                 )
                 .await?;
-                readiness_deadline = readiness_deadline.max(deadline);
+                readiness_deadlines.screen = Some(deadline);
                 if matches!(
                     status.state,
                     PreviewScreenState::Failed
@@ -815,7 +895,7 @@ async fn start_missing_sources(
             other => bail!("Unknown source kind {other} for live layout switch."),
         }
     }
-    Ok(readiness_deadline)
+    Ok(readiness_deadlines)
 }
 
 async fn active_recording_ffmpeg_path(state: &AppState) -> Option<String> {
@@ -830,7 +910,7 @@ async fn active_recording_ffmpeg_path(state: &AppState) -> Option<String> {
 async fn wait_for_sources_ready(
     state: &AppState,
     intent_id: u64,
-    deadline: Instant,
+    deadlines: SourceReadinessDeadlines,
     needs: SceneSourceNeeds,
     target_sources: &SourceSelection,
     action_label: &'static str,
@@ -841,7 +921,27 @@ async fn wait_for_sources_ready(
         if missing_sources(needs, readiness.live).is_empty() {
             return Ok(());
         }
-        if Instant::now() >= deadline {
+        let now = Instant::now();
+        let mut expired = Vec::new();
+        if needs.camera
+            && !readiness.live.camera
+            && deadlines.camera.is_some_and(|deadline| now >= deadline)
+        {
+            expired.push(format!(
+                "camera ({}s)",
+                warm_source_start_timeout("camera").as_secs()
+            ));
+        }
+        if needs.screen
+            && !readiness.live.screen
+            && deadlines.screen.is_some_and(|deadline| now >= deadline)
+        {
+            expired.push(format!(
+                "screen ({}s)",
+                warm_source_start_timeout("screen").as_secs()
+            ));
+        }
+        if !expired.is_empty() {
             let still_missing =
                 missing_readiness_messages(needs, &readiness, Some(target_sources)).join("; ");
             if needs.camera && !readiness.live.camera {
@@ -851,8 +951,8 @@ async fn wait_for_sources_ready(
                 cancel_pending_source_start_for_intent(state, intent_id, "screen").await;
             }
             bail!(
-                "Live {action_label} blocked: {still_missing} within {}s total source-start/readiness time. The previous layout is still live.",
-                warm_source_start_timeout(if needs.screen { "screen" } else { "camera" }).as_secs()
+                "Live {action_label} blocked after {} exceeded its source-start/readiness budget: {still_missing}. The previous layout is still live.",
+                expired.join(" + ")
             );
         }
         sleep(WARM_SOURCE_POLL).await;
@@ -1747,6 +1847,7 @@ mod tests {
                 Duration::from_secs(5),
                 "screen",
                 None,
+                None,
                 source_task,
             )
             .await
@@ -1817,6 +1918,7 @@ mod tests {
                 Duration::from_secs(5),
                 "screen",
                 None,
+                None,
                 source_task,
             )
             .await
@@ -1878,6 +1980,7 @@ mod tests {
                 Duration::from_millis(50),
                 "screen",
                 None,
+                None,
                 source_task,
             ),
         )
@@ -1923,6 +2026,7 @@ mod tests {
             warm_source_start_timeout("screen"),
             "screen",
             None,
+            None,
             source_task,
         )
         .await;
@@ -1962,6 +2066,7 @@ mod tests {
             warm_source_start_timeout("screen"),
             "screen",
             Some(restart_ready_rx),
+            None,
             source_task,
         )
         .await;
@@ -2001,6 +2106,7 @@ mod tests {
             intent_id,
             Duration::from_millis(1),
             "screen",
+            None,
             None,
             source_task,
         )
@@ -2045,7 +2151,10 @@ mod tests {
         let error = wait_for_sources_ready(
             &state,
             intent_id,
-            Instant::now(),
+            SourceReadinessDeadlines {
+                camera: None,
+                screen: Some(Instant::now()),
+            },
             SceneSourceNeeds {
                 camera: false,
                 screen: true,
@@ -2061,6 +2170,44 @@ mod tests {
                 .to_string()
                 .contains("ScreenCaptureKit stream failed to start: display was disconnected")
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn screen_readiness_budget_is_not_extended_by_a_later_camera_deadline() {
+        let state = test_state();
+        let target = sources(true, true);
+        let needs = SceneSourceNeeds {
+            camera: true,
+            screen: true,
+        };
+        let intent_id = begin_layout_intent(&state, Some(25), needs)
+            .await
+            .expect("dual-source intent should register");
+        let started = Instant::now();
+        let camera_start = tokio::spawn(async {
+            sleep(Duration::from_secs(20)).await;
+            42_u64
+        });
+
+        let error = await_layout_source_start(
+            &state,
+            intent_id,
+            Duration::from_secs(20),
+            "camera",
+            None,
+            Some(SourceReadinessGuard {
+                source_label: "screen",
+                deadline: started + WARM_SCREEN_START_TIMEOUT,
+                target_sources: target,
+            }),
+            camera_start,
+        )
+        .await
+        .expect_err("the screen must fail at its own deadline");
+
+        assert_eq!(Instant::now() - started, WARM_SCREEN_START_TIMEOUT);
+        assert!(error.to_string().contains("screen (15s)"));
+        assert!(!error.to_string().contains("camera (5s)"));
     }
 
     #[test]

--- a/crates/videorc-backend/src/preview_screen.rs
+++ b/crates/videorc-backend/src/preview_screen.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use image::ImageEncoder;
 use image::codecs::png::PngEncoder;
 use image::imageops::FilterType;
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
@@ -345,6 +346,25 @@ pub async fn start_preview_screen(
     state: AppState,
     params: PreviewScreenStartParams,
 ) -> PreviewScreenStatus {
+    start_preview_screen_with_restart_signal(state, params, None).await
+}
+
+/// The live-layout deadline starts only after the old capture thread is fully
+/// retired. Discovery and first-frame readiness get their whole source budget;
+/// the bounded ScreenCaptureKit stop is accounted for separately.
+pub(crate) async fn start_preview_screen_for_live_switch(
+    state: AppState,
+    params: PreviewScreenStartParams,
+    restart_ready: oneshot::Sender<()>,
+) -> PreviewScreenStatus {
+    start_preview_screen_with_restart_signal(state, params, Some(restart_ready)).await
+}
+
+async fn start_preview_screen_with_restart_signal(
+    state: AppState,
+    params: PreviewScreenStartParams,
+    mut restart_ready: Option<oneshot::Sender<()>>,
+) -> PreviewScreenStatus {
     let Some(source) = selected_screen_source(&params) else {
         stop_preview_screen(&state).await;
         let status =
@@ -447,12 +467,14 @@ pub async fn start_preview_screen(
     };
     let start_lease = match begin_screen_start(&state, start_key.clone(), starting).await {
         PreviewScreenStartRegistration::JoinExisting => {
+            signal_screen_restart_ready(&mut restart_ready);
             return wait_for_screen_start(&state, &start_key).await;
         }
         PreviewScreenStartRegistration::Started(lease) => lease,
     };
 
     stop_current_screen_for_restart(&state).await;
+    signal_screen_restart_ready(&mut restart_ready);
 
     let run_id = Uuid::new_v4().to_string();
     let shared = Arc::new(StdMutex::new(PreviewScreenShared::default()));
@@ -725,6 +747,12 @@ pub async fn start_preview_screen(
                 preview_screen_status(&state).await
             }
         }
+    }
+}
+
+fn signal_screen_restart_ready(restart_ready: &mut Option<oneshot::Sender<()>>) {
+    if let Some(restart_ready) = restart_ready.take() {
+        let _ = restart_ready.send(());
     }
 }
 


### PR DESCRIPTION
## What changed

- keep the camera live-start budget at 5 seconds and give screen switches 15 seconds
- start the screen readiness clock only after the previous ScreenCaptureKit stream has retired
- propagate native ScreenCaptureKit failure details through live-layout RPC errors
- preserve a backend-committed source selection when renderer output proof arrives late, with a keyed warning instead of an error toast
- add Rust and desktop integration regressions for the timing, native-error, and committed-selection paths

## Root cause

The active-session switch path charged old-stream teardown, source discovery, startup, and first-frame readiness against one 5-second deadline even though ScreenCaptureKit discovery alone can take up to 12 seconds. A second renderer-side 5-second presentation proof could then turn an already committed backend switch into a failure toast and snap the picker back.

## User impact

Slow monitor switches no longer look like backend failures or revert the selected monitor. Genuine ScreenCaptureKit failures now include their native error detail.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @videorc/desktop test` (1,326 passed, 1 skipped)
- `pnpm build`
- `cargo fmt --check --all`
- `cargo clippy -p videorc-backend -- -D warnings`
- `cargo test -p videorc-backend` (1,538 passed across targets, 8 ignored)
- focused `live_layout::tests` (26 passed)
- recording-studio phases 1–21 passed, plus focused preview-surface and preview-window probes
- Shadscan: 41 baseline / 41 final, ruleset 2026.07.34

## Local smoke limitations

- `probe:preview-lifecycle` independently reproduced an existing “Main window is not ready for preview motion smoke” close-state failure
- real ScreenCaptureKit harnesses reached capture/motion validation, then were blocked by `preview.surface.create` being restricted to Electron main
- no automated multi-display gate exists; the handoff calls for final by-eye A→B switching on the owner’s two-monitor Mac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live camera and screen switching now remains committed when output confirmation is delayed or fails.
  * Screen switching is more reliable during capture restarts, with improved handling of startup failures and timeouts.
  * Clearer error details are shown when a screen cannot start.

* **Improvements**
  * Delayed output confirmation now displays a warning instead of canceling the source change.
  * Camera and screen startup timing is tuned separately for improved responsiveness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->