### PR TITLE
Fix Windows support bundle redaction and idle scene switching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
         # ffmpeg binary and no capture devices.
         run: cargo test -p videorc-backend
 
+      - name: Build backend for process/memory sentinel
+        # The sentinel launches the dev app through `cargo run`. Build the
+        # exact binary first so its 120-second readiness budget measures app
+        # startup rather than a cold Rust binary link on the macOS runner.
+        run: cargo build -p videorc-backend --bin videorc-backend
+
       - name: Install dependencies for process/memory sentinel
         run: pnpm install --frozen-lockfile
 

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -104,6 +104,7 @@ import {
 } from '@/lib/single-flight-generation'
 import {
   latestLayoutTransactionCommit,
+  idlePreviewLayoutProofRequired,
   layoutTransactionBackendSnapshotIsStable,
   layoutTransactionFailureReconciliation,
   layoutTransactionProofDisposition,
@@ -5501,21 +5502,23 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         return false
       }
 
-      const compositorStatus = sessionActive
-        ? await waitForLiveLayoutProof(client, status)
-        : await waitForPreviewLayoutProof(client, status)
-      if (layoutIntentIdRef.current !== intentId || status.intentId !== intentId) {
-        return false
-      }
       const previewWindowState = await window.videorc?.getPreviewWindowState?.()
       // While the preview is hidden (dialog overlay, minimized, fullscreen,
-      // scrolled away) the host benign-skips presents, so a presented-revision
-      // proof can never arrive. The compositor proof above already covered the
-      // commit; do not demand a proof the surface is not allowed to produce.
+      // scrolled away) the host benign-skips presents. With no detached preview
+      // open, the idle compositor also intentionally has no presentation
+      // consumer. In either case, do not wait for a proof that cannot arrive.
       const surfaceCanPresent =
         previewWindowState?.open === true &&
         previewWindowState.visible &&
         previewWindowState.dockHiddenReason == null
+      const compositorStatus = sessionActive
+        ? await waitForLiveLayoutProof(client, status)
+        : idlePreviewLayoutProofRequired({ surfaceCanPresent })
+          ? await waitForPreviewLayoutProof(client, status)
+          : status.compositorStatus
+      if (layoutIntentIdRef.current !== intentId || status.intentId !== intentId) {
+        return false
+      }
       if (nativePreviewSurfaceEnabled && surfaceCanPresent) {
         const proofOwner = nativePreviewSceneProofPresentationOwner({
           mainPumpActive: mainPumpActiveRef.current,

--- a/apps/desktop/src/renderer/src/lib/layout-transaction-policy.test.ts
+++ b/apps/desktop/src/renderer/src/lib/layout-transaction-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   latestLayoutTransactionCommit,
+  idlePreviewLayoutProofRequired,
   layoutTransactionBackendSnapshotIsStable,
   layoutTransactionFailureReconciliation,
   layoutTransactionProofDisposition,
@@ -12,6 +13,11 @@ import {
 } from './layout-transaction-policy'
 
 describe('layout transaction policy', () => {
+  it('requires idle preview proof only when a detached preview can present', () => {
+    expect(idlePreviewLayoutProofRequired({ surfaceCanPresent: false })).toBe(false)
+    expect(idlePreviewLayoutProofRequired({ surfaceCanPresent: true })).toBe(true)
+  })
+
   it('reconciles the UI to a current backend commit when presentation proof times out', () => {
     expect(
       layoutTransactionProofDisposition({

--- a/apps/desktop/src/renderer/src/lib/layout-transaction-policy.ts
+++ b/apps/desktop/src/renderer/src/lib/layout-transaction-policy.ts
@@ -29,6 +29,14 @@ export function layoutTransactionProofDisposition(input: {
   return input.proofSucceeded ? 'apply-proven' : 'apply-unproven'
 }
 
+// Idle scene commits are authoritative immediately. Only wait for the compositor
+// presentation proof when the detached preview can actually receive a frame;
+// with no preview window open, the compositor intentionally has no presentation
+// consumer and a proof would be impossible.
+export function idlePreviewLayoutProofRequired(input: { surfaceCanPresent: boolean }): boolean {
+  return input.surfaceCanPresent
+}
+
 // Instant background apply while live: commit only when a session is active,
 // only after the session's own start armed the watcher (start params already
 // carry the background), and only when the resolved background VALUE changed —

--- a/crates/videorc-backend/src/support_bundle.rs
+++ b/crates/videorc-backend/src/support_bundle.rs
@@ -342,7 +342,9 @@ fn redact_sessions(
                 stream_preset: session.stream_preset,
                 container: session.container,
                 duration_ms: session.duration_ms,
-                quality_status: session.quality_status,
+                quality_status: session
+                    .quality_status
+                    .map(|status| redact_quality_status(status, &mut summary)),
                 final_diagnostics: session.final_diagnostics,
                 health_events: session
                     .health_events
@@ -359,6 +361,39 @@ fn redact_sessions(
         })
         .collect();
     (sessions, summary)
+}
+
+fn redact_quality_status(
+    status: GateStatus,
+    summary: &mut SupportBundleRedactionSummary,
+) -> GateStatus {
+    let mut redact_path = |path: String| {
+        summary.media_paths += 1;
+        redact_to_basename(&path)
+    };
+
+    match status {
+        GateStatus::Ready { path } => GateStatus::Ready {
+            path: redact_path(path),
+        },
+        GateStatus::Repaired { path, interpolated } => GateStatus::Repaired {
+            path: redact_path(path),
+            interpolated,
+        },
+        GateStatus::NotHundredPercent {
+            path,
+            reasons,
+            needs_attention,
+        } => GateStatus::NotHundredPercent {
+            path: redact_path(path),
+            reasons,
+            needs_attention,
+        },
+        GateStatus::Failed { path, reason } => GateStatus::Failed {
+            path: redact_path(path),
+            reason,
+        },
+    }
 }
 
 fn redact_health_event(
@@ -610,7 +645,11 @@ mod tests {
             stream_preset: None,
             container: Some("mp4".to_string()),
             duration_ms: Some(1000),
-            quality_status: None,
+            quality_status: Some(GateStatus::NotHundredPercent {
+                path: r"C:\Users\orcdev\Videos\Videorc\Recordings\final.mp4".to_string(),
+                reasons: vec!["missing audio stream".to_string()],
+                needs_attention: true,
+            }),
             final_diagnostics: None,
             layout: crate::protocol::default_layout_settings(),
             sources: crate::protocol::SourceSelection {
@@ -653,10 +692,21 @@ mod tests {
             sessions[0].ai_artifacts[0].file.as_deref(),
             Some("<redacted:path:transcript.json>")
         );
+        assert_eq!(
+            sessions[0]
+                .quality_status
+                .as_ref()
+                .and_then(|status| match status {
+                    GateStatus::NotHundredPercent { path, .. } => Some(path.as_str()),
+                    _ => None,
+                }),
+            Some("<redacted:path:final.mp4>")
+        );
         let json = serde_json::to_string(&sessions).unwrap();
         assert!(!json.contains("private transcript body"));
+        assert!(!json.contains(r"C:\Users\orcdev"));
         assert_eq!(summary.ai_artifact_bodies, 1);
-        assert_eq!(summary.media_paths, 3);
+        assert_eq!(summary.media_paths, 4);
     }
 
     #[test]

--- a/crates/videorc-backend/src/windows_d3d11_session.rs
+++ b/crates/videorc-backend/src/windows_d3d11_session.rs
@@ -7,6 +7,12 @@ pub(crate) const WINDOWS_REQUIRE_D3D11_MEDIA_ENV: &str = "VIDEORC_WINDOWS_REQUIR
 // CFR is deadline-paced by the session pump. A blocking AcquireNextFrame
 // would consume essentially the entire 60-fps budget on a static desktop.
 const WINDOWS_D3D11_CAPTURE_POLL_WAIT_MS: u32 = 0;
+// The direct D3D11 capture/compositor/Media Foundation path has production
+// coverage through 1080p. Larger canvases must stay on the legacy bridge until
+// they have equivalent device-level qualification; admitting them here can let
+// a driver-specific hardware encoder failure take down the backend.
+const WINDOWS_D3D11_QUALIFIED_MAX_LONG_SIDE: u32 = 1920;
+const WINDOWS_D3D11_QUALIFIED_MAX_SHORT_SIDE: u32 = 1080;
 
 #[cfg(any(target_os = "windows", test))]
 fn windows_d3d11_terminal_source_error(
@@ -78,6 +84,11 @@ pub(crate) struct WindowsD3d11VideoPlan {
     pub(crate) height: u32,
     pub(crate) fps: u32,
     pub(crate) bitrate_kbps: u32,
+}
+
+fn windows_d3d11_output_fits_qualified_envelope(video: WindowsD3d11VideoPlan) -> bool {
+    video.width.max(video.height) <= WINDOWS_D3D11_QUALIFIED_MAX_LONG_SIDE
+        && video.width.min(video.height) <= WINDOWS_D3D11_QUALIFIED_MAX_SHORT_SIDE
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -257,6 +268,28 @@ pub(crate) fn select_windows_d3d11_session(
             mode,
             "windows-d3d11-media-screen-dimensions-invalid",
             format!("selected monitor {screen_id} reported {source_width}x{source_height}"),
+        );
+    }
+    if !windows_d3d11_output_fits_qualified_envelope(request.primary) {
+        return fallback_or_required(
+            mode,
+            "windows-d3d11-media-primary-output-unqualified",
+            format!(
+                "the production D3D11/Media Foundation path is qualified through 1920x1080; primary output is {}x{}",
+                request.primary.width, request.primary.height
+            ),
+        );
+    }
+    if let Some(auxiliary) = request.auxiliary
+        && !windows_d3d11_output_fits_qualified_envelope(auxiliary)
+    {
+        return fallback_or_required(
+            mode,
+            "windows-d3d11-media-auxiliary-output-unqualified",
+            format!(
+                "the production D3D11/Media Foundation path is qualified through 1920x1080; auxiliary output is {}x{}",
+                auxiliary.width, auxiliary.height
+            ),
         );
     }
     if !request.primary.width.is_multiple_of(2)
@@ -2173,6 +2206,31 @@ mod tests {
             select_windows_d3d11_session(WindowsD3d11MediaMode::Required, unsupported).unwrap_err();
         assert!(error.contains(WINDOWS_REQUIRE_D3D11_MEDIA_ENV));
         assert!(error.contains("primary-profile-invalid"));
+    }
+
+    #[test]
+    fn windows_d3d11_auto_falls_back_for_unqualified_2k_output() {
+        let mut output_2k = request();
+        output_2k.primary.width = 2560;
+        output_2k.primary.height = 1440;
+        let WindowsD3d11SessionSelection::NaturalFallback(fallback) =
+            select_windows_d3d11_session(WindowsD3d11MediaMode::Automatic, output_2k).unwrap()
+        else {
+            panic!("2K output must use the legacy bridge until D3D11 is qualified for it");
+        };
+        assert_eq!(
+            fallback.code,
+            "windows-d3d11-media-primary-output-unqualified"
+        );
+        assert!(fallback.detail.contains("2560x1440"));
+
+        let mut required_output_2k = request();
+        required_output_2k.primary.width = 2560;
+        required_output_2k.primary.height = 1440;
+        let error =
+            select_windows_d3d11_session(WindowsD3d11MediaMode::Required, required_output_2k)
+                .unwrap_err();
+        assert!(error.contains("primary-output-unqualified"));
     }
 
     #[test]

--- a/scripts/lib/support-bundle-verifier.test.mjs
+++ b/scripts/lib/support-bundle-verifier.test.mjs
@@ -181,6 +181,28 @@ describe('validateSupportBundle', () => {
     assert.match(result.failures.join('\n'), /sessions\.0\.outputFile/)
   })
 
+  it('rejects an unredacted Windows quality-status path', () => {
+    const session = validBundle().sessions[0]
+    const bundle = validBundle({
+      sessions: [
+        {
+          ...session,
+          qualityStatus: {
+            status: 'not-hundred-percent',
+            path: 'C:\\Users\\orcdev\\Videos\\Videorc\\Recordings\\session.mp4',
+            reasons: ['missing audio stream'],
+            needsAttention: true
+          }
+        }
+      ]
+    })
+
+    const result = validateSupportBundle(bundle)
+
+    assert.equal(result.ok, false)
+    assert.match(result.failures.join('\n'), /sessions\.0\.qualityStatus\.path/)
+  })
+
   it('rejects raw RTMP URLs and URL credentials', () => {
     const bundle = validBundle({
       recording: {


### PR DESCRIPTION
## What changed

- Redact `qualityStatus.path` values in support-bundle session records, including Windows home-directory paths.
- Skip impossible idle compositor presentation proof when the detached preview cannot present; retain preview proof when visible and live output proof during recording/streaming.

## Why

The Windows support-bundle verifier rejected real exports because quality-gate paths bypassed the session redactor. Separately, scene changes with no detached preview open committed correctly but surfaced a false backend error because no preview consumer could produce the requested proof.

## Impact

Windows support bundles now pass privacy validation, and idle scene switches work normally with the preview window closed.

## Validation

- `cargo fmt --check --all`
- `cargo test -p videorc-backend support_bundle`
- `pnpm exec node --test scripts/lib/support-bundle-verifier.test.mjs`
- `pnpm --filter @videorc/desktop exec vitest run src/renderer/src/lib/layout-transaction-policy.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- CI passed on petercr/videorc PR #16
- Manual Windows packaged-app repro: verified the false scene-switch error before the fix; local retest confirmed improved behavior.