### PR TITLE
Add Linux L1 compile and CI gate

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,33 +25,16 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.0.9
-          run_install: false
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24.6.0'
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check
-        run: cargo check -p videorc-backend
-
-      - name: Format check
-        run: cargo fmt --check --all
-
       - name: Clippy
+        # clippy -D warnings is the compile gate (compile errors fail it
+        # regardless of the lint allows), matching ci.yml and windows.yml —
+        # no separate cargo check, no pnpm (nothing in this job runs JS), and
+        # no fmt (rustfmt output is platform-independent; ci.yml owns it).
         # cfg(linux) makes macOS/Windows-only helpers dead or their imports
         # unused. Keep this allow list identical to windows.yml while the
         # cross-platform warning wall is burned down; drop both lists together.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,63 @@
+name: Linux
+
+# Linux L1 is a compile-and-test gate, not a shipping application claim.
+# Capture, preview, encoding, packaging, and device acceptance land in later
+# phases tracked by docs/linux-port-plan.md.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: linux-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gates:
+    name: Linux gates (Rust compile + test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.0.9
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.6.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check
+        run: cargo check -p videorc-backend
+
+      - name: Format check
+        run: cargo fmt --check --all
+
+      - name: Clippy
+        # cfg(linux) makes macOS/Windows-only helpers dead or their imports
+        # unused. Keep this allow list identical to windows.yml while the
+        # cross-platform warning wall is burned down; drop both lists together.
+        run: cargo clippy -p videorc-backend -- -D warnings -A dead_code -A unused_imports -A unused_variables -A unused_mut
+
+      - name: Test
+        # Platform-neutral tests run normally. Tests that require Apple or
+        # Windows frameworks remain gated at their implementation boundary.
+        run: cargo test -p videorc-backend

--- a/crates/videorc-backend/src/bin/native_preview_host_helper.rs
+++ b/crates/videorc-backend/src/bin/native_preview_host_helper.rs
@@ -8,6 +8,10 @@ mod metal_compositor;
 #[allow(dead_code)]
 #[path = "../native_preview_host.rs"]
 mod native_preview_host;
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+#[path = "../source_mask.rs"]
+mod source_mask;
 
 #[cfg(target_os = "macos")]
 mod protocol {

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -45,6 +45,7 @@ use crate::scene_geometry::{
     scene_crop_from_transform, scene_mask_allows, scene_source_fit, scene_source_rect_pixels,
     scene_source_render_transform,
 };
+pub use crate::source_mask::SourceMask;
 use crate::state::AppState;
 use crate::windows_d3d11_device::{
     DxgiAdapterLuid, WindowsD3d11MediaRole, WindowsD3d11TextureFormat,
@@ -2278,13 +2279,11 @@ struct PreparedGpuSource<'a> {
 }
 
 #[cfg(target_os = "macos")]
-fn scene_mask_into_metal(mask: SceneMask) -> crate::metal_compositor::SourceMask {
+fn scene_mask_into_metal(mask: SceneMask) -> SourceMask {
     match mask {
-        SceneMask::None => crate::metal_compositor::SourceMask::None,
-        SceneMask::Circle => crate::metal_compositor::SourceMask::Circle,
-        SceneMask::Rounded { radius_pct } => {
-            crate::metal_compositor::SourceMask::Rounded { radius_pct }
-        }
+        SceneMask::None => SourceMask::None,
+        SceneMask::Circle => SourceMask::Circle,
+        SceneMask::Rounded { radius_pct } => SourceMask::Rounded { radius_pct },
     }
 }
 

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -51,6 +51,7 @@ mod scene_geometry;
 mod screen_capture;
 mod secrets;
 mod session_ops;
+mod source_mask;
 mod source_registry;
 mod source_status;
 mod state;

--- a/crates/videorc-backend/src/metal_compositor.rs
+++ b/crates/videorc-backend/src/metal_compositor.rs
@@ -21,6 +21,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::time::Instant;
 
+pub use crate::source_mask::SourceMask;
+
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_core_foundation::{CFBoolean, CFDictionary, CFRetained, CFType, CGSize};
@@ -260,15 +262,6 @@ pub struct GpuSourceContentKey {
     pub namespace: u64,
     pub revision: u64,
     pub variant: u64,
-}
-
-/// Camera-bubble mask shared by both software compositors (the FFmpeg leg mirrors
-/// the same constants in its filter graph).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SourceMask {
-    None,
-    Circle,
-    Rounded { radius_pct: u32 },
 }
 
 impl SourceMask {

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use image::ImageEncoder;
 use image::codecs::png::PngEncoder;
 use image::imageops::FilterType;
+use rayon::prelude::*;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
@@ -14,6 +15,7 @@ use crate::camera_capture::{
     CameraFormatSummary, camera_capability_matrix_for_id, parse_native_camera_id,
     parse_windows_dshow_camera_id,
 };
+use crate::color::{ycbcr_bt709_full_to_bgr, ycbcr_bt709_video_to_bgr};
 use crate::diagnostics::{
     PreviewCameraCaptureTimingStats, apply_preview_camera_capability_stats,
     apply_preview_camera_capture_timing_stats, apply_preview_camera_source_stats,
@@ -1909,10 +1911,95 @@ mod windows {
     }
 }
 
+/// NV12 (4:2:0 bi-planar Y'CbCr) -> BGRA, parallelized across output rows.
+///
+/// The conversion is platform-neutral even though AVFoundation is currently
+/// its only production caller. Keeping it outside the macOS module makes the
+/// pixel seam available to future Linux PipeWire capture without importing an
+/// Apple framework module.
+#[allow(clippy::too_many_arguments)]
+fn nv12_to_bgra(
+    y: &[u8],
+    y_stride: usize,
+    cbcr: &[u8],
+    cbcr_stride: usize,
+    width: usize,
+    height: usize,
+    full_range: bool,
+    out: &mut [u8],
+) {
+    let row_bytes = width * 4;
+    out.par_chunks_mut(row_bytes)
+        .enumerate()
+        .for_each(|(row, out_row)| {
+            if row >= height {
+                return;
+            }
+            let y_row = &y[row * y_stride..];
+            let cbcr_row = &cbcr[(row / 2) * cbcr_stride..];
+            for (x, pixel) in out_row.chunks_exact_mut(4).enumerate() {
+                let chroma = (x / 2) * 2;
+                let (b, g, r) = if full_range {
+                    ycbcr_bt709_full_to_bgr(y_row[x], cbcr_row[chroma], cbcr_row[chroma + 1])
+                } else {
+                    ycbcr_bt709_video_to_bgr(y_row[x], cbcr_row[chroma], cbcr_row[chroma + 1])
+                };
+                pixel[0] = b;
+                pixel[1] = g;
+                pixel[2] = r;
+                pixel[3] = 255;
+            }
+        });
+}
+
+/// Packed 4:2:2 Y'CbCr -> BGRA, parallelized by row. `uyvy` selects the byte
+/// order: UYVY (`2vuy`, Cb Y0 Cr Y1) when true, YUY2 (`yuvs`, Y0 Cb Y1 Cr)
+/// when false.
+fn yuv422_to_bgra(
+    plane: &[u8],
+    stride: usize,
+    width: usize,
+    height: usize,
+    uyvy: bool,
+    out: &mut [u8],
+) {
+    let row_bytes = width * 4;
+    out.par_chunks_mut(row_bytes)
+        .enumerate()
+        .for_each(|(row, out_row)| {
+            if row >= height {
+                return;
+            }
+            let src = &plane[row * stride..];
+            for (pair, out8) in out_row.chunks_exact_mut(8).enumerate() {
+                let i = pair * 4;
+                let (cb, y0, cr, y1) = if uyvy {
+                    (src[i], src[i + 1], src[i + 2], src[i + 3])
+                } else {
+                    (src[i + 1], src[i], src[i + 3], src[i + 2])
+                };
+                let (b0, g0, r0) = ycbcr_bt709_video_to_bgr(y0, cb, cr);
+                let (b1, g1, r1) = ycbcr_bt709_video_to_bgr(y1, cb, cr);
+                out8[0] = b0;
+                out8[1] = g0;
+                out8[2] = r0;
+                out8[3] = 255;
+                out8[4] = b1;
+                out8[5] = g1;
+                out8[6] = r1;
+                out8[7] = 255;
+            }
+        });
+}
+
 #[cfg(target_os = "macos")]
 mod macos {
     use std::slice;
 
+    use super::*;
+    use crate::camera_capture::{
+        CameraFormatSummary, NativeCameraPermission, choose_camera_format,
+    };
     use dispatch2::DispatchQueue;
     use objc2::rc::{Retained, autoreleasepool};
     use objc2::runtime::{AnyObject, ProtocolObject};
@@ -1936,13 +2023,6 @@ mod macos {
         kCVPixelFormatType_422YpCbCr8_yuvs,
     };
     use objc2_foundation::{NSDictionary, NSNumber, NSObject, NSObjectProtocol, NSString};
-    use rayon::prelude::*;
-
-    use super::*;
-    use crate::camera_capture::{
-        CameraFormatSummary, NativeCameraPermission, choose_camera_format,
-    };
-    use crate::color::{ycbcr_bt709_full_to_bgr, ycbcr_bt709_video_to_bgr};
 
     struct CameraDelegateIvars {
         shared: Arc<StdMutex<PreviewCameraShared>>,
@@ -2611,81 +2691,6 @@ mod macos {
         true
     }
 
-    /// NV12 (4:2:0 bi-planar Y'CbCr) -> BGRA, parallelized across output rows.
-    #[allow(clippy::too_many_arguments)]
-    fn nv12_to_bgra(
-        y: &[u8],
-        y_stride: usize,
-        cbcr: &[u8],
-        cbcr_stride: usize,
-        width: usize,
-        height: usize,
-        full_range: bool,
-        out: &mut [u8],
-    ) {
-        let row_bytes = width * 4;
-        out.par_chunks_mut(row_bytes)
-            .enumerate()
-            .for_each(|(row, out_row)| {
-                if row >= height {
-                    return;
-                }
-                let y_row = &y[row * y_stride..];
-                let cbcr_row = &cbcr[(row / 2) * cbcr_stride..];
-                for (x, pixel) in out_row.chunks_exact_mut(4).enumerate() {
-                    let chroma = (x / 2) * 2;
-                    let (b, g, r) = if full_range {
-                        ycbcr_bt709_full_to_bgr(y_row[x], cbcr_row[chroma], cbcr_row[chroma + 1])
-                    } else {
-                        ycbcr_bt709_video_to_bgr(y_row[x], cbcr_row[chroma], cbcr_row[chroma + 1])
-                    };
-                    pixel[0] = b;
-                    pixel[1] = g;
-                    pixel[2] = r;
-                    pixel[3] = 255;
-                }
-            });
-    }
-
-    /// Packed 4:2:2 Y'CbCr -> BGRA, parallelized by row. `uyvy` selects the byte
-    /// order: UYVY (`2vuy`, Cb Y0 Cr Y1) when true, YUY2 (`yuvs`, Y0 Cb Y1 Cr) when false.
-    fn yuv422_to_bgra(
-        plane: &[u8],
-        stride: usize,
-        width: usize,
-        height: usize,
-        uyvy: bool,
-        out: &mut [u8],
-    ) {
-        let row_bytes = width * 4;
-        out.par_chunks_mut(row_bytes)
-            .enumerate()
-            .for_each(|(row, out_row)| {
-                if row >= height {
-                    return;
-                }
-                let src = &plane[row * stride..];
-                for (pair, out8) in out_row.chunks_exact_mut(8).enumerate() {
-                    let i = pair * 4;
-                    let (cb, y0, cr, y1) = if uyvy {
-                        (src[i], src[i + 1], src[i + 2], src[i + 3])
-                    } else {
-                        (src[i + 1], src[i], src[i + 3], src[i + 2])
-                    };
-                    let (b0, g0, r0) = ycbcr_bt709_video_to_bgr(y0, cb, cr);
-                    let (b1, g1, r1) = ycbcr_bt709_video_to_bgr(y1, cb, cr);
-                    out8[0] = b0;
-                    out8[1] = g0;
-                    out8[2] = r0;
-                    out8[3] = 255;
-                    out8[4] = b1;
-                    out8[5] = g1;
-                    out8[6] = r1;
-                    out8[7] = 255;
-                }
-            });
-    }
-
     fn cm_time_seconds(time: CMTime) -> Option<f64> {
         let seconds = unsafe { time.seconds() };
         seconds.is_finite().then_some(seconds)
@@ -2784,6 +2789,33 @@ mod tests {
             fps: 60,
             bitrate_kbps: 9000,
         }
+    }
+
+    #[test]
+    fn shared_nv12_conversion_preserves_bt709_video_range_pixels() {
+        let y = [16, 235, 81, 145];
+        let cbcr = [128, 128];
+        let mut out = [0; 16];
+
+        nv12_to_bgra(&y, 2, &cbcr, 2, 2, 2, false, &mut out);
+
+        for (index, luma) in y.into_iter().enumerate() {
+            let (b, g, r) = ycbcr_bt709_video_to_bgr(luma, 128, 128);
+            assert_eq!(&out[index * 4..index * 4 + 4], &[b, g, r, 255]);
+        }
+    }
+
+    #[test]
+    fn shared_yuv422_conversion_accepts_uyvy_and_yuy2_ordering() {
+        let mut uyvy_out = [0; 8];
+        let mut yuy2_out = [0; 8];
+
+        yuv422_to_bgra(&[128, 16, 128, 235], 4, 2, 1, true, &mut uyvy_out);
+        yuv422_to_bgra(&[16, 128, 235, 128], 4, 2, 1, false, &mut yuy2_out);
+
+        assert_eq!(uyvy_out, yuy2_out);
+        assert_eq!(uyvy_out[3], 255);
+        assert_eq!(uyvy_out[7], 255);
     }
 
     #[test]

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1220,7 +1220,11 @@ pub struct StreamHealth {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum EncodeBackend {
-    /// libx264 (software), used on non-macOS/non-Windows fallback builds.
+    /// libx264 (software). LEGACY: no code path selects this since the Linux
+    /// L1 port removed the non-macOS/non-Windows fallback — Linux returns a
+    /// typed PlatformEncoderUnsupported instead, and the LGPL-only ffmpeg
+    /// policy forbids reintroducing GPL x264. Kept only so historical
+    /// diagnostics payloads still deserialize.
     SoftwareX264,
     /// h264_videotoolbox (hardware, sw fallback allowed).
     HardwareVideotoolbox,

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -22569,7 +22569,7 @@ mod tests {
     }
 
     #[test]
-    fn captioned_record_and_stream_rejects_multiple_target_profiles() {
+    fn captioned_record_and_stream_respects_platform_output_capability() {
         let mut params = base_params(true, true);
         params.output.video = video_preset_defaults(VideoPreset::StreamSafe1080p30);
         params.captions = Some(crate::protocol::CaptionsSessionParams {
@@ -22594,8 +22594,22 @@ mod tests {
         twitch.output_bitrate_kbps = Some(6000);
         params.streaming = Some(streaming);
 
-        let error = validate_outputs(&params).unwrap_err().to_string();
-        assert!(error.contains("one captioned stream profile"), "{error}");
+        if separate_encoded_provider_output_role_available(&params) {
+            let error = validate_outputs(&params).unwrap_err().to_string();
+            assert!(error.contains("one captioned stream profile"), "{error}");
+        } else {
+            validate_outputs(&params)
+                .expect("a shared encoder collapses targets to one caption-safe profile");
+            let profiles = resolved_enabled_stream_output_videos(&params)
+                .expect("shared provider output profiles");
+            assert_eq!(profiles.len(), 2);
+            assert!(
+                profiles
+                    .iter()
+                    .all(|profile| same_video_profile(profile, &params.output.video)),
+                "an unproven split role must resolve every target to the shared recording profile"
+            );
+        }
 
         let mut captions_off = base_params(true, true);
         captions_off.output.video = VideoSettings {

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -1722,7 +1722,7 @@ pub async fn start_session(
         &encoder_output_topology,
         requested_encoder_bridge_video_output,
     )
-    .await;
+    .await?;
     let encoder_bridge_video_output = windows_encoded_bridge_decision.effective;
     if params.output.stream_enabled {
         let provider_plan = resolve_provider_stream_output_plan(&params)?;
@@ -7264,8 +7264,6 @@ enum FfmpegH264Platform {
     Macos,
     WindowsHardware,
     WindowsSoftware,
-    #[cfg(test)]
-    PortableTestOpenH264,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7450,10 +7448,12 @@ fn current_ffmpeg_h264_platform()
     }
     #[cfg(all(test, not(target_os = "macos"), not(target_os = "windows")))]
     {
-        // Cross-platform unit tests still exercise the complete argument
-        // topology without claiming a production Linux encoder. The runtime
-        // selector itself is covered separately and remains unsupported.
-        Ok(FfmpegH264Platform::PortableTestOpenH264)
+        // Cross-platform unit tests exercise the REAL Windows software
+        // encoder table (OpenH264) rather than a test-only twin: a private
+        // variant duplicating those args would silently go stale the next
+        // time the #149-tuned OpenH264 args change. The runtime selector's
+        // Linux refusal is covered separately via RuntimePlatform::Linux.
+        Ok(FfmpegH264Platform::WindowsSoftware)
     }
     #[cfg(all(
         not(test),
@@ -7499,14 +7499,6 @@ fn ffmpeg_h264_encoder(platform: FfmpegH264Platform) -> FfmpegH264Encoder {
             // libopenh264 measured ~2.5x realtime on the same box. OpenH264 is
             // the reliable software fallback; hardware Media Foundation stays
             // the probed fast path.
-            codec: "libopenh264",
-            pix_fmt: "yuv420p",
-            backend: EncodeBackend::SoftwareOpenH264,
-        },
-        #[cfg(test)]
-        FfmpegH264Platform::PortableTestOpenH264 => FfmpegH264Encoder {
-            // Test-only portable fixture. Production Linux selection returns
-            // PlatformEncoderUnsupported and never reaches an encoder.
             codec: "libopenh264",
             pix_fmt: "yuv420p",
             backend: EncodeBackend::SoftwareOpenH264,
@@ -7560,12 +7552,8 @@ fn windows_media_foundation_hardware_probe_args(video: &VideoSettings) -> Vec<St
 #[cfg(target_os = "windows")]
 const WINDOWS_MEDIA_FOUNDATION_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 
-fn default_h264_encode_backend() -> EncodeBackend {
-    ffmpeg_h264_encoder(
-        current_ffmpeg_h264_platform()
-            .expect("macOS and Windows always have a configured H.264 encoder"),
-    )
-    .backend
+fn default_h264_encode_backend() -> std::result::Result<EncodeBackend, PlatformEncoderUnsupported> {
+    Ok(ffmpeg_h264_encoder(current_ffmpeg_h264_platform()?).backend)
 }
 
 fn append_h264_encoding_args(
@@ -7654,15 +7642,6 @@ fn append_h264_encoding_args_for_platform_with_timing(
             // libopenh264 tuned per the #149 real-device benchmark (~2.5x
             // realtime at 1080p30/8Mbps on the bundled build): bitrate rate
             // control with frame-skip permitted only under overshoot.
-            args.extend([
-                "-rc_mode".to_string(),
-                "bitrate".to_string(),
-                "-allow_skip_frames".to_string(),
-                "1".to_string(),
-            ]);
-        }
-        #[cfg(test)]
-        FfmpegH264Platform::PortableTestOpenH264 => {
             args.extend([
                 "-rc_mode".to_string(),
                 "bitrate".to_string(),
@@ -8783,7 +8762,12 @@ async fn resolve_windows_encoded_bridge_decision(
     ffmpeg_path: &str,
     plan: &EncoderOutputTopologyPlan,
     requested: EncoderBridgeVideoOutput,
-) -> WindowsEncodedBridgeDecision {
+) -> std::result::Result<WindowsEncodedBridgeDecision, PlatformEncoderUnsupported> {
+    // Resolve the fallback backend FIRST and as a value: this function is
+    // reachable on every platform (the topology-probe RPC calls it, and the
+    // renderer fires that probe automatically), so an unsupported platform
+    // must surface as the typed error, never as a panic mid-argument.
+    let fallback_encode_backend = default_h264_encode_backend()?;
     let graphics_adapter_driver_identity = graphics_adapter_driver_identity();
     let capability_key = output_topology_capability_key(
         ffmpeg_path,
@@ -8806,12 +8790,12 @@ async fn resolve_windows_encoded_bridge_decision(
     } else {
         None
     };
-    select_windows_encoded_bridge_decision(
+    Ok(select_windows_encoded_bridge_decision(
         requested,
         capability_key,
         probe,
-        default_h264_encode_backend(),
-    )
+        fallback_encode_backend,
+    ))
 }
 
 #[cfg(target_os = "windows")]
@@ -8865,7 +8849,7 @@ pub async fn probe_stream_output_topology(
     let plan = encoder_output_topology_plan_from_probe(&params);
     let ffmpeg_path = resolve_ffmpeg_path(params.ffmpeg_path.clone());
     let requested = recording_encoder_bridge_video_output(params.recording_profile.is_some(), true);
-    let decision = resolve_windows_encoded_bridge_decision(&ffmpeg_path, &plan, requested).await;
+    let decision = resolve_windows_encoded_bridge_decision(&ffmpeg_path, &plan, requested).await?;
 
     Ok(StreamOutputTopologyProbeResult {
         capability_key: decision.capability_key,
@@ -15012,24 +14996,7 @@ mod tests {
             Some("1")
         );
 
-        let mut fallback_args = Vec::new();
-        append_h264_encoding_args_for_platform(
-            &mut fallback_args,
-            &video,
-            FfmpegH264Platform::PortableTestOpenH264,
-            true,
-        );
-        assert_eq!(arg_value(&fallback_args, "-c:v"), Some("libopenh264"));
-        assert_eq!(arg_value(&fallback_args, "-pix_fmt"), Some("yuv420p"));
-        assert_eq!(arg_value(&fallback_args, "-rc_mode"), Some("bitrate"));
-        assert_eq!(arg_value(&fallback_args, "-allow_skip_frames"), Some("1"));
-
-        for args in [
-            &macos_args,
-            &windows_args,
-            &windows_software_args,
-            &fallback_args,
-        ] {
+        for args in [&macos_args, &windows_args, &windows_software_args] {
             assert_eq!(arg_value(args, "-b:v"), Some("6000k"));
             assert_eq!(arg_value(args, "-maxrate"), Some("6000k"));
             assert_eq!(arg_value(args, "-bufsize"), Some("12000k"));
@@ -15054,10 +15021,6 @@ mod tests {
         );
         assert_eq!(
             ffmpeg_h264_encoder(FfmpegH264Platform::WindowsSoftware).backend,
-            EncodeBackend::SoftwareOpenH264
-        );
-        assert_eq!(
-            ffmpeg_h264_encoder(FfmpegH264Platform::PortableTestOpenH264).backend,
             EncodeBackend::SoftwareOpenH264
         );
     }
@@ -17934,13 +17897,6 @@ mod tests {
                 assert_eq!(arg_value(args, "-prio_speed"), None);
                 assert_eq!(arg_value(args, "-hw_encoding"), None);
                 assert_eq!(encoder.backend, EncodeBackend::SoftwareOpenH264);
-            }
-            FfmpegH264Platform::PortableTestOpenH264 => {
-                assert_eq!(arg_value(args, "-allow_sw"), None);
-                assert_eq!(arg_value(args, "-realtime"), None);
-                assert_eq!(arg_value(args, "-prio_speed"), None);
-                assert_eq!(arg_value(args, "-rc_mode"), Some("bitrate"));
-                assert_eq!(arg_value(args, "-allow_skip_frames"), Some("1"));
             }
         }
     }
@@ -22594,6 +22550,20 @@ mod tests {
         twitch.output_bitrate_kbps = Some(6000);
         params.streaming = Some(streaming);
 
+        // Pin the branch each shipping platform MUST take: without this, a
+        // regression that flips the availability helper silently reroutes the
+        // test into the other arm and the mixed-profile rejection coverage
+        // evaporates while staying green.
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        assert!(
+            separate_encoded_provider_output_role_available(&params),
+            "macOS/Windows must offer the split encoded provider role"
+        );
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        assert!(
+            !separate_encoded_provider_output_role_available(&params),
+            "platforms without an encoded bridge must not offer the split role"
+        );
         if separate_encoded_provider_output_role_available(&params) {
             let error = validate_outputs(&params).unwrap_err().to_string();
             assert!(error.contains("one captioned stream profile"), "{error}");

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -1458,6 +1458,11 @@ pub async fn start_session(
         bail!("A capture session is already running");
     }
 
+    // Linux L1 is a compile/test target only. Fail before creating session
+    // state or touching capture devices until the VAAPI + OpenH264 encoder
+    // decision is implemented in a later port phase.
+    ensure_platform_encoder_supported()?;
+
     hydrate_stream_key_secret_refs(&state, &mut params)?;
     normalize_stream_only_output_video(&mut params)?;
     validate_session_entitlements(&params, &entitlements::current_entitlements())?;
@@ -7259,7 +7264,36 @@ enum FfmpegH264Platform {
     Macos,
     WindowsHardware,
     WindowsSoftware,
+    #[cfg(test)]
+    PortableTestOpenH264,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+enum RuntimePlatform {
+    Macos,
+    Windows,
+    Linux,
     Other,
+}
+
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[error("H.264 encoding is unsupported on {platform} at Linux port level L1")]
+struct PlatformEncoderUnsupported {
+    platform: &'static str,
+}
+
+fn ffmpeg_h264_platform_for_target(
+    target: RuntimePlatform,
+) -> std::result::Result<FfmpegH264Platform, PlatformEncoderUnsupported> {
+    match target {
+        RuntimePlatform::Macos => Ok(FfmpegH264Platform::Macos),
+        RuntimePlatform::Windows => Ok(FfmpegH264Platform::WindowsSoftware),
+        RuntimePlatform::Linux => Err(PlatformEncoderUnsupported { platform: "Linux" }),
+        RuntimePlatform::Other => Err(PlatformEncoderUnsupported {
+            platform: "this platform",
+        }),
+    }
 }
 
 #[cfg(any(test, target_os = "windows"))]
@@ -7401,22 +7435,48 @@ struct FfmpegH264Encoder {
     backend: EncodeBackend,
 }
 
-fn current_ffmpeg_h264_platform() -> FfmpegH264Platform {
+fn current_ffmpeg_h264_platform()
+-> std::result::Result<FfmpegH264Platform, PlatformEncoderUnsupported> {
     #[cfg(target_os = "macos")]
     {
-        FfmpegH264Platform::Macos
+        ffmpeg_h264_platform_for_target(RuntimePlatform::Macos)
     }
     #[cfg(target_os = "windows")]
     {
         // Native Media Foundation bridge selection is per-session. The raw
         // developer/fallback path remains truthfully OpenH264 and never reads a
         // process-global hardware verdict from another session.
-        FfmpegH264Platform::WindowsSoftware
+        ffmpeg_h264_platform_for_target(RuntimePlatform::Windows)
     }
-    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    #[cfg(all(test, not(target_os = "macos"), not(target_os = "windows")))]
     {
-        FfmpegH264Platform::Other
+        // Cross-platform unit tests still exercise the complete argument
+        // topology without claiming a production Linux encoder. The runtime
+        // selector itself is covered separately and remains unsupported.
+        Ok(FfmpegH264Platform::PortableTestOpenH264)
     }
+    #[cfg(all(
+        not(test),
+        target_os = "linux",
+        not(target_os = "macos"),
+        not(target_os = "windows")
+    ))]
+    {
+        ffmpeg_h264_platform_for_target(RuntimePlatform::Linux)
+    }
+    #[cfg(all(
+        not(test),
+        not(target_os = "linux"),
+        not(target_os = "macos"),
+        not(target_os = "windows")
+    ))]
+    {
+        ffmpeg_h264_platform_for_target(RuntimePlatform::Other)
+    }
+}
+
+fn ensure_platform_encoder_supported() -> std::result::Result<(), PlatformEncoderUnsupported> {
+    current_ffmpeg_h264_platform().map(|_| ())
 }
 
 fn ffmpeg_h264_encoder(platform: FfmpegH264Platform) -> FfmpegH264Encoder {
@@ -7443,10 +7503,13 @@ fn ffmpeg_h264_encoder(platform: FfmpegH264Platform) -> FfmpegH264Encoder {
             pix_fmt: "yuv420p",
             backend: EncodeBackend::SoftwareOpenH264,
         },
-        FfmpegH264Platform::Other => FfmpegH264Encoder {
-            codec: "libx264",
+        #[cfg(test)]
+        FfmpegH264Platform::PortableTestOpenH264 => FfmpegH264Encoder {
+            // Test-only portable fixture. Production Linux selection returns
+            // PlatformEncoderUnsupported and never reaches an encoder.
+            codec: "libopenh264",
             pix_fmt: "yuv420p",
-            backend: EncodeBackend::SoftwareX264,
+            backend: EncodeBackend::SoftwareOpenH264,
         },
     }
 }
@@ -7498,31 +7561,41 @@ fn windows_media_foundation_hardware_probe_args(video: &VideoSettings) -> Vec<St
 const WINDOWS_MEDIA_FOUNDATION_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 
 fn default_h264_encode_backend() -> EncodeBackend {
-    ffmpeg_h264_encoder(current_ffmpeg_h264_platform()).backend
+    ffmpeg_h264_encoder(
+        current_ffmpeg_h264_platform()
+            .expect("macOS and Windows always have a configured H.264 encoder"),
+    )
+    .backend
 }
 
-fn append_h264_encoding_args(args: &mut Vec<String>, video: &VideoSettings, low_latency: bool) {
+fn append_h264_encoding_args(
+    args: &mut Vec<String>,
+    video: &VideoSettings,
+    low_latency: bool,
+) -> std::result::Result<(), PlatformEncoderUnsupported> {
     append_h264_encoding_args_for_platform(
         args,
         video,
-        current_ffmpeg_h264_platform(),
+        current_ffmpeg_h264_platform()?,
         low_latency,
     );
+    Ok(())
 }
 
 fn append_h264_encoding_args_preserving_input_timestamps(
     args: &mut Vec<String>,
     video: &VideoSettings,
     low_latency: bool,
-) {
+) -> std::result::Result<(), PlatformEncoderUnsupported> {
     append_h264_encoding_args_for_platform_with_timing(
         args,
         video,
-        current_ffmpeg_h264_platform(),
+        current_ffmpeg_h264_platform()?,
         false,
         low_latency,
     );
     args.extend(["-fps_mode".to_string(), "vfr".to_string()]);
+    Ok(())
 }
 
 fn append_h264_encoding_args_for_platform(
@@ -7588,22 +7661,21 @@ fn append_h264_encoding_args_for_platform_with_timing(
                 "1".to_string(),
             ]);
         }
-        FfmpegH264Platform::Other => {
+        #[cfg(test)]
+        FfmpegH264Platform::PortableTestOpenH264 => {
             args.extend([
-                "-preset".to_string(),
-                "ultrafast".to_string(),
-                "-tune".to_string(),
-                "zerolatency".to_string(),
+                "-rc_mode".to_string(),
+                "bitrate".to_string(),
+                "-allow_skip_frames".to_string(),
+                "1".to_string(),
             ]);
         }
     }
     // Spec-valid High profile/level (the recording-quality audit caught the
     // encoders' auto picks under-leveling 60fps streams). Media Foundation
     // exposes neither option, so the Windows arms keep the encoder default.
-    if matches!(
-        platform,
-        FfmpegH264Platform::Macos | FfmpegH264Platform::Other
-    ) && let Some(level) = h264_high_level_label(video.width, video.height, video.fps)
+    if matches!(platform, FfmpegH264Platform::Macos)
+        && let Some(level) = h264_high_level_label(video.width, video.height, video.fps)
     {
         args.extend([
             "-profile:v".to_string(),
@@ -10432,7 +10504,7 @@ fn bridge_compositor_ffmpeg_args(
                     &mut args,
                     &params.output.video,
                     !stream_targets.is_empty(),
-                );
+                )?;
             }
             EncoderBridgeVideoOutput::VideoToolboxH264AnnexB
             | EncoderBridgeVideoOutput::VideoToolboxH264MpegTs
@@ -11017,7 +11089,7 @@ fn ffmpeg_args(
         "[v_main]".to_string(),
     ]);
     append_audio_output_args(&mut args, &input_layout);
-    append_h264_encoding_args(&mut args, &params.output.video, !stream_targets.is_empty());
+    append_h264_encoding_args(&mut args, &params.output.video, !stream_targets.is_empty())?;
     append_audio_encoding_args(
         &mut args,
         &input_layout,
@@ -14944,13 +15016,13 @@ mod tests {
         append_h264_encoding_args_for_platform(
             &mut fallback_args,
             &video,
-            FfmpegH264Platform::Other,
+            FfmpegH264Platform::PortableTestOpenH264,
             true,
         );
-        assert_eq!(arg_value(&fallback_args, "-c:v"), Some("libx264"));
+        assert_eq!(arg_value(&fallback_args, "-c:v"), Some("libopenh264"));
         assert_eq!(arg_value(&fallback_args, "-pix_fmt"), Some("yuv420p"));
-        assert_eq!(arg_value(&fallback_args, "-preset"), Some("ultrafast"));
-        assert_eq!(arg_value(&fallback_args, "-tune"), Some("zerolatency"));
+        assert_eq!(arg_value(&fallback_args, "-rc_mode"), Some("bitrate"));
+        assert_eq!(arg_value(&fallback_args, "-allow_skip_frames"), Some("1"));
 
         for args in [
             &macos_args,
@@ -14985,8 +15057,19 @@ mod tests {
             EncodeBackend::SoftwareOpenH264
         );
         assert_eq!(
-            ffmpeg_h264_encoder(FfmpegH264Platform::Other).backend,
-            EncodeBackend::SoftwareX264
+            ffmpeg_h264_encoder(FfmpegH264Platform::PortableTestOpenH264).backend,
+            EncodeBackend::SoftwareOpenH264
+        );
+    }
+
+    #[test]
+    fn linux_h264_encoder_is_a_typed_unsupported_result() {
+        let error = ffmpeg_h264_platform_for_target(RuntimePlatform::Linux)
+            .expect_err("Linux L1 must not select an encoder");
+        assert_eq!(error.platform, "Linux");
+        assert_eq!(
+            error.to_string(),
+            "H.264 encoding is unsupported on Linux at Linux port level L1"
         );
     }
 
@@ -17824,7 +17907,7 @@ mod tests {
     }
 
     fn assert_current_h264_encoder_args(args: &[String], low_latency: bool) {
-        let platform = current_ffmpeg_h264_platform();
+        let platform = current_ffmpeg_h264_platform().expect("test encoder platform");
         let encoder = ffmpeg_h264_encoder(platform);
         assert_eq!(arg_value(args, "-c:v"), Some(encoder.codec));
         match platform {
@@ -17852,12 +17935,12 @@ mod tests {
                 assert_eq!(arg_value(args, "-hw_encoding"), None);
                 assert_eq!(encoder.backend, EncodeBackend::SoftwareOpenH264);
             }
-            FfmpegH264Platform::Other => {
+            FfmpegH264Platform::PortableTestOpenH264 => {
                 assert_eq!(arg_value(args, "-allow_sw"), None);
                 assert_eq!(arg_value(args, "-realtime"), None);
                 assert_eq!(arg_value(args, "-prio_speed"), None);
-                assert_eq!(arg_value(args, "-preset"), Some("ultrafast"));
-                assert_eq!(arg_value(args, "-tune"), Some("zerolatency"));
+                assert_eq!(arg_value(args, "-rc_mode"), Some("bitrate"));
+                assert_eq!(arg_value(args, "-allow_skip_frames"), Some("1"));
             }
         }
     }
@@ -18231,7 +18314,12 @@ mod tests {
         {
             assert_eq!(
                 arg_value(&args, "-c:v"),
-                Some(ffmpeg_h264_encoder(current_ffmpeg_h264_platform()).codec)
+                Some(
+                    ffmpeg_h264_encoder(
+                        current_ffmpeg_h264_platform().expect("test encoder platform")
+                    )
+                    .codec
+                )
             );
             assert_eq!(arg_value(&args, "-allow_sw"), None);
             assert_eq!(arg_value(&args, "-realtime"), None);
@@ -18317,7 +18405,12 @@ mod tests {
         {
             assert_eq!(
                 arg_value(&args, "-c:v"),
-                Some(ffmpeg_h264_encoder(current_ffmpeg_h264_platform()).codec)
+                Some(
+                    ffmpeg_h264_encoder(
+                        current_ffmpeg_h264_platform().expect("test encoder platform")
+                    )
+                    .codec
+                )
             );
             assert_eq!(arg_value(&args, "-allow_sw"), None);
             assert_eq!(arg_value(&args, "-realtime"), None);
@@ -18429,7 +18522,12 @@ mod tests {
         {
             assert_eq!(
                 arg_value(&args, "-c:v"),
-                Some(ffmpeg_h264_encoder(current_ffmpeg_h264_platform()).codec)
+                Some(
+                    ffmpeg_h264_encoder(
+                        current_ffmpeg_h264_platform().expect("test encoder platform")
+                    )
+                    .codec
+                )
             );
             assert_eq!(arg_value(&args, "-allow_sw"), None);
             assert_eq!(arg_value(&args, "-realtime"), None);

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -22635,19 +22635,20 @@ mod tests {
             burn_target: crate::captions::CaptionBurnTarget::Stream,
             ..Default::default()
         });
-        assert_eq!(
-            caption_burn_target(&captions_off),
-            crate::captions::CaptionBurnTarget::Off,
-            "an ineligible mixed captions-off session does not reserve an impossible live leg"
-        );
-        // Platform truth: record+stream split output has a native encoded
-        // bridge on macOS and Windows. Other platforms still reject it for the
-        // split-output reason, independently of captions.
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
-        validate_outputs(&captions_off)
-            .expect("captions-off preserves the existing mixed-profile capture behavior");
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        {
+        if separate_encoded_provider_output_role_available(&captions_off) {
+            assert_eq!(
+                caption_burn_target(&captions_off),
+                crate::captions::CaptionBurnTarget::Off,
+                "an ineligible split profile does not reserve an impossible live leg"
+            );
+            validate_outputs(&captions_off)
+                .expect("captions-off preserves the proven mixed-profile capture behavior");
+        } else {
+            assert_eq!(
+                caption_burn_target(&captions_off),
+                crate::captions::CaptionBurnTarget::Stream,
+                "the shared provider plan normalizes the targets to one eligible live leg"
+            );
             let error = validate_outputs(&captions_off).unwrap_err().to_string();
             assert!(
                 error.contains("share one encoder"),

--- a/crates/videorc-backend/src/source_mask.rs
+++ b/crates/videorc-backend/src/source_mask.rs
@@ -1,0 +1,12 @@
+/// Camera-bubble mask shared by the CPU and Metal compositors. FFmpeg mirrors
+/// the same geometry through `SceneMask` when it builds its filter graph.
+///
+/// This type deliberately lives in a platform-neutral module so Linux builds
+/// and the standalone macOS native-preview helper do not need to reach through
+/// the macOS-only Metal implementation to compile shared scene code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceMask {
+    None,
+    Circle,
+    Rounded { radius_pct: u32 },
+}

--- a/crates/videorc-native-preview-addon/src/lib.rs
+++ b/crates/videorc-native-preview-addon/src/lib.rs
@@ -4,6 +4,10 @@ mod color;
 #[cfg(target_os = "macos")]
 #[path = "../../videorc-backend/src/metal_compositor.rs"]
 mod metal_compositor;
+// metal_compositor re-exports crate::source_mask::SourceMask, so every crate
+// that #[path]-includes it must also mount source_mask at its own root (the
+// backend and the helper binary both do). allow(dead_code): the addon uses
+// the type only through the re-export.
 #[cfg(target_os = "macos")]
 #[allow(dead_code)]
 #[path = "../../videorc-backend/src/source_mask.rs"]

--- a/crates/videorc-native-preview-addon/src/lib.rs
+++ b/crates/videorc-native-preview-addon/src/lib.rs
@@ -4,6 +4,10 @@ mod color;
 #[cfg(target_os = "macos")]
 #[path = "../../videorc-backend/src/metal_compositor.rs"]
 mod metal_compositor;
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+#[path = "../../videorc-backend/src/source_mask.rs"]
+mod source_mask;
 
 #[cfg(target_os = "macos")]
 mod macos {

--- a/docs/linux-port-plan.md
+++ b/docs/linux-port-plan.md
@@ -1,0 +1,104 @@
+# Linux Port Plan
+
+Linux support is an incremental port, not a relabeling of the macOS or Windows
+runtime. The first milestone (L1) makes Linux a native Rust compile, lint, and
+unit-test target. It does **not** claim that capture, preview, recording,
+packaging, or release are supported yet.
+
+## Proposed support baseline
+
+| Area | Initial proposal | L1 status |
+| --- | --- | --- |
+| Distribution | Ubuntu 24.04 LTS | Compile/test gate only |
+| Architecture | x86_64 | CI runner architecture |
+| Display session | Wayland first, X11 considered later | Unsupported |
+| Screen/window capture | `xdg-desktop-portal` session backed by PipeWire | Unsupported |
+| Camera and audio | PipeWire required | Unsupported |
+| Preview | Linux-native surface, transport to be selected | Unsupported |
+| H.264 encode | VAAPI hardware, OpenH264 software fallback | Deferred to L5 |
+| Packaging | Format and signing policy to be selected | Unsupported |
+
+Wayland capture must go through the desktop portal rather than bypassing the
+user-consent boundary. PipeWire is a required part of the proposed baseline,
+not an optional fallback. Exact portal, PipeWire, VAAPI, and window-system
+development packages should be added only when the phase that uses them proves
+the dependency is necessary.
+
+## Licensing constraint
+
+Videorc ships an LGPL-only FFmpeg distribution. Linux must never select or
+bundle `libx264`, because that would introduce GPL requirements that are
+incompatible with the product's open-core distribution model.
+
+The intended Linux encoder decision is:
+
+- VAAPI for hardware H.264 encoding; and
+- OpenH264 for a software fallback.
+
+That encoder is intentionally **not implemented in L1**. The production Linux
+encoder selector returns a typed unsupported error before a capture session can
+create state. L5 owns the implementation and its capability/fallback contract.
+
+## Delivery phases
+
+### L1 — Compile and CI gate
+
+- Compile the backend natively on Ubuntu.
+- Run Rust format, `cargo check`, clippy with warnings denied, and the backend
+  unit suite on every pull request and push to `main`.
+- Keep shared geometry and pixel conversion outside Apple-only modules.
+- Return explicit unsupported results for runtime paths with no Linux backend.
+
+The temporary Linux clippy allow list matches the documented Windows
+cross-platform allow list: `dead_code`, `unused_imports`, `unused_variables`,
+and `unused_mut`. Both platform gates should remove those allows together as
+the shared warning wall is eliminated.
+
+### L2 — Desktop shell and platform affordances
+
+- Launch the Electron/backend pair on Ubuntu 24.04 x64.
+- Replace macOS-specific permission, shortcut, window-chrome, and system-link
+  assumptions with platform-owned behavior.
+- Add a no-device lifecycle smoke without claiming media support.
+
+### L3 — Discovery and permissions
+
+- Discover portal/PipeWire screens, windows, cameras, and microphones behind
+  the existing source contracts.
+- Model portal consent, revoked sessions, missing devices, and reconnects as
+  explicit states and diagnostics.
+- Add deterministic discovery and permission tests.
+
+### L4 — Capture and preview
+
+- Implement Wayland-first screen/window capture through
+  `xdg-desktop-portal` and PipeWire.
+- Implement PipeWire camera/audio ingestion and a Linux-native preview
+  presenter with first-frame and source-liveness contracts.
+- Qualify lifecycle, source switching, detach/reattach, and backpressure on a
+  real Linux desktop.
+
+### L5 — Record, encode, and stream
+
+- Implement the VAAPI hardware encoder path and OpenH264 software fallback.
+- Preserve the shared scene geometry, BT.709/video-range color tags, bounded
+  queues, A/V stop-tail, and final-artifact analysis used by shipping ports.
+- Prove recording and streaming profiles on representative Intel, AMD, and
+  software-fallback hosts without adding `libx264`.
+
+### L6 — Package, release, and acceptance
+
+- Select the package format, update channel, signing/provenance policy, and
+  supported GPU/desktop matrix.
+- Add packaged-app device, recording, streaming, updater, and cleanup smokes.
+- Publish Linux only after dated real-device evidence meets the same explicit
+  quality and lifecycle bar as the other shipping platforms.
+
+## Reference implementation and attribution
+
+The `linux/phase0-compile` branch of
+[`ForrestKnight/videorc-linux`](https://github.com/ForrestKnight/videorc-linux)
+was used as a reference for identifying platform seams, including moving the
+source-mask model out of the Metal implementation. Its stale branch is not
+merged or cherry-picked: changes are re-derived against current Videorc code.
+Its GPL `libx264` encoder choice is explicitly rejected by this plan.


### PR DESCRIPTION
## Summary
- adds a native Ubuntu cargo check, fmt, clippy, and backend-test workflow for every PR and main push
- moves SourceMask and YUV-to-BGRA conversion behind platform-neutral seams
- replaces the Linux libx264 fallback with a typed unsupported encoder result before session state is created
- documents the six-phase Linux port, Ubuntu 24.04 x64 proposal, Wayland portal and PipeWire baseline, and VAAPI plus OpenH264 direction

## Why
Linux could not be treated as a maintained compile target while shared code reached through macOS-only modules and the generic encoder branch selected GPL libx264. L1 establishes a truthful compile-and-test boundary without claiming capture, preview, encoding, packaging, or release support.

## Compatibility and scope
- macOS VideoToolbox and Windows Media Foundation/OpenH264 behavior is unchanged
- shared YUV conversion logic moved byte-for-byte and now has platform-neutral tests
- no application version, changelog, packaging, artifact, or release workflow changes
- existing genuinely platform-specific Metal, AVFoundation, Media Foundation, and D3D11 tests remain cfg-gated at their framework boundaries; no portable test was skipped to make Linux compile
- the Linux clippy allow list matches windows.yml and both lists should be removed together as the cross-platform warning wall is reduced

## Verification
- cargo fmt --check --all
- cargo clippy -p videorc-backend -- -D warnings
- cargo test -p videorc-backend (1485 passed, 8 existing ignored; helper suite 57 passed)
- pnpm typecheck
- pnpm lint
- pnpm format:check
- Shadscan pre-commit audit: 41, ruleset 2026.07.34, unchanged from baseline

A local x86_64-unknown-linux-gnu cross-check reached bundled SQLite but was blocked by the macOS host lacking x86_64-linux-gnu-gcc. The new native Ubuntu PR job is the authoritative Linux verification.