### PR TITLE
ui: stop toasting the YouTube-OAuth-unavailable message

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -3518,10 +3518,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     async (accountId?: string, options: { background?: boolean } = {}) => {
       const unavailable = oauthUnavailableReason('youtube')
       if (unavailable) {
+        // No toast: the streaming tab's destination card already states the
+        // unavailable reason inline, and this fires on routine refreshes —
+        // repeating it as a toast was pure nag (owner request 2026-08-14).
         setYoutubeChannels([])
-        if (!options.background) {
-          toast.warning(unavailable)
-        }
         return
       }
       if (!client) {
@@ -3556,9 +3556,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   const selectYouTubeChannel = useCallback(
     async (channelId: string, accountId?: string) => {
-      const unavailable = oauthUnavailableReason('youtube')
-      if (unavailable) {
-        toast.warning(unavailable)
+      if (oauthUnavailableReason('youtube')) {
+        // Silent: the channel picker is not rendered while OAuth is
+        // unavailable, so this is unreachable through the UI; if reached
+        // programmatically the inline destination status already explains it.
         return
       }
       if (!client || wsStatus !== 'connected') {
@@ -7758,9 +7759,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   const connectPlatformAccount = useCallback(
     async (platform: PlatformAccount['platform']) => {
-      const unavailable = oauthUnavailableReason(platform)
-      if (unavailable) {
-        toast.warning(unavailable)
+      if (oauthUnavailableReason(platform)) {
+        // Silent: the destination card renders the unavailable reason inline
+        // right next to the control that triggers this, so the toast only
+        // duplicated visible copy (owner request 2026-08-14).
         return
       }
       if (!client || wsStatus !== 'connected') {


### PR DESCRIPTION
Owner request: the *"YouTube OAuth is temporarily unavailable while Videorc awaits Google approval. Use Manual RTMP for YouTube for now."* toast is annoying.

It fired from three renderer paths — `refreshYouTubeChannels` (including routine refreshes), `selectYouTubeChannel`, and `connectPlatformAccount` — while the streaming tab's destination card **already renders the same reason inline** (`streaming-tab.tsx:427`) right next to the controls that trigger these paths. Pure duplication, now silent, with comments at each site explaining why.

**Gating unchanged:** saved OAuth targets still normalize to manual RTMP on load (`capture.ts:1467`), the Go Live preflight still refuses an explicitly enabled unavailable OAuth destination, and the backend `validate_start_session_oauth_availability` still bails identically. Only the toast noise is removed.

Verified: typecheck, lint, format clean; desktop tests 1327 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary warning notifications when YouTube or other platform connections are unavailable.
  * Channel refresh and selection now continue quietly while preserving the existing connection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->