### PR TITLE
fix(camera): restart frameless zombie-live sessions instead of reusing them

### DIFF
--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -1008,8 +1008,20 @@ fn missing_readiness_messages(
 ) -> Vec<String> {
     let mut messages = Vec::new();
     if needs.camera && !readiness.live.camera {
+        // "Never delivered" and "went stale" are different failures: the first
+        // is a dead session or claimed device (Cam Link class), the second a
+        // stalled-but-once-working stream. Say which one it was.
+        let status = &readiness.camera_status;
+        let never_delivered = status.frames_captured == 0
+            && status.sequence.is_none()
+            && readiness.camera_frame.is_none();
+        let label = if never_delivered {
+            "camera session never delivered a frame"
+        } else {
+            "camera frames stopped or went stale"
+        };
         messages.push(format!(
-            "camera produced no fresh frames ({})",
+            "{label} ({})",
             camera_readiness_detail(readiness, target_sources)
         ));
     }
@@ -1032,13 +1044,14 @@ fn camera_readiness_detail(
         .map(|frame| frame.frame_age_ms)
         .or(status.frame_age_ms);
     format!(
-        "state: {}, target: {}, current: {}, frames captured: {}, latest sequence: {}, latest frame age: {}",
+        "state: {}, target: {}, current: {}, frames captured: {}, dropped: {}, latest sequence: {}, latest frame age: {}",
         camera_state_label(&status.state),
         target_sources
             .and_then(|sources| sources.camera_id.as_deref())
             .unwrap_or("none"),
         status.camera_id.as_deref().unwrap_or("none"),
         status.frames_captured,
+        status.dropped_frames,
         format_optional_u64(
             readiness
                 .camera_frame
@@ -2378,9 +2391,48 @@ mod tests {
         );
 
         assert_eq!(messages.len(), 2);
-        assert!(messages[0].contains("camera produced no fresh frames"));
+        // 42 frames were captured and went stale — this is the stale wording,
+        // not the never-delivered wording.
+        assert!(messages[0].contains("camera frames stopped or went stale"));
         assert!(messages[0].contains("latest frame age: 1501ms"));
         assert!(messages[1].contains("screen/window produced no initial frame"));
         assert!(messages[1].contains("frames captured: 0"));
+    }
+
+    #[test]
+    fn missing_readiness_messages_distinguish_a_camera_that_never_delivered() {
+        // The Cam Link zombie shape: Live status, zero frames ever, no frame
+        // store entry. The message must say "never delivered", not "stale",
+        // and must carry the dropped counter so a silent-device failure can be
+        // told apart from an unusable-format failure in field reports.
+        let mut camera = live_camera_status("camera:a", None, 0, None);
+        camera.dropped_frames = 7;
+        let mut target = sources(true, false);
+        target.camera_id = Some("camera:a".to_string());
+        let readiness = SourceReadiness {
+            live: SourceLiveness {
+                camera: false,
+                screen: false,
+            },
+            camera_status: camera,
+            screen_status: live_screen_status("screen:unused", None, 0, None),
+            camera_frame: None,
+            screen_frame: None,
+        };
+
+        let messages = missing_readiness_messages(
+            SceneSourceNeeds {
+                camera: true,
+                screen: false,
+            },
+            &readiness,
+            Some(&target),
+        );
+
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].contains("camera session never delivered a frame"));
+        assert!(messages[0].contains("frames captured: 0"));
+        assert!(messages[0].contains("dropped: 7"));
+        assert!(messages[0].contains("latest frame age: none"));
     }
 }

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -111,6 +111,12 @@ pub struct PreviewCameraRuntime {
     start_generation: u64,
     active: Option<NativeCameraPreviewThread>,
     poll_task: Option<JoinHandle<()>>,
+    /// When the current session acked Live. macOS acks Live as soon as
+    /// startRunning() returns — before any frame exists — so a session can be
+    /// "live" and frameless. This timestamp bounds how long that is treated
+    /// as normal startup rather than a dead session (see
+    /// camera_live_session_is_frameless_zombie).
+    live_acked_at: Option<Instant>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -324,6 +330,7 @@ pub fn initial_preview_camera_state() -> PreviewCameraRuntime {
         start_generation: 0,
         active: None,
         poll_task: None,
+        live_acked_at: None,
     }
 }
 
@@ -360,6 +367,15 @@ pub async fn start_preview_camera(
         if !keep_alive {
             stop_current_camera(&state).await;
         }
+    } else if camera_live_session_is_frameless_zombie(&state).await {
+        // Same source key, status Live — but the session never delivered a
+        // single frame and its first-frame grace has elapsed. Exclusive
+        // devices (Elgato Cam Link) get here when startRunning() succeeds
+        // while the device is mid-renegotiation or still held by a closing
+        // session: AVFoundation reports running, no sample buffer ever
+        // arrives, and the reuse path below would hand that dead status back
+        // forever. Tear the session down so this start is a real restart.
+        stop_current_camera(&state).await;
     }
     acquire_preview_camera_source(&state, source_key.clone(), SourceLifecycleStatus::Starting)
         .await;
@@ -520,6 +536,7 @@ pub async fn start_preview_camera(
                     slot.run_id = Some(run_id.clone());
                     slot.source_key = Some(source_key.clone());
                     slot.active = started_thread.take();
+                    slot.live_acked_at = Some(Instant::now());
                     true
                 }
             };
@@ -672,6 +689,7 @@ pub(crate) async fn begin_preview_camera_stop(state: &AppState) -> PreviewCamera
         slot.run_id = None;
         slot.source_key = None;
         slot.starting = None;
+        slot.live_acked_at = None;
         (slot.active.take(), slot.poll_task.take())
     };
     if let Some(task) = poll_task {
@@ -925,6 +943,7 @@ async fn stop_current_camera_inner(state: &AppState, clear_starting: bool) {
     let (previous, poll_task) = {
         let mut slot = state.preview_camera.lock().await;
         slot.run_id = None;
+        slot.live_acked_at = None;
         if clear_starting {
             slot.source_key = None;
             slot.starting = None;
@@ -1054,6 +1073,40 @@ async fn release_current_preview_camera_source(state: &AppState) -> bool {
         .iter()
         .find(|entry| entry.key == source_key)
         .is_some_and(|entry| !entry.consumers.is_empty())
+}
+
+/// How long a Live-acked session may stay frameless before reuse treats it as
+/// dead. First frames normally land well under a second after startRunning();
+/// the layout-readiness budget (5s) sits above this, so a genuinely slow first
+/// frame still has time to arrive after the forced restart.
+const CAMERA_FIRST_FRAME_REUSE_GRACE: Duration = Duration::from_secs(4);
+
+/// True when the current camera session acked Live, has never produced any
+/// frame evidence (no captured-frame count, nothing in the frame store), and
+/// has been in that state longer than the first-frame grace.
+async fn camera_live_session_is_frameless_zombie(state: &AppState) -> bool {
+    let slot = state.preview_camera.lock().await;
+    if slot.status.state != PreviewCameraState::Live {
+        return false;
+    }
+    let has_frame_evidence = slot.status.frames_captured > 0
+        || slot.status.sequence.is_some()
+        || slot.active.as_ref().is_some_and(|active| {
+            // WouldBlock means the capture thread holds the frame lock right
+            // now — that is evidence of life, not a zombie.
+            match active.shared.try_lock() {
+                Ok(shared) => shared.frame_store.latest().is_some(),
+                Err(TryLockError::WouldBlock) => true,
+                Err(TryLockError::Poisoned(poisoned)) => {
+                    poisoned.into_inner().frame_store.latest().is_some()
+                }
+            }
+        });
+    if has_frame_evidence {
+        return false;
+    }
+    slot.live_acked_at
+        .is_none_or(|acked| acked.elapsed() >= CAMERA_FIRST_FRAME_REUSE_GRACE)
 }
 
 async fn reuse_current_camera_source(
@@ -3327,5 +3380,78 @@ mod tests {
             status.message.as_deref(),
             Some("Native camera preview source reused.")
         );
+    }
+    #[tokio::test]
+    async fn frameless_live_slot_past_grace_is_a_zombie() {
+        // The Cam Link failure shape: Live acked, zero frames ever, grace long
+        // gone. The next same-key start must tear down and truly restart.
+        let state = test_state();
+        {
+            let mut slot = state.preview_camera.lock().await;
+            slot.status.state = PreviewCameraState::Live;
+            slot.status.camera_id = Some("camera:test".to_string());
+            slot.status.frames_captured = 0;
+            slot.status.sequence = None;
+            slot.source_key = Some(SourceKey::camera("camera:test".to_string()));
+            slot.live_acked_at =
+                Some(Instant::now() - CAMERA_FIRST_FRAME_REUSE_GRACE - Duration::from_millis(1));
+        }
+        assert!(camera_live_session_is_frameless_zombie(&state).await);
+    }
+
+    #[tokio::test]
+    async fn frameless_live_slot_within_grace_is_not_a_zombie() {
+        // A camera that acked Live a moment ago is still warming up; the
+        // readiness wait owns that window, not a forced restart.
+        let state = test_state();
+        {
+            let mut slot = state.preview_camera.lock().await;
+            slot.status.state = PreviewCameraState::Live;
+            slot.status.frames_captured = 0;
+            slot.status.sequence = None;
+            slot.live_acked_at = Some(Instant::now());
+        }
+        assert!(!camera_live_session_is_frameless_zombie(&state).await);
+    }
+
+    #[tokio::test]
+    async fn live_slot_with_frame_evidence_is_never_a_zombie() {
+        let state = test_state();
+        {
+            let mut slot = state.preview_camera.lock().await;
+            slot.status.state = PreviewCameraState::Live;
+            slot.status.frames_captured = 42;
+            slot.live_acked_at =
+                Some(Instant::now() - CAMERA_FIRST_FRAME_REUSE_GRACE - Duration::from_secs(60));
+        }
+        assert!(!camera_live_session_is_frameless_zombie(&state).await);
+    }
+
+    #[tokio::test]
+    async fn non_live_slot_is_not_a_zombie() {
+        // Starting/Failed/DeviceMissing states have their own handling; the
+        // zombie teardown must never fire for them.
+        let state = test_state();
+        {
+            let mut slot = state.preview_camera.lock().await;
+            slot.status.state = PreviewCameraState::Starting;
+            slot.live_acked_at =
+                Some(Instant::now() - CAMERA_FIRST_FRAME_REUSE_GRACE - Duration::from_secs(60));
+        }
+        assert!(!camera_live_session_is_frameless_zombie(&state).await);
+    }
+
+    #[tokio::test]
+    async fn frameless_live_slot_with_no_ack_timestamp_is_a_zombie() {
+        // A Live status with no recorded ack time (state restored oddly, or a
+        // pre-fix session) has no claim to the warmup grace.
+        let state = test_state();
+        {
+            let mut slot = state.preview_camera.lock().await;
+            slot.status.state = PreviewCameraState::Live;
+            slot.status.frames_captured = 0;
+            slot.live_acked_at = None;
+        }
+        assert!(camera_live_session_is_frameless_zombie(&state).await);
     }
 }


### PR DESCRIPTION
Owner-reported (Cam Link, macOS): switching a layout to the camera fails with *"camera produced no fresh frames (state: live, target: X, current: X, frames captured: 0, latest sequence: none, latest frame age: none)"* — and **every retry fails identically**.

## Root cause (full trace in the session, key points)

- macOS acks `Live` when `startRunning()` returns — **before any frame** (`preview_camera.rs:2002`); Windows only acks after the first frame.
- A session whose device delivers nothing (Cam Link dropping off USB during HDMI renegotiation — verified the device vanishes from the bus; or claimed elsewhere) stays `Live` with `frames_captured: 0` forever: no `AVCaptureSessionRuntimeError`/interruption observers exist to demote it.
- The layout switch calls `start_preview_camera`, which short-circuits in `reuse_current_camera_source` (same key ⇒ **returns the dead status verbatim, no restart**), then the 5s readiness wait polls an empty frame store. Renderer-side, `preview.camera.start` is also suppressed for a key already 'live'. **The state is unrecoverable without a manual deselect or app restart.**
- Not a #201 regression: the reported string predates #201 (which deleted it), and #201 touched no camera code.

## Fix

1. `camera_live_session_is_frameless_zombie`: Live-acked + zero frame evidence (counter, sequence, frame store; `WouldBlock` on the frame lock counts as alive) + past a **4s first-frame grace** (`live_acked_at` tracked on the slot, cleared on all stops) ⇒ `start_preview_camera` tears the session down **before** the reuse shortcut, making the switch a genuine restart. Healthy fast-path reuse is untouched; a just-started camera keeps its warmup window (the 5s readiness budget still owns first-frame patience).
2. Failure message now distinguishes **"camera session never delivered a frame"** from **"camera frames stopped or went stale"**, and prints `dropped_frames` — the counter that separates a silent device from one sending unusable buffers.

## Verification

- cargo test **1488 pass** (+5 zombie-predicate tests covering zombie/grace/evidence/non-live/no-ack, +1 never-delivered message test); clippy `-D warnings`, fmt clean
- typecheck / lint / format clean
- `smoke:recording-studio` core PASS; **device smoke blocked**: the Cam Link is currently absent from the USB bus (`system_profiler` shows no Elgato device) — which is itself consistent with the suspected trigger. To be run on reattachment: select Cam Link → switch layouts → verify recovery instead of the permanent block.

Follow-ups (not this PR): AVFoundation runtime-error/interruption observers to demote `Live` explicitly (C3), serializing the retirement stop's join before a same-device restart (C4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera readiness diagnostics by distinguishing sessions that never delivered video from streams that have become stale.
  * Camera diagnostics now include dropped-frame counts for clearer troubleshooting.
  * Cameras with no frame activity after the startup grace period are automatically stopped and restarted when launched from the same source.
  * Added safeguards to avoid unnecessary restarts when recent frame evidence is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->