### PR TITLE
release: 0.9.51-beta.1 — camera self-recovery + steadier live switching

### DIFF
--- a/changelog/0.9.51-beta.1.md
+++ b/changelog/0.9.51-beta.1.md
@@ -1,0 +1,31 @@
+---
+version: 0.9.51-beta.1
+date: 2026-08-15
+channel: beta
+platforms:
+  - macos
+title: Camera capture recovers itself, and switching scenes live is steadier
+summary: A camera that stopped delivering frames — Elgato Cam Link owners hit this after an HDMI re-plug — no longer wedges until you restart the app. Live scene and monitor switches are more tolerant of slow starts, and a nagging YouTube notice is gone.
+highlights:
+  - A camera session that never delivers a frame now restarts itself on the next switch instead of blocking forever — the fix for Cam Link-style capture devices after an HDMI or USB re-plug.
+  - Switching scenes or the captured monitor during a live session now tolerates slow screen-capture starts instead of failing spuriously.
+  - Scene switching while idle no longer glitches after a session ends.
+  - The repeated "YouTube OAuth is temporarily unavailable" popup is gone — the destination card still shows the status inline.
+---
+
+If your capture card dropped off USB for a moment — Cam Links do this during
+HDMI renegotiation — the camera could come back looking "live" while never
+delivering another frame, and every attempt to switch to it failed the same
+way until you restarted Videorc. The app now notices a camera session that
+has never produced a frame and restarts it for real on your next switch.
+Error messages also now say which failure happened: a camera that never
+delivered a frame reads differently from one whose frames went stale.
+
+Live switching is steadier across the board: changing the captured monitor
+mid-session tolerates slow ScreenCaptureKit starts instead of failing while
+the previous layout stays up, and idle scene switching after a session has
+been fixed.
+
+Housekeeping: the recurring "YouTube OAuth is temporarily unavailable" toast
+is removed. The same status still shows inline on the YouTube destination
+card, without interrupting you.


### PR DESCRIPTION
macOS Beta changelog entry. **No version bump** — package.json is already 0.9.51 from the Windows track; the macOS updater orders by numeric version (0.9.51 > installed 0.9.50), so this ships as `0.9.51-beta.1` alongside Windows `0.9.51-alpha.1` on the same numeric version.

Ships to macOS users: #206 (Cam Link zombie-session self-recovery + honest failure messages), #201 (live monitor-switch tolerance), #202 (idle scene switching), #205 (YouTube OAuth toast removed).

**Named consequence, per the runbook's held-entry rule:** the macOS upload publishes every committed changelog entry, which discloses `0.9.51-alpha.1` (Windows, currently pilot-only) in the public changelog. Owner-resolved: the Windows Alpha has already been publicly announced on X, and the signed-in pilot is real and downloadable, so the entry no longer discloses anything unannounced.

`pnpm changelog:check`: 54 entries valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)