### PR TITLE
fix(camera): stop switch retries from killing a still-warming camera session

### DIFF
--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -52,7 +52,13 @@ use crate::screen_capture::{
 };
 use crate::state::AppState;
 
-const WARM_CAMERA_START_TIMEOUT: Duration = Duration::from_secs(5);
+/// Camera warm-start budget covers teardown + AVCaptureSession config +
+/// startRunning() + the FIRST FRESH FRAME. External capture devices (Cam Link,
+/// Continuity Camera, virtual cams) can take well over 5s to deliver a first
+/// frame after HDMI renegotiation, so the camera gets the same budget as the
+/// screen. A retry within `preview_camera::CAMERA_FIRST_FRAME_REUSE_GRACE`
+/// joins the in-flight warm-up instead of restarting the device.
+const WARM_CAMERA_START_TIMEOUT: Duration = Duration::from_secs(15);
 const WARM_SCREEN_START_TIMEOUT: Duration = Duration::from_secs(15);
 const WARM_SOURCE_POLL: Duration = Duration::from_millis(100);
 const LAYOUT_INTENT_CANCEL_POLL: Duration = Duration::from_millis(25);
@@ -2011,8 +2017,21 @@ mod tests {
 
     #[test]
     fn live_source_start_budgets_are_source_specific() {
-        assert_eq!(warm_source_start_timeout("camera"), Duration::from_secs(5));
+        assert_eq!(warm_source_start_timeout("camera"), Duration::from_secs(15));
         assert_eq!(warm_source_start_timeout("screen"), Duration::from_secs(15));
+    }
+
+    #[test]
+    fn camera_zombie_grace_exceeds_the_camera_warm_start_budget() {
+        // If the grace were inside the budget, a switch retry would tear down a
+        // session that is still legitimately warming up and restart its clock —
+        // a camera slower than the grace could then never come back (the 0.9.51
+        // Cam Link retry storm). Retries must join the warm-up, not kill it.
+        assert!(
+            crate::preview_camera::CAMERA_FIRST_FRAME_REUSE_GRACE
+                > warm_source_start_timeout("camera"),
+            "CAMERA_FIRST_FRAME_REUSE_GRACE must stay above WARM_CAMERA_START_TIMEOUT"
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -2220,7 +2239,7 @@ mod tests {
 
         assert_eq!(Instant::now() - started, WARM_SCREEN_START_TIMEOUT);
         assert!(error.to_string().contains("screen (15s)"));
-        assert!(!error.to_string().contains("camera (5s)"));
+        assert!(!error.to_string().contains("camera (15s)"));
     }
 
     #[test]

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -1076,10 +1076,14 @@ async fn release_current_preview_camera_source(state: &AppState) -> bool {
 }
 
 /// How long a Live-acked session may stay frameless before reuse treats it as
-/// dead. First frames normally land well under a second after startRunning();
-/// the layout-readiness budget (5s) sits above this, so a genuinely slow first
-/// frame still has time to arrive after the forced restart.
-const CAMERA_FIRST_FRAME_REUSE_GRACE: Duration = Duration::from_secs(4);
+/// dead. This MUST exceed the camera's layout warm-start budget
+/// (`live_layout::WARM_CAMERA_START_TIMEOUT`): a readiness bail deliberately
+/// leaves the still-warming session in place, and the next switch attempt has
+/// to JOIN that warm-up — tearing it down restarts the device clock from zero,
+/// so a camera whose first frame is slower than the grace could never come
+/// back (0.9.51 Cam Link retry-storm regression). Only a session frameless
+/// longer than any legitimate warm-up is treated as dead.
+pub(crate) const CAMERA_FIRST_FRAME_REUSE_GRACE: Duration = Duration::from_secs(20);
 
 /// True when the current camera session acked Live, has never produced any
 /// frame evidence (no captured-frame count, nothing in the frame store), and
@@ -3410,6 +3414,24 @@ mod tests {
             slot.status.frames_captured = 0;
             slot.status.sequence = None;
             slot.live_acked_at = Some(Instant::now());
+        }
+        assert!(!camera_live_session_is_frameless_zombie(&state).await);
+    }
+
+    #[tokio::test]
+    async fn frameless_live_slot_inside_the_warm_start_budget_is_not_a_zombie() {
+        // The 0.9.51 Cam Link retry storm: a slow external device 10s into its
+        // warm-up (past the old 4s grace) was torn down by every retry, so its
+        // first frame could never arrive. A retry must JOIN this warm-up.
+        let state = test_state();
+        {
+            let mut slot = state.preview_camera.lock().await;
+            slot.status.state = PreviewCameraState::Live;
+            slot.status.camera_id = Some("camera:test".to_string());
+            slot.status.frames_captured = 0;
+            slot.status.sequence = None;
+            slot.source_key = Some(SourceKey::camera("camera:test".to_string()));
+            slot.live_acked_at = Some(Instant::now() - Duration::from_secs(10));
         }
         assert!(!camera_live_session_is_frameless_zombie(&state).await);
     }


### PR DESCRIPTION
## 0.9.51 regression — camera never comes back after switching away and back (Cam Link)

Root cause is an interaction between #201 and #206, found by span archaeology over `d1c8c346..main` (every commit + every runtime file audited):

1. **#201** gave the screen a 15s warm-start budget with teardown time excluded — but left the camera at **5s including** teardown, `AVCaptureSession` config, `startRunning()`, and the **first fresh frame**. External devices (Cam Link after HDMI renegotiation, Continuity Camera, virtual cams) routinely need more than that.
2. **#206**'s zombie predicate used a **4s grace that sits inside that 5s budget**. A slow camera misses the readiness window, the bail leaves the still-warming session in place (cancel only stops `Starting`, the state is `Live`), and the **next** switch attempt trips the predicate, tears the session down, and restarts the 5s clock. Every retry kills the warm-up it is waiting for → the camera can never come back.

## Fix

- `WARM_CAMERA_START_TIMEOUT` 5s → **15s** (parity with the screen budget).
- `CAMERA_FIRST_FRAME_REUSE_GRACE` 4s → **20s**, now strictly above the warm budget: a retry **joins** an in-flight warm-up (`reuse_current_camera_source` returns the Live session and the readiness wait covers its first frame) instead of restarting the device. Genuinely dead sessions (the original #206 Cam Link zombie) still self-heal — patiently instead of instantly.
- Invariant test pinning `grace > camera warm budget` so the two constants can't drift back into the trap.
- Regression test: a frameless Live session 10s into warm-up (past the old grace) is **not** a zombie.

## Verification

- `cargo test -p videorc-backend`: 1,548 passed, 0 failed (includes the two new tests).
- `cargo clippy -p videorc-backend -- -D warnings`, `cargo fmt --check`: clean.
- On-hardware camera→screen→camera loop: **blocked from agent context by per-binary TCC** (dev Electron in an isolated worktree has no camera grant; enumeration returns empty — same wall as the 0.9.36 postmortem). Owner check after merge: switch camera → screen share → camera with the Cam Link; the camera should recover within ~5–10s even on a slow HDMI handshake, with no permanent dead state.

Follow-ups tracked separately: readiness-bail orphan cleanup + renderer start-suppression guard hardening (P2), ghosting watch after this lands (P3 — recordings A/B already exonerated the compositor; the visible 'shadows' were stale held frames during the failed-switch storm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera startup reliability by allowing more time for cameras to warm up.
  * Extended the reuse window for recently acknowledged camera sessions, reducing unnecessary teardown and restarts.
  * Fixed readiness handling for slower-starting cameras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->