### PR TITLE
release: 0.9.52-beta.1 — camera switch-back fix for slow capture devices

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.51",
+  "version": "0.9.52",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.52-beta.1.md
+++ b/changelog/0.9.52-beta.1.md
@@ -1,0 +1,30 @@
+---
+version: 0.9.52-beta.1
+date: 2026-08-16
+channel: beta
+platforms:
+  - macos
+title: Switching back to a slow camera works again
+summary: Fixes a 0.9.51 regression where switching from camera to screen share and back left the camera dead — capture cards like the Elgato Cam Link that take a few seconds to wake were restarted over and over instead of being allowed to finish. Preview ghosting during failed switches goes with it.
+highlights:
+  - Switching camera → screen share → camera works again with slow-waking capture devices — Cam Link, Continuity Camera, and virtual cameras included.
+  - The camera now gets the same generous startup budget as screen capture, and a retried switch waits for a camera that is still warming up instead of restarting it from zero.
+  - The stale "shadow" frames some setups saw during those failed switches disappear along with the retry loop.
+---
+
+Version 0.9.51 tightened how Videorc detects a dead camera session, and that
+detector could misfire on cameras that legitimately take a few seconds to
+deliver their first frame — an Elgato Cam Link renegotiating HDMI being the
+prime example. Switching away to a screen share and back would find the
+camera still warming up, declare it dead, and restart it, which reset the
+warm-up clock every single try. The camera never got to finish starting.
+
+The camera now has the same startup budget as screen capture, and the
+dead-session detector only fires for sessions that have been frameless far
+longer than any legitimate warm-up. A retried switch joins the camera start
+already in flight instead of killing it, so even a slow HDMI handshake
+finishes and the picture comes back.
+
+If you saw ghosted or frozen "shadow" frames in the preview while switching
+during 0.9.51, that was this same loop holding the last good frame while it
+restarted the camera behind the scenes — it clears up with this fix.


### PR DESCRIPTION
Version bump 0.9.51 → 0.9.52 + changelog entry for the #208 camera warm-start fix (0.9.51 regression: camera→screen→camera retry storm on slow capture devices). macOS-only release.