### PR TITLE
fix(macos): preview quality batch — snow, capture geometry, crash, and toast noise

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -4335,12 +4335,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           }
         } else if (event.code === 'camera-cadence-mismatch') {
           // The camera is healthy but delivering a different rate than the session
-          // (e.g. a 24p HDMI feed into a 30fps session): the recording will stutter.
-          // Actionable at record start — the user can stop and fix the camera output.
-          toast.warning('Camera frame rate mismatch', {
-            description: event.message,
-            duration: 15000
-          })
+          // (e.g. a 24p HDMI feed into a 30fps session). The health event stays in
+          // the session record and diagnostics; a toast on every record start was
+          // noise for setups that live with a fixed-rate HDMI source.
         } else if (event.code === 'mic-silent') {
           // Plan 021 F3: the user must hear about a silent mic from the app,
           // not from playing the file back. Warn = mid-session (stopping and
@@ -8657,11 +8654,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           let unhealthy: StreamTargetSettings | null = null
           let unhealthyMessage: string | null = null
           for (const target of enabledOauthTargets) {
-            const unavailable = oauthUnavailableReason(target.platform)
-            if (unavailable) {
-              unhealthy = target
-              unhealthyMessage = unavailable
-              break
+            if (oauthUnavailableReason(target.platform)) {
+              // Feature-flagged-off OAuth (YouTube pending Google review) is a
+              // known product state: the go-live setup skips the target with an
+              // inline status, so it must not block or toast here either.
+              continue
             }
             if (target.platform === 'x') {
               const capability = await client.request<XNativeLiveCapability>(
@@ -8802,7 +8799,13 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         if (target.platform === 'youtube') {
           const unavailable = oauthUnavailableReason(target.platform)
           if (unavailable) {
-            throw new Error(unavailable)
+            // Known product state (feature-flagged off while Google review is
+            // pending), not a setup failure: keep it off the go-live failure
+            // toast and mark the destination inline instead.
+            nextStreaming = patchPreparedStreamTarget(nextStreaming, target.id, {
+              status: { state: 'warning', message: unavailable }
+            })
+            continue
           }
           const prepared = await client.request<PreparedYouTubeBroadcast>(
             'streamTargets.youtube.prepare',

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -1741,8 +1741,13 @@ async fn run_synthetic_compositor_loop(
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
     // Persisted GPU compositor (Some only on macOS when not disabled and a GPU exists);
     // built once and reused per frame. Held across the loop's awaits (it is Send).
-    let mut gpu_compositor = new_gpu_compositor();
-    let mut stream_gpu_compositor = stream_output.and_then(|_| new_gpu_compositor());
+    // Preview-owned compositors minify the scene into a small canvas; smooth
+    // (linear) sampling there kills the crawling-grain aliasing of a nearest
+    // minification. Recording/stream compositors keep nearest for exact crops.
+    let smooth_preview_scaling =
+        matches!(frame_consumer, CompositorFrameConsumer::NativePreview) && stream_output.is_none();
+    let mut gpu_compositor = new_gpu_compositor(smooth_preview_scaling);
+    let mut stream_gpu_compositor = stream_output.and_then(|_| new_gpu_compositor(false));
     let mut live_sources = CompositorLiveSources::refresh(&state).await;
     let mut render_cache = CompositorRenderCache::refresh_initial(&state).await;
     let mut next_live_source_refresh_at = Instant::now() + COMPOSITOR_LIVE_SOURCE_REFRESH_INTERVAL;
@@ -2328,11 +2333,11 @@ impl<'a> PreparedGpuSource<'a> {
 }
 
 #[cfg(target_os = "macos")]
-fn new_gpu_compositor() -> Option<GpuCompositor> {
+fn new_gpu_compositor(smooth_scaling: bool) -> Option<GpuCompositor> {
     if !metal_compositor_enabled() {
         return None;
     }
-    match GpuCompositor::new() {
+    match GpuCompositor::new_with_smooth_scaling(smooth_scaling) {
         Some(compositor) => {
             tracing::info!("Metal GPU compositor enabled");
             Some(compositor)
@@ -2346,7 +2351,7 @@ fn new_gpu_compositor() -> Option<GpuCompositor> {
     }
 }
 #[cfg(not(target_os = "macos"))]
-fn new_gpu_compositor() -> Option<GpuCompositor> {
+fn new_gpu_compositor(_smooth_scaling: bool) -> Option<GpuCompositor> {
     None
 }
 
@@ -5860,7 +5865,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn metal_compose_supports_test_pattern_source() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -5949,7 +5954,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn metal_compose_supports_test_pattern_overlay_without_camera_frame() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -6058,7 +6063,7 @@ mod tests {
 
     #[test]
     fn metal_compose_supports_side_by_side_screen_camera_layout() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -6144,7 +6149,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn metal_compose_background_under_inset_screen_target_or_skips() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -6238,7 +6243,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn publish_compositor_frame_retains_metal_target_export_handle_or_skips() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -6326,7 +6331,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn publish_compositor_frame_can_publish_metal_target_without_yuv_payload_or_skips() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -6465,7 +6470,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn metal_compose_missing_camera_frame_renders_placeholder_or_skips() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -6536,7 +6541,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn metal_compose_missing_active_screen_image_renders_placeholder_or_skips() {
-        let Some(mut gpu) = new_gpu_compositor() else {
+        let Some(mut gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: Metal compositor unavailable");
             return;
         };
@@ -6997,11 +7002,11 @@ mod tests {
             eprintln!("skipping: Metal compositor disabled");
             return;
         }
-        let Some(mut recording_gpu) = new_gpu_compositor() else {
+        let Some(mut recording_gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: recording Metal compositor unavailable");
             return;
         };
-        let Some(mut stream_gpu) = new_gpu_compositor() else {
+        let Some(mut stream_gpu) = new_gpu_compositor(false) else {
             eprintln!("skipping: stream Metal compositor unavailable");
             return;
         };

--- a/crates/videorc-backend/src/devices.rs
+++ b/crates/videorc-backend/src/devices.rs
@@ -75,6 +75,7 @@ async fn list_macos_devices(ffmpeg_path: &str) -> DeviceList {
         .devices
         .iter()
         .any(|device| device.status == DeviceStatus::PermissionRequired);
+    let native_camera_rows_present = !native_cameras.devices.is_empty();
     warnings.extend(native_cameras.warnings);
     devices.extend(native_cameras.devices);
 
@@ -96,7 +97,12 @@ async fn list_macos_devices(ffmpeg_path: &str) -> DeviceList {
             for device in av_devices {
                 match device.kind {
                     AvFoundationDeviceKind::Video => {
-                        if !device.name.to_lowercase().contains("capture screen") {
+                        // Mirror the microphone rule: the FFmpeg fallback rows are
+                        // a safety net for when native discovery returns nothing,
+                        // not duplicate picker entries beside every native camera.
+                        if !native_camera_rows_present
+                            && !device.name.to_lowercase().contains("capture screen")
+                        {
                             devices.push(Device {
                                 id: format!("camera:avfoundation:{}", device.index),
                                 name: format!("FFmpeg fallback - {}", device.name),

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -30,8 +30,9 @@ use tokio::time::{Instant, sleep};
 use crate::compositor::update_compositor_scene;
 use crate::live_scene::{ApplyMode, MutationContext, MutationKind, classify_mutation};
 use crate::preview_camera::{
-    PreviewCameraFrameInfo, begin_preview_camera_stop, finish_preview_camera_stop,
-    preview_camera_latest_frame_info, preview_camera_status, start_preview_camera,
+    PreviewCameraFrameInfo, begin_preview_camera_stop, camera_capture_geometry_is_stale,
+    finish_preview_camera_stop, preview_camera_latest_frame_info, preview_camera_status,
+    start_preview_camera,
 };
 use crate::preview_screen::{PreviewScreenFrameInfo, preview_screen_latest_frame_info};
 use crate::preview_screen::{
@@ -470,6 +471,7 @@ async fn apply_scene_transaction(
                 commit_scene_for_intent(state, intent_id, &scene, params.layout.clone(), None)
                     .await?;
             retire_unused_sources_after_commit(state, intent_id, needs).await;
+            resync_camera_capture_geometry_after_commit(state, intent_id, &params, needs).await;
             Ok(layout_apply_status(
                 intent_id,
                 if session_active { "hot" } else { "idle" },
@@ -512,6 +514,7 @@ async fn apply_scene_transaction(
             )
             .await?;
             retire_unused_sources_after_commit(state, intent_id, needs).await;
+            resync_camera_capture_geometry_after_commit(state, intent_id, &params, needs).await;
             Ok(layout_apply_status(
                 intent_id,
                 "warm",
@@ -963,6 +966,45 @@ async fn wait_for_sources_ready(
         }
         sleep(WARM_SOURCE_POLL).await;
     }
+}
+
+/// A hot preset switch keeps the live camera session, but AVFoundation output
+/// geometry is fixed at session start — a session capturing the inset overlay
+/// box keeps delivering 720p-class frames after the scene goes full-canvas
+/// (and vice versa). Re-derive the capture box after the commit and restart
+/// the camera in the background when it no longer matches; reuse refuses
+/// mismatched geometry, so the start lands as a real restart. The compositor
+/// holds the last frame across the restart, so the swap is a brief hold, not
+/// a blank slot.
+async fn resync_camera_capture_geometry_after_commit(
+    state: &AppState,
+    intent_id: u64,
+    params: &SceneConfigParams,
+    needs: SceneSourceNeeds,
+) {
+    if !needs.camera {
+        return;
+    }
+    let video = params.video.clone().unwrap_or_else(fallback_video_settings);
+    if !camera_capture_geometry_is_stale(state, &params.layout, &video).await {
+        return;
+    }
+    let start_params = PreviewCameraStartParams {
+        sources: params.sources.clone(),
+        layout: params.layout.clone(),
+        video,
+        ffmpeg_path: active_recording_ffmpeg_path(state).await,
+    };
+    let resync_state = state.clone();
+    tokio::spawn(async move {
+        let still_current = {
+            let intents = resync_state.layout_intents.lock().await;
+            intents.latest_intent_id == intent_id && intents.latest_needs_camera
+        };
+        if still_current {
+            let _ = start_preview_camera(resync_state, start_params).await;
+        }
+    });
 }
 
 async fn retire_unused_sources_after_commit(

--- a/crates/videorc-backend/src/metal_compositor.rs
+++ b/crates/videorc-backend/src/metal_compositor.rs
@@ -728,11 +728,25 @@ unsafe impl Sync for MetalSourceTextureCache {}
 impl MetalSceneCompositor {
     /// Build the compositor, or `None` when no Metal device / shader compile is available.
     pub fn new() -> Option<Self> {
+        Self::new_with_smooth_scaling(false)
+    }
+
+    /// `smooth_scaling` selects a linear min/mag sampler for scene draws.
+    /// Recording compositors keep the nearest sampler: their sources land at
+    /// ~1:1 scale and nearest preserves exact crop edges. Preview-owned
+    /// compositors render the scene into a small canvas — point-sampling that
+    /// minification re-picks a different subset of source pixels every frame,
+    /// which reads as crawling grain ("snow") on any noisy source.
+    pub fn new_with_smooth_scaling(smooth_scaling: bool) -> Option<Self> {
         let device = MTLCreateSystemDefaultDevice()?;
         let queue = device.newCommandQueue()?;
         let pipeline = build_pipeline(&device, false)?;
         let blend_pipeline = build_pipeline(&device, true)?;
-        let sampler = build_sampler(&device)?;
+        let sampler = if smooth_scaling {
+            build_preview_sampler(&device)?
+        } else {
+            build_sampler(&device)?
+        };
         let source_texture_cache = make_texture_cache(&device).map(MetalSourceTextureCache::new);
         Some(Self {
             device,
@@ -1298,6 +1312,10 @@ impl MetalPreviewPresenter {
         height: usize,
     ) -> Option<MetalImportedIosurfaceTexture> {
         let texture = import_iosurface_texture(&self.device, iosurface_id, width, height)?;
+        // The import trusts the IOSurface's own geometry over the caller's
+        // frame metadata; record what was actually imported.
+        let width = texture.width();
+        let height = texture.height();
         Some(MetalImportedIosurfaceTexture {
             iosurface_id,
             width,
@@ -1470,11 +1488,29 @@ pub fn import_iosurface_texture(
     height: usize,
 ) -> Option<Retained<MetalTexture>> {
     let surface = IOSurfaceRef::lookup(iosurface_id)?;
+    // Metal's validation layer aborts the whole process (assert -> SIGABRT,
+    // not a catchable error) when the descriptor disagrees with the
+    // IOSurface's real geometry. The caller's dimensions ride frame metadata
+    // and can be stale across a canvas resize — the preview -> recording
+    // handoff recreates surfaces at new sizes while old metadata is still in
+    // flight. The surface's own geometry is the only safe source of truth: a
+    // mismatched frame presents scaled for one beat instead of killing the
+    // app (observed as a recording-start crash in 0.9.52).
+    let surface_width = surface.width();
+    let surface_height = surface.height();
+    if surface_width == 0 || surface_height == 0 {
+        return None;
+    }
+    if surface_width != width || surface_height != height {
+        eprintln!(
+            "[videorc-native-preview] IOSurface {iosurface_id} is {surface_width}x{surface_height} but frame metadata says {width}x{height}; importing at surface geometry"
+        );
+    }
     let descriptor = unsafe {
         MTLTextureDescriptor::texture2DDescriptorWithPixelFormat_width_height_mipmapped(
             MTLPixelFormat::BGRA8Unorm,
-            width,
-            height,
+            surface_width,
+            surface_height,
             false,
         )
     };

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -125,6 +125,10 @@ struct PreviewCameraStartKey {
     ffmpeg_path: String,
     video: VideoSettings,
     target_fps: u32,
+    /// Derived capture box (inset overlay vs full canvas). Two starts that
+    /// agree on everything else but need different capture geometry must not
+    /// join each other's in-flight session.
+    capture_target: (u32, u32),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,6 +151,11 @@ struct NativeCameraPreviewThread {
     ffmpeg_path: String,
     layout: LayoutSettings,
     video: VideoSettings,
+    /// The capture target box this session's AVFoundation output geometry was
+    /// derived from at start. `layout` above is refreshed on reuse as
+    /// bookkeeping, so it cannot answer "what geometry is this session
+    /// actually delivering" — this field can.
+    capture_target: (u32, u32),
 }
 
 /// Fast half of a camera stop. Runtime ownership has already been detached and
@@ -422,6 +431,7 @@ pub async fn start_preview_camera(
         ffmpeg_path: ffmpeg_path.clone(),
         video: params.video.clone(),
         target_fps,
+        capture_target: camera_capture_target_dimensions(&params.layout, &params.video),
     };
     let start_lease = match begin_camera_start(&state, start_key.clone(), starting).await {
         PreviewCameraStartRegistration::JoinExisting => {
@@ -519,6 +529,7 @@ pub async fn start_preview_camera(
                 updated_at: Utc::now().to_rfc3339(),
                 message,
             };
+            let capture_target = camera_capture_target_dimensions(&params.layout, &params.video);
             let mut started_thread = Some(NativeCameraPreviewThread {
                 stop_tx,
                 join_handle: Some(join_handle),
@@ -526,6 +537,7 @@ pub async fn start_preview_camera(
                 ffmpeg_path,
                 layout: params.layout,
                 video: params.video,
+                capture_target,
             });
             let installed = {
                 let mut slot = state.preview_camera.lock().await;
@@ -1113,6 +1125,24 @@ async fn camera_live_session_is_frameless_zombie(state: &AppState) -> bool {
         .is_none_or(|acked| acked.elapsed() >= CAMERA_FIRST_FRAME_REUSE_GRACE)
 }
 
+/// True when the live camera session's configured capture box no longer
+/// matches what `layout`/`video` require. A hot preset switch (inset overlay
+/// <-> full canvas) keeps the session alive while its AVFoundation output
+/// stays sized for the old scene; only a restart re-derives the geometry.
+pub(crate) async fn camera_capture_geometry_is_stale(
+    state: &AppState,
+    layout: &LayoutSettings,
+    video: &VideoSettings,
+) -> bool {
+    let slot = state.preview_camera.lock().await;
+    if slot.status.state != PreviewCameraState::Live {
+        return false;
+    }
+    slot.active.as_ref().is_some_and(|active| {
+        active.capture_target != camera_capture_target_dimensions(layout, video)
+    })
+}
+
 async fn reuse_current_camera_source(
     state: &AppState,
     source_key: &SourceKey,
@@ -1129,6 +1159,10 @@ async fn reuse_current_camera_source(
         active.ffmpeg_path == ffmpeg_path
             && active.video == *video
             && slot.status.target_fps == target_fps
+            // AVFoundation output geometry is fixed at session start; a layout
+            // whose capture box differs (inset overlay vs full canvas) must
+            // restart the session, not adopt frames sized for the old scene.
+            && active.capture_target == camera_capture_target_dimensions(layout, video)
     });
     if !can_reuse {
         return None;
@@ -3257,6 +3291,7 @@ mod tests {
             ffmpeg_path: "ffmpeg".to_string(),
             video: video.clone(),
             target_fps: video.fps,
+            capture_target: camera_capture_target_dimensions(&test_layout(false), &video),
         };
         let starting = PreviewCameraStatus {
             state: PreviewCameraState::Starting,
@@ -3343,6 +3378,7 @@ mod tests {
                 ffmpeg_path: "ffmpeg".to_string(),
                 layout: test_layout(false),
                 video: video.clone(),
+                capture_target: camera_capture_target_dimensions(&test_layout(false), &video),
             });
         }
 
@@ -3385,6 +3421,63 @@ mod tests {
             Some("Native camera preview source reused.")
         );
     }
+    #[tokio::test]
+    async fn reuse_refuses_a_session_with_stale_capture_geometry() {
+        // A hot preset switch (inset overlay <-> full canvas) changes the
+        // derived capture box. The running session keeps delivering frames
+        // sized for the old scene, so reuse must force a restart instead of
+        // adopting them.
+        let state = test_state();
+        let video = test_video();
+        let source_key = SourceKey::camera("camera:avfoundation-native:test");
+        let full_canvas_layout = test_layout(false);
+        let mut inset_layout = test_layout(false);
+        inset_layout.layout_preset = LayoutPreset::ScreenCamera;
+        assert_ne!(
+            camera_capture_target_dimensions(&full_canvas_layout, &video),
+            camera_capture_target_dimensions(&inset_layout, &video),
+            "the two presets must derive different capture boxes for this test"
+        );
+        let (stop_tx, _stop_rx) = std_mpsc::channel();
+        {
+            let mut slot = state.preview_camera.lock().await;
+            slot.source_key = Some(source_key.clone());
+            slot.status.state = PreviewCameraState::Live;
+            slot.status.target_fps = video.fps;
+            slot.active = Some(NativeCameraPreviewThread {
+                stop_tx,
+                join_handle: None,
+                shared: Arc::new(StdMutex::new(PreviewCameraShared::default())),
+                ffmpeg_path: "ffmpeg".to_string(),
+                layout: inset_layout.clone(),
+                video: video.clone(),
+                capture_target: camera_capture_target_dimensions(&inset_layout, &video),
+            });
+        }
+
+        assert!(
+            reuse_current_camera_source(
+                &state,
+                &source_key,
+                "ffmpeg",
+                &full_canvas_layout,
+                &video,
+                video.fps
+            )
+            .await
+            .is_none(),
+            "a capture-geometry mismatch must not be reused"
+        );
+        assert!(
+            camera_capture_geometry_is_stale(&state, &full_canvas_layout, &video).await,
+            "the staleness probe must agree with reuse"
+        );
+        assert!(
+            !camera_capture_geometry_is_stale(&state, &inset_layout, &video).await,
+            "matching geometry must not report stale"
+        );
+    }
+
     #[tokio::test]
     async fn frameless_live_slot_past_grace_is_a_zombie() {
         // The Cam Link failure shape: Live acked, zero frames ever, grace long

--- a/crates/videorc-backend/src/preview_surface.rs
+++ b/crates/videorc-backend/src/preview_surface.rs
@@ -292,8 +292,8 @@ fn apply_validated_main_owned_preview_surface_bounds(
     slot.main_owned_generation = Some(params.generation);
     slot.main_owned_bounds = Some(params.bounds);
     slot.main_owned_host_bounds = Some(host_bounds);
-    slot.status.width = surface_dimension(safe_bounds.width);
-    slot.status.height = surface_dimension(safe_bounds.height);
+    slot.status.width = surface_render_dimension(safe_bounds.width, safe_bounds.scale_factor);
+    slot.status.height = surface_render_dimension(safe_bounds.height, safe_bounds.scale_factor);
     slot.status.bounds = Some(safe_bounds);
     slot.status.updated_at = Utc::now().to_rfc3339();
     Ok(slot.status.clone())
@@ -378,8 +378,8 @@ pub async fn create_preview_surface(
         transport: PreviewTransport::ElectronProofSurface,
         backing: PreviewSurfaceBacking::ElectronBrowserWindow,
         target_fps,
-        width: surface_dimension(bounds.width),
-        height: surface_dimension(bounds.height),
+        width: surface_render_dimension(bounds.width, bounds.scale_factor),
+        height: surface_render_dimension(bounds.height, bounds.scale_factor),
         frames_rendered: 0,
         presented_frame_id: None,
         compositor_frame_lag: None,
@@ -475,8 +475,8 @@ async fn try_reuse_live_surface(
         let mut next = slot.status.clone();
         next.source = params.source.clone();
         next.target_fps = target_fps;
-        next.width = surface_dimension(params.bounds.width);
-        next.height = surface_dimension(params.bounds.height);
+        next.width = surface_render_dimension(params.bounds.width, params.bounds.scale_factor);
+        next.height = surface_render_dimension(params.bounds.height, params.bounds.scale_factor);
         next.bounds = Some(params.bounds.clone());
         next.updated_at = Utc::now().to_rfc3339();
         let host_update = slot.native_host.update_bounds(&params.bounds);
@@ -513,8 +513,8 @@ pub async fn update_preview_surface_bounds(
     let (status, preview_run_id) = {
         let mut slot = state.preview_surface.lock().await;
         let mut next = slot.status.clone();
-        next.width = surface_dimension(params.bounds.width);
-        next.height = surface_dimension(params.bounds.height);
+        next.width = surface_render_dimension(params.bounds.width, params.bounds.scale_factor);
+        next.height = surface_render_dimension(params.bounds.height, params.bounds.scale_factor);
         next.bounds = Some(params.bounds.clone());
         next.updated_at = Utc::now().to_rfc3339();
         if next.state == PreviewSurfaceState::Unavailable
@@ -1093,6 +1093,20 @@ fn surface_dimension(value: f64) -> u32 {
     value.round().clamp(1.0, f64::from(u32::MAX)) as u32
 }
 
+/// Preview canvas dimensions in device pixels. The dock-slot bounds arrive in
+/// CSS points; compositing the scene at point size and upscaling to a Retina
+/// drawable throws away half the resolution before the present blit can do
+/// anything about it. The scale is clamped so a corrupt renderer value cannot
+/// balloon the canvas.
+fn surface_render_dimension(value: f64, scale_factor: f64) -> u32 {
+    let scale = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor.clamp(1.0, 3.0)
+    } else {
+        1.0
+    };
+    surface_dimension(value * scale)
+}
+
 fn unavailable_status(message: Option<String>) -> PreviewSurfaceStatus {
     PreviewSurfaceStatus {
         state: PreviewSurfaceState::Unavailable,
@@ -1150,6 +1164,18 @@ mod tests {
         )
     }
 
+    #[test]
+    fn surface_render_dimension_scales_to_device_pixels() {
+        // Bounds arrive in CSS points; the canvas must render at device pixels.
+        assert_eq!(surface_render_dimension(700.0, 2.0), 1400);
+        assert_eq!(surface_render_dimension(700.0, 1.0), 700);
+        // Corrupt or missing scale factors fall back to 1x, and runaway
+        // values clamp so the canvas cannot balloon.
+        assert_eq!(surface_render_dimension(700.0, f64::NAN), 700);
+        assert_eq!(surface_render_dimension(700.0, 0.0), 700);
+        assert_eq!(surface_render_dimension(700.0, 10.0), 2100);
+    }
+
     fn bounds(width: f64, height: f64) -> PreviewSurfaceBounds {
         PreviewSurfaceBounds {
             screen_x: 100.0,
@@ -1188,8 +1214,8 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(first.width, 1280);
-        assert_eq!(first.height, 720);
+        assert_eq!(first.width, 2560);
+        assert_eq!(first.height, 1440);
         assert!(
             serde_json::to_value(&first)
                 .unwrap()
@@ -1245,8 +1271,8 @@ mod tests {
         assert_eq!(status.transport, PreviewTransport::ElectronProofSurface);
         assert_eq!(status.backing, PreviewSurfaceBacking::ElectronBrowserWindow);
         assert_eq!(status.target_fps, 60);
-        assert_eq!(status.width, 800);
-        assert_eq!(status.height, 450);
+        assert_eq!(status.width, 1600);
+        assert_eq!(status.height, 900);
         assert_eq!(status.pending_host_command_count, 1);
         assert_eq!(
             compositor.frame_pipeline.consumer.as_deref(),
@@ -1316,12 +1342,12 @@ mod tests {
         destroy_preview_surface(&state).await;
 
         assert_eq!(second_compositor.run_id, first_compositor.run_id);
-        assert_eq!(second_compositor.width, 640);
-        assert_eq!(second_compositor.height, 360);
+        assert_eq!(second_compositor.width, 1280);
+        assert_eq!(second_compositor.height, 720);
         assert_eq!(duplicate.started_at, first.started_at);
         assert_eq!(duplicate.source, PreviewSurfaceSource::Screen);
-        assert_eq!(duplicate.width, 640);
-        assert_eq!(duplicate.height, 360);
+        assert_eq!(duplicate.width, 1280);
+        assert_eq!(duplicate.height, 720);
         assert_eq!(duplicate.transport, PreviewTransport::NativeSurface);
         assert_eq!(duplicate.backing, PreviewSurfaceBacking::CaMetalLayer);
         assert_eq!(duplicate.presented_frame_id, Some(42));
@@ -1468,8 +1494,8 @@ mod tests {
         destroy_preview_surface(&state).await;
 
         assert_eq!(status.state, PreviewSurfaceState::Live);
-        assert_eq!(status.width, 640);
-        assert_eq!(status.height, 360);
+        assert_eq!(status.width, 1280);
+        assert_eq!(status.height, 720);
         assert_eq!(resize_count, 1);
         assert_eq!(
             last_command_kind,
@@ -1899,7 +1925,7 @@ mod tests {
         )
         .await;
         let verification = async {
-            let initial = wait_for_frame_dimensions_after(&state, 160, 90, None).await?;
+            let initial = wait_for_frame_dimensions_after(&state, 320, 180, None).await?;
             let initial_status = compositor_status(&state).await;
 
             update_preview_surface_bounds(
@@ -1910,7 +1936,7 @@ mod tests {
             )
             .await;
             let portrait =
-                wait_for_frame_dimensions_after(&state, 90, 160, Some(initial.sequence)).await?;
+                wait_for_frame_dimensions_after(&state, 180, 320, Some(initial.sequence)).await?;
 
             // The owner's 2026-07-14 regression was this reverse direction:
             // horizontal mode returned while the compositor kept publishing
@@ -1923,7 +1949,7 @@ mod tests {
             )
             .await;
             let landscape =
-                wait_for_frame_dimensions_after(&state, 160, 90, Some(portrait.sequence)).await?;
+                wait_for_frame_dimensions_after(&state, 320, 180, Some(portrait.sequence)).await?;
             let final_status = compositor_status(&state).await;
             Ok::<_, String>((initial_status, portrait, landscape, final_status))
         }
@@ -1932,13 +1958,13 @@ mod tests {
 
         let (initial_status, portrait, landscape, final_status) =
             verification.expect("preview compositor should follow both orientation changes");
-        assert_eq!(portrait.width, 90);
-        assert_eq!(portrait.height, 160);
-        assert_eq!(landscape.width, 160);
-        assert_eq!(landscape.height, 90);
+        assert_eq!(portrait.width, 180);
+        assert_eq!(portrait.height, 320);
+        assert_eq!(landscape.width, 320);
+        assert_eq!(landscape.height, 180);
         assert_eq!(final_status.run_id, initial_status.run_id);
-        assert_eq!(final_status.width, 160);
-        assert_eq!(final_status.height, 90);
+        assert_eq!(final_status.width, 320);
+        assert_eq!(final_status.height, 180);
     }
 
     #[tokio::test]
@@ -1953,7 +1979,7 @@ mod tests {
             },
         )
         .await;
-        wait_for_frame_dimensions_after(&state, 160, 90, None)
+        wait_for_frame_dimensions_after(&state, 320, 180, None)
             .await
             .expect("preview compositor should publish before ownership changes");
         let preview_run_id = compositor_status(&state)


### PR DESCRIPTION
One unified macOS quality batch (owner-requested single release), covering seven fixes:

## Snowy preview (idle preview only — recordings were always clean)
1. **Device-pixel canvas**: the idle preview composited the whole scene at the dock-slot size in CSS points and upscaled to the Retina drawable. It now renders at device pixels (`surface_render_dimension`, scale clamped 1–3×).
2. **Linear preview sampler**: scene minification into the small preview canvas used a nearest sampler — point-sampling re-picks different source pixels every frame, i.e. crawling grain on any noisy source. Preview-owned compositors now sample linear; recording/stream keep nearest for exact crop edges.
3. **Capture-geometry resync**: AVFoundation output geometry is fixed at session start, but hot preset switches (inset overlay ↔ full canvas) never re-derived it. Sessions now record their capture box; reuse refuses mismatches; layout commits restart a stale camera in the background.

## Recording-start crash (owner crash report, SIGABRT 16:01 2026-08-16)
4. `import_iosurface_texture` built its Metal descriptor from in-flight frame metadata; the preview → recording canvas handoff recreates IOSurfaces at new sizes, and Metal's validation layer **aborts the process** on mismatch. The importer now trusts the IOSurface's own geometry — a stale frame presents scaled for one beat instead of killing the app. Also protects fix 1, which makes size transitions more common.

## Noise
5. FFmpeg fallback camera rows hidden whenever native camera discovery returns rows (mirrors the existing microphone rule); they remain as the safety net when native discovery is empty.
6. The Go Live flow no longer toasts the feature-flagged YouTube OAuth message (the numbered-list toast #205 missed); the destination card shows it inline, and the lifecycle check skips the inert target.
7. `camera-cadence-mismatch` no longer toasts; the health event still lands in session records and diagnostics.

## Verification
- `cargo test -p videorc-backend`: **1,492 passed, 0 failed** (preview_surface expectations moved to device pixels — the 2× fixture now genuinely exercises the scale path; new reuse-geometry + staleness tests)
- `cargo test -p videorc-native-preview-addon`: 45 passed; addon builds clean
- clippy `-D warnings`, `cargo fmt --check`: clean
- `pnpm typecheck`, `lint`, `format:check`: clean; desktop unit tests **1,327 passed**
- `pnpm smoke:recording-matrix` on real hardware: **12/12 combos PASS** (bt709, correct levels, bounded stop tails) — exercises the exact preview→recording handoff that crashed
- Owner eyeball check after release: docked preview clean of snow, camera→screen→camera, record start without crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview rendering now scales more smoothly on supported displays and adapts to device pixel density.
  * Camera previews automatically resynchronize when layout changes require updated capture dimensions.
* **Bug Fixes**
  * Prevented duplicate camera entries on macOS when native devices are available.
  * Unavailable OAuth destinations no longer block Go Live; YouTube displays an inline warning instead.
  * Camera frame-rate mismatch notifications no longer interrupt workflows, while details remain available in diagnostics.
  * Improved handling of invalid or mismatched preview surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->