### PR TITLE
release: 0.9.53-beta.1 — sharper preview, recording-start crash fix, quieter app

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.53-beta.1.md
+++ b/changelog/0.9.53-beta.1.md
@@ -1,0 +1,38 @@
+---
+version: 0.9.53-beta.1
+date: 2026-08-16
+channel: beta
+platforms:
+  - macos
+title: A sharper preview, a crash fixed, and a quieter app
+summary: The docked preview no longer looks grainy or "snowy" — it now renders at your display's full Retina resolution with proper smoothing. A crash that could kill the app when starting a recording is fixed, duplicate camera entries are gone from the picker, and two nagging toasts are retired.
+highlights:
+  - The preview now renders at full Retina resolution with proper scaling, eliminating the grainy "snow" some setups saw in the docked preview — recordings were never affected.
+  - Fixed a crash that could take down the whole app when starting a recording while the preview was open.
+  - Switching layout presets now re-tunes the camera capture automatically, so an inset camera moved to full-canvas stays sharp.
+  - The camera picker no longer shows duplicate "FFmpeg fallback" entries beside your real cameras.
+  - The "YouTube OAuth is temporarily unavailable" message no longer pops up when going live — the YouTube destination card shows the status inline instead.
+  - The camera frame-rate mismatch warning no longer interrupts every recording; it is recorded in the session's health log instead.
+---
+
+The docked preview was quietly rendering at a fraction of your display's
+resolution and scaling the scene down with a pixel-picking filter — on a
+Retina display with a noisy or high-resolution camera, that showed up as
+crawling grain, like analog snow, especially in dark backgrounds. The
+preview now composites at full device resolution with proper smoothing.
+Recordings never had this problem; only the on-screen preview did.
+
+Starting a recording while the preview was open could crash the entire app:
+the preview and the recording briefly disagree about canvas size during the
+handoff, and the graphics driver treated that disagreement as fatal. The
+handoff now resolves it gracefully.
+
+Cameras also behave better across layout changes. A camera set up for the
+small inset box kept delivering inset-sized frames after you switched to a
+full-canvas layout (and the reverse); Videorc now notices and re-tunes the
+capture in the background.
+
+And some housekeeping: duplicate "FFmpeg fallback" camera entries are gone
+from the picker (the fallback only appears if real camera discovery fails),
+the YouTube OAuth notice no longer toasts during Go Live, and the camera
+frame-rate mismatch warning moved from a toast to the session health log.


### PR DESCRIPTION
Version bump 0.9.52 → 0.9.53 + changelog for #210 (macOS preview quality batch: snow fix, capture geometry resync, Metal crash fix, picker/toast noise). macOS-only release.