### PR TITLE
fix(studio): polish batch — takeover hint, saved toast, sign-out placement

### DIFF
--- a/apps/desktop/src/renderer/src/components/account-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/account-menu.tsx
@@ -117,20 +117,10 @@ export function AccountMenu({
         <DropdownMenuSeparator />
 
         {signedIn ? (
-          <>
-            <DropdownMenuItem onSelect={openAccount}>
-              <UserCircle />
-              Account
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              disabled={isSignOutDisabled(account, live)}
-              variant="destructive"
-              onSelect={signOut}
-            >
-              <SignOut />
-              Sign out
-            </DropdownMenuItem>
-          </>
+          <DropdownMenuItem onSelect={openAccount}>
+            <UserCircle />
+            Account
+          </DropdownMenuItem>
         ) : (
           <DropdownMenuItem onSelect={signIn}>
             <SignIn />
@@ -155,6 +145,20 @@ export function AccountMenu({
           <GearSix />
           Settings
         </DropdownMenuItem>
+
+        {signedIn ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              disabled={isSignOutDisabled(account, live)}
+              variant="destructive"
+              onSelect={signOut}
+            >
+              <SignOut />
+              Sign out
+            </DropdownMenuItem>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
@@ -191,11 +191,15 @@ function TakeoverControls({ onOpenAssets }: { onOpenAssets: () => void }): React
               )
             })}
           </div>
-          <span className="text-xs text-muted-foreground">
+          {/* Reserve two lines of text-xs so swapping between the three hint
+              strings can never reflow the content below (the active-takeover
+              copy is longer than the idle hint and used to push everything
+              down when it wrapped). */}
+          <span className="block min-h-8 text-xs text-muted-foreground">
             {disconnected
               ? `Backend socket is ${wsStatus} — takeovers need the backend.`
               : activeScreen
-                ? `${activeScreen.name} is covering the output. Click it to go back to the scene.`
+                ? `${activeScreen.name} is covering the output — click it to return.`
                 : 'Click a takeover to cover the output — works while live.'}
           </span>
         </>

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -2385,6 +2385,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   // Stable handle for callbacks that only need to READ the config (labels,
   // lookups) without re-creating themselves on every config change.
   const lastRecordingStateRef = useRef<string | null>(null)
+  // The idle status tick that ends a session does not reliably carry the
+  // finished session's id; remember the last one seen so the saved-toast
+  // actions can target the right recording.
+  const lastRecordingSessionIdRef = useRef<string | null>(null)
   // Quality-gate toast dedupe: the gate can re-emit an updated not-100 verdict for
   // the same session (fast assessment, then post-repair); one toast is enough.
   const qualityToastSessionsRef = useRef<Set<string>>(new Set())
@@ -4244,6 +4248,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         const status = payload as RecordingStatus
         const previousState = lastRecordingStateRef.current
         lastRecordingStateRef.current = status.state
+        if (status.sessionId) {
+          lastRecordingSessionIdRef.current = status.sessionId
+        }
         applyRecordingStatus(status)
         if (['idle', 'failed'].includes(status.state)) {
           setStreamTargets([])
@@ -4260,16 +4267,37 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         ) {
           void refreshSessions(nextClient)
         }
-        // D6: the moment a recording lands is the moment to publish it.
+        // A finished recording gets its two natural next steps: watch it, or
+        // find it in the Library. (The publish pitch lives in the Publish tab,
+        // not in this toast — owner call, 2026-08-16.)
         if (
           status.state === 'idle' &&
           ['recording', 'streaming', 'stopping'].includes(previousState ?? '')
         ) {
+          const finishedSessionId = status.sessionId ?? lastRecordingSessionIdRef.current
+          const openInLibrary = (): void =>
+            openLibraryFromQualityToast(finishedSessionId ?? undefined)
           toast.success('Recording saved', {
-            description: 'Turn it into a publishable upload?',
             action: {
-              label: 'Make it publishable',
-              onClick: () => window.dispatchEvent(new CustomEvent('videorc:open-publish'))
+              label: 'Play',
+              onClick: () => {
+                if (!finishedSessionId || !window.videorc?.openSession) {
+                  openInLibrary()
+                  return
+                }
+                void window.videorc.openSession(finishedSessionId).then((problem) => {
+                  // The export can still be finalizing right after the toast
+                  // fires; the Library row shows the honest state, so land
+                  // there instead of erroring on an eager click.
+                  if (problem) {
+                    openInLibrary()
+                  }
+                })
+              }
+            },
+            cancel: {
+              label: 'Open in Library',
+              onClick: openInLibrary
             },
             duration: 12000
           })


### PR DESCRIPTION
Three of the four owner-reported items for 0.9.54, plus the diagnosis and first fix for the fourth:

## In this PR
1. **Takeover hint layout shift** — the hint area under the takeover buttons now reserves two lines of height, so swapping between the idle/active/disconnected strings can never push content below it. Active copy tightened (`— click it to return.`).
2. **'Recording saved' toast** — publish pitch removed; **Play** (primary) opens the recording in the default player via the same `openSession` path the Library row uses, and falls back to focusing the Library row while the export is still finalizing; **Open in Library** (secondary) focuses the session. The session id is captured from the last status tick that carried one.
3. **Sign out last** — moved to the bottom of the account dropdown behind a separator.

## Item 4: transcript generation (diagnosed; fix in flight)
The desktop chain is healthy end-to-end — `ai_artifacts` shows every attempt reached the server, which replied **500 'AI transcription could not be completed'** (the catch-all for an unmapped exception). Production env vars exist but are write-only sensitive, and the AI job runner had **zero logging**, so the real cause was unrecoverable. Shipped to videorc-web (`9e22784d`, auto-deploying): the runner's failure path now logs the underlying error. Next owner transcript attempt pinpoints the root cause in Vercel logs; the fix lands as a follow-up (likely web-side only — no desktop change needed, error surfacing already works: the Publish card shows the failed state with the server message).

## Verification
- `pnpm typecheck`, `lint`, `format:check`: clean
- Desktop unit tests: 1,327 passed
- No Rust / recording / native-preview surface touched — no smoke required
- Owner acceptance after release: click a takeover (nothing moves), stop a recording (Play + Open in Library both land on the right session), account menu (Sign out last).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording completion notifications now offer **Play** and **Open in Library** actions.
  * Playback notifications automatically fall back to the Library when playback is unavailable.

* **Bug Fixes**
  * Improved recording completion handling when session details are unavailable.
  * Prevented layout shifting when takeover hints change.

* **Style**
  * Updated the takeover message wording and account menu layout for clearer separation of actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->