### PR TITLE
release: 0.9.54-beta.1 — steadier Studio details

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.53",
+  "version": "0.9.54",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.54-beta.1.md
+++ b/changelog/0.9.54-beta.1.md
@@ -1,0 +1,23 @@
+---
+version: 0.9.54-beta.1
+date: 2026-08-17
+channel: beta
+platforms:
+  - macos
+title: Steadier Studio details
+summary: The takeover hint no longer nudges the Studio layout, a saved recording offers Play and Open in Library right from the toast, and Sign out moved to the bottom of the account menu where it belongs.
+highlights:
+  - Clicking a takeover no longer shifts the Studio layout — the hint text keeps a fixed footprint in every state.
+  - The "Recording saved" toast now offers the two things you actually want next — Play, and Open in Library — instead of a publishing pitch.
+  - Sign out is now the last item in the account menu, separated from everyday actions.
+---
+
+Small paper cuts, all from daily driving. The helper text under the takeover
+buttons used to grow by a line when a takeover was active, pushing the rest
+of the session panel down mid-broadcast; it now reserves its space so
+nothing moves. When a recording finishes, the toast gives you Play — it
+opens the file in your default player, or lands you on the Library row if
+the export is still finishing — and Open in Library, which jumps straight
+to that session. And the account menu now keeps Sign out at the very
+bottom, behind a divider, instead of mid-list where it could catch a
+mis-click.


### PR DESCRIPTION
Version bump 0.9.53 → 0.9.54 + changelog for #212 (takeover hint footprint, saved-recording toast Play/Open in Library, Sign out last). Transcript server-side fix tracks separately (web 9e22784d logging deployed; root cause pending one owner retry). macOS-only release.