### PR TITLE
fix(sessions): stop mp4 noise-cleanup derivatives from poisoning sessions.list

### DIFF
--- a/crates/videorc-backend/src/noise_cleanup.rs
+++ b/crates/videorc-backend/src/noise_cleanup.rs
@@ -2337,6 +2337,75 @@ mod tests {
     }
 
     #[test]
+    fn mp4_derivative_stores_no_container_and_routes_to_mp4_path() {
+        // The literal "mp4" once landed in the container column, which the
+        // session protocol enum rejects — one such row broke sessions.list
+        // (and recording) for every client. mp4-family derivatives follow the
+        // import convention: file in mp4_path, container empty.
+        let base = std::env::temp_dir().join(format!(
+            "videorc-cleanup-mp4-container-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        let source_path = base.join("source.mp4");
+        let output_path = base.join("source — Noise Cleaned.mp4");
+        std::fs::write(&source_path, b"source bytes").unwrap();
+        std::fs::write(&output_path, b"cleaned bytes").unwrap();
+        let database = Database::open_in_memory_for_tests();
+        let now = Utc::now().to_rfc3339();
+        database
+            .create_completed_session(
+                &completed_recording(
+                    "source",
+                    &source_path,
+                    "record",
+                    Some("microphone:1".to_string()),
+                ),
+                &now,
+                Some(source_path.to_str().unwrap()),
+                Some(1000),
+                Some(12),
+            )
+            .unwrap();
+        let identity = capture_session_file_bound_identity(&source_path)
+            .unwrap()
+            .unwrap();
+        let full_sha256 = full_file_sha256(&source_path).unwrap();
+        let job = database
+            .create_or_get_noise_cleanup_job("source", &identity, NOISE_CLEANUP_PRESET)
+            .unwrap();
+        database
+            .bind_noise_cleanup_source_fingerprint(&job.job.id, &full_sha256)
+            .unwrap();
+        database
+            .complete_noise_cleanup_derivative(
+                &job.job.id,
+                "source",
+                "derivative",
+                "Source title — Noise Cleaned",
+                "Source title",
+                output_path.to_str().unwrap(),
+                "mp4",
+                Some(1000),
+                19,
+            )
+            .unwrap();
+
+        let derivative = database
+            .list_sessions(20)
+            .unwrap()
+            .into_iter()
+            .find(|session| session.id == "derivative")
+            .expect("derivative session must list");
+        assert_eq!(
+            derivative.container, None,
+            "mp4 must not leak into container"
+        );
+        assert_eq!(derivative.mp4_path.as_deref(), output_path.to_str());
+        assert_eq!(derivative.output_path, None);
+    }
+
+    #[test]
     fn externally_missing_output_keeps_derivative_metadata_and_reserves_its_path() {
         let base = std::env::temp_dir().join(format!(
             "videorc-cleanup-external-output-delete-{}",

--- a/crates/videorc-backend/src/storage.rs
+++ b/crates/videorc-backend/src/storage.rs
@@ -2576,7 +2576,9 @@ impl Database {
              SELECT ?3, ?4, ?6, ?6, 'completed', mode,
                     CASE WHEN ?9 = 0 THEN ?7 ELSE NULL END,
                     CASE WHEN ?9 = 1 THEN ?7 ELSE NULL END,
-                    stream_preset, ?8, COALESCE(?10, duration_ms), sources_json, layout_json,
+                    stream_preset,
+                    CASE WHEN ?9 = 1 THEN NULL ELSE ?8 END,
+                    COALESCE(?10, duration_ms), sources_json, layout_json,
                     output_json, NULL, ?11, ?2, ?5, 'noise-cleanup'
              FROM sessions WHERE id = ?2",
             params![
@@ -5224,6 +5226,19 @@ impl Database {
             ",
         )?;
         ensure_column(&conn, "sessions", "container", "container TEXT")?;
+        // Noise-cleanup derivatives used to store their literal mp4-family
+        // extension as the container, which the session protocol enum rejects —
+        // one such row broke sessions.list (and with it recording) for every
+        // client (2026-08-17). mp4-family files follow the import convention:
+        // the file lives in mp4_path, container stays empty.
+        conn.execute(
+            "UPDATE sessions
+             SET mp4_path = COALESCE(mp4_path, output_path),
+                 output_path = NULL,
+                 container = NULL
+             WHERE container IN ('mp4', 'mov', 'm4v')",
+            [],
+        )?;
         ensure_column(&conn, "sessions", "duration_ms", "duration_ms INTEGER")?;
         ensure_column(
             &conn,


### PR DESCRIPTION
**Owner-reported blocker: 'cannot record — container must be one of none, mkv, flv, tee.'**

One session row with `container = 'mp4'` (written by `complete_noise_cleanup_derivative`, which stored the literal container while correctly routing the file to `mp4_path`) fails the protocol enum during `sessions.list` validation — killing the sessions list and recording for every client that sees the row.

- Write path: the derivative INSERT now nulls the container for mp4-family outputs, matching the Library-import convention (`session_ops.rs` has always done this).
- Repair: a startup migration moves any existing `mp4/mov/m4v` container rows to the same shape (file into `mp4_path`, container cleared) — the owner's poisoned row heals on next app launch.
- Regression test drives the real derivative commit and asserts `container = None`, `mp4_path` set, `output_path` empty.

Gates: 1,493 backend tests pass (incl. new), clippy `-D warnings` + fmt clean. No renderer/TS change.