### PR TITLE
release: 0.9.55-beta.1 — recording unblocked after a Noise Cleanup edge case

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.54",
+  "version": "0.9.55",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.55-beta.1.md
+++ b/changelog/0.9.55-beta.1.md
@@ -1,0 +1,18 @@
+---
+version: 0.9.55-beta.1
+date: 2026-08-17
+channel: beta
+platforms:
+  - macos
+title: Recording unblocked after a Noise Cleanup edge case
+summary: A Noise Cleanup result saved as MP4 could leave the session library in a state that blocked recording entirely. The bad entry heals itself on launch, and new cleanups store correctly.
+highlights:
+  - Fixed a state where one Noise Cleanup result could block recording with a "container must be one of…" error — existing libraries repair themselves on launch.
+---
+
+If you ran Noise Cleanup on an MP4 recording, the cleaned copy could be
+saved in a way the app's own session list refused to load — and with the
+list down, recording was blocked with a cryptic "container must be one of
+none, mkv, flv, tee" error. New cleanups now save correctly, and any
+affected entry in your library is repaired automatically the next time
+Videorc starts. No recordings were harmed; this was bookkeeping, not media.


### PR DESCRIPTION
Version bump 0.9.54 → 0.9.55 + changelog for #214 (mp4 container poison fix + self-healing migration). macOS-only.