### PR TITLE
release: 0.9.56-beta.1 — Record recovers a tired camera instead of refusing

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.55",
+  "version": "0.9.56",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.56-beta.1.md
+++ b/changelog/0.9.56-beta.1.md
@@ -1,0 +1,30 @@
+---
+version: 0.9.56-beta.1
+date: 2026-08-19
+channel: beta
+platforms:
+  - macos
+title: Record recovers a tired camera instead of refusing
+summary: Clicking Record after hours of camera uptime could silently do nothing when the capture card's frame delivery had drifted. Recording now restarts the camera on the spot and, if it stays jittery, records anyway with a warning — the button always does something.
+highlights:
+  - A camera that drifted into uneven frame delivery (long-running capture cards do this) no longer blocks recording — Videorc restarts it automatically before encoding begins.
+  - If the camera stays jittery after the restart, the recording starts anyway with a stutter warning in the session health log, instead of refusing outright.
+  - 24p and 25p sources feeding a 30fps session now get an honest frame-timing budget, so healthy cameras stop tripping the startup check.
+---
+
+Capture cards that run for hours can drift into delivering frames in
+bursts. The preview hides it — but the Record button ran a strict timing
+check and simply refused to start, with an error most people never saw:
+the button just did nothing.
+
+Recording startup now works in stages. If the camera's timing hasn't
+settled, Videorc restarts the camera session on the spot — that clears the
+drift in almost every case — and waits out the warm-up. If delivery is
+still uneven but frames are flowing, the recording starts anyway and a
+warning lands in the session's health log; a stuttery take you can see
+beats a take that never existed. Only a camera delivering nothing at all
+still stops the recording.
+
+The timing budget is also honest about your source now: a 23.976p or 25p
+HDMI feed into a 30fps session is measured against its own frame rate,
+so healthy film-rate cameras no longer sit on the edge of the check.


### PR DESCRIPTION
Version bump 0.9.55 → 0.9.56 + changelog for #217 (cadence barrier ladder: restart, degrade-with-warning, source-honest threshold). macOS-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera recovery when starting recordings on macOS.
  * Added fallback recording with stutter warnings when video frames arrive unevenly.
  * Recording now fails only when no frames are delivered.
  * Corrected timing for 23.976p and 25p sources in 30fps sessions.

* **Release**
  * Updated the desktop app to version 0.9.56 beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->