### PR TITLE
fix(oauth): let a Twitch device grant complete without an authorization code

### DIFF
--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -1426,7 +1426,8 @@ async fn complete_oauth_callback(
                     return result;
                 }
             }
-        } else if let (Some(exchange), Some(code)) = (outcome.exchange, outcome.authorization_code)
+        } else if let Some((exchange, code)) =
+            oauth::provider_exchange_to_run(outcome.exchange, outcome.authorization_code)
         {
             let code_verifier = match oauth::recover_pkce_verifier(
                 &exchange,

--- a/crates/videorc-backend/src/oauth.rs
+++ b/crates/videorc-backend/src/oauth.rs
@@ -2053,6 +2053,28 @@ pub async fn exchange_authorization_code(
 /// device grant instead WAITS here, polling until the user approves in the
 /// browser, so every caller downstream — checkpointing, profile fetch,
 /// account storage, events — stays identical for both grant types.
+/// Which provider exchange, if any, a completion outcome should run.
+///
+/// A redirect grant needs the provider's single-use authorization code. A
+/// device grant (Twitch) NEVER has one — the poller trades the stored device
+/// code instead — so requiring `Some(code)` at the driver was exactly the bug
+/// that made the whole device flow authorize into the void: the background
+/// completion task matched no arm, the session was retired at spawn time, and
+/// nobody was listening by the time the user approved in the browser
+/// (0.9.50–0.9.56). The placeholder code is ignored by
+/// `obtain_provider_token` for device grants.
+pub fn provider_exchange_to_run(
+    exchange: Option<PendingOAuthExchange>,
+    authorization_code: Option<String>,
+) -> Option<(PendingOAuthExchange, String)> {
+    let exchange = exchange?;
+    match authorization_code {
+        Some(code) => Some((exchange, code)),
+        None if exchange.is_device_grant() => Some((exchange, String::new())),
+        None => None,
+    }
+}
+
 pub async fn obtain_provider_token(
     exchange: &PendingOAuthExchange,
     authorization_code: &str,
@@ -5038,6 +5060,38 @@ mod tests {
         let redirect = PendingOAuthWork::ProviderExchange(device_exchange_fixture(None));
         assert!(!redirect.is_code_less_resumable());
         assert!(!PendingOAuthWork::Generic.is_code_less_resumable());
+    }
+
+    #[test]
+    fn completion_driver_runs_a_device_exchange_without_a_code() {
+        // The 0.9.50–0.9.56 outage: the driver destructured
+        // `(Some(exchange), Some(code))`, which a device grant can never
+        // satisfy — the background completion matched no arm, the session was
+        // retired at spawn time, and the user's browser approval landed on
+        // nothing. All three shapes are pinned here so "who supplies the
+        // code" can never quietly kill the device flow again (#187 fixed the
+        // same disease one layer lower).
+        let device = provider_exchange_to_run(Some(device_exchange_fixture(Some("dc"))), None);
+        let (exchange, code) = device.expect("a device grant must run without a code");
+        assert!(exchange.is_device_grant());
+        assert!(
+            code.is_empty(),
+            "the placeholder code must be inert — obtain_provider_token ignores it"
+        );
+
+        // A redirect exchange with its code runs with that exact code.
+        let redirect = provider_exchange_to_run(
+            Some(device_exchange_fixture(None)),
+            Some("auth-code".to_string()),
+        );
+        let (_, code) = redirect.expect("a redirect grant with a code must run");
+        assert_eq!(code, "auth-code");
+
+        // A redirect exchange with NO code must never run — that code is the
+        // single-use provider credential, there is nothing to trade without it.
+        assert!(provider_exchange_to_run(Some(device_exchange_fixture(None)), None).is_none());
+        // No exchange, nothing to run.
+        assert!(provider_exchange_to_run(None, Some("auth-code".to_string())).is_none());
     }
 
     #[test]


### PR DESCRIPTION
**Owner report:** authorizing Videorc on Twitch's device page just lands on twitch.tv/settings/connections and the app never connects.

## Root cause
The completion driver in `complete_oauth_callback` gated the provider exchange on `else if let (Some(exchange), Some(code))` — a device grant **never** has an authorization code, so the background completion task (spawned at connect time by design, since device flow has no redirect) matched no arm, `token_and_checkpoint` fell to `None`, and the spawn site retired the session as done. By the time the user clicked Authorize, nobody was listening. Empty pending state, no account row, no error anywhere — all three observed symptoms.

#187 fixed the same class one layer lower (`is_code_less_resumable`), #188 built the background driver — this destructure kept the whole path permanently unreachable across 0.9.50–0.9.56.

## Fix
Arm selection extracted to `oauth::provider_exchange_to_run`: redirect exchanges still require their single-use code; a device exchange runs with an inert empty placeholder (`obtain_provider_token` ignores it — it trades the stored device code). Downstream (5s polling loop, profile fetch, secret storage, account row, events) is untouched and already correct.

## Verification
- New test pins all three shapes: device + no code **runs**, redirect + no code never runs, redirect + code runs with that code.
- oauth module 51/51; full backend suite 1,498 passed; clippy `-D warnings` + fmt clean. (One known-flaky compositor test failed once under parallel load and passed on rerun — documented pre-existing.)
- Live wire check with the bundled client id: `POST /oauth2/device` succeeds, unapproved token poll returns `authorization_pending` — the wire was healthy all along.
- Post-merge owner check (the only step needing a human): Connect Twitch, authorize — the account card should fill in within ~5s of approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth completion for redirect-based sign-ins and Twitch device authorization.
  * Preserved reliable code exchange, retry handling, checkpoint recovery, account storage, and cleanup.
  * Added safeguards for missing authorization details during OAuth flows.

* **Tests**
  * Added coverage for device authorization, redirect sign-in, missing exchanges, and missing authorization codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->