### PR TITLE
release: 0.9.57-beta.1 — connecting Twitch completes now

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.56",
+  "version": "0.9.57",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.57-beta.1.md
+++ b/changelog/0.9.57-beta.1.md
@@ -1,0 +1,22 @@
+---
+version: 0.9.57-beta.1
+date: 2026-08-19
+channel: beta
+platforms:
+  - macos
+title: Connecting Twitch completes now
+summary: Authorizing Videorc on Twitch's device page finally lands back in the app — the connection completes within a few seconds of clicking Authorize. Previous betas showed the Twitch page but never picked up the approval.
+highlights:
+  - Connecting a Twitch account works end to end — approve on Twitch's page and the account card fills in a few seconds later.
+  - Earlier betas opened the Twitch authorization page but silently never completed the connection; that listener now genuinely waits for your approval.
+---
+
+Connecting Twitch uses Twitch's device authorization: Videorc shows you a
+code page in the browser, you approve, and the app polls Twitch until the
+approval lands. A bug in the completion machinery ended that polling before
+it ever started — so approving on Twitch's page did nothing, with no error
+anywhere. The poller now runs the way it was designed to, and the
+connection completes within about five seconds of clicking Authorize.
+
+If you tried connecting Twitch in a previous beta and gave up: it wasn't
+you, and it works now. Reconnect from the streaming destinations panel.


### PR DESCRIPTION
Version bump 0.9.56 → 0.9.57 + changelog for #219 (device-grant completion driver fix). macOS-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release information for version 0.9.57 Beta 1.

* **Bug Fixes**
  * Fixed Twitch device authorization on macOS so connections complete within a few seconds after approval.
  * Improved authorization polling to reliably detect completed connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->