### PR TITLE
fix(recording): mid-session camera safety + bounded stream teardown + full-preset zoom

### DIFF
--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -3325,7 +3325,7 @@ impl RawVideoFifoWriter {
     fn close_and_join(&mut self) {
         self.frame_mailbox.close();
         if let Some(join) = self.join.take() {
-            let _ = join.join();
+            bounded_writer_join(join);
         }
     }
 }
@@ -3616,9 +3616,27 @@ impl VideoToolboxFifoWriter {
     fn close_and_join(&mut self) {
         self.frame_tx.take();
         if let Some(join) = self.join.take() {
-            let _ = join.join();
+            bounded_writer_join(join);
         }
     }
+}
+
+/// Join a writer thread with a bounded grace, then DETACH it. A writer blocked
+/// on a stalled sink (dead RTMP ingest, wedged fifo consumer) must not wedge
+/// session teardown — the unbounded join here was one of the two places a
+/// stop against an unresponsive Twitch endpoint hung until Force stop
+/// (owner report, 2026-08-19). A detached thread is reaped when the fifo/pipe
+/// closes or at process teardown.
+fn bounded_writer_join<T>(join: std::thread::JoinHandle<T>) {
+    const WRITER_CLOSE_JOIN_GRACE: Duration = Duration::from_secs(3);
+    let deadline = Instant::now() + WRITER_CLOSE_JOIN_GRACE;
+    while !join.is_finished() {
+        if Instant::now() >= deadline {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let _ = join.join();
 }
 
 enum PreservingOutputFrameOffer<T> {

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -985,6 +985,15 @@ async fn resync_camera_capture_geometry_after_commit(
     if !needs.camera {
         return;
     }
+    // NEVER restart the camera while a capture session owns the pipeline: the
+    // encoder assumes fixed camera frame geometry, and a mid-stream restart
+    // that re-derives it misreads buffers as color garbage and can kill the
+    // take (0.9.53–0.9.57 regression, owner-reported on a live scene switch).
+    // Stale geometry mid-session is the long-standing correct behavior — the
+    // scene math absorbs the scale — and the next idle commit re-syncs it.
+    if state.recording.lock().await.is_some() {
+        return;
+    }
     let video = params.video.clone().unwrap_or_else(fallback_video_settings);
     if !camera_capture_geometry_is_stale(state, &params.layout, &video).await {
         return;
@@ -1323,6 +1332,70 @@ mod tests {
         fn drop(&mut self) {
             self.0.store(true, Ordering::Release);
         }
+    }
+
+    #[tokio::test]
+    async fn geometry_resync_is_inert_while_a_session_is_recording() {
+        // The 0.9.53–0.9.57 regression: a hot preset switch mid-recording
+        // (inset -> full canvas changes the capture box) force-restarted the
+        // camera under the encoder — geometry changed mid-stream, buffers were
+        // misread as color garbage, and the take could die. The resync must be
+        // a no-op while any capture session owns the pipeline.
+        let state = test_state();
+        let video = crate::protocol::VideoSettings {
+            preset: crate::protocol::VideoPreset::Tutorial1440p30,
+            width: 2560,
+            height: 1440,
+            fps: 30,
+            bitrate_kbps: 8000,
+        };
+        // Installed under the inset preset; the committed scene goes
+        // full-canvas, so the capture box is genuinely stale.
+        let inset_layout = default_layout_settings();
+        let mut full_layout = default_layout_settings();
+        full_layout.layout_preset = crate::protocol::LayoutPreset::CameraOnly;
+        crate::preview_camera::test_install_live_camera_for_layout(
+            &state,
+            "camera:avfoundation-native:0",
+            &inset_layout,
+            &video,
+        )
+        .await;
+        assert!(
+            camera_capture_geometry_is_stale(&state, &full_layout, &video).await,
+            "the scenario must be a real staleness case for this test to mean anything"
+        );
+        *state.recording.lock().await =
+            Some(crate::recording::test_active_recording_stub("mid-session"));
+
+        let needs = SceneSourceNeeds {
+            camera: true,
+            screen: false,
+        };
+        let intent_id = begin_layout_intent(&state, Some(7), needs)
+            .await
+            .expect("intent must register");
+        let params = crate::protocol::SceneConfigParams {
+            sources: sources(true, false),
+            layout: full_layout,
+            video: Some(video),
+            background: None,
+            protected_overlay_window_ids: Vec::new(),
+        };
+        resync_camera_capture_geometry_after_commit(&state, intent_id, &params, needs).await;
+        // Give a wrongly-spawned restart time to touch the slot.
+        sleep(Duration::from_millis(80)).await;
+
+        let status = preview_camera_status(&state).await;
+        assert_eq!(
+            status.state,
+            crate::protocol::PreviewCameraState::Live,
+            "mid-recording resync must never restart the camera"
+        );
+        assert_eq!(
+            status.frames_captured, 42,
+            "the live session must be untouched"
+        );
     }
 
     fn sources(camera: bool, screen: bool) -> SourceSelection {

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -1125,6 +1125,37 @@ async fn camera_live_session_is_frameless_zombie(state: &AppState) -> bool {
         .is_none_or(|acked| acked.elapsed() >= CAMERA_FIRST_FRAME_REUSE_GRACE)
 }
 
+/// Test-only: install a healthy Live camera slot whose capture target was
+/// derived from `layout`, so cross-module tests (live_layout's geometry
+/// resync) can arm a staleness scenario without reaching into private slot
+/// fields.
+#[cfg(test)]
+pub(crate) async fn test_install_live_camera_for_layout(
+    state: &AppState,
+    camera_id: &str,
+    layout: &LayoutSettings,
+    video: &VideoSettings,
+) {
+    let (stop_tx, _stop_rx) = std_mpsc::channel();
+    let mut slot = state.preview_camera.lock().await;
+    slot.source_key = Some(SourceKey::camera(camera_id.to_string()));
+    slot.status.state = PreviewCameraState::Live;
+    slot.status.camera_id = Some(camera_id.to_string());
+    slot.status.target_fps = video.fps;
+    slot.status.frames_captured = 42;
+    slot.status.sequence = Some(42);
+    slot.live_acked_at = Some(Instant::now());
+    slot.active = Some(NativeCameraPreviewThread {
+        stop_tx,
+        join_handle: None,
+        shared: Arc::new(StdMutex::new(PreviewCameraShared::default())),
+        ffmpeg_path: "ffmpeg".to_string(),
+        layout: layout.clone(),
+        video: video.clone(),
+        capture_target: camera_capture_target_dimensions(layout, video),
+    });
+}
+
 /// True when the live camera session's configured capture box no longer
 /// matches what `layout`/`video` require. A hot preset switch (inset overlay
 /// <-> full canvas) keeps the session alive while its AVFoundation output

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -281,7 +281,11 @@ const IDLE_PREVIEW_WIDTH: u32 = 1280;
 const IDLE_PREVIEW_HEIGHT: u32 = 720;
 const IDLE_PREVIEW_FPS: u32 = 10;
 const IDLE_PREVIEW_JPEG_QUALITY: u32 = 4;
-const STOP_FINALIZE_TIMEOUT: Duration = Duration::from_secs(20);
+// Must comfortably contain the streaming escalation ladder (quit grace 8s +
+// kill grace 5s) plus process reaping and finalization, so the FIRST stop
+// click completes even against a dead RTMP ingest instead of stranding the
+// UI on "Stopping…" until a Force stop (owner report, 2026-08-19).
+const STOP_FINALIZE_TIMEOUT: Duration = Duration::from_secs(25);
 const FINAL_DURATION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 // A just-exited FFmpeg can leave its MP4 briefly unavailable to a Windows
 // filter driver (Defender/indexing are common examples). Do not demote an
@@ -942,6 +946,50 @@ pub struct ActiveRecording {
     /// Renderer/status hint only. Successful finalization uses the ordered
     /// monitor result above rather than sampling this flag after process exit.
     pub stop_requested: bool,
+}
+
+/// Test-only stub of an active capture session, crate-visible so guards in
+/// other modules (e.g. live_layout's mid-recording camera-resync guard) can
+/// arm `state.recording` without rebuilding this large literal.
+#[cfg(test)]
+pub(crate) fn test_active_recording_stub(session_id: &str) -> ActiveRecording {
+    ActiveRecording {
+        session_id: session_id.to_string(),
+        pid: 0,
+        stdin: None,
+        output_path: None,
+        stream_url: None,
+        ffmpeg_path: "test-ffmpeg".to_string(),
+        started_at: Utc::now().to_rfc3339(),
+        capture_epoch: Arc::new(std::sync::OnceLock::new()),
+        capture_started_fallback: Instant::now(),
+        mode: "record".to_string(),
+        audio_tracks: Vec::new(),
+        pipeline: RecordingPipeline::new(false, true, &[]),
+        native_audio: None,
+        ffmpeg_live_audio_session: None,
+        screen_overlay: None,
+        encoder_bridge: None,
+        encoder_bridge_stream: None,
+        #[cfg(target_os = "windows")]
+        windows_d3d11_monitor: None,
+        #[cfg(target_os = "windows")]
+        windows_d3d11_media: None,
+        #[cfg(target_os = "windows")]
+        windows_d3d11_recovery: None,
+        #[cfg(target_os = "windows")]
+        windows_d3d11_preview_compositor_suspension: None,
+        stream_targets_snapshot: Arc::new(StdMutex::new(crate::streaming::StreamTargetsSnapshot {
+            session_id: session_id.to_string(),
+            targets: Vec::new(),
+        })),
+        captioned_copy_requested: false,
+        keep_original_media: false,
+        comment_highlight_available: false,
+        _capture_permit: None,
+        stop_intent_sender: None,
+        stop_requested: false,
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -3415,11 +3463,28 @@ pub async fn stop_recording(state: AppState) -> Result<RecordingStatus> {
         tokio::spawn(stop_fallback(state.clone(), pid, session_id, output_path));
     }
 
-    Ok(
-        wait_for_final_recording_status(&mut final_status_events, &wait_session_id)
-            .await
-            .unwrap_or(status),
-    )
+    match wait_for_final_recording_status(&mut final_status_events, &wait_session_id).await {
+        Some(final_status) => Ok(final_status),
+        None => {
+            // The escalation ladder (quit -> TERM -> KILL) overran the finalize
+            // window — almost always a stream endpoint that stopped responding.
+            // Say so instead of returning a bare "Stopping" that strands the UI
+            // with no explanation until the user finds Force stop.
+            let _ = emit_health_event(
+                &state,
+                Some(&wait_session_id),
+                HealthLevel::Warn,
+                "recording-stop-finalize-overrun",
+                "Stopping is taking longer than expected — a stream endpoint is not responding. The session is being shut down in the background; Force stop ends it immediately.",
+            );
+            let mut status = status;
+            status.message = Some(
+                "A stream endpoint is not responding; finishing the stop in the background."
+                    .to_string(),
+            );
+            Ok(status)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10554,12 +10619,7 @@ fn bridge_compositor_ffmpeg_args(
 
     let stream_legs = stream_targets
         .iter()
-        .map(|target| {
-            format!(
-                "[f=flv:onfail=ignore:flvflags=no_duration_filesize]{}",
-                escape_tee_target(&target.url)
-            )
-        })
+        .map(|target| rtmp_tee_leg(&target.url))
         .collect::<Vec<_>>();
 
     match (output_path, stream_targets) {
@@ -11074,6 +11134,21 @@ fn append_bridge_audio_input_args(
     }
 }
 
+/// One tee slave spec for an RTMP(S) leg. `onfail=ignore` keeps a dying
+/// platform from killing the recording or the other streams; `rw_timeout`
+/// (microseconds) bounds every socket operation so a stalled ingest ERRORS OUT
+/// instead of blocking the tee muxer's teardown forever — an unresponsive
+/// Twitch endpoint used to wedge the whole stop path until Force stop
+/// (owner report, 2026-08-19). Steady-state overflow is already handled by
+/// the fifo wrapper's drop_pkts_on_overflow; this bounds the CLOSE.
+fn rtmp_tee_leg(url: &str) -> String {
+    format!(
+        "[f=flv:onfail=ignore:flvflags=no_duration_filesize:rw_timeout={RTMP_LEG_RW_TIMEOUT_US}]{}",
+        escape_tee_target(url)
+    )
+}
+const RTMP_LEG_RW_TIMEOUT_US: u64 = 8_000_000;
+
 fn bridge_recording_video_filter(video_input_index: usize, video: &VideoSettings) -> String {
     let fps = video.fps.max(1);
     format!("[{video_input_index}:v]setpts=PTS-STARTPTS,fps={fps}[v_main]")
@@ -11124,12 +11199,7 @@ fn ffmpeg_args(
 
     let stream_legs = stream_targets
         .iter()
-        .map(|target| {
-            format!(
-                "[f=flv:onfail=ignore:flvflags=no_duration_filesize]{}",
-                escape_tee_target(&target.url)
-            )
-        })
+        .map(|target| rtmp_tee_leg(&target.url))
         .collect::<Vec<_>>();
 
     match (output_path, stream_targets) {
@@ -19336,6 +19406,16 @@ mod tests {
         assert!(
             native_window_recording_path_message(false).contains("FFmpeg AVFoundation fallback")
         );
+    }
+
+    #[test]
+    fn rtmp_tee_legs_carry_a_socket_deadline() {
+        // Without rw_timeout a stalled ingest blocks the tee muxer teardown
+        // forever and the stop path hangs until Force stop.
+        let leg = rtmp_tee_leg("rtmp://live.twitch.tv/app/streamkey");
+        assert!(leg.starts_with("[f=flv:onfail=ignore:flvflags=no_duration_filesize:rw_timeout="));
+        assert!(leg.contains(":rw_timeout=8000000]"));
+        assert!(leg.ends_with("rtmp://live.twitch.tv/app/streamkey"));
     }
 
     #[test]

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -131,8 +131,7 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
             if let Some(camera_id) = params.sources.camera_id.clone() {
                 let mut camera =
                     camera_source(camera_id, &params.layout, output_width, output_height);
-                camera.transform = full_frame_transform();
-                camera.default_transform = full_frame_transform();
+                place_camera_keeping_crop(&mut camera, full_frame_transform());
                 scene.sources.push(camera);
             } else {
                 scene.sources.push(base_source(&params.sources));
@@ -166,8 +165,7 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
             if let Some(camera_id) = params.sources.camera_id.clone() {
                 let mut camera =
                     camera_source(camera_id, &params.layout, output_width, output_height);
-                camera.transform = region_transform(camera_x, camera_fraction);
-                camera.default_transform = camera.transform.clone();
+                place_camera_keeping_crop(&mut camera, region_transform(camera_x, camera_fraction));
                 scene.sources.push(camera);
             }
         }
@@ -212,8 +210,7 @@ pub fn scene_from_capture_config(params: SceneConfigParams) -> Scene {
             {
                 let mut camera =
                     camera_source(camera_id, &params.layout, output_width, output_height);
-                camera.transform = full_frame_transform();
-                camera.default_transform = full_frame_transform();
+                place_camera_keeping_crop(&mut camera, full_frame_transform());
                 scene.sources.push(camera);
             } else {
                 scene.sources.push(base_source(&params.sources));
@@ -375,6 +372,22 @@ fn camera_source(
     }
 }
 
+/// Place a camera into a preset frame while keeping the zoom/pan crop that
+/// `camera_source` derived from the layout. Placement transforms only say
+/// WHERE the camera sits; overwriting the whole transform silently discarded
+/// the crop, which made Zoom / Pan X / Pan Y no-ops in every preset except
+/// ScreenCamera (owner report, 2026-08-19). All three render paths (Metal,
+/// CPU, FFmpeg) consume the same crop fields, so parity holds.
+fn place_camera_keeping_crop(camera: &mut SceneSource, placement: SceneTransform) {
+    let mut placed = placement;
+    placed.crop_left = camera.transform.crop_left;
+    placed.crop_top = camera.transform.crop_top;
+    placed.crop_right = camera.transform.crop_right;
+    placed.crop_bottom = camera.transform.crop_bottom;
+    camera.transform = placed.clone();
+    camera.default_transform = placed;
+}
+
 fn full_frame_transform() -> SceneTransform {
     SceneTransform {
         x: 0.0,
@@ -446,8 +459,10 @@ fn push_vertical_stack(
 
     if let Some(camera_id) = params.sources.camera_id.clone() {
         let mut camera = camera_source(camera_id, &params.layout, output_width, output_height);
-        camera.transform = vertical_band_transform(bands.camera_y, bands.camera_height);
-        camera.default_transform = camera.transform.clone();
+        place_camera_keeping_crop(
+            &mut camera,
+            vertical_band_transform(bands.camera_y, bands.camera_height),
+        );
         scene.sources.push(camera);
     }
 }
@@ -473,8 +488,7 @@ fn collapsed_vertical_single_source(
         (true, Some(_)) => None,
         (false, Some(camera_id)) => {
             let mut camera = camera_source(camera_id, &params.layout, output_width, output_height);
-            camera.transform = full_frame_transform();
-            camera.default_transform = full_frame_transform();
+            place_camera_keeping_crop(&mut camera, full_frame_transform());
             Some(camera)
         }
         (_, None) => Some(base_source(&params.sources)),
@@ -1001,6 +1015,35 @@ mod tests {
         assert_eq!(scene.sources[0].transform.width, 1.0);
         assert!(scene.sources[1].transform.x > 0.6);
         assert!(scene.sources[1].transform.y > 0.6);
+    }
+
+    #[test]
+    fn camera_zoom_crop_survives_every_preset_placement() {
+        // Zoom/pan derive a crop in camera_source; the placement arms used to
+        // overwrite the whole transform and silently discard it, making
+        // Zoom / Pan X / Pan Y no-ops outside ScreenCamera.
+        for preset in [
+            LayoutPreset::CameraOnly,
+            LayoutPreset::SideBySide,
+            LayoutPreset::VerticalCameraOnly,
+            LayoutPreset::VerticalSplit,
+        ] {
+            let mut params = base_params();
+            params.layout.layout_preset = preset.clone();
+            params.layout.camera_zoom = 150;
+            params.layout.camera_offset_x = 20;
+            let scene = scene_from_capture_config(params);
+            let camera = scene
+                .sources
+                .iter()
+                .find(|source| matches!(source.kind, SceneSourceKind::Camera))
+                .unwrap_or_else(|| panic!("{preset:?} must place the camera"));
+            assert!(
+                camera.transform.crop_left > 0.0 || camera.transform.crop_right > 0.0,
+                "{preset:?} must keep the zoom crop, got {:?}",
+                camera.transform
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
PR-A of the post-first-livestream batch (vault plan 2026-08-19). Three recording-safety fixes:

## 1. Scene switch mid-recording no longer corrupts the camera (0.9.53–0.9.57 regression)
The capture-geometry resync (#210) had no recording guard: a hot preset switch mid-session force-restarted the camera under the encoder — geometry changed mid-stream and buffers were misread as color garbage ('strange colors'), risking the take. The resync is now inert while any session owns the pipeline; stale geometry mid-session is the long-standing correct behavior, and the next idle commit re-syncs. Regression test arms a real stale-geometry Live camera + an active-recording stub and proves the slot is untouched.

## 2. Stopping a livestream can no longer hang on a dead ingest
No Twitch API call exists on the stop path — the hang was the RTMP teardown:
- every FLV tee leg now carries `rw_timeout=8s` (**verified accepted by the bundled FFmpeg** against a blackholed TEST-NET endpoint) so a stalled socket errors out instead of blocking the tee muxer close forever
- encoder-bridge writer joins are bounded (3s grace → detach) — the second unbounded wait on that path
- `STOP_FINALIZE_TIMEOUT` 20s → 25s so the TERM(8s)/KILL(5s) ladder + reaping fits inside the first Stop click
- on overrun, the status now says a stream endpoint is unresponsive instead of a bare 'Stopping…'

## 3. Camera zoom/pan crop survives every preset
The placement arms overwrote the whole camera transform, silently discarding the zoom/pan crop — Zoom/Pan were no-ops outside ScreenCamera. `place_camera_keeping_crop` carries the crop into all arms (three-path render parity holds — all paths consume the same crop fields). Test pins four presets. (The renderer half — the sliders never *committing* — lands in PR-B.)

## Verification
- 1,501 backend tests pass (3 new), clippy `-D warnings` + fmt clean
- `smoke:recording-matrix`: **12/12 PASS**
- `smoke:multistream`: **PASS** — record+stream fan-out with the new rw_timeout legs, dead leg isolated, recording finalized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Camera capture remains stable during active recording, avoiding unnecessary restarts and dropped frames.
  - Camera zoom and pan positioning now remain consistent across layout presets.
  - Recording finalization provides clearer status feedback when stopping takes longer than expected.
  - Streaming connections now handle stalled network destinations more reliably.
  - Application shutdown is more responsive when video output is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->