### PR TITLE
release: 0.9.58-beta.1 — livestream lessons

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.58-beta.1.md
+++ b/changelog/0.9.58-beta.1.md
@@ -1,0 +1,45 @@
+---
+version: 0.9.58-beta.1
+date: 2026-08-19
+channel: beta
+platforms:
+  - macos
+title: Livestream lessons — steadier scenes, a stop that stops, and smarter takeovers
+summary: Everything learned from the first real Twitch livestream. Scene switches can no longer glitch the camera mid-recording, stopping a stream completes on the first click even when a platform stalls, takeovers mute your mic automatically, comments move fully into their own window, and camera zoom and pan finally work live.
+highlights:
+  - Switching scenes while recording no longer risks strange colors or a dropped take — the camera is left untouched mid-session.
+  - Stopping a livestream completes on the first click even when a streaming platform stops responding; no more Force stop.
+  - Activating a takeover now mutes your microphone automatically, and clearing it restores your previous mic state.
+  - Comments now live only in their own window — ⌘J opens it. Notes stays invisible on recordings; comments and captions are visible.
+  - Camera zoom, pan, fit, and mirror apply live in every layout — no session restart needed — and the camera margin can go to 0.
+  - Your account avatar and each platform account's avatar now show in the app, background presets toggle off with a second click, and the caption size buttons fit their labels.
+---
+
+The first real livestream taught us a lot, and this release ships all of it.
+
+Recording safety first: changing scenes mid-recording could restart the
+camera underneath the encoder, which showed up as psychedelic colors and
+could end the take. The camera is now left alone while a session is
+running. And stopping a stream no longer depends on the platform being
+polite — a stalled ingest used to block the shutdown until you pressed
+Force stop; every streaming connection now has a hard timeout, and if a
+platform still drags its feet the app says so and finishes in the
+background.
+
+Takeovers got smarter: covering the output with an image now mutes your
+microphone, and removing the takeover restores exactly the mic state you
+had — if you unmuted manually in between, that choice wins.
+
+Comments moved out of the Studio into their own window for good, like
+Notes — ⌘J or ⌘⇧J opens it. On recordings, only Notes stays invisible;
+comments and captions are part of the show and now appear in your
+captures and in the source picker.
+
+Camera framing is finally live: zoom, pan, fit, and mirror used to sit in
+the app without reaching the running scene until the next session. They
+apply instantly now, in every layout preset, and the camera margin
+minimum drops from 8 to 0.
+
+Plus the small things: your real avatar (and each connected platform's
+avatar) shows instead of a placeholder, clicking an active background
+preset removes it, and the caption text-size buttons no longer overflow.


### PR DESCRIPTION
Version bump 0.9.57 → 0.9.58 + changelog for #221 (recording safety: mid-session camera guard, bounded stream teardown, full-preset zoom) and #222 (takeover mute, window-only comments, notes-only capture privacy, live framing, avatars, polish). macOS-only.