### PR TITLE
fix(recording): round-2 backend batch — notes-safe capture, cover-crop pan, X viewers

### DIFF
--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -2446,6 +2446,7 @@ fn push_caption_overlay_gpu_source<'a>(
         },
         false,
         SceneCrop::none(),
+        (0.0, 0.0),
         canvas_width,
         canvas_height,
     ) else {
@@ -2521,6 +2522,7 @@ fn try_gpu_compose(
                     },
                     matches!(background.fit, BackgroundFit::Fit),
                     background_zoom_crop(Some(background)),
+                    (0.0, 0.0),
                     inputs.width,
                     inputs.height,
                 )
@@ -2580,6 +2582,7 @@ fn try_gpu_compose(
                 CompositorSceneSourceFit::Contain
             ),
             SceneCrop::none(),
+            (0.0, 0.0),
             inputs.width,
             inputs.height,
         )
@@ -2655,6 +2658,7 @@ fn try_gpu_compose(
                 CompositorSceneSourceFit::Contain
             ),
             SceneCrop::none(),
+            (0.0, 0.0),
             inputs.width,
             inputs.height,
         )
@@ -2737,6 +2741,7 @@ fn try_gpu_compose(
                             SceneFit::Contain
                         ),
                         source_crop,
+                        source_cover_pan(&SceneSourceKind::Camera, layout),
                         inputs.width,
                         inputs.height,
                     )
@@ -2776,6 +2781,7 @@ fn try_gpu_compose(
                             SceneFit::Contain
                         ),
                         source_crop,
+                        source_cover_pan(&SceneSourceKind::Camera, layout),
                         inputs.width,
                         inputs.height,
                     )
@@ -2825,6 +2831,7 @@ fn try_gpu_compose(
                         rect,
                         screen_contain,
                         source_crop,
+                        source_cover_pan(&source.kind, layout),
                         inputs.width,
                         inputs.height,
                     )
@@ -2853,6 +2860,7 @@ fn try_gpu_compose(
                         rect,
                         screen_contain,
                         source_crop,
+                        source_cover_pan(&source.kind, layout),
                         inputs.width,
                         inputs.height,
                     )
@@ -2883,6 +2891,7 @@ fn try_gpu_compose(
                     rect,
                     false,
                     SceneCrop::none(),
+                    (0.0, 0.0),
                     inputs.width,
                     inputs.height,
                 )
@@ -3253,16 +3262,21 @@ fn gpu_compositor_frame(
 }
 
 #[cfg(target_os = "macos")]
+// Placement is a flat description of one draw: geometry in, shader vec4s out.
+// Bundling the eight scalars into structs would add indirection at ~10 call
+// sites for no reuse.
+#[allow(clippy::too_many_arguments)]
 fn gpu_source_placement(
     source_width: u32,
     source_height: u32,
     rect: PixelRect,
     contain: bool,
     crop: SceneCrop,
+    pan: (f64, f64),
     output_width: u32,
     output_height: u32,
 ) -> Option<([f32; 4], [f32; 4])> {
-    let fit = source_fit(source_width, source_height, rect, contain, crop)?;
+    let fit = source_fit(source_width, source_height, rect, contain, crop, pan)?;
     let output_width = f64::from(output_width.max(1));
     let output_height = f64::from(output_height.max(1));
     let source_width = f64::from(source_width.max(1));
@@ -3704,6 +3718,7 @@ fn render_compositor_yuv420p_scene(inputs: CompositorRenderInputs<'_>, bytes: &m
             scene_content_rect_pixels(stage_margin, width, height),
             SourceRenderOptions {
                 crop: SceneCrop::none(),
+                pan: (0.0, 0.0),
                 // Screen-image stand-ins are screen-like: contain, never crop.
                 contain: matches!(
                     compositor_scene_source_fit(&SceneSourceKind::Screen, &snapshot.layout),
@@ -3753,6 +3768,7 @@ fn render_compositor_yuv420p_scene(inputs: CompositorRenderInputs<'_>, bytes: &m
                         rect,
                         SourceRenderOptions {
                             crop: scene_crop_from_transform(&transform),
+                            pan: (0.0, 0.0),
                             contain: screen_contain,
                             mirror_x: false,
                             mask: SceneMask::None,
@@ -3773,6 +3789,7 @@ fn render_compositor_yuv420p_scene(inputs: CompositorRenderInputs<'_>, bytes: &m
                         rect,
                         SourceRenderOptions {
                             crop: scene_crop_from_transform(&transform),
+                            pan: (0.0, 0.0),
                             contain: screen_contain,
                             mirror_x: false,
                             mask: SceneMask::None,
@@ -3797,6 +3814,7 @@ fn render_compositor_yuv420p_scene(inputs: CompositorRenderInputs<'_>, bytes: &m
                     rect,
                     SourceRenderOptions {
                         crop: scene_crop_from_transform(&transform),
+                        pan: source_cover_pan(&SceneSourceKind::Camera, &snapshot.layout),
                         contain: matches!(
                             scene_source_fit(&SceneSourceKind::Camera, &snapshot.layout),
                             SceneFit::Contain
@@ -4010,6 +4028,8 @@ enum SourcePixelFormat {
 #[derive(Debug, Clone, Copy)]
 struct SourceRenderOptions {
     crop: SceneCrop,
+    /// Fill-mode cover pan (normalized -1..=1); see `source_cover_pan`.
+    pan: (f64, f64),
     contain: bool,
     mirror_x: bool,
     mask: SceneMask,
@@ -4147,6 +4167,7 @@ fn render_scene_background(
         },
         SourceRenderOptions {
             crop: background_zoom_crop(Some(background)),
+            pan: (0.0, 0.0),
             contain: matches!(background.fit, BackgroundFit::Fit),
             mirror_x: false,
             mask: SceneMask::None,
@@ -4258,6 +4279,7 @@ fn render_synthetic_source_rect(
         rect,
         SourceRenderOptions {
             crop: SceneCrop::none(),
+            pan: (0.0, 0.0),
             contain: false,
             mirror_x: false,
             mask: SceneMask::None,
@@ -4446,6 +4468,7 @@ fn blit_rgba_to_yuv420p(
         rect,
         options.contain,
         options.crop,
+        options.pan,
     ) else {
         return false;
     };
@@ -4659,12 +4682,28 @@ struct SourceFit {
     source_height: f64,
 }
 
+/// Fill-mode pan for a scene source: which part of the cover-crop aspect
+/// slack stays visible (normalized -1..=1). Only the camera has pan controls;
+/// every other source keeps the centered default. The mapping mirrors the
+/// legacy FFmpeg `crop_offset_expr`, keeping the three render paths in
+/// parity.
+fn source_cover_pan(kind: &SceneSourceKind, layout: &LayoutSettings) -> (f64, f64) {
+    match kind {
+        SceneSourceKind::Camera => (
+            f64::from(layout.camera_offset_x.clamp(-100, 100)) / 100.0,
+            f64::from(layout.camera_offset_y.clamp(-100, 100)) / 100.0,
+        ),
+        _ => (0.0, 0.0),
+    }
+}
+
 fn source_fit(
     source_width: u32,
     source_height: u32,
     rect: PixelRect,
     contain: bool,
     crop: SceneCrop,
+    pan: (f64, f64),
 ) -> Option<SourceFit> {
     if rect.width == 0 || rect.height == 0 || source_width == 0 || source_height == 0 {
         return None;
@@ -4696,11 +4735,18 @@ fn source_fit(
             source_height: source_h,
         })
     } else {
+        // Fill/cover: pan chooses WHICH part of the aspect slack stays
+        // visible instead of hard-centering it. fraction = (1 + pan) / 2
+        // mirrors the legacy FFmpeg crop_offset_expr ((in-out)/2 +
+        // offset*(in-out)/200), so all render paths agree — pan was silently
+        // ignored here, which made Pan X/Y no-ops at zoom 100 (owner report,
+        // 2026-08-19).
+        let pan_fraction = |pan: f64| (1.0 + pan.clamp(-1.0, 1.0)) / 2.0;
         let (source_x, source_y, fitted_source_width, fitted_source_height) =
             if source_aspect > rect_aspect {
                 let fitted_source_width = source_h * rect_aspect;
                 (
-                    source_x + (source_w - fitted_source_width) / 2.0,
+                    source_x + (source_w - fitted_source_width) * pan_fraction(pan.0),
                     source_y,
                     fitted_source_width,
                     source_h,
@@ -4709,7 +4755,7 @@ fn source_fit(
                 let fitted_source_height = source_w / rect_aspect;
                 (
                     source_x,
-                    source_y + (source_h - fitted_source_height) / 2.0,
+                    source_y + (source_h - fitted_source_height) * pan_fraction(pan.1),
                     source_w,
                     fitted_source_height,
                 )
@@ -5516,6 +5562,7 @@ mod tests {
                     right: 0.0,
                     bottom: 0.0,
                 },
+                pan: (0.0, 0.0),
                 contain: false,
                 mirror_x: false,
                 mask: SceneMask::None,
@@ -5555,6 +5602,7 @@ mod tests {
             },
             SourceRenderOptions {
                 crop: SceneCrop::none(),
+                pan: (0.0, 0.0),
                 contain: false,
                 mirror_x: false,
                 mask: SceneMask::None,
@@ -5616,6 +5664,7 @@ mod tests {
             },
             SourceRenderOptions {
                 crop: SceneCrop::none(),
+                pan: (0.0, 0.0),
                 contain: false,
                 mirror_x: false,
                 mask: SceneMask::None,
@@ -5674,6 +5723,7 @@ mod tests {
             },
             SourceRenderOptions {
                 crop: SceneCrop::none(),
+                pan: (0.0, 0.0),
                 contain: false,
                 mirror_x: false,
                 mask: SceneMask::None,
@@ -5735,6 +5785,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cover_pan_chooses_the_visible_window_of_the_aspect_slack() {
+        // A 16:9 source into a square box in Fill mode has horizontal slack;
+        // pan must pick which part survives — it was hard-centered before
+        // (owner report, 2026-08-19: Pan X/Y did nothing at default zoom).
+        // Matches the legacy FFmpeg crop_offset_expr mapping.
+        let rect = PixelRect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let fit_for = |pan_x: f64| {
+            source_fit(1920, 1080, rect, false, SceneCrop::none(), (pan_x, 0.0)).expect("cover fit")
+        };
+        let centered = fit_for(0.0);
+        assert!((centered.source_x - (1920.0 - 1080.0) / 2.0).abs() < 0.001);
+        let left = fit_for(-1.0);
+        assert!(left.source_x.abs() < 0.001, "full left pan starts at 0");
+        let right = fit_for(1.0);
+        assert!(
+            (right.source_x - (1920.0 - 1080.0)).abs() < 0.001,
+            "full right pan ends at the source edge"
+        );
+        // Out-of-range pan clamps instead of sampling outside the source.
+        let overshoot = fit_for(5.0);
+        assert!((overshoot.source_x - (1920.0 - 1080.0)).abs() < 0.001);
+        // Contain mode never pans — there is no crop to move.
+        let contained =
+            source_fit(1920, 1080, rect, true, SceneCrop::none(), (1.0, 1.0)).expect("contain fit");
+        assert!(contained.source_x.abs() < 0.001);
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_source_placement_reports_transform_crop_to_shader() {
@@ -5754,6 +5837,7 @@ mod tests {
                 right: 0.0,
                 bottom: 0.0,
             },
+            (0.0, 0.0),
             4,
             2,
         )
@@ -5777,6 +5861,7 @@ mod tests {
             },
             true,
             SceneCrop::none(),
+            (0.0, 0.0),
             4,
             4,
         )

--- a/crates/videorc-backend/src/live_chat.rs
+++ b/crates/videorc-backend/src/live_chat.rs
@@ -1341,6 +1341,7 @@ pub async fn start_live_chat(state: &AppState, params: LiveChatStartParams) -> L
                 params.session_id.clone(),
                 youtube_viewers,
                 twitch_viewers,
+                None,
             ));
             let mut coordinator = state.live_chat.lock().await;
             coordinator.attach_task(handle);
@@ -1427,6 +1428,19 @@ pub async fn start_x_live_chat(
         status_base_url: params.status_base_url,
         access_url: params.access_url,
     };
+    // X viewer counts ride the same session lifecycle as the chat connector
+    // (plan 028 specified them; they were never implemented — owner report,
+    // 2026-08-19: "cannot see how many watchers there are from X").
+    let viewer_handle = tokio::spawn(crate::viewer_stats::run_viewer_sampler(
+        state.clone(),
+        params.session_id.clone(),
+        None,
+        None,
+        Some(crate::viewer_stats::XViewerConfig {
+            broadcast_id: config.broadcast_id.clone(),
+            api_base_url: None,
+        }),
+    ));
     let handle = tokio::spawn(crate::x_chat::run_x_chat_connector(
         state.clone(),
         params.session_id,
@@ -1434,6 +1448,7 @@ pub async fn start_x_live_chat(
     ));
     {
         let mut coordinator = state.live_chat.lock().await;
+        coordinator.attach_task(viewer_handle);
         coordinator.attach_task(handle);
     }
 

--- a/crates/videorc-backend/src/preview_screen.rs
+++ b/crates/videorc-backend/src/preview_screen.rs
@@ -1438,14 +1438,33 @@ async fn reuse_current_screen_source(
         active.ffmpeg_path == ffmpeg_path
             && active.video == *video
             && slot.status.target_fps == target_fps
-            && active.protected_overlay_window_ids == protected_overlay_window_ids
     });
     if !can_reuse {
         return None;
     }
+    // A changed exclusion set must NEVER force a restart: opening/closing the
+    // Notes window flips the id set, and the resulting SCK teardown mid-
+    // recording froze the screen and corrupted colors (owner report,
+    // 2026-08-19 — the same disease as the mid-recording camera restart).
+    // Privacy is not at stake: Electron content protection excludes those
+    // windows from EVERY capture at the OS level independently of this
+    // filter, which is best-effort hygiene. The stored set updates so status
+    // stays truthful, and the SCK filter picks it up at the next real start.
+    let ids_changed = slot
+        .active
+        .as_ref()
+        .is_some_and(|active| active.protected_overlay_window_ids != protected_overlay_window_ids);
+    if ids_changed && let Some(active) = slot.active.as_mut() {
+        active.protected_overlay_window_ids = protected_overlay_window_ids.to_vec();
+    }
     let mut status = slot.status.clone();
     status.updated_at = Utc::now().to_rfc3339();
-    status.message = Some("Native screen preview source reused.".to_string());
+    status.message = Some(if ids_changed {
+        "Native screen preview source reused; the capture exclusion set updates at the next capture start (content protection already hides those windows)."
+            .to_string()
+    } else {
+        "Native screen preview source reused.".to_string()
+    });
     slot.status = status.clone();
     Some(status)
 }
@@ -4019,7 +4038,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn changed_protected_overlay_windows_prevent_screen_source_reuse() {
+    async fn changed_protected_overlay_windows_reuse_without_restart() {
         let state = test_state();
         let source_key = SourceKey::screen("screen:screencapturekit:5");
         let (stop_tx, _stop_rx) = std_mpsc::channel();
@@ -4068,10 +4087,33 @@ mod tests {
                 .await
                 .is_some()
         );
-        assert!(
+        // A changed exclusion set must reuse, not restart: the SCK teardown it
+        // used to force froze the screen mid-recording when the Notes window
+        // opened/closed (2026-08-19). Content protection is the privacy layer;
+        // the stored set updates so status stays truthful.
+        let status =
             reuse_current_screen_source(&state, &source_key, "ffmpeg", &video, video.fps, &[7])
                 .await
-                .is_none()
+                .expect("an exclusion-set change alone must never force a restart");
+        assert!(
+            status
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("exclusion set updates")),
+            "the reuse must say the filter change is deferred"
+        );
+        let slot = state.preview_screen.lock().await;
+        assert_eq!(
+            slot.run_id.as_deref(),
+            Some("run-1"),
+            "the running session must be untouched"
+        );
+        assert_eq!(
+            slot.active
+                .as_ref()
+                .map(|active| active.protected_overlay_window_ids.clone()),
+            Some(vec![7]),
+            "the stored exclusion set must reflect the new truth"
         );
     }
 }

--- a/crates/videorc-backend/src/viewer_stats.rs
+++ b/crates/videorc-backend/src/viewer_stats.rs
@@ -41,6 +41,14 @@ pub struct TwitchViewerConfig {
     pub api_base_url: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XViewerConfig {
+    pub broadcast_id: String,
+    #[serde(default)]
+    pub api_base_url: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ViewerPlatformCount {
@@ -150,14 +158,27 @@ async fn fetch_twitch_count(client: &reqwest::Client, config: &TwitchViewerConfi
     parse_twitch_viewer_count(&body)
 }
 
+async fn fetch_x_count(client: &reqwest::Client, config: &XViewerConfig) -> Option<u64> {
+    // Credentials are resolved per poll so a rotated token is picked up
+    // without restarting the sampler.
+    let credentials = crate::x_live::x_livestream_credentials().ok().flatten()?;
+    let base = config
+        .api_base_url
+        .as_deref()
+        .unwrap_or(crate::x_live::DEFAULT_API_BASE_URL);
+    crate::x_live::fetch_broadcast_viewer_count(client, &credentials, base, &config.broadcast_id)
+        .await
+}
+
 /// Session-scoped sampler task; aborted with the live-chat connectors on stop.
 pub async fn run_viewer_sampler(
     state: AppState,
     session_id: String,
     youtube: Option<YouTubeViewerConfig>,
     twitch: Option<TwitchViewerConfig>,
+    x: Option<XViewerConfig>,
 ) {
-    if youtube.is_none() && twitch.is_none() {
+    if youtube.is_none() && twitch.is_none() && x.is_none() {
         return;
     }
     let client = reqwest::Client::new();
@@ -179,6 +200,9 @@ pub async fn run_viewer_sampler(
                 StreamPlatform::Twitch,
                 fetch_twitch_count(&client, config).await,
             ));
+        }
+        if let Some(config) = x.as_ref() {
+            counts.push((StreamPlatform::X, fetch_x_count(&client, config).await));
         }
 
         let at = chrono::Utc::now().to_rfc3339();

--- a/crates/videorc-backend/src/x_chat.rs
+++ b/crates/videorc-backend/src/x_chat.rs
@@ -193,14 +193,26 @@ pub async fn run_x_chat_connector(state: AppState, session_id: String, config: X
         }
         reconnect_attempts += 1;
         if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
+            let message = format!(
+                "X live chat stopped after {MAX_RECONNECT_ATTEMPTS} consecutive connection attempts: {error}"
+            );
+            // Owner report 2026-08-19: an empty X comment feed with no trace
+            // anywhere burned a livestream's worth of debugging. The terminal
+            // failure lands in the session health record so the cause is on
+            // file even if nobody watched the provider row live.
+            let _ = crate::recording::emit_health_event(
+                &state,
+                Some(&session_id),
+                crate::protocol::HealthLevel::Warn,
+                "x-live-chat-failed",
+                &message,
+            );
             set_provider_and_emit(
                 &state,
                 StreamPlatform::X,
                 config.target_id.as_deref(),
                 LiveChatProviderConnectionState::Failed,
-                &format!(
-                    "X live chat stopped after {MAX_RECONNECT_ATTEMPTS} consecutive connection attempts: {error}"
-                ),
+                &message,
             )
             .await;
             return;

--- a/crates/videorc-backend/src/x_live.rs
+++ b/crates/videorc-backend/src/x_live.rs
@@ -18,7 +18,7 @@ type HmacSha1 = Hmac<Sha1>;
 
 const X_LIVESTREAM_DOCS_URL: &str = "https://github.com/xdevplatform/x-livestream-sample";
 const X_API_OVERVIEW_URL: &str = "https://docs.x.com/x-api/overview";
-const DEFAULT_API_BASE_URL: &str = "https://api.x.com";
+pub const DEFAULT_API_BASE_URL: &str = "https://api.x.com";
 const DEFAULT_SOURCE_NAME: &str = "Videorc Primary Encoder";
 const DEFAULT_LOCALE: &str = "en";
 const DEFAULT_CHAT_OPTION: u8 = 2;
@@ -1138,6 +1138,54 @@ async fn publish_broadcast(
     send_x_request(client, credentials, Method::PUT, url, Some(body)).await
 }
 
+/// Best-effort concurrent-viewer count for a live X broadcast (plan 028:
+/// `GET /2/users/{uid}/broadcasts/{bid}` surfaces state + viewer counts). The
+/// producer API's field name varies across its Periscope lineage, so parse
+/// defensively; a missing count is a skipped sample, never an error — the
+/// sampler's failure discipline (viewer_stats.rs) forbids degrading the
+/// stream over telemetry.
+pub async fn fetch_broadcast_viewer_count(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    broadcast_id: &str,
+) -> Option<u64> {
+    let url = endpoint(
+        base_url,
+        &format!(
+            "/2/users/{}/broadcasts/{}",
+            credentials.user_id, broadcast_id
+        ),
+    )
+    .ok()?;
+    let value: serde_json::Value = send_x_request(client, credentials, Method::GET, url, None)
+        .await
+        .ok()?;
+    parse_x_broadcast_viewer_count(&value)
+}
+
+pub fn parse_x_broadcast_viewer_count(body: &serde_json::Value) -> Option<u64> {
+    let broadcast = body.get("broadcast").unwrap_or(body);
+    for key in [
+        "viewer_count",
+        "total_watching",
+        "concurrent_viewers",
+        "num_watching",
+        "watching_count",
+    ] {
+        let Some(count) = broadcast.get(key) else {
+            continue;
+        };
+        if let Some(count) = count.as_u64() {
+            return Some(count);
+        }
+        if let Some(count) = count.as_str().and_then(|value| value.parse().ok()) {
+            return Some(count);
+        }
+    }
+    None
+}
+
 async fn end_broadcast(
     client: &reqwest::Client,
     credentials: &XLivestreamCredentials,
@@ -1429,6 +1477,26 @@ fn x_should_not_tweet(metadata: &StreamMetadataDraft) -> bool {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn broadcast_viewer_count_parses_defensively_across_field_lineages() {
+        use serde_json::json;
+        // Enveloped, numeric.
+        assert_eq!(
+            parse_x_broadcast_viewer_count(&json!({"broadcast": {"total_watching": 42}})),
+            Some(42)
+        );
+        // Bare object, string-typed count (Periscope lineage).
+        assert_eq!(
+            parse_x_broadcast_viewer_count(&json!({"viewer_count": "7"})),
+            Some(7)
+        );
+        // No recognized field = skipped sample, never a panic.
+        assert_eq!(
+            parse_x_broadcast_viewer_count(&json!({"broadcast": {"state": "RUNNING"}})),
+            None
+        );
+    }
     use super::*;
     use crate::streaming::PlatformAccountStatus;
 


### PR DESCRIPTION
PR-C of the round-2 batch (vault plan 2026-08-19 evening). Four backend fixes:

## 1. Notes window can no longer glitch a recording
Opening/closing Notes changes the capture-exclusion id set; the screen source refused to reuse a session with different ids and did a **full SCK teardown mid-recording** (blocking thread join + rediscovery + fresh SCStream) — the frozen screen + color garbage the owner saw. Same disease as the mid-recording camera restart (#221). Exclusion-set changes now ALWAYS reuse: privacy holds regardless because Electron content protection excludes those windows from every capture at the OS level; the SCK filter refreshes at the next real start. Reuse test rewritten to pin the new policy (run_id preserved, stored ids updated).

## 2. Pan X / Pan Y actually pan
The compositor's Fill cover-crop hard-centered the aspect slack — pan was ignored at any zoom, and at zoom 100 the zoom-crop path returns zero unconditionally, so pan moved nothing anywhere. `source_fit` now places the slack window by pan ((1+pan)/2, clamped), exactly mirroring the legacy FFmpeg `crop_offset_expr` — three-path parity restored. Camera-only; screens/backgrounds keep centered. Tests: full-left/center/full-right/overshoot-clamp/contain-never-pans.

## 3. X viewer counts (specified in plan 028, never implemented)
OAuth1-signed `GET /2/users/{uid}/broadcasts/{bid}` + defensive count parser (field name varies across the producer API's lineage; string or numeric) + an X arm in the viewer sampler, spawned on the X chat session lifecycle. Credentials resolve per poll; a missing count is a skipped sample, never an error.

## 4. X chat terminal failure is now on the record
When the X connector exhausts its reconnects, a `x-live-chat-failed` warn health event lands in the session record — an empty X comment feed with no trace anywhere burned a livestream's worth of debugging.

## Verification
- 1,503 backend tests (4 new), clippy `-D warnings`, fmt clean
- `smoke:recording-matrix` **12/12 PASS**; `smoke:multistream` **PASS** (fan-out + dead-leg isolation + finalization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera pan controls for source placement across supported rendering modes.
  * Added live viewer-count sampling for X broadcasts.
  * Added support for updating protected overlay filters without restarting an active preview session.
* **Bug Fixes**
  * Improved handling of X live-chat connection failures with clearer status and health notifications.
  * Preserved centered placement for non-camera sources and existing contain-mode behavior.
* **Reliability**
  * Improved compatibility with varied X viewer-count response formats and credential updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->