### PR TITLE
release: 0.9.59-beta.1 — notes-proof recording, real camera panning, X viewer counts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.59-beta.1.md
+++ b/changelog/0.9.59-beta.1.md
@@ -1,0 +1,41 @@
+---
+version: 0.9.59-beta.1
+date: 2026-08-19
+channel: beta
+platforms:
+  - macos
+title: Notes-proof recording, real camera panning, and X viewer counts
+summary: Opening Notes mid-recording no longer disturbs the capture, camera pan finally moves the picture in fill layouts, X shows its live viewer count, the docked preview clips to its rounded panel, and a Reset button restores camera defaults in one click.
+highlights:
+  - Opening or closing the Notes window during a recording no longer causes lag or corrupted colors — the capture keeps running untouched.
+  - Camera Pan X and Pan Y now actually move the visible window, including at 100% zoom in fill layouts — preview and recording agree.
+  - X livestreams now report their live viewer count alongside YouTube and Twitch, and X comment problems are recorded in the session health log.
+  - X comments are labelled honestly — X provides no send API, so the app says "receive-only" instead of looking broken.
+  - The docked preview clips to its rounded panel — no more square corners poking out.
+  - One-click "Reset camera settings" restores placement, frame, lens, and chroma-key defaults.
+  - Your account avatar now updates from videorc.com while you're signed in, larger avatars are accepted, and the Dock icon sits at the standard macOS size.
+  - The caption text-size buttons fit their labels at every window width.
+---
+
+The dual-platform livestream round. The biggest fix mirrors last release's
+lesson from the other side: opening or closing the Notes window used to
+force a full screen-capture restart — mid-recording, that meant lag and
+garbage colors. Capture now keeps running; your privacy is unchanged, since
+Notes is excluded from recordings by the OS itself.
+
+Camera framing is complete now: Pan X and Pan Y always had a dead zone —
+at 100% zoom they did nothing at all, and the recording path and preview
+disagreed about them. Panning now chooses which part of the picture stays
+visible in fill layouts, identically in preview and recordings. A new
+"Reset camera settings" button puts placement, frame, lens, and chroma key
+back to defaults in one click.
+
+X streaming grows up: viewer counts now appear for X alongside YouTube and
+Twitch, comment-connection failures are recorded in the session health log
+instead of vanishing, and the comments panel says plainly that X chat is
+receive-only — X publishes no API for sending.
+
+And the visual polish: the docked preview is clipped to its rounded panel,
+the Dock icon now matches the size of every other app, your real avatar
+shows up (and refreshes when you change it on videorc.com), and the caption
+size buttons no longer overflow.


### PR DESCRIPTION
Version bump 0.9.58 → 0.9.59 + changelog for #224 (notes-safe capture, cover-crop pan, X viewers, X chat health event) and #225 (rounded native preview, camera reset, captions row, account refresh, HIG icon, X read-only honesty). macOS-only.