### PR TITLE
release: trim 0.9.59 changelog highlights to the six-bullet limit

### DIFF
--- a/changelog/0.9.59-beta.1.md
+++ b/changelog/0.9.59-beta.1.md
@@ -8,12 +8,10 @@ title: Notes-proof recording, real camera panning, and X viewer counts
 summary: Opening Notes mid-recording no longer disturbs the capture, camera pan finally moves the picture in fill layouts, X shows its live viewer count, the docked preview clips to its rounded panel, and a Reset button restores camera defaults in one click.
 highlights:
   - Opening or closing the Notes window during a recording no longer causes lag or corrupted colors — the capture keeps running untouched.
-  - Camera Pan X and Pan Y now actually move the visible window, including at 100% zoom in fill layouts — preview and recording agree.
-  - X livestreams now report their live viewer count alongside YouTube and Twitch, and X comment problems are recorded in the session health log.
-  - X comments are labelled honestly — X provides no send API, so the app says "receive-only" instead of looking broken.
+  - Camera Pan X and Pan Y now actually move the visible window, including at 100% zoom in fill layouts — preview and recording agree, and a one-click "Reset camera settings" restores the defaults.
+  - X livestreams now report their live viewer count, comment-connection problems land in the session health log, and the comments panel says plainly that X chat is receive-only (X provides no send API).
   - The docked preview clips to its rounded panel — no more square corners poking out.
-  - One-click "Reset camera settings" restores placement, frame, lens, and chroma-key defaults.
-  - Your account avatar now updates from videorc.com while you're signed in, larger avatars are accepted, and the Dock icon sits at the standard macOS size.
+  - Your account avatar now updates from videorc.com while signed in, and the Dock icon sits at the standard macOS size.
   - The caption text-size buttons fit their labels at every window width.
 ---
 


### PR DESCRIPTION
changelog:check failed on #226 (8 highlights, max 6) but a shell pipe masked the exit and the release PR merged anyway. Merged into 3 combined bullets; 62 entries valid now. Caught before any build/upload — the uploader would have failed closed.