### PR TITLE
feat(scripts): add in-place download progress bar to Windows FFmpeg fetcher

### DIFF
--- a/scripts/fetch-ffmpeg-windows.mjs
+++ b/scripts/fetch-ffmpeg-windows.mjs
@@ -98,32 +98,40 @@ if (!haveZip) {
   let lastUpdate = 0
   const startTime = Date.now()
 
+  function renderProgress() {
+    const now = Date.now()
+    lastUpdate = now
+    const elapsedSec = (now - startTime) / 1000 || 0.001
+    const speedMB = (downloadedBytes / (1024 * 1024) / elapsedSec).toFixed(1)
+    const currentMB = (downloadedBytes / (1024 * 1024)).toFixed(1)
+    if (totalBytes > 0) {
+      const totalMB = (totalBytes / (1024 * 1024)).toFixed(1)
+      const pct = Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
+      const barWidth = 25
+      const filled = Math.min(barWidth, Math.floor((barWidth * downloadedBytes) / totalBytes))
+      const bar =
+        '='.repeat(filled) +
+        (filled < barWidth ? '>' : '') +
+        ' '.repeat(Math.max(0, barWidth - filled - 1))
+      process.stdout.write(
+        `\r  [${bar}] ${pct}% (${currentMB} / ${totalMB} MB) @ ${speedMB} MB/s `
+      )
+    } else {
+      process.stdout.write(`\r  ${currentMB} MB downloaded @ ${speedMB} MB/s `)
+    }
+  }
+
   const progressStream = new Transform({
     transform(chunk, _encoding, callback) {
       downloadedBytes += chunk.length
-      const now = Date.now()
-      if (now - lastUpdate > 100 || (totalBytes > 0 && downloadedBytes >= totalBytes)) {
-        lastUpdate = now
-        const elapsedSec = (now - startTime) / 1000 || 0.001
-        const speedMB = (downloadedBytes / (1024 * 1024) / elapsedSec).toFixed(1)
-        const currentMB = (downloadedBytes / (1024 * 1024)).toFixed(1)
-        if (totalBytes > 0) {
-          const totalMB = (totalBytes / (1024 * 1024)).toFixed(1)
-          const pct = Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
-          const barWidth = 25
-          const filled = Math.min(barWidth, Math.floor((barWidth * downloadedBytes) / totalBytes))
-          const bar =
-            '='.repeat(filled) +
-            (filled < barWidth ? '>' : '') +
-            ' '.repeat(Math.max(0, barWidth - filled - 1))
-          process.stdout.write(
-            `\r  [${bar}] ${pct}% (${currentMB} / ${totalMB} MB) @ ${speedMB} MB/s `
-          )
-        } else {
-          process.stdout.write(`\r  ${currentMB} MB downloaded @ ${speedMB} MB/s `)
-        }
+      if (Date.now() - lastUpdate > 100) {
+        renderProgress()
       }
       callback(null, chunk)
+    },
+    flush(callback) {
+      renderProgress()
+      callback()
     }
   })
 

--- a/scripts/fetch-ffmpeg-windows.mjs
+++ b/scripts/fetch-ffmpeg-windows.mjs
@@ -16,7 +16,7 @@ import { createHash } from 'node:crypto'
 import { createWriteStream } from 'node:fs'
 import { mkdir, readFile, readdir, rm, copyFile, writeFile, stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
-import { Readable } from 'node:stream'
+import { Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
@@ -92,7 +92,43 @@ if (!haveZip) {
         : ''
     fail(`download failed: HTTP ${response.status} for ${pin.url}${pruned}`)
   }
-  await pipeline(Readable.fromWeb(response.body), createWriteStream(downloadPath))
+
+  const totalBytes = Number(response.headers.get('content-length') || 0)
+  let downloadedBytes = 0
+  let lastUpdate = 0
+  const startTime = Date.now()
+
+  const progressStream = new Transform({
+    transform(chunk, _encoding, callback) {
+      downloadedBytes += chunk.length
+      const now = Date.now()
+      if (now - lastUpdate > 100 || (totalBytes > 0 && downloadedBytes >= totalBytes)) {
+        lastUpdate = now
+        const elapsedSec = (now - startTime) / 1000 || 0.001
+        const speedMB = (downloadedBytes / (1024 * 1024) / elapsedSec).toFixed(1)
+        const currentMB = (downloadedBytes / (1024 * 1024)).toFixed(1)
+        if (totalBytes > 0) {
+          const totalMB = (totalBytes / (1024 * 1024)).toFixed(1)
+          const pct = Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
+          const barWidth = 25
+          const filled = Math.min(barWidth, Math.floor((barWidth * downloadedBytes) / totalBytes))
+          const bar =
+            '='.repeat(filled) +
+            (filled < barWidth ? '>' : '') +
+            ' '.repeat(Math.max(0, barWidth - filled - 1))
+          process.stdout.write(
+            `\r  [${bar}] ${pct}% (${currentMB} / ${totalMB} MB) @ ${speedMB} MB/s `
+          )
+        } else {
+          process.stdout.write(`\r  ${currentMB} MB downloaded @ ${speedMB} MB/s `)
+        }
+      }
+      callback(null, chunk)
+    }
+  })
+
+  await pipeline(Readable.fromWeb(response.body), progressStream, createWriteStream(downloadPath))
+  process.stdout.write('\n')
 }
 
 const actualSha = await sha256Of(downloadPath)


### PR DESCRIPTION
### Description
Improves developer experience on Windows by adding an in-place live progress bar when running `pnpm ffmpeg:fetch:windows`.

### Changes
- Reads `content-length` from the download response.
- Streams through a `Transform` stream with in-place carriage-return (`\r`) terminal updates.
- Displays visual loading bar (`[=====>  ]`), percentage, download size (`MB / MB`), and transfer speed (`MB/s`) without flooding terminal lines.

### Verification
- Ran `pnpm format:check` (clean).
- Ran `pnpm test:scripts` (1,036 passed, 0 failed).
- Verified live rendering in Windows PowerShell.

Before 
<img width="2112" height="222" alt="Screenshot 2026-08-20 024137" src="https://github.com/user-attachments/assets/81348a01-49cf-4c3a-b391-3068f4e7364b" />

After 
<img width="2103" height="220" alt="Screenshot 2026-08-20 024102" src="https://github.com/user-attachments/assets/8803a8aa-fae8-49bd-b802-5fc365350406" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added download progress reporting for FFmpeg on Windows, including percentage completion and transfer speed when available.
  * Displays downloaded size and transfer speed when total file size cannot be determined.

* **Bug Fixes**
  * Improved reliability when detecting and managing backend processes by allowing more time for process checks to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->