### PR TITLE
feat(comments): X chat send — the platform finally has an API for it

### DIFF
--- a/apps/desktop/src/renderer/src/components/comments-destination-status.test.ts
+++ b/apps/desktop/src/renderer/src/components/comments-destination-status.test.ts
@@ -34,7 +34,7 @@ describe('comments destination status', () => {
         providers,
         sendTargets: ['youtube', 'twitch']
       })
-    ).toBe('Sends to YouTube + Twitch · X receive-only (X provides no send API)')
+    ).toBe('Sends to YouTube + Twitch · X receive-only')
   })
 
   it('surfaces per-destination failures without hiding receive-only destinations', () => {
@@ -44,7 +44,7 @@ describe('comments destination status', () => {
         sendTargets: ['youtube', 'twitch'],
         failures: [{ destinationId: 'twitch-target', platform: 'twitch', reason: 'Token expired' }]
       })
-    ).toBe('Sends to YouTube + Twitch · Twitch failed · X receive-only (X provides no send API)')
+    ).toBe('Sends to YouTube + Twitch · Twitch failed · X receive-only')
   })
 
   it('distinguishes a missing write scope from a receive-only provider', () => {
@@ -56,9 +56,7 @@ describe('comments destination status', () => {
         ],
         sendTargets: []
       })
-    ).toBe(
-      'No writable destinations · Twitch reconnect to send · X receive-only (X provides no send API)'
-    )
+    ).toBe('No writable destinations · Twitch reconnect to send · X receive-only')
   })
 
   it('names the bound account so a wrong-channel manual stream is visible', () => {
@@ -92,9 +90,7 @@ describe('comments destination status', () => {
     expect(providerMarkup).toContain('YouTube')
     expect(providerMarkup).toContain('Connected')
     expect(providerMarkup).toContain('Receive-only')
-    expect(composerMarkup).toContain(
-      'Sends to YouTube + Twitch · Twitch failed · X receive-only (X provides no send API)'
-    )
+    expect(composerMarkup).toContain('Sends to YouTube + Twitch · Twitch failed · X receive-only')
     expect(composerMarkup).toContain('Twitch: Token expired')
   })
 })

--- a/apps/desktop/src/renderer/src/components/comments-destination-status.tsx
+++ b/apps/desktop/src/renderer/src/components/comments-destination-status.tsx
@@ -111,14 +111,9 @@ export function commentsDestinationSummary({
       continue
     }
     if (provider.write === 'read-only' || provider.state === 'connected') {
-      // X has no documented send API — say it is the platform's limit, not a
-      // Videorc breakage (owner report, 2026-08-19: "cannot send comments
-      // inside of X").
-      parts.push(
-        provider.platform === 'x'
-          ? 'X receive-only (X provides no send API)'
-          : `${CHAT_PLATFORM_LABELS[provider.platform]} receive-only`
-      )
+      // X sends now (closed-beta chat API, 2026-08-19) — read-only here only
+      // means THIS stream lacks send context (e.g. a manual-RTMP X target).
+      parts.push(`${CHAT_PLATFORM_LABELS[provider.platform]} receive-only`)
       continue
     }
     if (provider.state === 'failed') {

--- a/crates/videorc-backend/src/live_chat.rs
+++ b/crates/videorc-backend/src/live_chat.rs
@@ -325,7 +325,13 @@ pub fn chat_capability(
                 } else {
                     CommentsReadState::Unavailable
                 },
-                write: CommentsWriteState::ReadOnly,
+                write: if x_live_ready {
+                    // POST /2/broadcasts/:id/chat accepts the OAuth 1.0a user
+                    // context we already hold (closed-beta Livestream API).
+                    CommentsWriteState::Ready
+                } else {
+                    CommentsWriteState::ReadOnly
+                },
                 required_scope: None,
                 account_id: account.map(|account| account.account_id.clone()),
                 account_label: account.map(|account| account.account_label.clone()),
@@ -487,6 +493,12 @@ pub enum ChatSenderConfig {
         live_chat_id: Option<String>,
     },
     Twitch(crate::twitch_chat::TwitchChatSenderConfig),
+    /// X live-broadcast chat (closed-beta Livestream API). Credentials are
+    /// resolved per send so a rotated token is picked up without restarting
+    /// the session.
+    X {
+        broadcast_id: String,
+    },
     Fake(FakeChatSendBehavior),
     #[cfg(test)]
     FakeProbe {
@@ -1396,7 +1408,7 @@ pub async fn start_x_live_chat(
             account_id: None,
             account_label: None,
             read: CommentsReadState::WaitingForBroadcastContext,
-            write: CommentsWriteState::ReadOnly,
+            write: CommentsWriteState::Ready,
             state: LiveChatProviderConnectionState::Disabled,
             message: crate::x_chat::x_chat_message(false).to_string(),
             last_connected_at: None,
@@ -1441,6 +1453,9 @@ pub async fn start_x_live_chat(
             api_base_url: None,
         }),
     ));
+    let sender_destination_id =
+        comments_destination_id(StreamPlatform::X, config.target_id.as_deref());
+    let sender_broadcast_id = config.broadcast_id.clone();
     let handle = tokio::spawn(crate::x_chat::run_x_chat_connector(
         state.clone(),
         params.session_id,
@@ -1450,6 +1465,12 @@ pub async fn start_x_live_chat(
         let mut coordinator = state.live_chat.lock().await;
         coordinator.attach_task(viewer_handle);
         coordinator.attach_task(handle);
+        coordinator.register_sender(
+            sender_destination_id,
+            ChatSenderConfig::X {
+                broadcast_id: sender_broadcast_id,
+            },
+        );
     }
 
     let snapshot = current_status(state).await;
@@ -1811,6 +1832,34 @@ async fn send_to_destination(
         } => Err("YouTube live chat is not resolved yet — try again in a moment.".to_string()),
         ChatSenderConfig::Twitch(config) => {
             crate::twitch_chat::send_twitch_chat_message(client, &config, text).await
+        }
+        ChatSenderConfig::X { broadcast_id } => {
+            // X caps messages at 140 chars while the shared composer allows
+            // more; fail the X leg honestly instead of truncating — the
+            // partial-send phase already renders per-destination failures.
+            if text.chars().count() > crate::x_live::X_CHAT_MESSAGE_MAX_CHARS {
+                return Err(format!(
+                    "X limits chat messages to {} characters — shorten the message to reach X.",
+                    crate::x_live::X_CHAT_MESSAGE_MAX_CHARS
+                ));
+            }
+            let credentials = crate::x_live::x_livestream_credentials()
+                .ok()
+                .flatten()
+                .ok_or_else(|| {
+                    "X Live authorization is missing — authorize X Live to send chat.".to_string()
+                })?;
+            crate::x_live::send_broadcast_chat_message(
+                client,
+                &credentials,
+                crate::x_live::DEFAULT_API_BASE_URL,
+                &broadcast_id,
+                text,
+            )
+            .await
+            .map(|timestamp| ProviderSendReceipt {
+                provider_message_id: (!timestamp.is_empty()).then_some(timestamp),
+            })
         }
         ChatSenderConfig::Fake(behavior) => match behavior {
             FakeChatSendBehavior::Sent => Ok(ProviderSendReceipt {
@@ -3154,6 +3203,43 @@ mod tests {
         assert_eq!(capability.account_id.as_deref(), Some("connected-channel"));
         assert_eq!(capability.read, CommentsReadState::Ready);
         assert_eq!(capability.write, CommentsWriteState::Ready);
+    }
+
+    #[tokio::test]
+    async fn x_send_enforces_the_140_char_platform_cap_before_any_network() {
+        // The shared composer allows 200 chars; X caps at 140. The X leg must
+        // fail honestly (Partial phase renders it) instead of truncating.
+        let client = reqwest::Client::new();
+        let long_message = "x".repeat(141);
+        let error = send_to_destination(
+            &client,
+            ChatSenderConfig::X {
+                broadcast_id: "1AbCdEfGhIjKl".to_string(),
+            },
+            &long_message,
+        )
+        .await
+        .expect_err("141 chars must fail the X leg");
+        assert!(
+            error.contains("140"),
+            "the error must name the limit: {error}"
+        );
+
+        // Within the cap but with no stored X Live credentials, the arm must
+        // fail on authorization — proving credentials resolve per send.
+        let error = send_to_destination(
+            &client,
+            ChatSenderConfig::X {
+                broadcast_id: "1AbCdEfGhIjKl".to_string(),
+            },
+            "hello",
+        )
+        .await
+        .expect_err("missing credentials must fail the X leg");
+        assert!(
+            error.contains("authoriz") || error.contains("Authoriz"),
+            "the error must point at authorization: {error}"
+        );
     }
 
     #[test]

--- a/crates/videorc-backend/src/x_chat.rs
+++ b/crates/videorc-backend/src/x_chat.rs
@@ -112,9 +112,9 @@ struct XChatFrame {
 
 pub fn x_chat_message(has_x_account: bool) -> &'static str {
     if has_x_account {
-        "X live chat can be read for native X broadcasts."
+        "X live chat can be read and sent for native X broadcasts."
     } else {
-        "Connect or configure X native live before reading X chat."
+        "Connect or configure X native live before using X chat."
     }
 }
 

--- a/crates/videorc-backend/src/x_live.rs
+++ b/crates/videorc-backend/src/x_live.rs
@@ -1150,14 +1150,9 @@ pub async fn fetch_broadcast_viewer_count(
     base_url: &str,
     broadcast_id: &str,
 ) -> Option<u64> {
-    let url = endpoint(
-        base_url,
-        &format!(
-            "/2/users/{}/broadcasts/{}",
-            credentials.user_id, broadcast_id
-        ),
-    )
-    .ok()?;
+    // GET /2/broadcasts/:id — the user-prefixed route is deprecated (docs
+    // verified 2026-08-19); ownership is still enforced by the auth context.
+    let url = endpoint(base_url, &format!("/2/broadcasts/{broadcast_id}")).ok()?;
     let value: serde_json::Value = send_x_request(client, credentials, Method::GET, url, None)
         .await
         .ok()?;
@@ -1184,6 +1179,67 @@ pub fn parse_x_broadcast_viewer_count(body: &serde_json::Value) -> Option<u64> {
         }
     }
     None
+}
+
+/// Maximum chat message length X accepts (`POST /2/broadcasts/:id/chat`).
+pub const X_CHAT_MESSAGE_MAX_CHARS: usize = 140;
+
+/// Send a plain-text chat message to a LIVE broadcast as the authorized user.
+/// Closed-beta Livestream API (docs verified 2026-08-19): OAuth 1.0a user
+/// context is an accepted auth for this route, so the existing "Authorize X
+/// Live" credentials qualify. Returns the server timestamp (nanoseconds,
+/// decimal string) — which is also the message id. Errors are user-facing
+/// strings for the comments send surface.
+pub async fn send_broadcast_chat_message(
+    client: &reqwest::Client,
+    credentials: &XLivestreamCredentials,
+    base_url: &str,
+    broadcast_id: &str,
+    text: &str,
+) -> Result<String, String> {
+    let url = endpoint(base_url, &format!("/2/broadcasts/{broadcast_id}/chat"))
+        .map_err(|error| format!("X chat endpoint could not be built: {error}"))?;
+    let authorization = oauth1_authorization_header(
+        "POST",
+        url.as_str(),
+        credentials,
+        &oauth_nonce(),
+        oauth_timestamp(),
+    )
+    .map_err(|error| format!("X chat request could not be signed: {error}"))?;
+    let response = client
+        .post(url)
+        .header("Authorization", authorization)
+        .json(&json!({ "text": text }))
+        .send()
+        .await
+        .map_err(|error| format!("Could not reach X to send the chat message: {error}"))?;
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.unwrap_or_default();
+    if status.as_u16() == 403 {
+        return Err(
+            "X did not permit this account to chat in the broadcast (chat settings may limit who can post)."
+                .to_string(),
+        );
+    }
+    if status.as_u16() == 400 {
+        return Err(
+            "X rejected the chat message — the broadcast may not be live yet or has ended."
+                .to_string(),
+        );
+    }
+    if !status.is_success() {
+        return Err(format!("X chat send failed with HTTP {}.", status.as_u16()));
+    }
+    let data = body.get("data").cloned().unwrap_or_default();
+    if data.get("success").and_then(|value| value.as_bool()) != Some(true) {
+        return Err("X reported the chat message was not sent.".to_string());
+    }
+    Ok(data
+        .get("timestamp")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string())
 }
 
 async fn end_broadcast(


### PR DESCRIPTION
Executes the vault plan "X Chat Send Plan (API unblocked)" (2026-08-19). X's closed-beta Livestream API ships `POST /2/broadcasts/:id/chat` and **accepts OAuth 1.0a user context** — the Authorize-X-Live credentials Videorc already holds. Verified against the gated docs through the owner's beta access; the send endpoint's OpenAPI lists `UserToken` alongside OAuth2 `broadcast.write`.

## What lands
- **S1 — X sender**: `ChatSenderConfig::X` registered on the X chat session; credentials resolve per send; 400 → "broadcast may not be live", 403 → "chat settings may limit who can post"; response timestamp (ns) becomes the provider message id. The **140-char X cap** fails the X leg honestly (composer allows 200; partial-send already renders per-destination failures). Capability flips to `write: Ready` when X Live credentials exist; manual-RTMP X targets stay read-only.
- **S2 — deprecated route migration**: the 0.9.59 viewer poll moves to `GET /2/broadcasts/:id` (docs deprecate the user-prefixed path).
- The freshly-shipped "(X provides no send API)" copy is retired — it was true for years and obsolete within a week.

## Read path note (no code change)
The docs confirm our WebSocket read flow is the documented one, header-for-header — so the owner's silent-feed stream stays a runtime condition; 0.9.59's `x-live-chat-failed` health event captures the cause on the next stream.

## Verification
- 1,504 backend tests (new: cap-before-network, per-send credential resolution), clippy `-D warnings`, fmt
- Desktop: 1,321 tests, typecheck, lint, format
- Live proof requires an actual X livestream: type in the Comments window, see it on X — owner acceptance on the next stream. Closed-beta caveat: X warns of breaking changes; every failure surfaces with the server's reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * X live broadcasts now support sending chat messages when authorized.
  * Chat messages are limited to 140 characters and provide clearer authorization and delivery feedback.
  * X viewer counts use the current broadcast endpoint.

* **Bug Fixes**
  * Updated X chat descriptions to accurately reflect receive-only or send-enabled capabilities.
  * Removed outdated messaging about X lacking a send API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->