### PR TITLE
release: 0.9.60-beta.1 — send chat messages to X

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.60-beta.1.md
+++ b/changelog/0.9.60-beta.1.md
@@ -1,0 +1,27 @@
+---
+version: 0.9.60-beta.1
+date: 2026-08-19
+channel: beta
+platforms:
+  - macos
+title: Send chat messages to X
+summary: X quietly shipped a chat-send API in their livestream beta, and Videorc wires it in the same week — type in the Comments window and your message posts to the X broadcast as you. X's 140-character limit is handled honestly across multi-platform sends.
+highlights:
+  - Sending chat to X livestreams works — messages post to your live broadcast as you, using the X Live authorization you already have.
+  - Messages over X's 140-character limit still deliver to Twitch and YouTube while the X result explains the limit — nothing is silently cut.
+  - X viewer counts now use X's current API route.
+---
+
+X's new livestream API (in closed beta) finally includes a way to send
+chat messages — something the platform never offered before. Videorc wires
+it straight into the shared Comments composer: type once, and the message
+goes to every connected platform, now including your X broadcast, posted
+as you with the X Live authorization you already granted.
+
+Platform limits are handled honestly. X caps chat messages at 140
+characters while Twitch and YouTube allow more — an over-length message
+still delivers everywhere else, and the X result tells you about the limit
+instead of quietly cutting your words.
+
+One note: X marks this API as beta and may change it — if X breaks
+something, Videorc will say exactly what failed rather than guessing.


### PR DESCRIPTION
Version bump 0.9.59 → 0.9.60 + changelog for #229 (X chat send via the closed-beta Livestream API, honest 140-char handling, viewer route migration). macOS-only.