### PR TITLE
fix(windows): fix compositor source_fit arity and increase process probe timeout

### DIFF
--- a/apps/desktop/src/main/backend-owned-processes.ts
+++ b/apps/desktop/src/main/backend-owned-processes.ts
@@ -607,7 +607,7 @@ function exactProbeExecOptions(): {
   maxBuffer: number
   windowsHide: true
 } {
-  return { encoding: 'utf8', timeout: 1000, maxBuffer: 16 * 1024, windowsHide: true }
+  return { encoding: 'utf8', timeout: 5000, maxBuffer: 16 * 1024, windowsHide: true }
 }
 
 function sleepSync(delayMs: number): void {

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -4080,7 +4080,7 @@ pub(crate) fn render_camera_overlay_bgra(
         width: overlay_width,
         height: overlay_height,
     };
-    let Some(fit) = source_fit(source_width, source_height, rect, contain, crop) else {
+    let Some(fit) = source_fit(source_width, source_height, rect, contain, crop, (0.0, 0.0)) else {
         return false;
     };
     let Some(byte_len) = usize::try_from(overlay_width)

--- a/scripts/fetch-ffmpeg-windows.mjs
+++ b/scripts/fetch-ffmpeg-windows.mjs
@@ -98,32 +98,40 @@ if (!haveZip) {
   let lastUpdate = 0
   const startTime = Date.now()
 
+  function renderProgress() {
+    const now = Date.now()
+    lastUpdate = now
+    const elapsedSec = (now - startTime) / 1000 || 0.001
+    const speedMB = (downloadedBytes / (1024 * 1024) / elapsedSec).toFixed(1)
+    const currentMB = (downloadedBytes / (1024 * 1024)).toFixed(1)
+    if (totalBytes > 0) {
+      const totalMB = (totalBytes / (1024 * 1024)).toFixed(1)
+      const pct = Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
+      const barWidth = 25
+      const filled = Math.min(barWidth, Math.floor((barWidth * downloadedBytes) / totalBytes))
+      const bar =
+        '='.repeat(filled) +
+        (filled < barWidth ? '>' : '') +
+        ' '.repeat(Math.max(0, barWidth - filled - 1))
+      process.stdout.write(
+        `\r  [${bar}] ${pct}% (${currentMB} / ${totalMB} MB) @ ${speedMB} MB/s `
+      )
+    } else {
+      process.stdout.write(`\r  ${currentMB} MB downloaded @ ${speedMB} MB/s `)
+    }
+  }
+
   const progressStream = new Transform({
     transform(chunk, _encoding, callback) {
       downloadedBytes += chunk.length
-      const now = Date.now()
-      if (now - lastUpdate > 100 || (totalBytes > 0 && downloadedBytes >= totalBytes)) {
-        lastUpdate = now
-        const elapsedSec = (now - startTime) / 1000 || 0.001
-        const speedMB = (downloadedBytes / (1024 * 1024) / elapsedSec).toFixed(1)
-        const currentMB = (downloadedBytes / (1024 * 1024)).toFixed(1)
-        if (totalBytes > 0) {
-          const totalMB = (totalBytes / (1024 * 1024)).toFixed(1)
-          const pct = Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
-          const barWidth = 25
-          const filled = Math.min(barWidth, Math.floor((barWidth * downloadedBytes) / totalBytes))
-          const bar =
-            '='.repeat(filled) +
-            (filled < barWidth ? '>' : '') +
-            ' '.repeat(Math.max(0, barWidth - filled - 1))
-          process.stdout.write(
-            `\r  [${bar}] ${pct}% (${currentMB} / ${totalMB} MB) @ ${speedMB} MB/s `
-          )
-        } else {
-          process.stdout.write(`\r  ${currentMB} MB downloaded @ ${speedMB} MB/s `)
-        }
+      if (Date.now() - lastUpdate > 100) {
+        renderProgress()
       }
       callback(null, chunk)
+    },
+    flush(callback) {
+      renderProgress()
+      callback()
     }
   })
 

--- a/scripts/fetch-ffmpeg-windows.mjs
+++ b/scripts/fetch-ffmpeg-windows.mjs
@@ -16,7 +16,7 @@ import { createHash } from 'node:crypto'
 import { createWriteStream } from 'node:fs'
 import { mkdir, readFile, readdir, rm, copyFile, writeFile, stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
-import { Readable } from 'node:stream'
+import { Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
@@ -92,7 +92,43 @@ if (!haveZip) {
         : ''
     fail(`download failed: HTTP ${response.status} for ${pin.url}${pruned}`)
   }
-  await pipeline(Readable.fromWeb(response.body), createWriteStream(downloadPath))
+
+  const totalBytes = Number(response.headers.get('content-length') || 0)
+  let downloadedBytes = 0
+  let lastUpdate = 0
+  const startTime = Date.now()
+
+  const progressStream = new Transform({
+    transform(chunk, _encoding, callback) {
+      downloadedBytes += chunk.length
+      const now = Date.now()
+      if (now - lastUpdate > 100 || (totalBytes > 0 && downloadedBytes >= totalBytes)) {
+        lastUpdate = now
+        const elapsedSec = (now - startTime) / 1000 || 0.001
+        const speedMB = (downloadedBytes / (1024 * 1024) / elapsedSec).toFixed(1)
+        const currentMB = (downloadedBytes / (1024 * 1024)).toFixed(1)
+        if (totalBytes > 0) {
+          const totalMB = (totalBytes / (1024 * 1024)).toFixed(1)
+          const pct = Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
+          const barWidth = 25
+          const filled = Math.min(barWidth, Math.floor((barWidth * downloadedBytes) / totalBytes))
+          const bar =
+            '='.repeat(filled) +
+            (filled < barWidth ? '>' : '') +
+            ' '.repeat(Math.max(0, barWidth - filled - 1))
+          process.stdout.write(
+            `\r  [${bar}] ${pct}% (${currentMB} / ${totalMB} MB) @ ${speedMB} MB/s `
+          )
+        } else {
+          process.stdout.write(`\r  ${currentMB} MB downloaded @ ${speedMB} MB/s `)
+        }
+      }
+      callback(null, chunk)
+    }
+  })
+
+  await pipeline(Readable.fromWeb(response.body), progressStream, createWriteStream(downloadPath))
+  process.stdout.write('\n')
 }
 
 const actualSha = await sha256Of(downloadPath)


### PR DESCRIPTION
### Summary of Changes

This PR resolves two Windows-specific startup and build issues:

1. **Rust E0061 Compilation Error (`crates/videorc-backend/src/compositor.rs`)**:
   - `source_fit(...)` was updated upstream with a 6th parameter `pan: (f64, f64)`.
   - The Windows-only `render_camera_overlay_bgra` function was still calling `source_fit` with 5 arguments.
   - **Fix**: Passed `(0.0, 0.0)` as the default pan argument.

2. **Backend Hard Termination on Windows Startup (`apps/desktop/src/main/backend-owned-processes.ts`)**:
   - When Electron launches `videorc-backend`, it probes and registers the process identity via `powershell.exe -Command Get-Process...`.
   - Cold PowerShell startup inside an Electron child process on Windows typically takes 1.5–2.5 seconds.
   - The previous `1000ms` timeout in `exactProbeExecOptions()` caused `execFileSync` to abort with `ETIMEDOUT`.
   - Because the probe timed out, Electron treated the backend as unprobeable and immediately sent `SIGKILL`, resulting in `Backend admin connection is unavailable` errors in the UI.
   - **Fix**: Increased `timeout` from `1000ms` to `5000ms`.

### Verification
- `cargo build -p videorc-backend` compiles cleanly on Windows.
- `pnpm --filter @videorc/desktop test` (147 test files passed, 1320 tests passed).
- Verified Electron successfully connects to `videorc-backend` on Windows without premature termination.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Windows process detection by allowing more time for process checks.
  * Improved Windows camera overlay positioning during source fitting.

* **Enhancements**
  * Added progress reporting to Windows FFmpeg downloads, including percentage, transfer size, and download speed when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->