### PR TITLE
release: 0.9.61-beta.1 — first community contributions

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.60",
+  "version": "0.9.61",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.61-beta.1.md
+++ b/changelog/0.9.61-beta.1.md
@@ -1,0 +1,22 @@
+---
+version: 0.9.61-beta.1
+date: 2026-08-20
+channel: beta
+platforms:
+  - macos
+title: First community contributions
+summary: Videorc's first outside contributions since going open source — Windows build and startup fixes plus a nicer FFmpeg download experience for contributors, courtesy of TechnicalExpo. Nothing changes on macOS day-to-day; this release keeps the shared codebase healthy.
+highlights:
+  - First community contributions merged — thanks to TechnicalExpo for fixing the Windows build, a Windows backend startup failure, and adding a live progress bar to the contributor FFmpeg fetcher.
+  - The Windows backend no longer gets killed at startup on machines where its identity probe was slow — groundwork for the Windows Alpha track.
+---
+
+A milestone release more than a feature release: the first outside pull
+requests since Videorc went open source, both from TechnicalExpo.
+
+One fixed the Windows build (a camera-compositor change on our side had
+broken it — invisible to macOS checks), one fixed a Windows startup
+failure where a slow process probe caused the app to kill its own healthy
+backend, and one gives contributors a live progress bar while fetching
+FFmpeg. Day-to-day macOS behavior is unchanged; the shared codebase is
+healthier, and the Windows Alpha track benefits directly.


### PR DESCRIPTION
Version bump 0.9.60 → 0.9.61 + changelog for #228/#231 (community: Windows build fix, probe timeout, FFmpeg fetch progress) and #232 (isTTY follow-up). macOS-only lane; macOS behavior unchanged.