### PR TITLE
fix(ipc): allow cornerRadius in previewBoundsSchema (fixes #232)

### DIFF
--- a/apps/desktop/src/shared/electron-ipc-contract.test.ts
+++ b/apps/desktop/src/shared/electron-ipc-contract.test.ts
@@ -163,7 +163,8 @@ describe('Electron IPC contract', () => {
       screenY: 0,
       width: 1280,
       height: 720,
-      scaleFactor: 2
+      scaleFactor: 2,
+      cornerRadius: 18
     }
     const layout = {
       layoutPreset: 'screen-camera',

--- a/apps/desktop/src/shared/electron-ipc-contract.test.ts
+++ b/apps/desktop/src/shared/electron-ipc-contract.test.ts
@@ -296,6 +296,9 @@ describe('Electron IPC contract', () => {
     expect(
       validateElectronInvokeResult('preview-surface:set-frame-polling-suppressed', surfaceStatus)
     ).toEqual(surfaceStatus)
+    expect(
+      validateElectronInvokeResult('preview-surface:drain-host-commands', surfaceStatus)
+    ).toEqual(surfaceStatus)
     const d3d11SurfaceStatus = {
       ...surfaceStatus,
       transport: 'd3d11-shared-texture',
@@ -305,6 +308,15 @@ describe('Electron IPC contract', () => {
     expect(validateElectronInvokeResult('preview-surface:status', d3d11SurfaceStatus)).toEqual(
       d3d11SurfaceStatus
     )
+    for (const invalid of [
+      { ...surfaceStatus, bounds: { ...bounds, cornerRadius: -1 } },
+      { ...surfaceStatus, bounds: { ...bounds, cornerRadius: 257 } }
+    ]) {
+      expect(() => validateElectronInvokeResult('preview-surface:status', invalid)).toThrow()
+      expect(() =>
+        validateElectronInvokeResult('preview-surface:drain-host-commands', invalid)
+      ).toThrow()
+    }
     for (const leaked of [
       { ...d3d11SurfaceStatus, nativeWindowHandle: '0x0000000000000001' },
       { ...d3d11SurfaceStatus, processId: 42 },

--- a/apps/desktop/src/shared/electron-ipc-contract.ts
+++ b/apps/desktop/src/shared/electron-ipc-contract.ts
@@ -506,6 +506,7 @@ const previewBoundsSchema = objectSchema(
     clipY: optionalSchema(numberSchema()),
     clipWidth: optionalSchema(numberSchema({ min: 0, max: 65_536 })),
     clipHeight: optionalSchema(numberSchema({ min: 0, max: 65_536 })),
+    cornerRadius: optionalSchema(numberSchema({ min: 0, max: 256 })),
     visible: optionalSchema(booleanSchema),
     orderAboveWindowId: optionalSchema(nonNegativeSafeIntegerSchema),
     elevated: optionalSchema(booleanSchema)


### PR DESCRIPTION
Fixes #232

### Summary of Changes
- Added `cornerRadius: optionalSchema(numberSchema({ min: 0, max: 256 }))` to `previewBoundsSchema` in `apps/desktop/src/shared/electron-ipc-contract.ts`.
- Added regression test in `apps/desktop/src/shared/electron-ipc-contract.test.ts` to verify `cornerRadius` passes IPC bounds validation for `preview-surface:status` and related channels.

### Verification
- `pnpm --filter @videorc/desktop test electron-ipc-contract` (passed)
- `pnpm --filter @videorc/desktop test` (all 147 test files, 1320 tests passed)
- `pnpm format:check` (passed)
- `pnpm typecheck` (passed)
- Verified locally that runtime `RuntimeSchemaError` on `preview-surface:status` is resolved.

cc @TheOrcDev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when detecting Windows processes by allowing more time for system responses.
  * Preserved centered cropping for Windows camera overlays.
  * Added support for rounded preview surfaces with configurable corner radii.

* **Developer Experience**
  * Windows FFmpeg downloads now show live progress, including percentage, transfer speed, and downloaded size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->