### PR TITLE
release: 0.9.62-beta.1 — quieter internals for the docked preview

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.61",
+  "version": "0.9.62",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.62-beta.1.md
+++ b/changelog/0.9.62-beta.1.md
@@ -1,0 +1,25 @@
+---
+version: 0.9.62-beta.1
+date: 2026-08-20
+channel: beta
+platforms:
+  - macos
+title: Quieter internals for the docked preview
+summary: A background validation error that fired repeatedly while the docked preview was open (introduced with the rounded preview in 0.9.59) is fixed — reported and patched by community contributor TechnicalExpo the same night.
+highlights:
+  - Fixed a repeating internal validation error while the docked preview was open — introduced alongside 0.9.59's rounded preview, reported and fixed by TechnicalExpo.
+  - A new cross-layer test makes this whole class of "one validator missed" bugs fail in CI instead of shipping.
+---
+
+The rounded docked preview shipped in 0.9.59 carried a hidden passenger:
+one of the app's internal validation layers didn't know about the new
+corner-radius field, so two background channels threw errors over and over
+while the docked preview was open. Nothing looked wrong on screen — the
+rounding itself worked — but the app was quietly shouting into its own
+logs.
+
+Community contributor TechnicalExpo caught it, filed the issue with a
+clean stack trace, and fixed it the same night. Alongside the fix, a new
+test now runs every internal validator against one shared fixture, so a
+field reaching all-but-one validation layer — the exact mistake, made
+three times in one week — fails in CI instead of reaching a release.


### PR DESCRIPTION
Version bump 0.9.61 → 0.9.62 + changelog for #235 (cornerRadius in the Electron IPC schema, fixes #232 — community fix by TechnicalExpo) and #236 (cross-layer bounds parity test). macOS-only.