### PR TITLE
feat: animated scene transitions — scene changes can move now

### DIFF
--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -219,6 +219,24 @@ export function SettingsTab({
                 />
               </div>
             </Field>
+            <Field>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <FieldLabel htmlFor="animate-scene-changes">Animate scene changes</FieldLabel>
+                  <p className="text-xs text-muted-foreground">
+                    Layout switches glide into place instead of cutting — visible live on stream and
+                    in recordings.
+                  </p>
+                </div>
+                <Switch
+                  checked={settings.animateSceneChanges !== false}
+                  id="animate-scene-changes"
+                  onCheckedChange={(checked) =>
+                    setSettings((current) => ({ ...current, animateSceneChanges: checked }))
+                  }
+                />
+              </div>
+            </Field>
           </FieldGroup>
 
           <div className="flex flex-col gap-0.5">

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -391,6 +391,10 @@ function openLibraryFromQualityToast(sessionId?: string): void {
 const TELEMETRY_UI_COMMIT_INTERVAL_MS = 1000
 const SIGNED_IN_ENTITLEMENT_REFRESH_INTERVAL_MS = 5 * 60_000
 const LIVE_CHAT_RECOVERY_RETRY_DELAY_MS = 250
+/// Scene-motion duration: content motion on-air sits just above the UI's
+/// 100-150ms tier; >=500ms reads as a broadcast wipe.
+const SCENE_TRANSITION_MS = 320
+
 const SESSION_LIST_PAGE_LIMIT = 50
 export const SESSION_DETAIL_BUFFER_LIMIT = 120
 const SESSION_DETAIL_CACHE_LIMIT = 8
@@ -2375,9 +2379,18 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const [screenImportPending, setScreenImportPending] = useState(false)
   const [streamMetadataSavePending, setStreamMetadataSavePending] = useState(false)
   const [supportBundleExportPending, setSupportBundleExportPending] = useState(false)
-  const [settings, setSettings] = useState<SettingsState>(() =>
-    loadJson(STORAGE_KEYS.settings, defaultSettings)
-  )
+  const [settings, setSettings] = useState<SettingsState>(() => {
+    const loaded = loadJson(STORAGE_KEYS.settings, defaultSettings)
+    // Scene motion defaults on, but an OS-level reduced-motion preference
+    // flips the DEFAULT off until the user chooses explicitly in Settings.
+    if (
+      loaded.animateSceneChanges === undefined &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return { ...loaded, animateSceneChanges: false }
+    }
+    return loaded
+  })
   const settingsRef = useRef(settings)
   settingsRef.current = settings
   // Stable handle for callbacks that only need to READ the config (labels,
@@ -5738,7 +5751,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             // state, so the transaction carries its target canvas explicitly.
             video: options?.videoOverride ?? requestedConfig.video,
             background: activeSceneBackground,
-            protectedOverlayWindowIds
+            protectedOverlayWindowIds,
+            // Scene motion: the committed layout glides into place (320ms
+            // ease) in preview, stream, and recording alike. Absent = instant.
+            ...(settingsRef.current.animateSceneChanges !== false
+              ? { transitionMs: SCENE_TRANSITION_MS }
+              : {})
           })
           const committedSnapshot: LayoutTransactionSnapshot = {
             sceneRevision: status.sceneRevision,

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -42,6 +42,11 @@ export type SettingsState = {
     streamToggle?: string
     micToggle?: string
   }
+  /**
+   * Scene motion: layout changes glide (320ms ease) in the live output —
+   * preview, stream, AND recording — instead of cutting. Default on.
+   */
+  animateSceneChanges?: boolean
 }
 
 export type CaptionBurnTarget = 'off' | 'stream' | 'recording' | 'both'
@@ -319,7 +324,8 @@ export const MICROPHONE_SYNC_OFFSET_MAX_MS = 1000
 export const defaultSettings: SettingsState = {
   outputDirectory: '',
   outputDirectoryHandle: undefined,
-  keepOriginalRecording: false
+  keepOriginalRecording: false,
+  animateSceneChanges: true
 }
 
 export const rtmpDefaults: Record<RtmpPreset, string> = {

--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -555,6 +555,50 @@ describe('backend RPC contract', () => {
     ).toMatchObject({ artifacts: [{ id: 'artifact-1' }] })
   })
 
+  it('accepts transitionMs on layout transactions and rejects out-of-range values', () => {
+    // transitionMs crosses exactly one wire validator (this allowUnknown:false
+    // schema) — issue #232 class: a field added to N−1 of N layers throws
+    // RuntimeSchemaError in production. Pin the one layer here.
+    const layoutParams = {
+      intentId: 7,
+      sources: { cameraId: 'cam-1', screenId: 'screen-1' },
+      layout: {
+        layoutPreset: 'screen-camera',
+        cameraTransformMode: 'preset',
+        cameraTransform: null,
+        cameraCorner: 'bottom-right',
+        cameraSize: 'medium',
+        cameraShape: 'rounded',
+        cameraCornerRadiusPct: 12,
+        cameraAspect: 'source',
+        cameraChromaKeyEnabled: false,
+        cameraChromaKeyColor: '#00ff00',
+        cameraChromaKeySimilarityPct: 40,
+        cameraChromaKeySmoothnessPct: 10,
+        cameraChromaKeySpillPct: 10,
+        cameraMargin: 16,
+        cameraFit: 'fill',
+        cameraMirror: false,
+        cameraZoom: 100,
+        cameraOffsetX: 0,
+        cameraOffsetY: 0,
+        sideBySideSplit: '50-50',
+        sideBySideCameraSide: 'left'
+      },
+      transitionMs: 320
+    }
+    expect(validateBackendRpcParams('scene.layout.apply_live', layoutParams)).toEqual(layoutParams)
+    expect(validateBackendRpcParams('scene.layout.apply_preview', layoutParams)).toEqual(
+      layoutParams
+    )
+    expect(() =>
+      validateBackendRpcParams('scene.layout.apply_live', { ...layoutParams, transitionMs: 2000 })
+    ).toThrow()
+    expect(() =>
+      validateBackendRpcParams('scene.layout.apply_live', { ...layoutParams, transitionMs: 0.5 })
+    ).toThrow()
+  })
+
   it('validates every destructive contract named in the runtime registry', () => {
     expect(runtimeValidatedBackendRpcMethods).toEqual(
       expect.arrayContaining([

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -581,7 +581,8 @@ const sceneConfigSchema = objectSchema(
     background: optionalSchema(boundedBackendParamValueSchema),
     protectedOverlayWindowIds: optionalSchema(
       arraySchema(numberSchema({ integer: true, min: 0 }), { maxLength: 16 })
-    )
+    ),
+    transitionMs: optionalSchema(numberSchema({ integer: true, min: 0, max: 1000 }))
   },
   { allowUnknown: false }
 )

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -510,6 +510,8 @@ export interface SceneConfigParams {
   video?: VideoSettings
   background?: EffectiveSceneBackground
   protectedOverlayWindowIds?: number[]
+  /** Scene-motion duration (ms) for this commit; absent/0 = instant switch. */
+  transitionMs?: number
 }
 
 export interface SceneTransformUpdateParams {

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -288,6 +288,12 @@ impl CompositorPixelFormat {
 pub struct CompositorRuntime {
     pub status: CompositorStatus,
     scene: Option<CompositorSceneSnapshot>,
+    /// Active scene-motion transition: the previous scene's EFFECTIVE
+    /// transforms glide toward the committed scene over `duration`. Applied
+    /// once per tick at the snapshot choke point in publish_compositor_frame,
+    /// so every render path (Metal, CPU, preview, stream, recording) sees
+    /// identical geometry by construction.
+    scene_transition: Option<SceneTransition>,
     image_sources: CompositorImageCache,
     frame_store: CompositorFrameStore,
     stream_frame_store: Option<CompositorFrameStore>,
@@ -472,6 +478,7 @@ struct CompositorRenderCache {
     frame_store: CompositorFrameStore,
     stream_frame_store: Option<CompositorFrameStore>,
     snapshot: Option<CompositorSceneSnapshot>,
+    transition: Option<SceneTransition>,
     active_image_source: Option<CompositorImageSource>,
     background_image_source: Option<CompositorImageSource>,
 }
@@ -510,6 +517,7 @@ impl CompositorRenderCache {
             frame_store: compositor.frame_store.clone(),
             stream_frame_store: compositor.stream_frame_store.clone(),
             snapshot: compositor.scene.clone(),
+            transition: compositor.scene_transition.clone(),
             active_image_source,
             background_image_source,
         }
@@ -706,6 +714,128 @@ fn same_screen_source(
 ) -> bool {
     previous.and_then(PreviewScreenFrameSource::source_key)
         == next.and_then(PreviewScreenFrameSource::source_key)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SceneTransition {
+    /// The scene being left, with EFFECTIVE transforms captured at commit
+    /// time (a commit landing mid-transition re-anchors from wherever the
+    /// glide currently is, so rapid preset clicks stay smooth).
+    from: Scene,
+    started_at: Instant,
+    duration: Duration,
+}
+
+/// Soft start, soft landing, no overshoot — the design language's
+/// nothing-bounces rule for on-air motion.
+fn ease_in_out_cubic(t: f64) -> f64 {
+    let t = t.clamp(0.0, 1.0);
+    if t < 0.5 {
+        4.0 * t * t * t
+    } else {
+        1.0 - (-2.0 * t + 2.0).powi(3) / 2.0
+    }
+}
+
+fn scene_transition_progress(transition: &SceneTransition, now: Instant) -> f64 {
+    let duration = transition.duration.as_secs_f64();
+    if duration <= 0.0 {
+        return 1.0;
+    }
+    (now.saturating_duration_since(transition.started_at)
+        .as_secs_f64()
+        / duration)
+        .clamp(0.0, 1.0)
+}
+
+fn lerp_f64(from: f64, to: f64, p: f64) -> f64 {
+    from + (to - from) * p
+}
+
+/// Full-geometry interpolation: position, size, AND crops, so zoom/pan
+/// framing glides with the layout instead of popping.
+fn lerp_scene_transform(from: &SceneTransform, to: &SceneTransform, p: f64) -> SceneTransform {
+    SceneTransform {
+        x: lerp_f64(from.x, to.x, p),
+        y: lerp_f64(from.y, to.y, p),
+        width: lerp_f64(from.width, to.width, p),
+        height: lerp_f64(from.height, to.height, p),
+        crop_left: lerp_f64(from.crop_left, to.crop_left, p),
+        crop_top: lerp_f64(from.crop_top, to.crop_top, p),
+        crop_right: lerp_f64(from.crop_right, to.crop_right, p),
+        crop_bottom: lerp_f64(from.crop_bottom, to.crop_bottom, p),
+    }
+}
+
+/// A source with no predecessor grows in from 92% about its own center —
+/// pure geometry, no shader/opacity work (that is the V2 fade).
+fn synthetic_enter_from(to: &SceneTransform) -> SceneTransform {
+    const ENTER_SCALE: f64 = 0.92;
+    let width = to.width * ENTER_SCALE;
+    let height = to.height * ENTER_SCALE;
+    SceneTransform {
+        x: to.x + (to.width - width) / 2.0,
+        y: to.y + (to.height - height) / 2.0,
+        width,
+        height,
+        crop_left: to.crop_left,
+        crop_top: to.crop_top,
+        crop_right: to.crop_right,
+        crop_bottom: to.crop_bottom,
+    }
+}
+
+/// Camera glides to camera; the base capture (screen/window/test pattern)
+/// glides to the base, even when the preset swaps which kind fills it.
+fn scene_motion_family(kind: &SceneSourceKind) -> u8 {
+    match kind {
+        SceneSourceKind::Camera => 0,
+        SceneSourceKind::Screen | SceneSourceKind::Window | SceneSourceKind::TestPattern => 1,
+    }
+}
+
+/// The per-tick effective scene: every visible target source's transform is
+/// eased from its predecessor (matched by motion family) or from a grow-in
+/// origin when it just entered. Exited sources vanish on the first frame by
+/// construction (only target sources render).
+fn scene_with_transition(scene: Scene, transition: &SceneTransition, now: Instant) -> Scene {
+    let progress = ease_in_out_cubic(scene_transition_progress(transition, now));
+    if progress >= 1.0 {
+        return scene;
+    }
+    let mut scene = scene;
+    for source in scene.sources.iter_mut() {
+        if !source.visible {
+            continue;
+        }
+        let from = transition
+            .from
+            .sources
+            .iter()
+            .find(|previous| {
+                previous.visible
+                    && scene_motion_family(&previous.kind) == scene_motion_family(&source.kind)
+            })
+            .map(|previous| previous.transform.clone())
+            .unwrap_or_else(|| synthetic_enter_from(&source.transform));
+        source.transform = lerp_scene_transform(&from, &source.transform, progress);
+    }
+    scene
+}
+
+fn snapshot_with_transition(
+    snapshot: Option<CompositorSceneSnapshot>,
+    transition: Option<&SceneTransition>,
+    now: Instant,
+) -> Option<CompositorSceneSnapshot> {
+    let Some(transition) = transition else {
+        return snapshot;
+    };
+    let mut snapshot = snapshot?;
+    if let Some(scene) = snapshot.scene.take() {
+        snapshot.scene = Some(scene_with_transition(scene, transition, now));
+    }
+    Some(snapshot)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -930,6 +1060,7 @@ pub fn initial_compositor_state() -> CompositorRuntime {
     CompositorRuntime {
         status: stopped_status(Some("Compositor is not running.".to_string())),
         scene: None,
+        scene_transition: None,
         image_sources: CompositorImageCache::new(
             COMPOSITOR_IMAGE_CACHE_BUDGET_BYTES,
             COMPOSITOR_IMAGE_CACHE_ENTRY_BUDGET,
@@ -1377,6 +1508,7 @@ pub async fn update_compositor_scene(
         scene,
         layout,
         active_screen,
+        transition_ms,
     } = params;
     let active_screen = active_screen.map(|screen| {
         state
@@ -1393,6 +1525,26 @@ pub async fn update_compositor_scene(
             return compositor.status.clone();
         }
 
+        // Scene motion: capture the OUTGOING scene's effective transforms so
+        // the new scene glides from wherever things currently are (including
+        // mid-flight re-anchoring when commits interrupt a running glide).
+        let now = Instant::now();
+        let previous_effective = compositor.scene.as_ref().and_then(|previous| {
+            previous.scene.clone().map(|previous_scene| {
+                match compositor.scene_transition.as_ref() {
+                    Some(active) => scene_with_transition(previous_scene, active, now),
+                    None => previous_scene,
+                }
+            })
+        });
+        compositor.scene_transition = match (transition_ms, previous_effective, scene.as_ref()) {
+            (Some(duration_ms), Some(from), Some(_)) if duration_ms > 0 => Some(SceneTransition {
+                from,
+                started_at: now,
+                duration: Duration::from_millis(u64::from(duration_ms.min(1_000))),
+            }),
+            _ => None,
+        };
         let snapshot = CompositorSceneSnapshot {
             revision,
             scene,
@@ -1459,6 +1611,7 @@ pub async fn update_compositor_active_screen(
             scene,
             layout,
             active_screen,
+            transition_ms: None,
         },
     )
     .await
@@ -3297,6 +3450,160 @@ fn gpu_source_placement(
 }
 
 #[cfg(test)]
+mod scene_motion_tests {
+    use super::*;
+    use crate::protocol::{Scene, SceneSource, SceneSourceKind, SceneTransform};
+
+    fn transform(x: f64, y: f64, width: f64, height: f64) -> SceneTransform {
+        SceneTransform {
+            x,
+            y,
+            width,
+            height,
+            crop_left: 0.0,
+            crop_top: 0.0,
+            crop_right: 0.0,
+            crop_bottom: 0.0,
+        }
+    }
+
+    fn source(kind: SceneSourceKind, t: SceneTransform) -> SceneSource {
+        SceneSource {
+            id: format!("{kind:?}"),
+            kind,
+            name: String::new(),
+            device_id: None,
+            visible: true,
+            locked: false,
+            transform: t.clone(),
+            default_transform: t,
+        }
+    }
+
+    fn scene_with(sources: Vec<SceneSource>) -> Scene {
+        Scene {
+            id: "scene".to_string(),
+            name: "scene".to_string(),
+            sources,
+            outputs: Vec::new(),
+            background: None,
+        }
+    }
+
+    #[test]
+    fn easing_is_soft_bounded_and_monotonic() {
+        assert_eq!(ease_in_out_cubic(0.0), 0.0);
+        assert_eq!(ease_in_out_cubic(1.0), 1.0);
+        assert!((ease_in_out_cubic(0.5) - 0.5).abs() < 1e-9);
+        // No overshoot, ever — the nothing-bounces rule.
+        let mut previous = 0.0;
+        for step in 0..=100 {
+            let value = ease_in_out_cubic(f64::from(step) / 100.0);
+            assert!((0.0..=1.0).contains(&value));
+            assert!(value >= previous);
+            previous = value;
+        }
+        // Out-of-range inputs clamp instead of extrapolating.
+        assert_eq!(ease_in_out_cubic(-1.0), 0.0);
+        assert_eq!(ease_in_out_cubic(2.0), 1.0);
+    }
+
+    #[test]
+    fn mid_transition_geometry_sits_between_the_two_layouts() {
+        // The owner's example: side-by-side camera gliding to the corner.
+        let from_camera = transform(0.7, 0.0, 0.3, 1.0);
+        let to_camera = transform(0.75, 0.05, 0.2, 0.2);
+        let transition = SceneTransition {
+            from: scene_with(vec![source(SceneSourceKind::Camera, from_camera.clone())]),
+            started_at: Instant::now() - Duration::from_millis(160),
+            duration: Duration::from_millis(320),
+        };
+        let animated = scene_with_transition(
+            scene_with(vec![source(SceneSourceKind::Camera, to_camera.clone())]),
+            &transition,
+            Instant::now(),
+        );
+        let camera = &animated.sources[0].transform;
+        // Strictly between the endpoints on every animated axis.
+        assert!(camera.x > from_camera.x && camera.x < to_camera.x);
+        assert!(camera.width < from_camera.width && camera.width > to_camera.width);
+        assert!(camera.height < from_camera.height && camera.height > to_camera.height);
+    }
+
+    #[test]
+    fn finished_transition_returns_the_target_scene_untouched() {
+        let to = scene_with(vec![source(
+            SceneSourceKind::Camera,
+            transform(0.1, 0.1, 0.2, 0.2),
+        )]);
+        let transition = SceneTransition {
+            from: scene_with(vec![source(
+                SceneSourceKind::Camera,
+                transform(0.0, 0.0, 1.0, 1.0),
+            )]),
+            started_at: Instant::now() - Duration::from_secs(5),
+            duration: Duration::from_millis(320),
+        };
+        let animated = scene_with_transition(to.clone(), &transition, Instant::now());
+        assert_eq!(
+            animated, to,
+            "an expired glide must cost and change nothing"
+        );
+    }
+
+    #[test]
+    fn base_family_glides_across_capture_kinds_and_entrants_grow_in() {
+        // Screen in the old scene, Window in the new: same slot, must glide.
+        let transition = SceneTransition {
+            from: scene_with(vec![source(
+                SceneSourceKind::Screen,
+                transform(0.0, 0.0, 0.7, 1.0),
+            )]),
+            started_at: Instant::now() - Duration::from_millis(160),
+            duration: Duration::from_millis(320),
+        };
+        let animated = scene_with_transition(
+            scene_with(vec![
+                source(SceneSourceKind::Window, transform(0.0, 0.0, 1.0, 1.0)),
+                source(SceneSourceKind::Camera, transform(0.75, 0.05, 0.2, 0.2)),
+            ]),
+            &transition,
+            Instant::now(),
+        );
+        let window = &animated.sources[0].transform;
+        assert!(
+            window.width > 0.7 && window.width < 1.0,
+            "base glides across kinds"
+        );
+        // The camera has no predecessor: grows in from 92% about its center.
+        let camera = &animated.sources[1].transform;
+        assert!(camera.width > 0.2 * 0.92 && camera.width < 0.2);
+        assert!(camera.x > 0.75 && camera.x < 0.75 + 0.2 * 0.04 + 1e-9);
+    }
+
+    #[test]
+    fn zero_or_absent_duration_never_installs_motion() {
+        let transition = SceneTransition {
+            from: scene_with(vec![source(
+                SceneSourceKind::Camera,
+                transform(0.0, 0.0, 1.0, 1.0),
+            )]),
+            started_at: Instant::now(),
+            duration: Duration::from_millis(0),
+        };
+        let to = scene_with(vec![source(
+            SceneSourceKind::Camera,
+            transform(0.1, 0.1, 0.2, 0.2),
+        )]);
+        assert_eq!(
+            scene_with_transition(to.clone(), &transition, Instant::now()),
+            to,
+            "zero duration is an instant switch"
+        );
+    }
+}
+
+#[cfg(test)]
 fn rgba_to_bgra_bytes(rgba: &[u8]) -> Vec<u8> {
     let mut bgra = Vec::with_capacity(rgba.len());
     for pixel in rgba.chunks_exact(4) {
@@ -3357,7 +3664,11 @@ async fn publish_compositor_frame(
     render_cache.refresh_nonblocking(state);
     let frame_store = render_cache.frame_store.clone();
     let stream_frame_store = render_cache.stream_frame_store.clone();
-    let snapshot = render_cache.snapshot.clone();
+    let snapshot = snapshot_with_transition(
+        render_cache.snapshot.clone(),
+        render_cache.transition.as_ref(),
+        Instant::now(),
+    );
     let active_image_source = render_cache.active_image_source.clone();
     let background_image_source = render_cache.background_image_source.clone();
     let scene_snapshot_ms = scene_snapshot_started_at.elapsed().as_secs_f64() * 1000.0;
@@ -5252,6 +5563,7 @@ mod tests {
         let mut layout = crate::protocol::default_layout_settings();
         layout.layout_preset = layout_preset;
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: screen_id.map(ToString::to_string),
                 window_id: None,
@@ -5956,6 +6268,7 @@ mod tests {
         };
         let layout = crate::protocol::default_layout_settings();
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -6045,6 +6358,7 @@ mod tests {
         };
         let layout = crate::protocol::default_layout_settings();
         let mut scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -6157,6 +6471,7 @@ mod tests {
         layout.side_by_side_split = crate::protocol::SideBySideSplit::SixtyForty;
         layout.side_by_side_camera_side = crate::protocol::SideBySideCameraSide::Left;
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: Some("screen-1".to_string()),
                 window_id: None,
@@ -6241,6 +6556,7 @@ mod tests {
         let mut layout = crate::protocol::default_layout_settings();
         layout.layout_preset = LayoutPreset::ScreenOnly;
         let mut scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: Some("screen-1".to_string()),
                 window_id: None,
@@ -6335,6 +6651,7 @@ mod tests {
         let state = test_state();
         let layout = crate::protocol::default_layout_settings();
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -6423,6 +6740,7 @@ mod tests {
         let state = test_state();
         let layout = crate::protocol::default_layout_settings();
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -6561,6 +6879,7 @@ mod tests {
         };
         let layout = crate::protocol::default_layout_settings();
         let mut scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -7020,6 +7339,7 @@ mod tests {
         .await;
         let layout = crate::protocol::default_layout_settings();
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -7041,6 +7361,7 @@ mod tests {
         update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 1,
                 scene: Some(scene),
                 layout,
@@ -7098,6 +7419,7 @@ mod tests {
         let state = test_state();
         let layout = crate::protocol::default_layout_settings();
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -7688,6 +8010,7 @@ mod tests {
         let status = update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 10,
                 scene: Some(scene.clone()),
                 layout: layout.clone(),
@@ -7703,6 +8026,7 @@ mod tests {
         let stale = update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 9,
                 scene: None,
                 layout: layout.clone(),
@@ -7718,6 +8042,7 @@ mod tests {
         let newest = update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 11,
                 scene: None,
                 layout,
@@ -7749,6 +8074,7 @@ mod tests {
         let first = update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 1,
                 scene: None,
                 layout: layout.clone(),
@@ -7773,6 +8099,7 @@ mod tests {
         let second = update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 2,
                 scene: None,
                 layout: layout.clone(),
@@ -7789,6 +8116,7 @@ mod tests {
         let missing = update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 3,
                 scene: None,
                 layout,
@@ -7970,6 +8298,7 @@ mod tests {
         let mut layout = crate::protocol::default_layout_settings();
         layout.layout_preset = LayoutPreset::ScreenOnly;
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -8369,6 +8698,7 @@ mod tests {
         let mut layout = crate::protocol::default_layout_settings();
         layout.layout_preset = LayoutPreset::ScreenOnly;
         let mut scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: Some("screen:screencapturekit:1".to_string()),
                 window_id: None,
@@ -8468,6 +8798,7 @@ mod tests {
         layout.layout_preset = LayoutPreset::VerticalCameraTop;
         layout.camera_fit = crate::protocol::CameraFit::Fit;
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: Some("screen:screencapturekit:1".to_string()),
                 window_id: None,
@@ -8682,6 +9013,7 @@ mod tests {
         layout.layout_preset = LayoutPreset::CameraOnly;
         layout.camera_shape = CameraShape::Circle;
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -8858,6 +9190,7 @@ mod tests {
         let mut layout = crate::protocol::default_layout_settings();
         layout.layout_preset = LayoutPreset::CameraOnly;
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -8942,6 +9275,7 @@ mod tests {
         let mut layout = crate::protocol::default_layout_settings();
         layout.layout_preset = LayoutPreset::ScreenOnly;
         let scene = crate::scene::scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: crate::protocol::SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -8959,6 +9293,7 @@ mod tests {
         update_compositor_scene(
             &state,
             CompositorSceneUpdateParams {
+                transition_ms: None,
                 revision: 20,
                 scene: Some(scene),
                 layout,

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -467,9 +467,15 @@ async fn apply_scene_transaction(
     let live = source_liveness(state, target_sources).await;
     match plan_live_swap(mutation_kind, needs, live) {
         ApplyMode::Hot => {
-            let status =
-                commit_scene_for_intent(state, intent_id, &scene, params.layout.clone(), None)
-                    .await?;
+            let status = commit_scene_for_intent(
+                state,
+                intent_id,
+                &scene,
+                params.layout.clone(),
+                None,
+                params.transition_ms,
+            )
+            .await?;
             retire_unused_sources_after_commit(state, intent_id, needs).await;
             resync_camera_capture_geometry_after_commit(state, intent_id, &params, needs).await;
             Ok(layout_apply_status(
@@ -511,6 +517,7 @@ async fn apply_scene_transaction(
                 &scene,
                 params.layout.clone(),
                 Some(message.clone()),
+                params.transition_ms,
             )
             .await?;
             retire_unused_sources_after_commit(state, intent_id, needs).await;
@@ -760,6 +767,7 @@ async fn commit_scene_for_intent(
     scene: &Scene,
     layout: crate::protocol::LayoutSettings,
     message: Option<String>,
+    transition_ms: Option<u32>,
 ) -> Result<SceneCommitStatus> {
     // Keep registration and the commit edge mutually exclusive. Warm-up never holds
     // this guard, so a new request can supersede an older waiter immediately.
@@ -770,7 +778,9 @@ async fn commit_scene_for_intent(
             intents.latest_intent_id
         );
     }
-    let status = commit_scene_with_layout(state, scene, layout, message).await?;
+    let status =
+        commit_scene_with_layout_with_transition(state, scene, layout, message, transition_ms)
+            .await?;
     drop(intents);
     Ok(status)
 }
@@ -1209,9 +1219,27 @@ pub async fn commit_scene_with_layout(
     layout: crate::protocol::LayoutSettings,
     message: Option<String>,
 ) -> Result<SceneCommitStatus> {
+    commit_scene_with_layout_with_transition(state, scene, layout, message, None).await
+}
+
+pub async fn commit_scene_with_layout_with_transition(
+    state: &AppState,
+    scene: &Scene,
+    layout: crate::protocol::LayoutSettings,
+    message: Option<String>,
+    transition_ms: Option<u32>,
+) -> Result<SceneCommitStatus> {
     let now_millis = u64::try_from(Utc::now().timestamp_millis()).unwrap_or(0);
-    commit_scene_with_layout_at_time_with_policy(state, scene, layout, message, now_millis, false)
-        .await
+    commit_scene_with_layout_at_time_with_policy(
+        state,
+        scene,
+        layout,
+        message,
+        now_millis,
+        false,
+        transition_ms,
+    )
+    .await
 }
 
 pub async fn commit_idle_scene_with_layout(
@@ -1221,8 +1249,10 @@ pub async fn commit_idle_scene_with_layout(
     message: Option<String>,
 ) -> Result<SceneCommitStatus> {
     let now_millis = u64::try_from(Utc::now().timestamp_millis()).unwrap_or(0);
-    commit_scene_with_layout_at_time_with_policy(state, scene, layout, message, now_millis, true)
-        .await
+    commit_scene_with_layout_at_time_with_policy(
+        state, scene, layout, message, now_millis, true, None,
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -1233,10 +1263,13 @@ async fn commit_scene_with_layout_at_time(
     message: Option<String>,
     now_millis: u64,
 ) -> Result<SceneCommitStatus> {
-    commit_scene_with_layout_at_time_with_policy(state, scene, layout, message, now_millis, false)
-        .await
+    commit_scene_with_layout_at_time_with_policy(
+        state, scene, layout, message, now_millis, false, None,
+    )
+    .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn commit_scene_with_layout_at_time_with_policy(
     state: &AppState,
     scene: &Scene,
@@ -1244,6 +1277,7 @@ async fn commit_scene_with_layout_at_time_with_policy(
     message: Option<String>,
     now_millis: u64,
     idle_only: bool,
+    transition_ms: Option<u32>,
 ) -> Result<SceneCommitStatus> {
     // An unreadable background must DEGRADE, never kill the commit: failing here
     // took the whole preview down with it (every builtin .webp background before
@@ -1288,6 +1322,7 @@ async fn commit_scene_with_layout_at_time_with_policy(
             scene: Some(scene.clone()),
             layout,
             active_screen,
+            transition_ms,
         },
     )
     .await;
@@ -1376,6 +1411,7 @@ mod tests {
             .await
             .expect("intent must register");
         let params = crate::protocol::SceneConfigParams {
+            transition_ms: None,
             sources: sources(true, false),
             layout: full_layout,
             video: Some(video),
@@ -1440,6 +1476,7 @@ mod tests {
 
     fn config(preset: LayoutPreset, camera: bool, screen: bool) -> SceneConfigParams {
         SceneConfigParams {
+            transition_ms: None,
             sources: sources(camera, screen),
             layout: layout(preset),
             video: Some(fallback_video_settings()),

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -9726,6 +9726,7 @@ mod tests {
         let mut layout = protocol::default_layout_settings();
         layout.layout_preset = preset;
         let config = protocol::SceneConfigParams {
+            transition_ms: None,
             sources: protocol::SourceSelection {
                 screen_id: Some("screen:screencapturekit:1".to_string()),
                 window_id: None,

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -695,6 +695,10 @@ pub struct SceneConfigParams {
     pub background: Option<EffectiveSceneBackground>,
     #[serde(default)]
     pub protected_overlay_window_ids: Vec<u32>,
+    /// Scene-motion duration in ms for THIS commit (renderer sends it when
+    /// "Animate scene changes" is on). Absent/0 = instant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transition_ms: Option<u32>,
 }
 
 /// Backend-owned scene layout transaction. Renderer-generated intent ids are
@@ -2636,6 +2640,10 @@ pub struct CompositorSceneUpdateParams {
     pub layout: LayoutSettings,
     #[serde(default)]
     pub active_screen: Option<StreamScreen>,
+    /// Scene-motion duration in ms (clamped to 1000): the previous scene's
+    /// transforms glide to this one. Absent/0 = instant switch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transition_ms: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -3796,6 +3804,7 @@ mod tests {
     #[test]
     fn scene_config_round_trips_background_and_defaults_absent_background() {
         let plain = SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: None,
                 window_id: None,
@@ -3814,6 +3823,7 @@ mod tests {
         assert_eq!(legacy.background, None);
 
         let params = SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: None,
                 window_id: None,

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -1480,6 +1480,7 @@ async fn commit_recording_startup_scene_at_time(
             scene: Some(scene.clone()),
             layout,
             active_screen,
+            transition_ms: None,
         },
     )
     .await;
@@ -2370,6 +2371,7 @@ pub async fn start_session(
             .await;
             let scene = params.scene.clone().unwrap_or_else(|| {
                 scene_from_capture_config(SceneConfigParams {
+                    transition_ms: None,
                     sources: params.sources.clone(),
                     layout: params.layout.clone(),
                     video: Some(params.output.video.clone()),
@@ -8148,6 +8150,7 @@ async fn should_use_compositor_encoder_bridge(
     }
     let scene = params.scene.clone().unwrap_or_else(|| {
         scene_from_capture_config(SceneConfigParams {
+            transition_ms: None,
             sources: params.sources.clone(),
             layout: params.layout.clone(),
             video: Some(params.output.video.clone()),

--- a/crates/videorc-backend/src/scene.rs
+++ b/crates/videorc-backend/src/scene.rs
@@ -831,6 +831,7 @@ mod tests {
 
     fn base_params() -> SceneConfigParams {
         SceneConfigParams {
+            transition_ms: None,
             sources: SourceSelection {
                 screen_id: Some("screen:screencapturekit:1".to_string()),
                 window_id: None,

--- a/scripts/smoke-live-layout-switch-recording-app.mjs
+++ b/scripts/smoke-live-layout-switch-recording-app.mjs
@@ -188,7 +188,11 @@ async function runSwitchScenario(ws, smoke, { label, sources, streamTarget, dura
       layout: layout(preset),
       video,
       background: null,
-      protectedOverlayWindowIds: []
+      protectedOverlayWindowIds: [],
+      // Scene motion ON: each switch glides for 320ms mid-recording, so this
+      // smoke also gates that transitions never stall scene proof or corrupt
+      // the recording artifact.
+      transitionMs: 320
     })
     if (!status.applied) {
       throw new Error(`[${label}] ${preset} did not apply: ${JSON.stringify(status)}`)


### PR DESCRIPTION
## What

Optional **scene motion**: when the layout changes mid-session (preset click, camera drag commit, margin/zoom commit), the camera and screen **glide** from their old placement to the new one over 320ms — visible live in the **stream, the recording, and the preview**, not just the UI. Controlled by a new Settings toggle, **"Animate scene changes"** (default on; `prefers-reduced-motion` flips the default off until the user chooses).

Vault plan: `2026-08-20 - Videorc Animated Scene Transitions Plan`.

## The load-bearing decision

**Interpolate ONCE, at the scene level, before any render path sees the scene.** A `SceneTransition` sits beside the committed scene; every tick, `snapshot_with_transition` derives an eased effective scene at the single snapshot choke point in `publish_compositor_frame` — before the Metal/CPU split. All render paths get identical geometry **by construction** (the three-path-parity disease from the keyer/pan fixes cannot recur here). Capture is untouched: the composited quad animates, not the camera session — zero interaction with the mid-recording restart guard or SCK filters.

## Motion design

- 320ms cubic ease-in-out (`SCENE_TRANSITION_MS`) — soft start/land, no overshoot, nothing bounces.
- Full `SceneTransform` lerp: x/y/w/h **and all four crops** (zoom/pan framing changes glide too).
- Kind-family matching: camera↔camera; screen/window/test-pattern are one base family (a screen→window swap glides).
- Entering sources grow in from 92% about their target center; exiting sources drop on the first frame (fades need per-quad alpha in three shaders — deliberate V2).
- A commit mid-glide re-anchors from the **current effective transforms** — redirects stay smooth.
- No prior scene (session start, idle install) ⇒ instant. Param absent/0 ⇒ instant. Duration clamped to 1000ms.

## Validation-layer checklist (issue #232 class)

`transition_ms` touches N validators; all N updated and pinned:
- `protocol.rs` `SceneConfigParams` + `CompositorSceneUpdateParams` (serde default, skip-if-none) ✅
- backend-rpc `sceneConfigSchema` (**the only** `allowUnknown:false` wire validator this field crosses) ✅
- TS `SceneConfigParams` type ✅
- **Does not** cross the electron-ipc layer — grepped and verified ✅
- New contract test pins accept-at-320 / reject-out-of-range on both `apply_live` and `apply_preview` ✅

## Explicitly instant (documented, not hidden)

Windows D3D11-direct and legacy FFmpeg-filter paths build geometry at session start — switches stay instant there. No cfg(windows) signatures were touched (grepped `render_camera_overlay_bgra` callers — untouched).

## Gates

- `cargo test -p videorc-backend`: **1509 pass** (incl. 5 new scene-motion unit tests: easing bounds/monotonicity, mid-transition between endpoints, expiry, enter-grow-in + base-family glide, zero-duration instant)
- `cargo clippy -D warnings`, `cargo fmt --check`: clean
- `pnpm typecheck` / `lint` / `format:check`: clean
- desktop tests: **1323 pass** · `test:scripts`: **1040 pass**
- `smoke:recording-matrix`: **12/12 PASS** (transitions never fire on session-start commits)
- `smoke:live-layout-switch-recording`: **PASS** — the smoke now sends `transitionMs: 320` on every mid-recording `apply_live`, permanently gating transitions against scene-proof stalls, session death, and artifact corruption (recording + RTMP stream leg both verified)

## Owner acceptance (manual — agent camera capture is TCC-blind on this box)

Flip side-by-side ↔ screen+camera while live/recording: the camera should glide to its corner, and both the stream and the recording should show the motion. Toggle off in Settings → switches cut instantly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Animate scene changes” setting under Recording & storage.
  - Scene layout changes now glide smoothly over 320 ms in previews, streams, and recordings when enabled.
  - Animation can be disabled for instant scene switches.

- **Accessibility**
  - Animation defaults off when the operating system prefers reduced motion, unless explicitly configured.

- **Bug Fixes**
  - Improved consistency of scene transitions across live output, preview, and recording views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->