### PR TITLE
release: 0.9.63-beta.1 — animated scene transitions

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.62",
+  "version": "0.9.63",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.63-beta.1.md
+++ b/changelog/0.9.63-beta.1.md
@@ -1,0 +1,35 @@
+---
+version: 0.9.63-beta.1
+date: 2026-08-20
+channel: beta
+platforms:
+  - macos
+title: Scene changes can move now
+summary: Switching layouts mid-session now glides — the camera visibly slides to its new spot over a third of a second, live on your stream and in your recording. On by default, with a Settings toggle for instant cuts.
+highlights:
+  - Scene changes animate — flip from side-by-side to screen + camera and the camera glides to its corner instead of teleporting, with a soft ease that starts and lands gently.
+  - The motion is real, not cosmetic — your live stream, your recording, and the preview all show the same glide.
+  - Sources that appear with the new layout grow in smoothly; changing scenes again mid-glide redirects the motion without a jump.
+  - New "Animate scene changes" toggle in Settings (on by default) — turn it off for hard cuts; if your system prefers reduced motion, it starts off.
+---
+
+Until now, changing scenes was a hard cut: click a layout and every
+source teleported to its new position between one frame and the next.
+Functional, but it never looked intentional — especially live, where a
+teleporting camera reads as a glitch rather than a transition.
+
+Now the scene itself moves. Switch from side-by-side to screen + camera
+and the camera slides to its corner over 320 milliseconds with a soft
+ease — no bounce, no overshoot, just a deliberate glide. Zoom and
+framing changes ride along, so a preset that reframes your camera glides
+between framings instead of popping. Sources that are new to a layout
+grow into place, and if you change scenes again mid-motion, the glide
+redirects smoothly from wherever it was.
+
+The important part: this happens in the composited output itself, not
+just the preview. The stream your viewers watch and the file you record
+show exactly the same motion — one animation, computed once, everywhere.
+
+If you prefer hard cuts, Settings has a new "Animate scene changes"
+toggle. It's on by default; systems with a reduced-motion preference
+start with it off.


### PR DESCRIPTION
Version bump to 0.9.63 + changelog for the scene-motion release (#238). changelog:check passes (66 entries valid, latest 0.9.63-beta.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scene changes now transition smoothly over 320 milliseconds with easing.
  - New sources animate into view, while motion is preserved during layout and framing changes.
  - Interrupted transitions redirect smoothly instead of stopping abruptly.
  - Animations are applied consistently in previews, live output, and recordings.
  - Added an **Animate scene changes** setting, enabled by default unless reduced motion is preferred.

- **Release**
  - Updated the desktop application to version 0.9.63.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->