### PR TITLE
fix: scene-motion glitch — settle-gated camera resync + glide-preserving commits (+ motion off by default, System access polish)

### DIFF
--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -11,9 +11,11 @@ import {
   FolderOpen,
   GearSix,
   LockKey,
+  MinusCircle,
   PaintBrush,
   Sparkle,
-  Warning
+  Warning,
+  XCircle
 } from '@phosphor-icons/react'
 import { useTheme } from 'next-themes'
 import { useEffect, useState, type ReactElement } from 'react'
@@ -229,7 +231,7 @@ export function SettingsTab({
                   </p>
                 </div>
                 <Switch
-                  checked={settings.animateSceneChanges !== false}
+                  checked={settings.animateSceneChanges === true}
                   id="animate-scene-changes"
                   onCheckedChange={(checked) =>
                     setSettings((current) => ({ ...current, animateSceneChanges: checked }))
@@ -322,24 +324,6 @@ export function SettingsTab({
                   className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-row px-2.5 py-2 text-sm"
                 >
                   <span className="w-32 shrink-0 font-medium">{row.label}</span>
-                  <StatusBadge
-                    tone={
-                      row.state === 'granted'
-                        ? 'good'
-                        : row.state === 'not-granted' || row.state === 'device-issue'
-                          ? 'warn'
-                          : 'neutral'
-                    }
-                    value={
-                      row.state === 'granted'
-                        ? 'Granted'
-                        : row.state === 'not-granted'
-                          ? 'Not granted'
-                          : row.state === 'device-issue'
-                            ? 'Device issue'
-                            : 'Checked on first use'
-                    }
-                  />
                   {/* Q4 (plan 022): the permission TARGET is the actionable part —
                       truncation clipped it to "Captur…"/"Voice a…". The row
                       flex-wraps, so let the detail take a full line when tight
@@ -364,9 +348,32 @@ export function SettingsTab({
                       variant="outline"
                       onClick={() => void openSystemPermissionSettings(row.id)}
                     >
-                      Manage settings
+                      Manage
                     </Button>
                   ) : null}
+                  {row.state === 'granted' ? (
+                    <CheckCircle
+                      aria-label={`${row.label} granted`}
+                      className="size-4 shrink-0 text-success"
+                      weight="fill"
+                    />
+                  ) : row.state === 'not-granted' || row.state === 'device-issue' ? (
+                    <XCircle
+                      aria-label={
+                        row.state === 'device-issue'
+                          ? `${row.label} device issue`
+                          : `${row.label} not granted`
+                      }
+                      className="size-4 shrink-0 text-destructive"
+                      weight="fill"
+                    />
+                  ) : (
+                    <MinusCircle
+                      aria-label={`${row.label} checked on first use`}
+                      className="size-4 shrink-0 text-muted-foreground"
+                      weight="fill"
+                    />
+                  )}
                 </div>
               )
             })}

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -2379,18 +2379,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   const [screenImportPending, setScreenImportPending] = useState(false)
   const [streamMetadataSavePending, setStreamMetadataSavePending] = useState(false)
   const [supportBundleExportPending, setSupportBundleExportPending] = useState(false)
-  const [settings, setSettings] = useState<SettingsState>(() => {
-    const loaded = loadJson(STORAGE_KEYS.settings, defaultSettings)
-    // Scene motion defaults on, but an OS-level reduced-motion preference
-    // flips the DEFAULT off until the user chooses explicitly in Settings.
-    if (
-      loaded.animateSceneChanges === undefined &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-    ) {
-      return { ...loaded, animateSceneChanges: false }
-    }
-    return loaded
-  })
+  const [settings, setSettings] = useState<SettingsState>(() =>
+    loadJson(STORAGE_KEYS.settings, defaultSettings)
+  )
   const settingsRef = useRef(settings)
   settingsRef.current = settings
   // Stable handle for callbacks that only need to READ the config (labels,
@@ -5752,9 +5743,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
             video: options?.videoOverride ?? requestedConfig.video,
             background: activeSceneBackground,
             protectedOverlayWindowIds,
-            // Scene motion: the committed layout glides into place (320ms
-            // ease) in preview, stream, and recording alike. Absent = instant.
-            ...(settingsRef.current.animateSceneChanges !== false
+            // Scene motion (opt-in): the committed layout glides into place
+            // (320ms ease) in preview, stream, and recording alike. Absent =
+            // instant cut.
+            ...(settingsRef.current.animateSceneChanges === true
               ? { transitionMs: SCENE_TRANSITION_MS }
               : {})
           })

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -44,7 +44,8 @@ export type SettingsState = {
   }
   /**
    * Scene motion: layout changes glide (320ms ease) in the live output —
-   * preview, stream, AND recording — instead of cutting. Default on.
+   * preview, stream, AND recording — instead of cutting. Default OFF while
+   * the glide's interplay with idle camera restarts settles in the field.
    */
   animateSceneChanges?: boolean
 }
@@ -325,7 +326,7 @@ export const defaultSettings: SettingsState = {
   outputDirectory: '',
   outputDirectoryHandle: undefined,
   keepOriginalRecording: false,
-  animateSceneChanges: true
+  animateSceneChanges: false
 }
 
 export const rtmpDefaults: Record<RtmpPreset, string> = {

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -823,6 +823,38 @@ fn scene_with_transition(scene: Scene, transition: &SceneTransition, now: Instan
     scene
 }
 
+/// Decide what transition a scene commit installs. A commit that asks for
+/// motion glides from the current effective transforms over the requested
+/// duration. A commit that DOESN'T mention motion (config reloads, camera
+/// installs, source rebinds routinely re-commit in the background) must not
+/// snap a running glide — it carries the glide forward from the current
+/// effective transforms across the remaining time. An explicit 0 means
+/// "instant, now" and cancels any glide.
+fn next_scene_transition(
+    transition_ms: Option<u32>,
+    previous_effective: Option<Scene>,
+    has_target_scene: bool,
+    active_remaining: Option<Duration>,
+    now: Instant,
+) -> Option<SceneTransition> {
+    if !has_target_scene {
+        return None;
+    }
+    match (transition_ms, previous_effective) {
+        (Some(duration_ms), Some(from)) if duration_ms > 0 => Some(SceneTransition {
+            from,
+            started_at: now,
+            duration: Duration::from_millis(u64::from(duration_ms.min(1_000))),
+        }),
+        (None, Some(from)) => active_remaining.map(|remaining| SceneTransition {
+            from,
+            started_at: now,
+            duration: remaining,
+        }),
+        _ => None,
+    }
+}
+
 fn snapshot_with_transition(
     snapshot: Option<CompositorSceneSnapshot>,
     transition: Option<&SceneTransition>,
@@ -1529,6 +1561,10 @@ pub async fn update_compositor_scene(
         // the new scene glides from wherever things currently are (including
         // mid-flight re-anchoring when commits interrupt a running glide).
         let now = Instant::now();
+        let active_remaining = compositor.scene_transition.as_ref().and_then(|active| {
+            let remaining = active.duration.saturating_sub(now - active.started_at);
+            (!remaining.is_zero()).then_some(remaining)
+        });
         let previous_effective = compositor.scene.as_ref().and_then(|previous| {
             previous.scene.clone().map(|previous_scene| {
                 match compositor.scene_transition.as_ref() {
@@ -1537,14 +1573,13 @@ pub async fn update_compositor_scene(
                 }
             })
         });
-        compositor.scene_transition = match (transition_ms, previous_effective, scene.as_ref()) {
-            (Some(duration_ms), Some(from), Some(_)) if duration_ms > 0 => Some(SceneTransition {
-                from,
-                started_at: now,
-                duration: Duration::from_millis(u64::from(duration_ms.min(1_000))),
-            }),
-            _ => None,
-        };
+        compositor.scene_transition = next_scene_transition(
+            transition_ms,
+            previous_effective,
+            scene.is_some(),
+            active_remaining,
+            now,
+        );
         let snapshot = CompositorSceneSnapshot {
             revision,
             scene,
@@ -3488,6 +3523,48 @@ mod scene_motion_tests {
             outputs: Vec::new(),
             background: None,
         }
+    }
+
+    #[test]
+    fn background_commit_mid_glide_carries_the_glide_forward() {
+        // Config reloads and camera installs re-commit the scene WITHOUT a
+        // transition while a glide is running. That commit must not snap —
+        // it continues from the current effective transforms across the
+        // remaining time (owner-reported 0.9.63 glitch: the glide aborted
+        // with a visible jump when the camera pipeline re-committed).
+        let now = Instant::now();
+        let from = scene_with(vec![source(
+            SceneSourceKind::Camera,
+            transform(0.4, 0.2, 0.4, 0.6),
+        )]);
+        let carried = next_scene_transition(
+            None,
+            Some(from.clone()),
+            true,
+            Some(Duration::from_millis(180)),
+            now,
+        )
+        .expect("an active glide must survive a background commit");
+        assert_eq!(carried.duration, Duration::from_millis(180));
+        assert_eq!(carried.started_at, now);
+        assert_eq!(carried.from, from);
+        // No active glide -> a background commit stays instant.
+        assert!(next_scene_transition(None, Some(from.clone()), true, None, now).is_none());
+        // An explicit 0 is a REQUEST for instant and cancels a running glide.
+        assert!(
+            next_scene_transition(
+                Some(0),
+                Some(from.clone()),
+                true,
+                Some(Duration::from_millis(180)),
+                now
+            )
+            .is_none()
+        );
+        // A motion request installs the requested duration (clamped).
+        let requested =
+            next_scene_transition(Some(5_000), Some(from), true, None, now).expect("installs");
+        assert_eq!(requested.duration, Duration::from_millis(1_000));
     }
 
     #[test]

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -60,6 +60,11 @@ use crate::state::AppState;
 /// screen. A retry within `preview_camera::CAMERA_FIRST_FRAME_REUSE_GRACE`
 /// joins the in-flight warm-up instead of restarting the device.
 const WARM_CAMERA_START_TIMEOUT: Duration = Duration::from_secs(15);
+/// How long the scene must sit still before an idle geometry resync may
+/// restart the camera. Long enough that scene browsing (and any 320ms scene
+/// glide) never cycles the device; short enough that the capture box catches
+/// up soon after the user settles on a layout.
+const CAMERA_GEOMETRY_RESYNC_SETTLE: Duration = Duration::from_secs(2);
 const WARM_SCREEN_START_TIMEOUT: Duration = Duration::from_secs(15);
 const WARM_SOURCE_POLL: Duration = Duration::from_millis(100);
 const LAYOUT_INTENT_CANCEL_POLL: Duration = Duration::from_millis(25);
@@ -1008,21 +1013,40 @@ async fn resync_camera_capture_geometry_after_commit(
     if !camera_capture_geometry_is_stale(state, &params.layout, &video).await {
         return;
     }
+    let layout = params.layout.clone();
     let start_params = PreviewCameraStartParams {
         sources: params.sources.clone(),
         layout: params.layout.clone(),
-        video,
+        video: video.clone(),
         ffmpeg_path: active_recording_ffmpeg_path(state).await,
     };
     let resync_state = state.clone();
     tokio::spawn(async move {
+        // Settle first: browsing scenes fires a commit per click, and an
+        // immediate restart per click stacks camera restarts on top of each
+        // other — overlapping warm-ups misread renegotiation buffers as color
+        // garbage and cycle the device off/on in plain view (owner-reported on
+        // 0.9.63 scene motion, same family as the 0.9.51 retry storm). Waiting
+        // out the settle window means only the LAST switch restarts the
+        // camera, well after any 320ms scene glide has landed.
+        sleep(CAMERA_GEOMETRY_RESYNC_SETTLE).await;
         let still_current = {
             let intents = resync_state.layout_intents.lock().await;
             intents.latest_intent_id == intent_id && intents.latest_needs_camera
         };
-        if still_current {
-            let _ = start_preview_camera(resync_state, start_params).await;
+        if !still_current {
+            return;
         }
+        // Re-check the world after the settle window: a session may have
+        // started (resync must stay inert mid-recording), or a newer commit
+        // may have restarted the camera into matching geometry already.
+        if resync_state.recording.lock().await.is_some() {
+            return;
+        }
+        if !camera_capture_geometry_is_stale(&resync_state, &layout, &video).await {
+            return;
+        }
+        let _ = start_preview_camera(resync_state, start_params).await;
     });
 }
 
@@ -1427,6 +1451,71 @@ mod tests {
             status.state,
             crate::protocol::PreviewCameraState::Live,
             "mid-recording resync must never restart the camera"
+        );
+        assert_eq!(
+            status.frames_captured, 42,
+            "the live session must be untouched"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn geometry_resync_settles_and_yields_to_a_newer_scene_switch() {
+        // Browsing scenes fires one commit per click. An immediate restart per
+        // click stacks camera restarts (renegotiation garbage on screen, the
+        // device cycling off/on — owner-reported on 0.9.63 scene motion). The
+        // resync must wait out the settle window and stand down when a newer
+        // intent supersedes it, so only the LAST switch can restart the camera.
+        let state = test_state();
+        let video = crate::protocol::VideoSettings {
+            preset: crate::protocol::VideoPreset::Tutorial1440p30,
+            width: 2560,
+            height: 1440,
+            fps: 30,
+            bitrate_kbps: 8000,
+        };
+        let inset_layout = default_layout_settings();
+        let mut full_layout = default_layout_settings();
+        full_layout.layout_preset = crate::protocol::LayoutPreset::CameraOnly;
+        crate::preview_camera::test_install_live_camera_for_layout(
+            &state,
+            "camera:avfoundation-native:0",
+            &inset_layout,
+            &video,
+        )
+        .await;
+        assert!(
+            camera_capture_geometry_is_stale(&state, &full_layout, &video).await,
+            "the scenario must be a real staleness case for this test to mean anything"
+        );
+
+        let needs = SceneSourceNeeds {
+            camera: true,
+            screen: false,
+        };
+        let intent_id = begin_layout_intent(&state, Some(7), needs)
+            .await
+            .expect("intent must register");
+        let params = crate::protocol::SceneConfigParams {
+            transition_ms: Some(320),
+            sources: sources(true, false),
+            layout: full_layout,
+            video: Some(video),
+            background: None,
+            protected_overlay_window_ids: Vec::new(),
+        };
+        resync_camera_capture_geometry_after_commit(&state, intent_id, &params, needs).await;
+        // The user clicks another scene before the settle window elapses.
+        begin_layout_intent(&state, Some(8), needs)
+            .await
+            .expect("newer intent must register");
+        // Run well past the settle window (paused clock auto-advances).
+        sleep(CAMERA_GEOMETRY_RESYNC_SETTLE + Duration::from_secs(1)).await;
+
+        let status = preview_camera_status(&state).await;
+        assert_eq!(
+            status.state,
+            crate::protocol::PreviewCameraState::Live,
+            "a superseded resync must never restart the camera"
         );
         assert_eq!(
             status.frames_captured, 42,


### PR DESCRIPTION
## The glitch (owner-reported on 0.9.63)

Switching scenes with motion on: the camera flashed color garbage ("those colors again") and went dark "like it's turning off and back on."

## Diagnosis

Two independent mechanisms, both traced in code:

**1. Every idle preset switch restarted the camera — and browsing scenes stacked restarts.**
`resync_camera_capture_geometry_after_commit` fires after each commit; side-by-side vs screen+camera vs camera-only all have different capture boxes, so each switch was "stale" and force-restarted the camera immediately. Clicking through scenes stacked restarts on top of each other; overlapping warm-ups misread renegotiation buffers as color garbage (same family as the 0.9.51 retry storm and the 0.9.53–0.9.57 mid-recording bug, which was only guarded while recording) and cycled the device off/on in plain view. The glide made it obvious: the camera died mid-motion.

**Fix:** the resync now sleeps a 2s settle window, then re-checks intent freshness (a newer scene switch supersedes it), recording state, and staleness before restarting. Rapid scene browsing produces exactly ONE restart, after the user settles, long after the 320ms glide has landed.

**2. Background commits mid-glide snapped the scene.**
Config reloads, camera installs, and source rebinds re-commit the scene without `transition_ms`; the transition install treated that as "instant" and killed a running glide — a visible jump right when the camera pipeline re-committed. Extracted `next_scene_transition`: a no-motion commit landing mid-glide now carries the glide forward from the current effective transforms across the REMAINING duration. An explicit `transitionMs: 0` still cancels.

## Also in this PR (owner requests)

- **"Animate scene changes" defaults OFF for now** — the toggle turns it on per user; the reduced-motion default hint is removed (meaningless with default off).
- **System access rows**: the `Granted` badge is replaced by a right-aligned status icon — green filled check (granted), red filled X (not granted / device issue), muted minus (checked on first use) — and the granted-row button is now just **"Manage"**.

## Gates

- `cargo test`: **1511 pass** — two new regression tests: `geometry_resync_settles_and_yields_to_a_newer_scene_switch` (paused-clock, superseded intent never restarts) and `background_commit_mid_glide_carries_the_glide_forward`
- clippy `-D warnings`, `cargo fmt --check`: clean
- `pnpm typecheck` / `lint` / `format:check`: clean · desktop tests **1323 pass**
- `smoke:live-layout-switch-recording` (transitions on, mid-recording switches + RTMP leg): **PASS**

## Owner acceptance

With motion ON in Settings: click through scenes quickly — the camera must keep its picture (no color garbage, no off/on cycle); the glide must complete without a snap. ~2s after you stop on a scene, the camera may do its one legitimate geometry restart (brief hold on the last frame). System access card: check icons right-aligned, "Manage" buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated settings permission indicators with clearer state-specific icons.
  * Renamed “Manage settings” to “Manage” for a simpler interface.

* **Bug Fixes**
  * Scene animations are now disabled by default unless explicitly enabled.
  * Scene transitions better preserve active motion and correctly handle instant changes.
  * Improved camera resynchronization after scene changes, reducing unnecessary restarts and stale layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->