### PR TITLE
release: 0.9.64-beta.1 — smooth scene motion, steady camera

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.63",
+  "version": "0.9.64",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.64-beta.1.md
+++ b/changelog/0.9.64-beta.1.md
@@ -1,0 +1,35 @@
+---
+version: 0.9.64-beta.1
+date: 2026-08-20
+channel: beta
+platforms:
+  - macos
+title: Smooth scene motion, steady camera
+summary: The scene-motion glitch from 0.9.63 is fixed — switching scenes no longer flashes camera color garbage or cycles the camera off and on. Scene animation is now opt-in from Settings while it settles in.
+highlights:
+  - Fixed the camera glitching on scene changes — quick scene switching used to restart the camera once per click, stacking restarts that showed color garbage and cycled the device off and on. Now the camera restarts at most once, quietly, after you settle on a scene.
+  - Scene glides no longer jump mid-motion — background scene updates used to cut a running animation short with a visible snap; they now carry the glide through.
+  - "Animate scene changes" is now off by default — flip it on in Settings when you want layout switches to glide.
+  - System access rows in Settings now show a clean green check or red X on the right, with a compact Manage button.
+---
+
+0.9.63's scene animation shipped with a rough edge: switching scenes
+could make the camera flash blocks of wrong colors and go dark for a
+moment, like the camera was turning off and back on. It was.
+
+Under the hood, every scene layout uses a differently-sized camera
+capture region, and each switch immediately restarted the camera to
+match. Clicking through scenes stacked those restarts on top of each
+other — and overlapping camera warm-ups showed up on screen as color
+garbage while the device visibly power-cycled. A second bug let routine
+background scene updates cut a running glide short with a visible jump.
+
+Both are fixed. The camera now waits until you've settled on a scene for
+a couple of seconds before doing a single, quiet geometry catch-up — the
+picture holds steady the whole time — and glides always run to
+completion. While the motion polish settles in, "Animate scene changes"
+now starts off; turn it on in Settings to get the glide.
+
+The System access section in Settings also got a cleanup: each
+permission row now shows a green check or a red X at the right edge
+instead of a text badge, with a compact Manage button.


### PR DESCRIPTION
Version bump + changelog for the scene-motion glitch fix (#240). changelog:check passes.