### PR TITLE
fix: layout-invariant camera capture (no more restarts on scene switch) + Dock icon honors the bundle icns

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7252,6 +7252,16 @@ function setDockIcon(): void {
   if (process.platform !== 'darwin') {
     return
   }
+  // Packaged builds must NOT override the Dock icon: the bundle's icon.icns
+  // is drawn on Apple's icon grid (art at ~80% with transparent margins),
+  // while this override replaced it at runtime with the full-bleed
+  // videorc-logo.png — which is why the Dock icon rendered visibly larger
+  // than every neighbor no matter how the .icns was fixed. The override only
+  // earns its keep in dev, where Electron would otherwise show its default
+  // icon.
+  if (app.isPackaged) {
+    return
+  }
 
   const icon = resolveAppIcon()
   if (icon) {

--- a/crates/videorc-backend/src/live_layout.rs
+++ b/crates/videorc-backend/src/live_layout.rs
@@ -1408,16 +1408,23 @@ mod tests {
             fps: 30,
             bitrate_kbps: 8000,
         };
-        // Installed under the inset preset; the committed scene goes
-        // full-canvas, so the capture box is genuinely stale.
-        let inset_layout = default_layout_settings();
-        let mut full_layout = default_layout_settings();
-        full_layout.layout_preset = crate::protocol::LayoutPreset::CameraOnly;
+        // Installed under a smaller output canvas; the committed scene uses a
+        // larger one, so the capture box is genuinely stale. (Capture geometry
+        // is layout-invariant — only a canvas change can arm staleness.)
+        let mut installed_video = video.clone();
+        installed_video.preset = crate::protocol::VideoPreset::Stream1080p60;
+        installed_video.width = 1920;
+        installed_video.height = 1080;
+        let full_layout = {
+            let mut layout = default_layout_settings();
+            layout.layout_preset = crate::protocol::LayoutPreset::CameraOnly;
+            layout
+        };
         crate::preview_camera::test_install_live_camera_for_layout(
             &state,
             "camera:avfoundation-native:0",
-            &inset_layout,
-            &video,
+            &default_layout_settings(),
+            &installed_video,
         )
         .await;
         assert!(
@@ -1473,14 +1480,20 @@ mod tests {
             fps: 30,
             bitrate_kbps: 8000,
         };
-        let inset_layout = default_layout_settings();
-        let mut full_layout = default_layout_settings();
-        full_layout.layout_preset = crate::protocol::LayoutPreset::CameraOnly;
+        let mut installed_video = video.clone();
+        installed_video.preset = crate::protocol::VideoPreset::Stream1080p60;
+        installed_video.width = 1920;
+        installed_video.height = 1080;
+        let full_layout = {
+            let mut layout = default_layout_settings();
+            layout.layout_preset = crate::protocol::LayoutPreset::CameraOnly;
+            layout
+        };
         crate::preview_camera::test_install_live_camera_for_layout(
             &state,
             "camera:avfoundation-native:0",
-            &inset_layout,
-            &video,
+            &default_layout_settings(),
+            &installed_video,
         )
         .await;
         assert!(

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -22,9 +22,10 @@ use crate::diagnostics::{
 use crate::ffmpeg::resolve_ffmpeg_path;
 use crate::frame_store::{FrameHandle, FrameStore, FrameStoreStats};
 use crate::preview_bmp::{LatestPreviewBmpPoll, PreviewBmpCursor, encode_latest_bgra_bmp};
+#[cfg(any(target_os = "windows", test))]
+use crate::protocol::{CameraAspect, CameraShape, CameraSize, CameraTransformMode, LayoutPreset};
 use crate::protocol::{
-    CameraAspect, CameraCapabilityFormat, CameraShape, CameraSize, CameraTransformMode,
-    LayoutPreset, LayoutSettings, PreviewCameraStartParams, PreviewCameraState,
+    CameraCapabilityFormat, LayoutSettings, PreviewCameraStartParams, PreviewCameraState,
     PreviewCameraStatus, VideoSettings,
 };
 use crate::source_registry::{SourceConsumerReason, SourceKey};
@@ -33,10 +34,10 @@ use crate::state::AppState;
 
 const PREVIEW_CAMERA_DEFAULT_PNG_WIDTH: u32 = 1280;
 const PREVIEW_CAMERA_MAX_PNG_WIDTH: u32 = 1920;
+#[cfg(any(target_os = "windows", test))]
 const CAMERA_REFERENCE_WIDTH: u32 = 1280;
+#[cfg(any(target_os = "windows", test))]
 const CAMERA_REFERENCE_HEIGHT: u32 = 720;
-const CAMERA_OVERLAY_CAPTURE_MIN_WIDTH: u32 = 1280;
-const CAMERA_OVERLAY_CAPTURE_MIN_HEIGHT: u32 = 720;
 const CAMERA_CAPTURE_CPU_COPY_ENV: &str = "VIDEORC_CAMERA_CAPTURE_CPU_COPY";
 const WINDOWS_CAMERA_PREVIEW_STARTUP_TIMEOUT: Duration = Duration::from_secs(12);
 #[cfg(any(target_os = "windows", test))]
@@ -1601,29 +1602,23 @@ fn windows_camera_mjpeg_capture_modes(width: u32, height: u32) -> Vec<(u32, u32)
     modes
 }
 
-fn camera_capture_target_dimensions(layout: &LayoutSettings, video: &VideoSettings) -> (u32, u32) {
-    // Only the inset scenes (ScreenCamera + its vertical twin) render the
-    // camera as a small overlay box; everywhere else the camera can span the
-    // canvas, so capture at full output size.
-    if !matches!(
-        layout.layout_preset,
-        LayoutPreset::ScreenCamera | LayoutPreset::VerticalScreenCamera
-    ) {
-        return (video.width, video.height);
-    }
-
-    let (overlay_width, overlay_height) = camera_overlay_target_dimensions(layout, video);
-
-    (
-        overlay_width
-            .max(CAMERA_OVERLAY_CAPTURE_MIN_WIDTH)
-            .min(video.width.max(1)),
-        overlay_height
-            .max(CAMERA_OVERLAY_CAPTURE_MIN_HEIGHT)
-            .min(video.height.max(1)),
-    )
+fn camera_capture_target_dimensions(_layout: &LayoutSettings, video: &VideoSettings) -> (u32, u32) {
+    // Capture geometry is LAYOUT-INVARIANT on purpose: always the full output
+    // canvas, for every preset. The inset scenes used to capture a small
+    // overlay box as an optimization, which made camera-only <-> screen+camera
+    // the one preset pair whose capture boxes differed — so exactly those
+    // switches force-restarted the camera (device power-cycles, renegotiation
+    // garbage on screen; owner-reported through 0.9.64). The compositor's
+    // scene math scales the full-size frame into any inset, capturing big and
+    // scaling down only improves inset quality, and a preset switch can now
+    // NEVER invalidate a running camera session. Only genuine output-canvas
+    // changes (video preset/orientation) re-derive capture geometry.
+    // The Windows D3D11 overlay path does its own overlay sizing in
+    // windows_camera_preview_output_dimensions.
+    (video.width, video.height)
 }
 
+#[cfg(any(target_os = "windows", test))]
 fn camera_overlay_target_dimensions(layout: &LayoutSettings, video: &VideoSettings) -> (u32, u32) {
     if let (CameraTransformMode::Custom, Some(transform)) =
         (layout.camera_transform_mode, layout.camera_transform)
@@ -1646,6 +1641,7 @@ fn camera_overlay_target_dimensions(layout: &LayoutSettings, video: &VideoSettin
     }
 }
 
+#[cfg(any(target_os = "windows", test))]
 fn scaled_camera_box_size(
     size: &CameraSize,
     shape: &CameraShape,
@@ -1675,11 +1671,13 @@ fn scaled_camera_box_size(
     )
 }
 
+#[cfg(any(target_os = "windows", test))]
 fn camera_output_scale(video: &VideoSettings) -> f64 {
     (f64::from(video.width) / f64::from(CAMERA_REFERENCE_WIDTH))
         .min(f64::from(video.height) / f64::from(CAMERA_REFERENCE_HEIGHT))
 }
 
+#[cfg(any(target_os = "windows", test))]
 fn scale_camera_dimension(value: f64) -> u32 {
     value.round().max(1.0).min(f64::from(u32::MAX)) as u32
 }
@@ -3211,15 +3209,20 @@ mod tests {
     }
 
     #[test]
-    fn screen_camera_overlay_capture_target_uses_overlay_quality_floor() {
+    fn screen_camera_capture_target_keeps_output_resolution() {
+        // Capture geometry is layout-invariant: the inset preset captures the
+        // SAME full canvas as every other preset, so a camera-only <->
+        // screen+camera switch can never invalidate a running camera session
+        // (owner-reported restarts with renegotiation garbage through 0.9.64).
         let mut layout = test_layout(false);
         layout.layout_preset = LayoutPreset::ScreenCamera;
         layout.camera_size = CameraSize::Medium;
         layout.camera_shape = CameraShape::Rectangle;
+        let video = test_video();
 
         assert_eq!(
-            camera_capture_target_dimensions(&layout, &test_video()),
-            (1280, 720)
+            camera_capture_target_dimensions(&layout, &video),
+            (video.width, video.height)
         );
     }
 
@@ -3454,20 +3457,32 @@ mod tests {
     }
     #[tokio::test]
     async fn reuse_refuses_a_session_with_stale_capture_geometry() {
-        // A hot preset switch (inset overlay <-> full canvas) changes the
-        // derived capture box. The running session keeps delivering frames
-        // sized for the old scene, so reuse must force a restart instead of
-        // adopting them.
+        // Capture geometry is layout-invariant, so only a genuine output
+        // canvas change (video preset/orientation) can make it stale. A
+        // session capturing the old canvas keeps delivering frames sized for
+        // it, so reuse must force a restart instead of adopting them.
         let state = test_state();
         let video = test_video();
+        let mut larger_canvas = test_video();
+        larger_canvas.preset = VideoPreset::Tutorial1440p30;
+        larger_canvas.width = 2560;
+        larger_canvas.height = 1440;
         let source_key = SourceKey::camera("camera:avfoundation-native:test");
         let full_canvas_layout = test_layout(false);
-        let mut inset_layout = test_layout(false);
-        inset_layout.layout_preset = LayoutPreset::ScreenCamera;
-        assert_ne!(
+        let inset_layout = {
+            let mut layout = test_layout(false);
+            layout.layout_preset = LayoutPreset::ScreenCamera;
+            layout
+        };
+        assert_eq!(
             camera_capture_target_dimensions(&full_canvas_layout, &video),
             camera_capture_target_dimensions(&inset_layout, &video),
-            "the two presets must derive different capture boxes for this test"
+            "presets must share ONE capture box — a preset switch never restarts the camera"
+        );
+        assert_ne!(
+            camera_capture_target_dimensions(&full_canvas_layout, &video),
+            camera_capture_target_dimensions(&full_canvas_layout, &larger_canvas),
+            "an output canvas change must derive a different capture box for this test"
         );
         let (stop_tx, _stop_rx) = std_mpsc::channel();
         {
@@ -3492,20 +3507,24 @@ mod tests {
                 &source_key,
                 "ffmpeg",
                 &full_canvas_layout,
-                &video,
-                video.fps
+                &larger_canvas,
+                larger_canvas.fps
             )
             .await
             .is_none(),
             "a capture-geometry mismatch must not be reused"
         );
         assert!(
-            camera_capture_geometry_is_stale(&state, &full_canvas_layout, &video).await,
+            camera_capture_geometry_is_stale(&state, &full_canvas_layout, &larger_canvas).await,
             "the staleness probe must agree with reuse"
         );
         assert!(
+            !camera_capture_geometry_is_stale(&state, &full_canvas_layout, &video).await,
+            "the same canvas must not report stale — regardless of preset"
+        );
+        assert!(
             !camera_capture_geometry_is_stale(&state, &inset_layout, &video).await,
-            "matching geometry must not report stale"
+            "a preset switch alone must NEVER report stale"
         );
     }
 


### PR DESCRIPTION
## Camera glitch on camera ↔ screen+camera (owner-reported, survived 0.9.64)

**Why exactly that pair:** `camera_capture_target_dimensions` captured the full output canvas for every preset EXCEPT ScreenCamera/VerticalScreenCamera, which captured a small overlay box. So camera-only ↔ screen+camera was the *only* switch pair whose capture geometry differed — and the geometry resync that reconciled it restarted the camera. 0.9.64's settle-gate collapsed restart *stacking*, but the single legitimate restart still power-cycles the device (LED off/on, renegotiation garbage) in plain view. The owner's report names exactly this pair, both directions.

**Fix — capture geometry is now layout-invariant:** every preset captures the full output canvas. The compositor's scene math already scales the frame into any inset (capturing big and scaling down *improves* inset quality — supersampling), and a preset switch can now **never** invalidate a running camera session — no restart, no glitch, in idle and live alike. Only genuine output-canvas changes (video preset / orientation flip) re-derive capture geometry, and those still go through 0.9.64's settle-gated, superseded-intent-aware resync.

- Windows D3D11 overlay path unchanged: `windows_camera_preview_output_dimensions` keeps its own overlay sizing (verified byte-identical by the existing overlay-sized BGRA buffer test); the overlay helpers are now cfg-gated to `windows/test`. No cfg(windows) signatures changed.
- Tests pin the invariant: preset pairs must share ONE capture box ("a preset switch alone must NEVER report stale"); staleness/reuse tests arm via canvas change instead.

## Dock icon still oversized (owner-reported, survived the 0.9.59 icns fix)

The icns was never the problem — I measured `build-resources/icon.icns`: art sits at exactly **80.5%** (824/1024, Apple's icon grid) with transparent rounded corners. The real culprit: `setDockIcon()` ran on every launch and **overrode the Dock icon at runtime** with the full-bleed 256px `videorc-logo.png` (92% content, no grid margins) via `app.dock.setIcon` — so no icns fix could ever show up. Packaged builds no longer override the Dock icon; the bundle's icns wins. Dev keeps the override so Electron's default icon doesn't show.

## Gates

- `cargo test`: **1511 pass** · clippy `-D warnings` · `fmt --check`: clean
- `pnpm typecheck` / `lint` / `format:check`: clean · desktop tests **1323 pass**
- `smoke:recording-matrix`: **12/12** · `smoke:live-layout-switch-recording` (transitions on): **PASS**

## Owner acceptance

After update: turn motion on, click camera ↔ screen+camera repeatedly — the camera LED must stay ON and the picture must never flash colors or go dark. The Dock icon should now sit at the same visual size as its neighbors (if it still looks big immediately after update, macOS may briefly serve a cached tile — it settles; `killall Dock` forces it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Packaged macOS builds now retain the properly formatted application icon in the Dock.
  * Camera previews now maintain consistent capture dimensions when layout presets change.
  * Camera reuse and refresh behavior now correctly responds to actual video canvas size changes.

* **Tests**
  * Updated camera layout tests to validate canvas-size changes independently from layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->