### PR TITLE
release: 0.9.65-beta.1 — the camera never blinks on scene changes

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.64",
+  "version": "0.9.65",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.65-beta.1.md
+++ b/changelog/0.9.65-beta.1.md
@@ -1,0 +1,33 @@
+---
+version: 0.9.65-beta.1
+date: 2026-08-20
+channel: beta
+platforms:
+  - macos
+title: The camera never blinks on scene changes
+summary: Scene switches can no longer restart the camera at all — the last cause of the camera flashing colors or going dark on camera ↔ screen + camera switches is gone. The app icon also finally sits at the proper macOS Dock size.
+highlights:
+  - Switching between camera-only and screen + camera no longer restarts the camera — the one preset pair that still power-cycled the device (colors, brief blackout) now shares the same capture geometry as every other scene, so the picture holds rock-steady through any switch.
+  - Camera quality in the screen + camera overlay actually improves — the camera now captures at full canvas size and scales down into the corner instead of capturing small.
+  - The Dock icon now renders at the proper macOS size — a runtime override had been quietly replacing the correctly-sized icon with a full-bleed logo on every launch since the beginning. If it still looks big right after updating, macOS is showing a cached tile; it settles on its own.
+---
+
+0.9.64 calmed the camera down on scene changes, but one pair of scenes
+still glitched: camera-only ↔ screen + camera. Under the hood, screen +
+camera was the single layout that captured the camera at a small
+overlay size while every other scene captured the full canvas — so
+exactly that switch changed the camera's capture geometry and forced a
+device restart, with the familiar color flash and blackout.
+
+That difference is now gone entirely. The camera captures at full
+canvas size in every scene, and the compositor scales it into the
+corner when needed — which also means the overlay picture is sharper,
+since it downscales a bigger frame. A scene switch can no longer
+invalidate the camera session under any circumstances: no restart, no
+colors, no blink, whether you're idle, recording, or live.
+
+And a long-standing cosmetic bug is finally dead: the app's Dock icon
+has rendered oversized since day one — not because the icon file was
+wrong (it's been drawn on Apple's icon grid since 0.9.59), but because
+the app was quietly replacing it at runtime with a full-bleed logo on
+every launch. It no longer does; the properly-sized icon wins.


### PR DESCRIPTION
Version bump + changelog for layout-invariant camera capture + Dock icon fix (#242). changelog:check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the 0.9.65 beta release for macOS.

- **Bug Fixes**
  - Scene changes no longer restart or disrupt the camera.
  - Screen-and-camera captures now scale more sharply.
  - Fixed an issue where the Dock icon could be replaced by an oversized runtime logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->