### PR TITLE
release: 0.9.66-beta.1 — meet the co-host (alpha)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.65",
+  "version": "0.9.66",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.66-beta.1.md
+++ b/changelog/0.9.66-beta.1.md
@@ -1,0 +1,43 @@
+---
+version: 0.9.66-beta.1
+date: 2026-08-22
+channel: beta
+platforms:
+  - macos
+title: Meet the co-host — an AI producer for your live chat (alpha)
+summary: Premium gets a live co-host that reads your chat while you stream, groups the questions people are actually asking, drafts replies you approve with one key, and flags messages that need a moderator's eye. Nothing is ever sent without you.
+highlights:
+  - The Comments window gains a Co-host pane (alpha, Premium) — unanswered questions from Twitch and YouTube are grouped across platforms and phrasings ("5 people asking what keyboard"), ranked, and kept until you answer or dismiss them.
+  - Press R on a question to get a drafted reply in the composer, edit it, and send with ⌘↩ — it goes to every writable platform through the normal fan-out and the question clears itself. The co-host never posts on its own.
+  - Press H to show the question on stream for ten seconds using the existing comment highlight; A marks it answered, ⌫ dismisses, ⌘J jumps to the pane.
+  - Teach it your FAQs — Settings → Co-host has a notes box; questions it can answer from your notes come with the answer pre-drafted and marked as such.
+  - Messages that look toxic, spammy, or self-promotional are flagged with a reason; the co-host only points, it never deletes or times anyone out.
+  - It only works while chat is actually moving — an idle chat makes zero AI calls, and it pauses honestly when you're signed out, out of Premium, out of daily quota, or haven't turned on cloud AI.
+---
+
+This is the first Premium feature that works *during* the stream instead
+of after it. Reading chat while performing is the thing a solo streamer
+can't do well, so the co-host does the producer's job: it watches the
+unified Twitch + YouTube chat, groups duplicate questions no matter how
+they're phrased or which platform they came from, ranks them, and drafts
+a reply for each one.
+
+You stay in charge of every word. A draft lands in the composer only when
+you ask for it (R), you edit it like any message, and ⌘↩ sends it through
+the same per-platform fan-out the composer has always used. When the send
+goes out, the question clears itself. H puts the question on stream for
+ten seconds via the existing comment highlight; A and ⌫ clear questions by
+hand; ⌘J focuses the pane from anywhere in the Comments window.
+
+Settings → Co-host holds the switch, a tone picker, and a notes box — the
+place to write "keyboard: Keychron Q1, mic: SM7B, editor: Neovim" once so
+the co-host can draft those answers for you every stream. It also lists
+messages that look toxic, spammy, or self-promotional with a one-line
+reason; it never deletes or times anyone out.
+
+It's marked alpha for a reason: grouping quality and draft tone will be
+tuned on real streams, X chat stays read-only until X's chat send lands,
+and drafts are trimmed to each platform's limit. The co-host makes one
+small AI call every few seconds of active chat and none at all while chat
+is quiet, counted against a daily Premium allowance, only after you've
+turned on cloud AI in Publish.


### PR DESCRIPTION
Version bump 0.9.65 → 0.9.66 and the macOS beta changelog entry for the live chat co-host (alpha, Premium) shipped in #245 (web: videorc-web #11, deployed; migration 0012 applied on Neon). Windows Alpha entry is intentionally NOT added — the Windows lane stays blocked on the Azure identity validation.