### PR TITLE
Linux L1.5: add LGPL VAAPI/OpenH264 encoder policy

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,8 +1,8 @@
 name: Linux
 
-# Linux L1 is a compile-and-test gate, not a shipping application claim.
-# Capture, preview, encoding, packaging, and device acceptance land in later
-# phases tracked by docs/linux-port-plan.md.
+# Linux L1.5 adds the production encoder policy to the compile-and-test gate.
+# It still is not a shipping application claim: capture, preview, packaging,
+# and real-device acceptance land in later phases tracked by the port plan.
 
 on:
   push:
@@ -15,12 +15,33 @@ concurrency:
 
 jobs:
   gates:
-    name: Linux gates (Rust compile + test)
+    name: Linux gates (FFmpeg policy + Rust compile/test)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Cache pinned Linux FFmpeg
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor/ffmpeg/_build
+            vendor/ffmpeg/linux-x64
+          key: linux-ffmpeg-${{ hashFiles('vendor/ffmpeg/linux-pin.json') }}
+
+      - name: Test Linux FFmpeg policy
+        run: node --test scripts/lib/ffmpeg-linux-pin.test.mjs
+
+      - name: Fetch and verify pinned Linux FFmpeg
+        # This executes the staged Linux binary and fails closed unless its
+        # configure flags and encoder table prove LGPL-only VAAPI + OpenH264.
+        run: node scripts/fetch-ffmpeg-linux.mjs
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -33,7 +54,7 @@ jobs:
       - name: Clippy
         # clippy -D warnings is the compile gate (compile errors fail it
         # regardless of the lint allows), matching ci.yml and windows.yml —
-        # no separate cargo check, no pnpm (nothing in this job runs JS), and
+        # no separate cargo check, no pnpm (the JS steps use Node directly), and
         # no fmt (rustfmt output is platform-independent; ci.yml owns it).
         # cfg(linux) makes macOS/Windows-only helpers dead or their imports
         # unused. Keep this allow list identical to windows.yml while the

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ vendor/ffmpeg/_src/
 vendor/ffmpeg/current/
 vendor/ffmpeg/macos-*/
 vendor/ffmpeg/windows-x64/
+vendor/ffmpeg/linux-x64/
 docs/acceptance/artifacts/
 
 .DS_Store

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7638,14 +7638,16 @@ function resolveBackendPermissionTargetPath(): string {
 }
 
 function resolvePackagedFfmpegBinDir(): string | null {
-  // Dev mode on Windows: use the pinned vendor FFmpeg from
-  // `pnpm ffmpeg:fetch:windows` when present, so development does not depend
-  // on a system-wide ffmpeg install. macOS dev keeps resolving via PATH.
+  // Dev mode on Windows and Linux: use the platform's pinned vendor FFmpeg
+  // when present, so runtime capability probes exercise the exact binary that
+  // will be packaged. macOS dev keeps resolving via PATH.
   const binDir = app.isPackaged
     ? join(process.resourcesPath, 'ffmpeg', 'bin')
     : process.platform === 'win32'
       ? join(workspaceRoot(), 'vendor', 'ffmpeg', 'windows-x64', 'bin')
-      : null
+      : process.platform === 'linux'
+        ? join(workspaceRoot(), 'vendor', 'ffmpeg', 'linux-x64', 'bin')
+        : null
   if (!binDir) {
     return null
   }

--- a/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
@@ -1304,6 +1304,8 @@ function formatEncodeBackend(backend?: string): string {
       return 'Software (x264)'
     case 'hardware-videotoolbox':
       return 'Hardware (VideoToolbox)'
+    case 'hardware-vaapi':
+      return 'Hardware (VAAPI)'
     case 'hardware-media-foundation':
       return 'Hardware (MediaFoundation)'
     case 'software-media-foundation':

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -368,6 +368,7 @@ const streamOutputBridgeSchema = enumSchema([
 const encodeBackendSchema = enumSchema([
   'software-x264',
   'hardware-videotoolbox',
+  'hardware-vaapi',
   'hardware-media-foundation',
   'software-media-foundation',
   'software-open-h264'

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1239,10 +1239,11 @@ export type PreviewTransport =
 export type EncodeBackend =
   | 'software-x264'
   | 'hardware-videotoolbox'
+  | 'hardware-vaapi'
   | 'hardware-media-foundation'
   | 'software-media-foundation'
-  // libopenh264 software fallback on Windows — software Media Foundation ran
-  // below realtime on real devices (issue #149).
+  // libopenh264 software fallback on Windows and Linux. On Linux it is the
+  // required LGPL fallback when no DRM render node passes the VAAPI probe.
   | 'software-open-h264'
 
 export type StreamOutputTopologyRole = 'shared' | 'recording' | 'stream'

--- a/crates/videorc-backend/src/camera_capture.rs
+++ b/crates/videorc-backend/src/camera_capture.rs
@@ -232,7 +232,9 @@ fn decode_hex(value: &str) -> Option<Vec<u8>> {
 
     value
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|chunk| {
             let high = hex_value(chunk[0])?;
             let low = hex_value(chunk[1])?;

--- a/crates/videorc-backend/src/captions.rs
+++ b/crates/videorc-backend/src/captions.rs
@@ -252,7 +252,9 @@ pub fn downmix_resample_to_16k_mono(samples: &[f32], channels: u16, sample_rate:
         .chunks_exact(channels)
         .map(|frame| frame.iter().sum::<f32>() / channels as f32)
         .collect();
-    mono.chunks_exact(3)
+    mono.as_chunks::<3>()
+        .0
+        .iter()
         .map(|window| {
             let value = (window[0] + window[1] + window[2]) / 3.0;
             (value.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16
@@ -1496,7 +1498,9 @@ fn decode_caption_overlay(png_base64: &str) -> Result<DecodedCaptionOverlay> {
 
     let rgba = Arc::new(image.into_raw());
     let bgra = Arc::new(
-        rgba.chunks_exact(4)
+        rgba.as_chunks::<4>()
+            .0
+            .iter()
             .flat_map(|pixel| [pixel[2], pixel[1], pixel[0], pixel[3]])
             .collect(),
     );

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -3332,7 +3332,7 @@ fn synthetic_hard_content_bgra(
     let mut bytes = vec![0; width * height * 4];
     // Deterministic per (frame, run): reproducible artifacts, zero skip blocks.
     let mut rng = sequence.wrapping_mul(0x9E37_79B9_7F4A_7C15).max(1);
-    for pixel in bytes.chunks_exact_mut(4) {
+    for pixel in bytes.as_chunks_mut::<4>().0 {
         let noise = xorshift64(&mut rng);
         pixel[0] = noise as u8;
         pixel[1] = (noise >> 8) as u8;
@@ -3689,7 +3689,7 @@ fn rgba_to_bgra_bytes(rgba: &[u8]) -> Vec<u8> {
 }
 
 fn rgba_to_bgra_in_place(bytes: &mut [u8]) {
-    for pixel in bytes.chunks_exact_mut(4) {
+    for pixel in bytes.as_chunks_mut::<4>().0 {
         pixel.swap(0, 2);
     }
 }

--- a/crates/videorc-backend/src/live_render.rs
+++ b/crates/videorc-backend/src/live_render.rs
@@ -128,7 +128,9 @@ impl SourceFrame {
     /// Builds a frame from interleaved rgb24 bytes (one captured rawvideo frame).
     pub fn from_rgb24(width: usize, height: usize, bytes: &[u8]) -> Self {
         let pixels = bytes
-            .chunks_exact(3)
+            .as_chunks::<3>()
+            .0
+            .iter()
             .map(|chunk| [chunk[0], chunk[1], chunk[2]])
             .collect();
         Self {

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -879,7 +879,7 @@ fn encode_preview_camera_png(
         return None;
     }
     let mut rgba = Vec::with_capacity(frame.bytes.len());
-    for pixel in frame.bytes.chunks_exact(4) {
+    for pixel in frame.bytes.as_chunks::<4>().0 {
         rgba.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
     }
     if layout.camera_mirror {
@@ -2057,7 +2057,7 @@ fn nv12_to_bgra(
             }
             let y_row = &y[row * y_stride..];
             let cbcr_row = &cbcr[(row / 2) * cbcr_stride..];
-            for (x, pixel) in out_row.chunks_exact_mut(4).enumerate() {
+            for (x, pixel) in out_row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
                 let chroma = (x / 2) * 2;
                 let (b, g, r) = if full_range {
                     ycbcr_bt709_full_to_bgr(y_row[x], cbcr_row[chroma], cbcr_row[chroma + 1])
@@ -2091,7 +2091,7 @@ fn yuv422_to_bgra(
                 return;
             }
             let src = &plane[row * stride..];
-            for (pair, out8) in out_row.chunks_exact_mut(8).enumerate() {
+            for (pair, out8) in out_row.as_chunks_mut::<8>().0.iter_mut().enumerate() {
                 let i = pair * 4;
                 let (cb, y0, cr, y1) = if uyvy {
                     (src[i], src[i + 1], src[i + 2], src[i + 3])

--- a/crates/videorc-backend/src/preview_screen.rs
+++ b/crates/videorc-backend/src/preview_screen.rs
@@ -976,7 +976,7 @@ fn encode_preview_screen_png(
         return None;
     }
     let mut rgba = Vec::with_capacity(frame.bytes.len());
-    for pixel in frame.bytes.chunks_exact(4) {
+    for pixel in frame.bytes.as_chunks::<4>().0 {
         rgba.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
     }
     let (rgba, width, height) =

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1225,21 +1225,20 @@ pub struct StreamHealth {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum EncodeBackend {
-    /// libx264 (software). LEGACY: no code path selects this since the Linux
-    /// L1 port removed the non-macOS/non-Windows fallback — Linux returns a
-    /// typed PlatformEncoderUnsupported instead, and the LGPL-only ffmpeg
-    /// policy forbids reintroducing GPL x264. Kept only so historical
+    /// libx264 (software). LEGACY: no code path selects this; Linux L1.5 uses
+    /// OpenH264 for its LGPL software fallback. Kept only so historical
     /// diagnostics payloads still deserialize.
     SoftwareX264,
     /// h264_videotoolbox (hardware, sw fallback allowed).
     HardwareVideotoolbox,
+    /// h264_vaapi on a capability-probed Linux DRM render node.
+    HardwareVaapi,
     /// h264_mf (MediaFoundation hardware/software hybrid), used by Windows builds.
     HardwareMediaFoundation,
     /// h264_mf's software MFT fallback after the exact hardware profile probe failed.
     SoftwareMediaFoundation,
-    /// libopenh264 (software), the Windows fallback after the hardware probe
-    /// failed — software Media Foundation ran below realtime on real devices
-    /// (issue #149).
+    /// libopenh264 (software): the Linux LGPL fallback and the Windows fallback
+    /// after the hardware probe failed (issue #149).
     SoftwareOpenH264,
 }
 
@@ -3977,7 +3976,11 @@ mod tests {
     }
 
     #[test]
-    fn media_foundation_backends_match_the_desktop_wire_contract() {
+    fn h264_backends_match_the_desktop_wire_contract() {
+        assert_eq!(
+            serde_json::to_value(EncodeBackend::HardwareVaapi).unwrap(),
+            serde_json::json!("hardware-vaapi")
+        );
         assert_eq!(
             serde_json::to_value(EncodeBackend::HardwareMediaFoundation).unwrap(),
             serde_json::json!("hardware-media-foundation")

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -2271,6 +2271,7 @@ pub async fn start_session(
     {
         let camera_overlay = if matches!(params.layout.layout_preset, LayoutPreset::ScreenCamera) {
             let scene = scene_from_capture_config(SceneConfigParams {
+                transition_ms: None,
                 sources: params.sources.clone(),
                 layout: params.layout.clone(),
                 video: Some(params.output.video.clone()),

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -1789,7 +1789,10 @@ pub async fn start_session(
         state.emit_log(
             "warn",
             format!(
-                "Using the OpenH264 software H.264 fallback after the requested Media Foundation encoded bridge was rejected: {reason}"
+                "Using the {} FFmpeg H.264 fallback after the requested Media Foundation encoded bridge was rejected: {reason}",
+                encode_backend_label(Some(
+                    windows_encoded_bridge_decision.effective_encode_backend
+                ))
             ),
         );
     } else if matches!(
@@ -1808,6 +1811,26 @@ pub async fn start_session(
                     .input_subtype
                     .as_deref()
                     .unwrap_or("<unknown>")
+            ),
+        );
+    } else if let Some(reason) = windows_encoded_bridge_decision
+        .encoder_selection_fallback_reason
+        .as_deref()
+    {
+        // Software fallback is an expected, fully supported Linux posture.
+        // Keep it visible in logs and diagnostics without raising a health
+        // warning or user-facing toast.
+        state.emit_log("info", reason);
+    } else if let Some(device) = windows_encoded_bridge_decision
+        .fallback_ffmpeg_encoder
+        .vaapi_device
+        .as_deref()
+    {
+        state.emit_log(
+            "info",
+            format!(
+                "VAAPI H.264 encoder selected after probing {}.",
+                device.display()
             ),
         );
     }
@@ -2167,7 +2190,14 @@ pub async fn start_session(
     initial_diagnostics.encoder_bridge_encoded_output_input_subtype =
         windows_encoded_bridge_decision.input_subtype.clone();
     initial_diagnostics.encoder_bridge_encoded_output_fallback_reason =
-        windows_encoded_bridge_decision.fallback_reason.clone();
+        windows_encoded_bridge_decision
+            .fallback_reason
+            .clone()
+            .or_else(|| {
+                windows_encoded_bridge_decision
+                    .encoder_selection_fallback_reason
+                    .clone()
+            });
     initial_diagnostics.recording_protected = use_encoder_bridge;
     #[cfg(target_os = "windows")]
     {
@@ -2482,12 +2512,13 @@ pub async fn start_session(
             .as_deref()
             .context("Encoder bridge FIFO path was not prepared")?;
         if params.output.record_enabled && !params.output.stream_enabled {
-            bridge_recording_ffmpeg_args(
+            bridge_recording_ffmpeg_args_with_encoder(
                 &capture,
                 &params,
                 output_path.as_deref(),
                 fifo_path,
                 encoder_bridge_video_output,
+                &windows_encoded_bridge_decision.fallback_ffmpeg_encoder,
             )?
         } else if let (Some(stream_output), Some(stream_fifo_path)) = (
             encoder_bridge_stream_output,
@@ -2504,22 +2535,24 @@ pub async fn start_session(
                 stream_output,
             )?
         } else {
-            bridge_compositor_ffmpeg_args(
+            bridge_compositor_ffmpeg_args_with_encoder(
                 &capture,
                 &params,
                 output_path.as_deref(),
                 &stream_targets,
                 fifo_path,
                 encoder_bridge_video_output,
+                &windows_encoded_bridge_decision.fallback_ffmpeg_encoder,
             )?
         }
     } else {
-        ffmpeg_args(
+        ffmpeg_args_with_encoder(
             &capture,
             &params,
             output_path.as_deref(),
             &stream_targets,
             screen_overlay.as_ref(),
+            &windows_encoded_bridge_decision.fallback_ffmpeg_encoder,
         )?
     };
     let ffmpeg_live_audio_filter_count = ffmpeg_live_microphone_filter_count(&args);
@@ -7426,6 +7459,8 @@ fn bool_label(value: bool) -> &'static str {
 #[allow(dead_code)]
 enum FfmpegH264Platform {
     Macos,
+    LinuxVaapi,
+    LinuxSoftware,
     WindowsHardware,
     WindowsSoftware,
 }
@@ -7440,9 +7475,52 @@ enum RuntimePlatform {
 }
 
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
-#[error("H.264 encoding is unsupported on {platform} at Linux port level L1")]
+#[error("H.264 encoding is unsupported on {platform}")]
 struct PlatformEncoderUnsupported {
     platform: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedFfmpegH264Encoder {
+    platform: FfmpegH264Platform,
+    vaapi_device: Option<PathBuf>,
+    fallback_reason: Option<String>,
+}
+
+impl ResolvedFfmpegH264Encoder {
+    fn for_platform(platform: FfmpegH264Platform) -> Self {
+        Self {
+            platform,
+            vaapi_device: None,
+            fallback_reason: None,
+        }
+    }
+
+    fn backend(&self) -> EncodeBackend {
+        ffmpeg_h264_encoder(self.platform).backend
+    }
+}
+
+#[cfg(any(test, target_os = "linux"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinuxH264EncoderPreference {
+    Auto,
+    Vaapi,
+    OpenH264,
+}
+
+#[cfg(any(test, target_os = "linux"))]
+impl LinuxH264EncoderPreference {
+    fn parse(value: Option<&str>) -> std::result::Result<Self, String> {
+        match value.map(str::trim).filter(|value| !value.is_empty()) {
+            None | Some("auto") => Ok(Self::Auto),
+            Some("vaapi") => Ok(Self::Vaapi),
+            Some("openh264") => Ok(Self::OpenH264),
+            Some(value) => Err(format!(
+                "VIDEORC_LINUX_H264_ENCODER must be auto, vaapi, or openh264; got {value}"
+            )),
+        }
+    }
 }
 
 fn ffmpeg_h264_platform_for_target(
@@ -7451,7 +7529,10 @@ fn ffmpeg_h264_platform_for_target(
     match target {
         RuntimePlatform::Macos => Ok(FfmpegH264Platform::Macos),
         RuntimePlatform::Windows => Ok(FfmpegH264Platform::WindowsSoftware),
-        RuntimePlatform::Linux => Err(PlatformEncoderUnsupported { platform: "Linux" }),
+        // The synchronous default is the portable LGPL fallback. Session
+        // startup replaces it with LinuxVaapi only after a real render-node
+        // encode probe succeeds for the exact bundled FFmpeg binary.
+        RuntimePlatform::Linux => Ok(FfmpegH264Platform::LinuxSoftware),
         RuntimePlatform::Other => Err(PlatformEncoderUnsupported {
             platform: "this platform",
         }),
@@ -7615,8 +7696,8 @@ fn current_ffmpeg_h264_platform()
         // Cross-platform unit tests exercise the REAL Windows software
         // encoder table (OpenH264) rather than a test-only twin: a private
         // variant duplicating those args would silently go stale the next
-        // time the #149-tuned OpenH264 args change. The runtime selector's
-        // Linux refusal is covered separately via RuntimePlatform::Linux.
+        // time the #149-tuned OpenH264 args change. Linux's portable default
+        // and runtime selector are covered explicitly below.
         Ok(FfmpegH264Platform::WindowsSoftware)
     }
     #[cfg(all(
@@ -7649,6 +7730,16 @@ fn ffmpeg_h264_encoder(platform: FfmpegH264Platform) -> FfmpegH264Encoder {
             codec: "h264_videotoolbox",
             pix_fmt: "yuv420p",
             backend: EncodeBackend::HardwareVideotoolbox,
+        },
+        FfmpegH264Platform::LinuxVaapi => FfmpegH264Encoder {
+            codec: "h264_vaapi",
+            pix_fmt: "vaapi",
+            backend: EncodeBackend::HardwareVaapi,
+        },
+        FfmpegH264Platform::LinuxSoftware => FfmpegH264Encoder {
+            codec: "libopenh264",
+            pix_fmt: "yuv420p",
+            backend: EncodeBackend::SoftwareOpenH264,
         },
         FfmpegH264Platform::WindowsHardware => FfmpegH264Encoder {
             codec: "h264_mf",
@@ -7716,37 +7807,170 @@ fn windows_media_foundation_hardware_probe_args(video: &VideoSettings) -> Vec<St
 #[cfg(target_os = "windows")]
 const WINDOWS_MEDIA_FOUNDATION_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 
-fn default_h264_encode_backend() -> std::result::Result<EncodeBackend, PlatformEncoderUnsupported> {
-    Ok(ffmpeg_h264_encoder(current_ffmpeg_h264_platform()?).backend)
+#[cfg(any(test, target_os = "linux"))]
+fn linux_render_device_candidates_in(dri_directory: &Path) -> Vec<PathBuf> {
+    let mut devices = std::fs::read_dir(dri_directory)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let name = name.to_str()?;
+            let suffix = name.strip_prefix("renderD")?;
+            suffix
+                .chars()
+                .all(|character| character.is_ascii_digit())
+                .then(|| entry.path())
+        })
+        .collect::<Vec<_>>();
+    devices.sort();
+    devices
 }
 
-fn append_h264_encoding_args(
-    args: &mut Vec<String>,
-    video: &VideoSettings,
-    low_latency: bool,
-) -> std::result::Result<(), PlatformEncoderUnsupported> {
-    append_h264_encoding_args_for_platform(
-        args,
-        video,
-        current_ffmpeg_h264_platform()?,
-        low_latency,
-    );
-    Ok(())
+#[cfg(any(test, target_os = "linux"))]
+fn linux_vaapi_probe_args(device: &Path) -> Vec<String> {
+    vec![
+        "-hide_banner".to_string(),
+        "-loglevel".to_string(),
+        "error".to_string(),
+        "-vaapi_device".to_string(),
+        device.display().to_string(),
+        "-f".to_string(),
+        "lavfi".to_string(),
+        "-i".to_string(),
+        "color=c=black:s=128x72:r=30".to_string(),
+        "-vf".to_string(),
+        "format=nv12,hwupload".to_string(),
+        "-frames:v".to_string(),
+        "3".to_string(),
+        "-an".to_string(),
+        "-c:v".to_string(),
+        "h264_vaapi".to_string(),
+        "-profile:v".to_string(),
+        "high".to_string(),
+        "-b:v".to_string(),
+        "1000k".to_string(),
+        "-f".to_string(),
+        "null".to_string(),
+        "-".to_string(),
+    ]
 }
 
-fn append_h264_encoding_args_preserving_input_timestamps(
+#[cfg(any(test, target_os = "linux"))]
+fn select_linux_h264_encoder(
+    preference: LinuxH264EncoderPreference,
+    accepted_device: Option<PathBuf>,
+    rejection_reason: Option<String>,
+) -> Result<ResolvedFfmpegH264Encoder> {
+    if preference == LinuxH264EncoderPreference::OpenH264 {
+        return Ok(ResolvedFfmpegH264Encoder {
+            platform: FfmpegH264Platform::LinuxSoftware,
+            vaapi_device: None,
+            fallback_reason: Some(
+                "OpenH264 software encoding was selected explicitly for this session.".to_string(),
+            ),
+        });
+    }
+    if let Some(device) = accepted_device {
+        return Ok(ResolvedFfmpegH264Encoder {
+            platform: FfmpegH264Platform::LinuxVaapi,
+            vaapi_device: Some(device),
+            fallback_reason: None,
+        });
+    }
+    let reason = rejection_reason.unwrap_or_else(|| {
+        "no /dev/dri/renderD* device was available for the VAAPI probe".to_string()
+    });
+    if preference == LinuxH264EncoderPreference::Vaapi {
+        bail!("VAAPI encoding was required but its render-node probe failed: {reason}");
+    }
+    Ok(ResolvedFfmpegH264Encoder {
+        platform: FfmpegH264Platform::LinuxSoftware,
+        vaapi_device: None,
+        fallback_reason: Some(format!(
+            "VAAPI was unavailable ({reason}); using the LGPL OpenH264 software fallback."
+        )),
+    })
+}
+
+#[cfg(target_os = "linux")]
+async fn probe_linux_vaapi_encoder(
+    ffmpeg_path: &str,
+    devices: &[PathBuf],
+) -> (Option<PathBuf>, Option<String>) {
+    const PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+    let mut rejections = Vec::new();
+    for device in devices {
+        let mut command = Command::new(ffmpeg_path);
+        command
+            .args(linux_vaapi_probe_args(device))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        match timeout(PROBE_TIMEOUT, command.output()).await {
+            Ok(Ok(output)) if output.status.success() => return (Some(device.clone()), None),
+            Ok(Ok(output)) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                rejections.push(format!(
+                    "{}: {}",
+                    device.display(),
+                    bounded_stream_output_topology_fallback_reason(&stderr)
+                ));
+            }
+            Ok(Err(error)) => rejections.push(format!("{}: {error}", device.display())),
+            Err(_) => rejections.push(format!("{}: probe timed out", device.display())),
+        }
+    }
+    let reason = (!rejections.is_empty()).then(|| rejections.join("; "));
+    (None, reason)
+}
+
+async fn default_h264_encode_backend(ffmpeg_path: &str) -> Result<ResolvedFfmpegH264Encoder> {
+    #[cfg(target_os = "linux")]
+    {
+        let preference = LinuxH264EncoderPreference::parse(
+            std::env::var("VIDEORC_LINUX_H264_ENCODER").ok().as_deref(),
+        )
+        .map_err(anyhow::Error::msg)?;
+        if preference == LinuxH264EncoderPreference::OpenH264 {
+            return select_linux_h264_encoder(preference, None, None);
+        }
+        let devices = linux_render_device_candidates_in(Path::new("/dev/dri"));
+        let (accepted_device, rejection_reason) =
+            probe_linux_vaapi_encoder(ffmpeg_path, &devices).await;
+        return select_linux_h264_encoder(preference, accepted_device, rejection_reason);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = ffmpeg_path;
+        Ok(ResolvedFfmpegH264Encoder::for_platform(
+            current_ffmpeg_h264_platform()?,
+        ))
+    }
+}
+
+fn append_h264_encoding_args_for_platform_preserving_input_timestamps(
     args: &mut Vec<String>,
     video: &VideoSettings,
+    platform: FfmpegH264Platform,
     low_latency: bool,
-) -> std::result::Result<(), PlatformEncoderUnsupported> {
-    append_h264_encoding_args_for_platform_with_timing(
-        args,
-        video,
-        current_ffmpeg_h264_platform()?,
-        false,
-        low_latency,
-    );
+) {
+    append_h264_encoding_args_for_platform_with_timing(args, video, platform, false, low_latency);
     args.extend(["-fps_mode".to_string(), "vfr".to_string()]);
+}
+
+fn append_h264_device_args(
+    args: &mut Vec<String>,
+    encoder: &ResolvedFfmpegH264Encoder,
+) -> Result<()> {
+    if encoder.platform != FfmpegH264Platform::LinuxVaapi {
+        return Ok(());
+    }
+    let device = encoder
+        .vaapi_device
+        .as_deref()
+        .context("The selected VAAPI encoder has no probed render device")?;
+    args.extend(["-vaapi_device".to_string(), device.display().to_string()]);
     Ok(())
 }
 
@@ -7793,6 +8017,20 @@ fn append_h264_encoding_args_for_platform_with_timing(
                 args.extend(["-prio_speed".to_string(), "1".to_string()]);
             }
         }
+        FfmpegH264Platform::LinuxVaapi => {
+            args.extend(["-rc_mode".to_string(), "VBR".to_string()]);
+            if low_latency {
+                args.extend(["-bf".to_string(), "0".to_string()]);
+            }
+        }
+        FfmpegH264Platform::LinuxSoftware => {
+            args.extend([
+                "-rc_mode".to_string(),
+                "bitrate".to_string(),
+                "-allow_skip_frames".to_string(),
+                "1".to_string(),
+            ]);
+        }
         FfmpegH264Platform::WindowsHardware => {
             args.extend(["-hw_encoding".to_string(), "1".to_string()]);
             args.extend([
@@ -7817,8 +8055,12 @@ fn append_h264_encoding_args_for_platform_with_timing(
     // Spec-valid High profile/level (the recording-quality audit caught the
     // encoders' auto picks under-leveling 60fps streams). Media Foundation
     // exposes neither option, so the Windows arms keep the encoder default.
-    if matches!(platform, FfmpegH264Platform::Macos)
-        && let Some(level) = h264_high_level_label(video.width, video.height, video.fps)
+    if matches!(
+        platform,
+        FfmpegH264Platform::Macos
+            | FfmpegH264Platform::LinuxVaapi
+            | FfmpegH264Platform::LinuxSoftware
+    ) && let Some(level) = h264_high_level_label(video.width, video.height, video.fps)
     {
         args.extend([
             "-profile:v".to_string(),
@@ -7877,6 +8119,7 @@ fn compositor_backend_label(backend: Option<CompositorBackend>) -> &'static str 
 fn encode_backend_label(backend: Option<EncodeBackend>) -> &'static str {
     match backend {
         Some(EncodeBackend::HardwareVideotoolbox) => "hardware-videotoolbox",
+        Some(EncodeBackend::HardwareVaapi) => "hardware-vaapi",
         Some(EncodeBackend::HardwareMediaFoundation) => "hardware-media-foundation",
         Some(EncodeBackend::SoftwareMediaFoundation) => "software-media-foundation",
         Some(EncodeBackend::SoftwareOpenH264) => "software-open-h264",
@@ -8377,6 +8620,8 @@ struct WindowsEncodedBridgeDecision {
     encoder_identity: Option<String>,
     input_subtype: Option<String>,
     fallback_reason: Option<String>,
+    fallback_ffmpeg_encoder: ResolvedFfmpegH264Encoder,
+    encoder_selection_fallback_reason: Option<String>,
 }
 
 impl WindowsEncodedBridgeDecision {
@@ -8397,6 +8642,10 @@ impl WindowsEncodedBridgeDecision {
             encoder_identity: None,
             input_subtype: None,
             fallback_reason: None,
+            fallback_ffmpeg_encoder: ResolvedFfmpegH264Encoder::for_platform(
+                FfmpegH264Platform::WindowsSoftware,
+            ),
+            encoder_selection_fallback_reason: None,
         }
     }
 }
@@ -8883,6 +9132,10 @@ fn select_windows_encoded_bridge_decision(
             encoder_identity: Some(encoder_identity),
             input_subtype: Some(input_subtype),
             fallback_reason: None,
+            fallback_ffmpeg_encoder: ResolvedFfmpegH264Encoder::for_platform(
+                FfmpegH264Platform::WindowsSoftware,
+            ),
+            encoder_selection_fallback_reason: None,
         },
         #[cfg(any(test, target_os = "windows"))]
         Some(MediaFoundationTopologyProbe::Rejected { reason }) => WindowsEncodedBridgeDecision {
@@ -8894,6 +9147,10 @@ fn select_windows_encoded_bridge_decision(
             encoder_identity: None,
             input_subtype: None,
             fallback_reason: Some(bounded_stream_output_topology_fallback_reason(&reason)),
+            fallback_ffmpeg_encoder: ResolvedFfmpegH264Encoder::for_platform(
+                FfmpegH264Platform::WindowsSoftware,
+            ),
+            encoder_selection_fallback_reason: None,
         },
         #[cfg(any(test, not(target_os = "windows")))]
         Some(MediaFoundationTopologyProbe::Unsupported { reason }) => {
@@ -8906,6 +9163,10 @@ fn select_windows_encoded_bridge_decision(
                 encoder_identity: None,
                 input_subtype: None,
                 fallback_reason: Some(bounded_stream_output_topology_fallback_reason(&reason)),
+                fallback_ffmpeg_encoder: ResolvedFfmpegH264Encoder::for_platform(
+                    FfmpegH264Platform::WindowsSoftware,
+                ),
+                encoder_selection_fallback_reason: None,
             }
         }
         None => WindowsEncodedBridgeDecision {
@@ -8919,6 +9180,10 @@ fn select_windows_encoded_bridge_decision(
             fallback_reason: Some(bounded_stream_output_topology_fallback_reason(
                 "Media Foundation output topology probe did not produce a verdict",
             )),
+            fallback_ffmpeg_encoder: ResolvedFfmpegH264Encoder::for_platform(
+                FfmpegH264Platform::WindowsSoftware,
+            ),
+            encoder_selection_fallback_reason: None,
         },
     }
 }
@@ -8927,12 +9192,13 @@ async fn resolve_windows_encoded_bridge_decision(
     ffmpeg_path: &str,
     plan: &EncoderOutputTopologyPlan,
     requested: EncoderBridgeVideoOutput,
-) -> std::result::Result<WindowsEncodedBridgeDecision, PlatformEncoderUnsupported> {
+) -> Result<WindowsEncodedBridgeDecision> {
     // Resolve the fallback backend FIRST and as a value: this function is
     // reachable on every platform (the topology-probe RPC calls it, and the
     // renderer fires that probe automatically), so an unsupported platform
     // must surface as the typed error, never as a panic mid-argument.
-    let fallback_encode_backend = default_h264_encode_backend()?;
+    let resolved_encoder = default_h264_encode_backend(ffmpeg_path).await?;
+    let fallback_encode_backend = resolved_encoder.backend();
     let graphics_adapter_driver_identity = graphics_adapter_driver_identity();
     let capability_key = output_topology_capability_key(
         ffmpeg_path,
@@ -8955,12 +9221,15 @@ async fn resolve_windows_encoded_bridge_decision(
     } else {
         None
     };
-    Ok(select_windows_encoded_bridge_decision(
+    let mut decision = select_windows_encoded_bridge_decision(
         requested,
         capability_key,
         probe,
         fallback_encode_backend,
-    ))
+    );
+    decision.encoder_selection_fallback_reason = resolved_encoder.fallback_reason.clone();
+    decision.fallback_ffmpeg_encoder = resolved_encoder;
+    Ok(decision)
 }
 
 #[cfg(target_os = "windows")]
@@ -9025,7 +9294,9 @@ pub async fn probe_stream_output_topology(
         effective_bridge_output: stream_output_bridge(decision.effective),
         effective_encode_backend: decision.effective_encode_backend,
         probe_state: decision.probe_state,
-        fallback_reason: decision.fallback_reason,
+        fallback_reason: decision
+            .fallback_reason
+            .or(decision.encoder_selection_fallback_reason),
     })
 }
 
@@ -10572,6 +10843,7 @@ fn recording_encoder_bridge_sources_ready(
         })
 }
 
+#[cfg(test)]
 fn bridge_recording_ffmpeg_args(
     capture: &CaptureInputs,
     params: &StartSessionParams,
@@ -10579,18 +10851,39 @@ fn bridge_recording_ffmpeg_args(
     fifo_path: &Path,
     video_output: EncoderBridgeVideoOutput,
 ) -> Result<Vec<String>> {
+    let encoder = ResolvedFfmpegH264Encoder::for_platform(current_ffmpeg_h264_platform()?);
+    bridge_recording_ffmpeg_args_with_encoder(
+        capture,
+        params,
+        output_path,
+        fifo_path,
+        video_output,
+        &encoder,
+    )
+}
+
+fn bridge_recording_ffmpeg_args_with_encoder(
+    capture: &CaptureInputs,
+    params: &StartSessionParams,
+    output_path: Option<&Path>,
+    fifo_path: &Path,
+    video_output: EncoderBridgeVideoOutput,
+    encoder: &ResolvedFfmpegH264Encoder,
+) -> Result<Vec<String>> {
     let output_path =
         output_path.context("Encoder bridge recording requires a local output path")?;
-    bridge_compositor_ffmpeg_args(
+    bridge_compositor_ffmpeg_args_with_encoder(
         capture,
         params,
         Some(output_path),
         &[],
         fifo_path,
         video_output,
+        encoder,
     )
 }
 
+#[cfg(test)]
 fn bridge_compositor_ffmpeg_args(
     capture: &CaptureInputs,
     params: &StartSessionParams,
@@ -10598,6 +10891,27 @@ fn bridge_compositor_ffmpeg_args(
     stream_targets: &[StreamTarget],
     fifo_path: &Path,
     video_output: EncoderBridgeVideoOutput,
+) -> Result<Vec<String>> {
+    let encoder = ResolvedFfmpegH264Encoder::for_platform(current_ffmpeg_h264_platform()?);
+    bridge_compositor_ffmpeg_args_with_encoder(
+        capture,
+        params,
+        output_path,
+        stream_targets,
+        fifo_path,
+        video_output,
+        &encoder,
+    )
+}
+
+fn bridge_compositor_ffmpeg_args_with_encoder(
+    capture: &CaptureInputs,
+    params: &StartSessionParams,
+    output_path: Option<&Path>,
+    stream_targets: &[StreamTarget],
+    fifo_path: &Path,
+    video_output: EncoderBridgeVideoOutput,
+    encoder: &ResolvedFfmpegH264Encoder,
 ) -> Result<Vec<String>> {
     validate_stream_targets_for_ffmpeg(stream_targets)?;
     let mut args = vec![
@@ -10611,6 +10925,7 @@ fn bridge_compositor_ffmpeg_args(
         "-progress".to_string(),
         "pipe:2".to_string(),
     ];
+    append_h264_device_args(&mut args, encoder)?;
     let input_layout =
         append_bridge_recording_input_args(&mut args, capture, params, fifo_path, video_output);
     // Copy-kind outputs (AnnexB/MpegTs) with stream targets fan out as one
@@ -10629,9 +10944,10 @@ fn bridge_compositor_ffmpeg_args(
             EncoderBridgeVideoOutput::RawYuv420p => {
                 args.extend([
                     "-filter_complex".to_string(),
-                    bridge_recording_video_filter(
+                    bridge_recording_video_filter_for_encoder(
                         input_layout.video_input_index,
                         &params.output.video,
+                        encoder,
                     ),
                     "-map".to_string(),
                     "[v_main]".to_string(),
@@ -10649,11 +10965,12 @@ fn bridge_compositor_ffmpeg_args(
         append_audio_output_args(&mut args, &input_layout);
         match video_output {
             EncoderBridgeVideoOutput::RawYuv420p => {
-                append_h264_encoding_args_preserving_input_timestamps(
+                append_h264_encoding_args_for_platform_preserving_input_timestamps(
                     &mut args,
                     &params.output.video,
+                    encoder.platform,
                     !stream_targets.is_empty(),
-                )?;
+                );
             }
             EncoderBridgeVideoOutput::VideoToolboxH264AnnexB
             | EncoderBridgeVideoOutput::VideoToolboxH264MpegTs
@@ -11208,17 +11525,46 @@ fn rtmp_tee_leg(url: &str) -> String {
 }
 const RTMP_LEG_RW_TIMEOUT_US: u64 = 8_000_000;
 
-fn bridge_recording_video_filter(video_input_index: usize, video: &VideoSettings) -> String {
+fn bridge_recording_video_filter_for_encoder(
+    video_input_index: usize,
+    video: &VideoSettings,
+    encoder: &ResolvedFfmpegH264Encoder,
+) -> String {
     let fps = video.fps.max(1);
-    format!("[{video_input_index}:v]setpts=PTS-STARTPTS,fps={fps}[v_main]")
+    let upload = if encoder.platform == FfmpegH264Platform::LinuxVaapi {
+        ",format=nv12,hwupload"
+    } else {
+        ""
+    };
+    format!("[{video_input_index}:v]setpts=PTS-STARTPTS,fps={fps}{upload}[v_main]")
 }
 
+#[cfg(test)]
 fn ffmpeg_args(
     capture: &CaptureInputs,
     params: &StartSessionParams,
     output_path: Option<&Path>,
     stream_targets: &[StreamTarget],
     screen_overlay: Option<&ScreenOverlayInput>,
+) -> Result<Vec<String>> {
+    let encoder = ResolvedFfmpegH264Encoder::for_platform(current_ffmpeg_h264_platform()?);
+    ffmpeg_args_with_encoder(
+        capture,
+        params,
+        output_path,
+        stream_targets,
+        screen_overlay,
+        &encoder,
+    )
+}
+
+fn ffmpeg_args_with_encoder(
+    capture: &CaptureInputs,
+    params: &StartSessionParams,
+    output_path: Option<&Path>,
+    stream_targets: &[StreamTarget],
+    screen_overlay: Option<&ScreenOverlayInput>,
+    encoder: &ResolvedFfmpegH264Encoder,
 ) -> Result<Vec<String>> {
     validate_stream_targets_for_ffmpeg(stream_targets)?;
     let mut args = vec![
@@ -11232,6 +11578,7 @@ fn ffmpeg_args(
         "-progress".to_string(),
         "pipe:2".to_string(),
     ];
+    append_h264_device_args(&mut args, encoder)?;
     let input_layout = append_input_args(
         &mut args,
         capture,
@@ -11239,7 +11586,7 @@ fn ffmpeg_args(
         &params.output.video,
         screen_overlay,
     );
-    let filter = recording_video_filter(capture, &input_layout, params, true);
+    let filter = recording_video_filter_for_encoder(capture, &input_layout, params, true, encoder);
 
     args.extend([
         "-filter_complex".to_string(),
@@ -11248,7 +11595,12 @@ fn ffmpeg_args(
         "[v_main]".to_string(),
     ]);
     append_audio_output_args(&mut args, &input_layout);
-    append_h264_encoding_args(&mut args, &params.output.video, !stream_targets.is_empty())?;
+    append_h264_encoding_args_for_platform(
+        &mut args,
+        &params.output.video,
+        encoder.platform,
+        !stream_targets.is_empty(),
+    );
     append_audio_encoding_args(
         &mut args,
         &input_layout,
@@ -11984,11 +12336,31 @@ fn test_tone_audio_track() -> AudioTrack {
     }
 }
 
+#[cfg(test)]
 fn recording_video_filter(
     capture: &CaptureInputs,
     input_layout: &InputLayout,
     params: &StartSessionParams,
     include_live_preview: bool,
+) -> String {
+    let encoder = ResolvedFfmpegH264Encoder::for_platform(
+        current_ffmpeg_h264_platform().unwrap_or(FfmpegH264Platform::WindowsSoftware),
+    );
+    recording_video_filter_for_encoder(
+        capture,
+        input_layout,
+        params,
+        include_live_preview,
+        &encoder,
+    )
+}
+
+fn recording_video_filter_for_encoder(
+    capture: &CaptureInputs,
+    input_layout: &InputLayout,
+    params: &StartSessionParams,
+    include_live_preview: bool,
+    encoder: &ResolvedFfmpegH264Encoder,
 ) -> String {
     let scene = params
         .scene
@@ -12012,7 +12384,14 @@ fn recording_video_filter(
     // primaries/transfer on the frames: hardware encoders (h264_videotoolbox)
     // build the VUI from frame properties and `scale` only sets matrix+range.
     // The preview leg stays unconverted.
-    let to_bt709 = "scale=out_color_matrix=bt709:out_range=tv,setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709:range=tv,format=yuv420p";
+    let encode_format = if encoder.platform == FfmpegH264Platform::LinuxVaapi {
+        "format=nv12,hwupload"
+    } else {
+        "format=yuv420p"
+    };
+    let to_bt709 = format!(
+        "scale=out_color_matrix=bt709:out_range=tv,setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709:range=tv,{encode_format}"
+    );
     if include_live_preview {
         format!(
             "{video};[{video_label}]split=2[v_main_rgb][v_preview];[v_main_rgb]{to_bt709}[v_main];[v_preview]{}[preview]",
@@ -15013,6 +15392,10 @@ mod tests {
             "hardware-videotoolbox"
         );
         assert_eq!(
+            encode_backend_label(Some(EncodeBackend::HardwareVaapi)),
+            "hardware-vaapi"
+        );
+        assert_eq!(
             encode_backend_label(Some(EncodeBackend::HardwareMediaFoundation)),
             "hardware-media-foundation"
         );
@@ -15166,7 +15549,36 @@ mod tests {
             Some("1")
         );
 
-        for args in [&macos_args, &windows_args, &windows_software_args] {
+        let mut linux_vaapi_args = Vec::new();
+        append_h264_encoding_args_for_platform(
+            &mut linux_vaapi_args,
+            &video,
+            FfmpegH264Platform::LinuxVaapi,
+            true,
+        );
+        assert_eq!(arg_value(&linux_vaapi_args, "-c:v"), Some("h264_vaapi"));
+        assert_eq!(arg_value(&linux_vaapi_args, "-pix_fmt"), Some("vaapi"));
+        assert_eq!(arg_value(&linux_vaapi_args, "-rc_mode"), Some("VBR"));
+        assert_eq!(arg_value(&linux_vaapi_args, "-bf"), Some("0"));
+
+        let mut linux_software_args = Vec::new();
+        append_h264_encoding_args_for_platform(
+            &mut linux_software_args,
+            &video,
+            FfmpegH264Platform::LinuxSoftware,
+            true,
+        );
+        assert_eq!(arg_value(&linux_software_args, "-c:v"), Some("libopenh264"));
+        assert_eq!(arg_value(&linux_software_args, "-pix_fmt"), Some("yuv420p"));
+        assert_eq!(arg_value(&linux_software_args, "-rc_mode"), Some("bitrate"));
+
+        for args in [
+            &macos_args,
+            &linux_vaapi_args,
+            &linux_software_args,
+            &windows_args,
+            &windows_software_args,
+        ] {
             assert_eq!(arg_value(args, "-b:v"), Some("6000k"));
             assert_eq!(arg_value(args, "-maxrate"), Some("6000k"));
             assert_eq!(arg_value(args, "-bufsize"), Some("12000k"));
@@ -15186,6 +15598,14 @@ mod tests {
             EncodeBackend::HardwareVideotoolbox
         );
         assert_eq!(
+            ffmpeg_h264_encoder(FfmpegH264Platform::LinuxVaapi).backend,
+            EncodeBackend::HardwareVaapi
+        );
+        assert_eq!(
+            ffmpeg_h264_encoder(FfmpegH264Platform::LinuxSoftware).backend,
+            EncodeBackend::SoftwareOpenH264
+        );
+        assert_eq!(
             ffmpeg_h264_encoder(FfmpegH264Platform::WindowsHardware).backend,
             EncodeBackend::HardwareMediaFoundation
         );
@@ -15196,13 +15616,97 @@ mod tests {
     }
 
     #[test]
-    fn linux_h264_encoder_is_a_typed_unsupported_result() {
-        let error = ffmpeg_h264_platform_for_target(RuntimePlatform::Linux)
-            .expect_err("Linux L1 must not select an encoder");
-        assert_eq!(error.platform, "Linux");
+    fn linux_h264_encoder_has_a_portable_lgpl_default() {
         assert_eq!(
-            error.to_string(),
-            "H.264 encoding is unsupported on Linux at Linux port level L1"
+            ffmpeg_h264_platform_for_target(RuntimePlatform::Linux),
+            Ok(FfmpegH264Platform::LinuxSoftware)
+        );
+    }
+
+    #[test]
+    fn linux_h264_encoder_preference_is_explicit_and_bounded() {
+        assert_eq!(
+            LinuxH264EncoderPreference::parse(None),
+            Ok(LinuxH264EncoderPreference::Auto)
+        );
+        assert_eq!(
+            LinuxH264EncoderPreference::parse(Some("auto")),
+            Ok(LinuxH264EncoderPreference::Auto)
+        );
+        assert_eq!(
+            LinuxH264EncoderPreference::parse(Some("vaapi")),
+            Ok(LinuxH264EncoderPreference::Vaapi)
+        );
+        assert_eq!(
+            LinuxH264EncoderPreference::parse(Some("openh264")),
+            Ok(LinuxH264EncoderPreference::OpenH264)
+        );
+        assert!(LinuxH264EncoderPreference::parse(Some("x264")).is_err());
+    }
+
+    #[test]
+    fn linux_render_device_candidates_include_only_numbered_render_nodes() {
+        let directory =
+            std::env::temp_dir().join(format!("videorc-linux-render-nodes-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).expect("create render-node fixture directory");
+        for name in ["renderD129", "card0", "renderD128", "renderDnope"] {
+            File::create(directory.join(name)).expect("create render-node fixture");
+        }
+
+        assert_eq!(
+            linux_render_device_candidates_in(&directory),
+            vec![directory.join("renderD128"), directory.join("renderD129")]
+        );
+
+        std::fs::remove_dir_all(directory).expect("remove render-node fixture directory");
+    }
+
+    #[test]
+    fn linux_vaapi_probe_exercises_upload_and_real_encoder() {
+        let device = Path::new("/dev/dri/renderD128");
+        let args = linux_vaapi_probe_args(device);
+        assert_eq!(
+            arg_value(&args, "-vaapi_device"),
+            Some("/dev/dri/renderD128")
+        );
+        assert_eq!(arg_value(&args, "-vf"), Some("format=nv12,hwupload"));
+        assert_eq!(arg_value(&args, "-c:v"), Some("h264_vaapi"));
+        assert_eq!(arg_value(&args, "-frames:v"), Some("3"));
+    }
+
+    #[test]
+    fn linux_encoder_selection_prefers_probed_vaapi_and_falls_back_to_openh264() {
+        let device = PathBuf::from("/dev/dri/renderD128");
+        let hardware =
+            select_linux_h264_encoder(LinuxH264EncoderPreference::Auto, Some(device.clone()), None)
+                .expect("probed VAAPI device");
+        assert_eq!(hardware.platform, FfmpegH264Platform::LinuxVaapi);
+        assert_eq!(hardware.vaapi_device, Some(device));
+        assert_eq!(hardware.backend(), EncodeBackend::HardwareVaapi);
+        assert_eq!(hardware.fallback_reason, None);
+
+        let software = select_linux_h264_encoder(
+            LinuxH264EncoderPreference::Auto,
+            None,
+            Some("driver rejected h264_vaapi".to_string()),
+        )
+        .expect("automatic OpenH264 fallback");
+        assert_eq!(software.platform, FfmpegH264Platform::LinuxSoftware);
+        assert_eq!(software.backend(), EncodeBackend::SoftwareOpenH264);
+        assert!(
+            software
+                .fallback_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("driver rejected h264_vaapi"))
+        );
+
+        assert!(
+            select_linux_h264_encoder(
+                LinuxH264EncoderPreference::Vaapi,
+                None,
+                Some("probe failed".to_string()),
+            )
+            .is_err()
         );
     }
 
@@ -18068,7 +18572,72 @@ mod tests {
                 assert_eq!(arg_value(args, "-hw_encoding"), None);
                 assert_eq!(encoder.backend, EncodeBackend::SoftwareOpenH264);
             }
+            FfmpegH264Platform::LinuxVaapi | FfmpegH264Platform::LinuxSoftware => {
+                unreachable!("test defaults never select a Linux runtime encoder")
+            }
         }
+    }
+
+    #[test]
+    fn linux_vaapi_session_args_bind_the_probed_device_and_upload_frames() {
+        let params = base_params(true, false);
+        let capture = CaptureInputs {
+            video: VideoInput::TestPattern,
+            camera_index: None,
+            microphone: None,
+        };
+        let encoder = ResolvedFfmpegH264Encoder {
+            platform: FfmpegH264Platform::LinuxVaapi,
+            vaapi_device: Some(PathBuf::from("/dev/dri/renderD128")),
+            fallback_reason: None,
+        };
+        let fifo_path = Path::new("/tmp/videorc-linux-vaapi.yuv");
+        let bridge_args = bridge_recording_ffmpeg_args_with_encoder(
+            &capture,
+            &params,
+            Some(Path::new("/tmp/videorc-linux-vaapi-bridge.mkv")),
+            fifo_path,
+            EncoderBridgeVideoOutput::RawYuv420p,
+            &encoder,
+        )
+        .expect("Linux VAAPI bridge args");
+        assert_eq!(
+            arg_value(&bridge_args, "-vaapi_device"),
+            Some("/dev/dri/renderD128")
+        );
+        assert_eq!(arg_value(&bridge_args, "-c:v"), Some("h264_vaapi"));
+        assert!(
+            arg_value(&bridge_args, "-filter_complex")
+                .is_some_and(|filter| filter.contains("format=nv12,hwupload[v_main]"))
+        );
+        let device_position = bridge_args
+            .iter()
+            .position(|arg| arg == "-vaapi_device")
+            .expect("VAAPI device option");
+        let input_position = bridge_args
+            .iter()
+            .position(|arg| arg == "-i")
+            .expect("first input option");
+        assert!(device_position < input_position);
+
+        let legacy_args = ffmpeg_args_with_encoder(
+            &capture,
+            &params,
+            Some(Path::new("/tmp/videorc-linux-vaapi-legacy.mkv")),
+            &[],
+            None,
+            &encoder,
+        )
+        .expect("Linux VAAPI legacy args");
+        assert_eq!(arg_value(&legacy_args, "-c:v"), Some("h264_vaapi"));
+        assert!(
+            arg_value(&legacy_args, "-filter_complex")
+                .is_some_and(|filter| filter.contains("format=nv12,hwupload[v_main]"))
+        );
+        assert!(
+            arg_value(&legacy_args, "-filter_complex")
+                .is_some_and(|filter| filter.contains("[v_preview]"))
+        );
     }
 
     #[test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -7938,7 +7938,7 @@ async fn default_h264_encode_backend(ffmpeg_path: &str) -> Result<ResolvedFfmpeg
         let devices = linux_render_device_candidates_in(Path::new("/dev/dri"));
         let (accepted_device, rejection_reason) =
             probe_linux_vaapi_encoder(ffmpeg_path, &devices).await;
-        return select_linux_h264_encoder(preference, accepted_device, rejection_reason);
+        select_linux_h264_encoder(preference, accepted_device, rejection_reason)
     }
     #[cfg(not(target_os = "linux"))]
     {

--- a/docs/linux-port-plan.md
+++ b/docs/linux-port-plan.md
@@ -1,51 +1,62 @@
 # Linux Port Plan
 
 Linux support is an incremental port, not a relabeling of the macOS or Windows
-runtime. The first milestone (L1) makes Linux a native Rust compile, lint, and
-unit-test target. It does **not** claim that capture, preview, recording,
+runtime. L1 established the native Rust gate. L1.5 adds a production-safe H.264
+encoder contract, but does **not** claim that capture, preview, recording,
 packaging, or release are supported yet.
 
-## Proposed support baseline
+## Support baseline
 
-| Area | Initial proposal | L1 status |
+| Area | Alpha baseline | Current status |
 | --- | --- | --- |
 | Distribution | Ubuntu 24.04 LTS | Compile/test gate only |
 | Architecture | x86_64 | CI runner architecture |
-| Display session | Wayland first, X11 considered later | Unsupported |
-| Screen/window capture | `xdg-desktop-portal` session backed by PipeWire | Unsupported |
-| Camera and audio | PipeWire required | Unsupported |
-| Preview | Linux-native surface, transport to be selected | Unsupported |
-| H.264 encode | VAAPI hardware, OpenH264 software fallback | Deferred to L5 |
-| Packaging | Format and signing policy to be selected | Unsupported |
+| Display session | Wayland first | Unsupported |
+| Screen/window capture | `xdg-desktop-portal` backed by PipeWire | L4 |
+| Camera | V4L2 | L3 |
+| Audio | PipeWire | L2 |
+| Preview | CPU composition and JPEG transport | L5 |
+| H.264 encode | VAAPI hardware, OpenH264 software fallback | L1.5 implemented; hardware proof pending |
+| Packaging | AppImage | L6 |
 
 Wayland capture must go through the desktop portal rather than bypassing the
-user-consent boundary. PipeWire is a required part of the proposed baseline,
-not an optional fallback. Exact portal, PipeWire, VAAPI, and window-system
+user-consent boundary. PipeWire is required for screen capture and audio; V4L2
+owns the first camera path. Exact portal, PipeWire, VAAPI, and window-system
 development packages should be added only when the phase that uses them proves
 the dependency is necessary.
 
-## Licensing constraint
+## Licensing and encoder constraint
 
 Videorc ships an LGPL-only FFmpeg distribution. Linux must never select or
-bundle `libx264`, because that would introduce GPL requirements that are
-incompatible with the product's open-core distribution model.
+bundle `libx264`, because that would introduce GPL requirements incompatible
+with the product's open-core distribution model.
 
-The intended Linux encoder decision is:
+The Linux encoder decision is:
 
-- VAAPI for hardware H.264 encoding; and
-- OpenH264 for a software fallback.
+- probe `/dev/dri/renderD*` with the exact staged FFmpeg binary and select VAAPI
+  only when a real `h264_vaapi` encode succeeds; and
+- use OpenH264 as a supported software fallback when automatic VAAPI probing
+  fails.
 
-That encoder is intentionally **not implemented in L1**. The production Linux
-encoder selector returns a typed unsupported error before a capture session can
-create state. L5 owns the implementation and its capability/fallback contract.
+`VIDEORC_LINUX_H264_ENCODER=auto|vaapi|openh264` controls the selection. `auto`
+is the default. Forced `vaapi` fails session startup if the probe fails; forced
+`openh264` chooses the software path directly. Automatic or explicit OpenH264
+selection is logged and exposed in diagnostics without raising a health alert.
+
+The binary pin lives in `vendor/ffmpeg/linux-pin.json`. Run
+`pnpm ffmpeg:fetch:linux` on Linux x64 to download and stage it. The fetch step
+checks the SHA-256, executes the binary, and fails closed unless the build is
+LGPL-only, enables VAAPI and OpenH264, disables x264/x265/fdk-aac, and exposes
+both `h264_vaapi` and `libopenh264` encoders. Linux CI repeats this check.
 
 ## Delivery phases
 
 ### L1 — Compile and CI gate
 
 - Compile the backend natively on Ubuntu.
-- Run Rust format, `cargo check`, clippy with warnings denied, and the backend
-  unit suite on every pull request and push to `main`.
+- Run clippy with warnings denied and the backend unit suite on every pull
+  request and push to `main`; the main CI workflow owns platform-independent
+  Rust formatting.
 - Keep shared geometry and pixel conversion outside Apple-only modules.
 - Return explicit unsupported results for runtime paths with no Linux backend.
 
@@ -54,42 +65,61 @@ cross-platform allow list: `dead_code`, `unused_imports`, `unused_variables`,
 and `unused_mut`. Both platform gates should remove those allows together as
 the shared warning wall is eliminated.
 
-### L2 — Desktop shell and platform affordances
+### L1.5 — Encoder policy and provisioning
 
-- Launch the Electron/backend pair on Ubuntu 24.04 x64.
-- Replace macOS-specific permission, shortcut, window-chrome, and system-link
-  assumptions with platform-owned behavior.
-- Add a no-device lifecycle smoke without claiming media support.
+- Pin and verify the Linux x64 LGPL FFmpeg bundle.
+- Select a probed VAAPI render node per session, with OpenH264 as the named
+  software fallback.
+- Preserve BT.709/video-range tags, profile/level, keyframe cadence, bounded
+  rate control, and truthful backend diagnostics.
+- Keep `libx264`, GPL, and nonfree builds out of provisioning and runtime args.
 
-### L3 — Discovery and permissions
+The code and CI contract are implemented. A real Ubuntu machine must still
+prove both the VAAPI path and the software fallback before the release can
+advance.
 
-- Discover portal/PipeWire screens, windows, cameras, and microphones behind
-  the existing source contracts.
-- Model portal consent, revoked sessions, missing devices, and reconnects as
-  explicit states and diagnostics.
-- Add deterministic discovery and permission tests.
+### Hardware stop before L2
 
-### L4 — Capture and preview
+Do not start L2 until a named Linux tester and a specific Ubuntu 24.04 x64
+machine are recorded. Virtual machines and CI runners do not satisfy this gate.
+Each later phase must include dated real-device evidence before the next phase
+starts.
+
+### L2 — PipeWire audio
+
+- Discover and ingest microphone audio through PipeWire.
+- Preserve mute/gain, sample format, reconnect, and explicit unavailable-state
+  behavior behind the shared source contracts.
+- Prove the phase with deterministic tests and a real-device audio artifact.
+
+### L3 — V4L2 camera
+
+- Discover and capture cameras through V4L2.
+- Preserve stable source identity, format negotiation, switching, reconnect,
+  and explicit unavailable-state behavior.
+- Prove a camera-only recording on the named Ubuntu hardware.
+
+### L4 — Portal and PipeWire screen capture
 
 - Implement Wayland-first screen/window capture through
   `xdg-desktop-portal` and PipeWire.
-- Implement PipeWire camera/audio ingestion and a Linux-native preview
-  presenter with first-frame and source-liveness contracts.
-- Qualify lifecycle, source switching, detach/reattach, and backpressure on a
-  real Linux desktop.
+- Model portal consent, cancellation, revoked sessions, missing sources, and
+  reconnects as explicit states and diagnostics.
+- Prove source switching and lifecycle behavior on the real Linux desktop.
 
-### L5 — Record, encode, and stream
+### L5 — CPU composition and JPEG preview
 
-- Implement the VAAPI hardware encoder path and OpenH264 software fallback.
-- Preserve the shared scene geometry, BT.709/video-range color tags, bounded
-  queues, A/V stop-tail, and final-artifact analysis used by shipping ports.
-- Prove recording and streaming profiles on representative Intel, AMD, and
-  software-fallback hosts without adding `libx264`.
+- Reuse shared scene geometry in a Linux CPU compositor.
+- Add the maintained JPEG preview transport with first-frame, liveness,
+  backpressure, detach/reattach, and truthful fallback diagnostics.
+- Prove composed recording and preview behavior without claiming a GPU-native
+  preview surface.
 
-### L6 — Package, release, and acceptance
+### L6 — AppImage, release lane, and acceptance
 
-- Select the package format, update channel, signing/provenance policy, and
-  supported GPU/desktop matrix.
+- Build an Ubuntu 24.04 x64 AppImage with the verified LGPL FFmpeg payload.
+- Use an isolated Linux Alpha lane with candidate, pilot, then public
+  promotion; never reuse or mutate the macOS Beta or Windows Alpha manifests.
 - Add packaged-app device, recording, streaming, updater, and cleanup smokes.
 - Publish Linux only after dated real-device evidence meets the same explicit
   quality and lifecycle bar as the other shipping platforms.
@@ -102,3 +132,5 @@ was used as a reference for identifying platform seams, including moving the
 source-mask model out of the Metal implementation. Its stale branch is not
 merged or cherry-picked: changes are re-derived against current Videorc code.
 Its GPL `libx264` encoder choice is explicitly rejected by this plan.
+Contributor coordination and DCO confirmation are tracked in
+[`#247`](https://github.com/TheOrcDev/videorc/issues/247).

--- a/docs/linux-port-plan.md
+++ b/docs/linux-port-plan.md
@@ -78,6 +78,23 @@ The code and CI contract are implemented. A real Ubuntu machine must still
 prove both the VAAPI path and the software fallback before the release can
 advance.
 
+Run the hardware-only acceptance command on the named Ubuntu 24.04 x64 tester
+box. It requires a webcam, a VAAPI render node, and explicit tester/machine
+labels; it fetches the pinned FFmpeg bundle, records 1080p30 through the real
+dev app once per forced backend, checks the final artifacts and diagnostics,
+and writes `linux-encoder-acceptance.json` beside the recordings:
+
+```bash
+VIDEORC_LINUX_TESTER_NAME="<person>" \
+VIDEORC_LINUX_TESTER_MACHINE="<specific box>" \
+VIDEORC_LINUX_PHYSICAL_HARDWARE=1 \
+pnpm smoke:linux-encoder-acceptance
+```
+
+`--backend=openh264` or `--backend=vaapi` may be used to diagnose one path,
+but only the default two-backend run emits `complete: true` evidence and clears
+the L1.5 hardware gate. CI runners and virtual machines are not substitutes.
+
 ### Hardware stop before L2
 
 Do not start L2 until a named Linux tester and a specific Ubuntu 24.04 x64

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "measure:av-sync": "node scripts/measure-av-sync.mjs",
     "smoke:dev": "node scripts/smoke-dev-app.mjs",
     "smoke:recording-matrix": "node scripts/smoke-recording-matrix-app.mjs",
+    "smoke:linux-encoder-acceptance": "node scripts/smoke-linux-encoder-acceptance.mjs",
     "smoke:remote-control": "node scripts/smoke-remote-control-app.mjs",
     "smoke:backend-single-instance": "node scripts/smoke-backend-single-instance.mjs",
     "smoke:backend-resilience": "node scripts/smoke-backend-resilience.mjs",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release:notify:discord": "node scripts/notify-discord-release.mjs",
     "ffmpeg:build:macos": "bash scripts/build-ffmpeg-macos.sh",
     "ffmpeg:fetch:windows": "node scripts/fetch-ffmpeg-windows.mjs",
+    "ffmpeg:fetch:linux": "node scripts/fetch-ffmpeg-linux.mjs",
     "build:native-preview-addon": "node scripts/build-native-preview-addon.mjs",
     "build:native-preview-addon:release": "node scripts/build-native-preview-addon.mjs --release --universal",
     "package:backend": "cargo build --release -p videorc-backend",

--- a/scripts/fetch-ffmpeg-linux.mjs
+++ b/scripts/fetch-ffmpeg-linux.mjs
@@ -1,0 +1,224 @@
+// Fetch the pinned Linux x64 LGPL FFmpeg bundle and stage the exact files the
+// future AppImage will carry. The executable configuration is verified on the
+// Linux host before it is accepted: VAAPI and OpenH264 are required, while
+// x264/x265/fdk-aac, GPL, and nonfree builds fail closed.
+
+import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { createReadStream, createWriteStream } from 'node:fs'
+import { chmod, copyFile, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { Readable, Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import { fileURLToPath } from 'node:url'
+
+import {
+  assessFfmpegLinuxPin,
+  assessLinuxFfmpegCapabilities
+} from './lib/ffmpeg-linux-pin.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const pinPath = join(repoRoot, 'vendor', 'ffmpeg', 'linux-pin.json')
+const downloadPath = join(repoRoot, 'vendor', 'ffmpeg', '_build', 'linux-download.tar.xz')
+const extractDir = join(repoRoot, 'vendor', 'ffmpeg', '_build', 'linux-extract')
+const outputDir = join(repoRoot, 'vendor', 'ffmpeg', 'linux-x64')
+const force = process.argv.includes('--force')
+
+function fail(message) {
+  console.error(`fetch-ffmpeg-linux: ${message}`)
+  process.exit(1)
+}
+
+async function fileExists(path) {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function sha256Of(path) {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+function runText(executable, args) {
+  return execFileSync(executable, args, {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+}
+
+function verifyOpenH264Encoder(executable) {
+  execFileSync(
+    executable,
+    [
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-f',
+      'lavfi',
+      '-i',
+      'color=c=black:s=128x72:r=30',
+      '-frames:v',
+      '3',
+      '-an',
+      '-c:v',
+      'libopenh264',
+      '-profile:v',
+      'high',
+      '-rc_mode',
+      'bitrate',
+      '-b:v',
+      '1000k',
+      '-f',
+      'null',
+      '-'
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  )
+}
+
+if (process.platform !== 'linux' || process.arch !== 'x64') {
+  fail(`requires Linux x64, got ${process.platform}/${process.arch}`)
+}
+
+const pin = JSON.parse(await readFile(pinPath, 'utf8'))
+const pinAssessment = assessFfmpegLinuxPin(pin)
+if (!pinAssessment.ok) {
+  fail(`${pinPath} is unusable:\n  - ${pinAssessment.problems.join('\n  - ')}`)
+}
+
+const ffmpegBin = join(outputDir, 'bin', 'ffmpeg')
+const ffprobeBin = join(outputDir, 'bin', 'ffprobe')
+const sourceTxt = join(outputDir, 'SOURCE.txt')
+const buildConfigTxt = join(outputDir, 'BUILD-CONFIG.txt')
+
+if (
+  !force &&
+  (await fileExists(ffmpegBin)) &&
+  (await fileExists(ffprobeBin)) &&
+  (await fileExists(sourceTxt)) &&
+  (await fileExists(buildConfigTxt))
+) {
+  const recorded = await readFile(sourceTxt, 'utf8')
+  if (recorded.includes(pin.sha256)) {
+    const capabilities = assessLinuxFfmpegCapabilities({
+      versionOutput: runText(ffmpegBin, ['-version']),
+      encodersOutput: runText(ffmpegBin, ['-hide_banner', '-encoders'])
+    })
+    if (capabilities.ok) {
+      verifyOpenH264Encoder(ffmpegBin)
+      console.log(`Pinned Linux FFmpeg already verified at ${ffmpegBin}`)
+      process.exit(0)
+    }
+  }
+}
+
+let haveTarball = false
+if (!force && (await fileExists(downloadPath))) {
+  haveTarball = (await sha256Of(downloadPath)) === pin.sha256
+}
+if (!haveTarball) {
+  console.log(`Downloading ${pin.url}`)
+  await mkdir(dirname(downloadPath), { recursive: true })
+  const response = await fetch(pin.url, { redirect: 'follow' })
+  if (!response.ok || !response.body) {
+    fail(`download failed: HTTP ${response.status} for ${pin.url}`)
+  }
+
+  const totalBytes = Number(response.headers.get('content-length') || 0)
+  let downloadedBytes = 0
+  let lastUpdate = 0
+  const startTime = Date.now()
+  const interactive = process.stdout.isTTY === true
+  const updateIntervalMs = interactive ? 100 : 10_000
+  const progress = new Transform({
+    transform(chunk, _encoding, callback) {
+      downloadedBytes += chunk.length
+      const now = Date.now()
+      if (now - lastUpdate >= updateIntervalMs) {
+        lastUpdate = now
+        const elapsedSeconds = Math.max(0.001, (now - startTime) / 1000)
+        const currentMiB = (downloadedBytes / 1024 / 1024).toFixed(1)
+        const speedMiB = (downloadedBytes / 1024 / 1024 / elapsedSeconds).toFixed(1)
+        const suffix = totalBytes
+          ? ` / ${(totalBytes / 1024 / 1024).toFixed(1)} MiB (${Math.floor((downloadedBytes / totalBytes) * 100)}%)`
+          : ''
+        const line = `${currentMiB}${suffix} at ${speedMiB} MiB/s`
+        if (interactive) process.stdout.write(`\r  ${line}`)
+        else console.log(`  ${line}`)
+      }
+      callback(null, chunk)
+    },
+    flush(callback) {
+      if (interactive) process.stdout.write('\n')
+      callback()
+    }
+  })
+  await pipeline(Readable.fromWeb(response.body), progress, createWriteStream(downloadPath))
+}
+
+const actualSha256 = await sha256Of(downloadPath)
+if (actualSha256 !== pin.sha256) {
+  fail(
+    `checksum mismatch for ${downloadPath}\n  expected: ${pin.sha256}\n  actual:   ${actualSha256}`
+  )
+}
+
+await rm(extractDir, { recursive: true, force: true })
+await mkdir(extractDir, { recursive: true })
+execFileSync('tar', ['-xJf', downloadPath, '-C', extractDir], { stdio: 'inherit' })
+
+const extracted = (await readdir(extractDir)).filter((name) => name.startsWith('ffmpeg-'))
+if (extracted.length !== 1) {
+  fail(`expected one ffmpeg-* directory, found ${extracted.join(', ') || '(none)'}`)
+}
+const tarRoot = join(extractDir, extracted[0])
+
+await rm(outputDir, { recursive: true, force: true })
+await mkdir(join(outputDir, 'bin'), { recursive: true })
+await copyFile(join(tarRoot, 'bin', 'ffmpeg'), ffmpegBin).catch(() =>
+  fail(`archive layout drift: ${extracted[0]}/bin/ffmpeg is missing`)
+)
+await copyFile(join(tarRoot, 'bin', 'ffprobe'), ffprobeBin).catch(() =>
+  fail(`archive layout drift: ${extracted[0]}/bin/ffprobe is missing`)
+)
+await copyFile(join(tarRoot, 'LICENSE.txt'), join(outputDir, 'LICENSE.txt')).catch(() =>
+  fail(`archive layout drift: ${extracted[0]}/LICENSE.txt is missing`)
+)
+await chmod(ffmpegBin, 0o755)
+await chmod(ffprobeBin, 0o755)
+
+const versionOutput = runText(ffmpegBin, ['-version'])
+const encodersOutput = runText(ffmpegBin, ['-hide_banner', '-encoders'])
+const capabilityAssessment = assessLinuxFfmpegCapabilities({ versionOutput, encodersOutput })
+if (!capabilityAssessment.ok) {
+  await rm(outputDir, { recursive: true, force: true })
+  fail(`archive violates the Linux encoder policy:\n  - ${capabilityAssessment.problems.join('\n  - ')}`)
+}
+try {
+  verifyOpenH264Encoder(ffmpegBin)
+} catch (error) {
+  await rm(outputDir, { recursive: true, force: true })
+  const stderr = error?.stderr?.toString().trim()
+  fail(`the staged libopenh264 encoder failed a real encode${stderr ? `: ${stderr}` : ''}`)
+}
+
+await writeFile(
+  sourceTxt,
+  [
+    'Prebuilt FFmpeg and FFprobe (Linux x64, LGPL) for Videorc.',
+    `Binary archive: ${pin.url}`,
+    `Binary SHA-256: ${pin.sha256}`,
+    'Corresponding source and reproducible build scripts: https://github.com/BtbN/FFmpeg-Builds',
+    'The release tag in the binary URL identifies the exact source/build revision.',
+    ''
+  ].join('\n')
+)
+await writeFile(buildConfigTxt, versionOutput)
+
+console.log(`Linux FFmpeg verified: VAAPI + OpenH264, LGPL-only (${outputDir})`)

--- a/scripts/lib/ffmpeg-linux-pin.mjs
+++ b/scripts/lib/ffmpeg-linux-pin.mjs
@@ -1,0 +1,85 @@
+const AUTOBUILD_DOWNLOAD =
+  /^https:\/\/github\.com\/BtbN\/FFmpeg-Builds\/releases\/download\/autobuild-(\d{4})-(\d{2})-(\d{2})-\d{2}-\d{2}\/(.+linux64-lgpl.+\.tar\.xz)$/
+
+const SHA256 = /^[0-9a-f]{64}$/
+
+export const REQUIRED_LINUX_FFMPEG_CONFIGURATION = [
+  '--enable-vaapi',
+  '--enable-libopenh264',
+  '--disable-libx264',
+  '--disable-libx265',
+  '--disable-libfdk-aac'
+]
+
+export const REQUIRED_LINUX_H264_ENCODERS = ['h264_vaapi', 'libopenh264']
+
+export function lastDayOfMonth(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
+}
+
+export function linuxAutobuildDurability(url) {
+  const match = AUTOBUILD_DOWNLOAD.exec(String(url ?? ''))
+  if (!match) return null
+  const [, yearText, monthText, dayText] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  return {
+    tagDate: `${yearText}-${monthText}-${dayText}`,
+    durable: day === lastDayOfMonth(year, month)
+  }
+}
+
+export function assessFfmpegLinuxPin(pin) {
+  const problems = []
+  const url = pin?.url
+  const sha256 = pin?.sha256
+
+  if (!url || typeof url !== 'string') {
+    problems.push('missing "url"')
+  } else if (!/linux64-lgpl/.test(url)) {
+    problems.push(`not a Linux x64 LGPL build: ${url}`)
+  }
+  if (!sha256 || typeof sha256 !== 'string') {
+    problems.push('missing "sha256"')
+  } else if (!SHA256.test(sha256)) {
+    problems.push(`"sha256" must be 64 lowercase hex characters, got "${sha256}"`)
+  }
+
+  const durability = linuxAutobuildDurability(url)
+  if (durability && !durability.durable) {
+    problems.push(
+      `autobuild-${durability.tagDate} is a prunable mid-month build; pin the final autobuild of a month`
+    )
+  }
+
+  return { ok: problems.length === 0, problems }
+}
+
+function configurationLine(versionOutput) {
+  return String(versionOutput ?? '')
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('configuration:'))
+}
+
+export function assessLinuxFfmpegCapabilities({ versionOutput, encodersOutput }) {
+  const problems = []
+  const configuration = configurationLine(versionOutput)
+  if (!configuration) {
+    problems.push('ffmpeg -version did not report a configuration line')
+  } else {
+    for (const flag of REQUIRED_LINUX_FFMPEG_CONFIGURATION) {
+      if (!configuration.includes(flag)) problems.push(`missing configure flag ${flag}`)
+    }
+    for (const forbidden of ['--enable-gpl', '--enable-nonfree']) {
+      if (configuration.includes(forbidden)) problems.push(`forbidden configure flag ${forbidden}`)
+    }
+  }
+
+  const encoders = String(encodersOutput ?? '')
+  for (const encoder of REQUIRED_LINUX_H264_ENCODERS) {
+    if (!encoders.split(/\s+/).includes(encoder)) problems.push(`missing H.264 encoder ${encoder}`)
+  }
+
+  return { ok: problems.length === 0, problems }
+}

--- a/scripts/lib/ffmpeg-linux-pin.test.mjs
+++ b/scripts/lib/ffmpeg-linux-pin.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  assessFfmpegLinuxPin,
+  assessLinuxFfmpegCapabilities,
+  linuxAutobuildDurability
+} from './ffmpeg-linux-pin.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const DURABLE_URL =
+  'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-31-14-10/ffmpeg-n8.1.2-34-g9b6c8969e0-linux64-lgpl-8.1.tar.xz'
+const SHA = '8c8b2897f2a8093ae2d985f7f1867d218451d4c567c1b2437f86a7c73a950b9f'
+
+describe('Linux FFmpeg pin', () => {
+  it('requires a durable Linux x64 LGPL autobuild with a lowercase SHA-256', () => {
+    assert.deepEqual(assessFfmpegLinuxPin({ url: DURABLE_URL, sha256: SHA }), {
+      ok: true,
+      problems: []
+    })
+    assert.deepEqual(linuxAutobuildDurability(DURABLE_URL), {
+      tagDate: '2026-07-31',
+      durable: true
+    })
+  })
+
+  it('rejects prunable, GPL, wrong-platform, and malformed pins', () => {
+    assert.match(
+      assessFfmpegLinuxPin({
+        url: DURABLE_URL.replace('2026-07-31-14-10', '2026-08-22-12-58'),
+        sha256: SHA
+      }).problems.join('\n'),
+      /prunable/
+    )
+    assert.match(
+      assessFfmpegLinuxPin({ url: DURABLE_URL.replace('lgpl', 'gpl'), sha256: SHA }).problems.join(
+        '\n'
+      ),
+      /LGPL/
+    )
+    assert.match(
+      assessFfmpegLinuxPin({ url: DURABLE_URL.replace('linux64', 'win64'), sha256: SHA }).problems.join(
+        '\n'
+      ),
+      /Linux x64 LGPL/
+    )
+    assert.match(
+      assessFfmpegLinuxPin({ url: DURABLE_URL, sha256: 'ABC' }).problems.join('\n'),
+      /64 lowercase hex/
+    )
+  })
+
+  it('keeps the committed pin durable', async () => {
+    const pin = JSON.parse(
+      await readFile(join(repoRoot, 'vendor', 'ffmpeg', 'linux-pin.json'), 'utf8')
+    )
+    const assessment = assessFfmpegLinuxPin(pin)
+    assert.equal(assessment.ok, true, assessment.problems.join('\n'))
+  })
+})
+
+describe('Linux FFmpeg capability policy', () => {
+  const versionOutput = [
+    'ffmpeg version 8.1.2',
+    'configuration: --disable-gpl --disable-nonfree --enable-vaapi --enable-libopenh264 --disable-libx264 --disable-libx265 --disable-libfdk-aac'
+  ].join('\n')
+  const encodersOutput = [' V..... h264_vaapi VAAPI H.264 encoder', ' V..... libopenh264 OpenH264'].join(
+    '\n'
+  )
+
+  it('accepts exactly the LGPL VAAPI plus OpenH264 contract', () => {
+    assert.deepEqual(assessLinuxFfmpegCapabilities({ versionOutput, encodersOutput }), {
+      ok: true,
+      problems: []
+    })
+  })
+
+  it('rejects GPL/nonfree flags, missing fallbacks, and incomplete configuration', () => {
+    const assessment = assessLinuxFfmpegCapabilities({
+      versionOutput: versionOutput.replace('--disable-gpl', '--enable-gpl'),
+      encodersOutput: ' V..... h264_vaapi VAAPI H.264 encoder'
+    })
+    assert.match(assessment.problems.join('\n'), /forbidden configure flag --enable-gpl/)
+    assert.match(assessment.problems.join('\n'), /missing H.264 encoder libopenh264/)
+    assert.match(
+      assessLinuxFfmpegCapabilities({ versionOutput: 'ffmpeg version 8.1.2', encodersOutput })
+        .problems.join('\n'),
+      /configuration line/
+    )
+  })
+})

--- a/scripts/lib/linux-encoder-acceptance.mjs
+++ b/scripts/lib/linux-encoder-acceptance.mjs
@@ -1,0 +1,140 @@
+export const LINUX_ENCODER_ACCEPTANCE_BACKENDS = Object.freeze(['openh264', 'vaapi'])
+
+const EXPECTED_DIAGNOSTIC_BACKEND = Object.freeze({
+  openh264: 'software-open-h264',
+  vaapi: 'hardware-vaapi'
+})
+
+export function parseLinuxEncoderAcceptanceArgs(args) {
+  let requested = 'all'
+  let sawBackend = false
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    let value
+    if (argument === '--backend') {
+      value = args[index + 1]
+      index += 1
+      if (!value) throw new Error('--backend requires all, openh264, or vaapi')
+    } else if (argument.startsWith('--backend=')) {
+      value = argument.slice('--backend='.length)
+    } else {
+      throw new Error(`Unknown Linux encoder acceptance argument: ${argument}`)
+    }
+
+    if (sawBackend) throw new Error('--backend may be provided only once')
+    sawBackend = true
+    requested = value
+  }
+
+  if (requested === 'all') {
+    return { requested, backends: [...LINUX_ENCODER_ACCEPTANCE_BACKENDS] }
+  }
+  if (!LINUX_ENCODER_ACCEPTANCE_BACKENDS.includes(requested)) {
+    throw new Error(`--backend must be all, openh264, or vaapi; got ${requested}`)
+  }
+  return { requested, backends: [requested] }
+}
+
+export function parseOsRelease(text) {
+  return Object.fromEntries(
+    String(text ?? '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#') && line.includes('='))
+      .map((line) => {
+        const separator = line.indexOf('=')
+        const key = line.slice(0, separator)
+        const rawValue = line.slice(separator + 1)
+        const quoted =
+          (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+          (rawValue.startsWith("'") && rawValue.endsWith("'"))
+        return [key, quoted ? rawValue.slice(1, -1) : rawValue]
+      })
+  )
+}
+
+export function assessLinuxEncoderAcceptanceHost({
+  platform,
+  arch,
+  osRelease,
+  testerName,
+  machineName,
+  physicalHardware,
+  videoDevices,
+  renderDevices,
+  backends
+}) {
+  const problems = []
+  if (platform !== 'linux' || arch !== 'x64') {
+    problems.push(`requires Linux x64, got ${platform}/${arch}`)
+  }
+  if (osRelease?.ID !== 'ubuntu' || osRelease?.VERSION_ID !== '24.04') {
+    problems.push(
+      `requires Ubuntu 24.04, got ${osRelease?.PRETTY_NAME ?? `${osRelease?.ID ?? 'unknown'} ${osRelease?.VERSION_ID ?? 'unknown'}`}`
+    )
+  }
+  if (!String(testerName ?? '').trim()) {
+    problems.push('VIDEORC_LINUX_TESTER_NAME must name the person running acceptance')
+  }
+  if (!String(machineName ?? '').trim()) {
+    problems.push('VIDEORC_LINUX_TESTER_MACHINE must name the specific hardware box')
+  }
+  if (physicalHardware !== '1') {
+    problems.push('VIDEORC_LINUX_PHYSICAL_HARDWARE=1 must attest this is a real, non-VM box')
+  }
+  if (!Array.isArray(videoDevices) || videoDevices.length === 0) {
+    problems.push('the named tester box must expose a webcam as /dev/video*')
+  }
+  if (
+    backends.includes('vaapi') &&
+    (!Array.isArray(renderDevices) || renderDevices.length === 0)
+  ) {
+    problems.push('VAAPI acceptance requires at least one /dev/dri/renderD* device')
+  }
+  return { ok: problems.length === 0, problems }
+}
+
+export function assessLinuxEncoderMatrixResults({ backend, results }) {
+  const problems = []
+  const expectedDiagnosticBackend = EXPECTED_DIAGNOSTIC_BACKEND[backend]
+  if (!expectedDiagnosticBackend) {
+    return { ok: false, problems: [`unknown Linux encoder backend ${backend}`], result: null }
+  }
+  if (!Array.isArray(results) || results.length !== 1) {
+    return {
+      ok: false,
+      problems: [`expected exactly one 1080p30 matrix result, got ${results?.length ?? 'none'}`],
+      result: null
+    }
+  }
+
+  const result = results[0]
+  if (result.combo !== '1080p30') problems.push(`expected combo 1080p30, got ${result.combo}`)
+  if (!Array.isArray(result.failures)) {
+    problems.push('matrix result omitted its failures array')
+  } else if (result.failures.length > 0) {
+    problems.push(...result.failures.map((failure) => `matrix failure: ${failure}`))
+  }
+  if (!String(result.outputPath ?? '').trim() || !(result.sizeBytes > 0)) {
+    problems.push('matrix result did not prove a non-empty recording artifact')
+  }
+  if (result.metrics?.width !== 1920 || result.metrics?.height !== 1080) {
+    problems.push(
+      `expected a 1920x1080 artifact, got ${result.metrics?.width ?? '?'}x${result.metrics?.height ?? '?'}`
+    )
+  }
+  if (
+    typeof result.metrics?.observedFps !== 'number' ||
+    Math.abs(result.metrics.observedFps - 30) > 0.6
+  ) {
+    problems.push(`expected artifact cadence near 30fps, got ${result.metrics?.observedFps ?? '?'}`)
+  }
+  if (result.bridgeDiagnostics?.encodeBackend !== expectedDiagnosticBackend) {
+    problems.push(
+      `expected diagnostics backend ${expectedDiagnosticBackend}, got ${result.bridgeDiagnostics?.encodeBackend ?? 'missing'}`
+    )
+  }
+
+  return { ok: problems.length === 0, problems, result }
+}

--- a/scripts/lib/linux-encoder-acceptance.test.mjs
+++ b/scripts/lib/linux-encoder-acceptance.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  assessLinuxEncoderAcceptanceHost,
+  assessLinuxEncoderMatrixResults,
+  parseLinuxEncoderAcceptanceArgs,
+  parseOsRelease
+} from './linux-encoder-acceptance.mjs'
+
+describe('Linux encoder acceptance arguments', () => {
+  it('runs both backends by default and accepts one explicit diagnostic backend', () => {
+    assert.deepEqual(parseLinuxEncoderAcceptanceArgs([]), {
+      requested: 'all',
+      backends: ['openh264', 'vaapi']
+    })
+    assert.deepEqual(parseLinuxEncoderAcceptanceArgs(['--backend=vaapi']), {
+      requested: 'vaapi',
+      backends: ['vaapi']
+    })
+    assert.deepEqual(parseLinuxEncoderAcceptanceArgs(['--backend', 'openh264']), {
+      requested: 'openh264',
+      backends: ['openh264']
+    })
+  })
+
+  it('rejects unknown, missing, and repeated backend arguments', () => {
+    assert.throws(() => parseLinuxEncoderAcceptanceArgs(['--backend']), /requires/)
+    assert.throws(() => parseLinuxEncoderAcceptanceArgs(['--backend=x264']), /openh264, or vaapi/)
+    assert.throws(
+      () => parseLinuxEncoderAcceptanceArgs(['--backend=vaapi', '--backend=openh264']),
+      /only once/
+    )
+    assert.throws(() => parseLinuxEncoderAcceptanceArgs(['--force']), /Unknown/)
+  })
+})
+
+describe('Linux encoder acceptance host contract', () => {
+  const validHost = {
+    platform: 'linux',
+    arch: 'x64',
+    osRelease: { ID: 'ubuntu', VERSION_ID: '24.04', PRETTY_NAME: 'Ubuntu 24.04.3 LTS' },
+    testerName: 'Tester One',
+    machineName: 'intel-laptop-a',
+    physicalHardware: '1',
+    videoDevices: ['/dev/video0'],
+    renderDevices: ['/dev/dri/renderD128'],
+    backends: ['openh264', 'vaapi']
+  }
+
+  it('parses os-release and accepts only the named Ubuntu hardware contract', () => {
+    assert.deepEqual(
+      parseOsRelease('ID=ubuntu\nVERSION_ID="24.04"\nPRETTY_NAME="Ubuntu 24.04.3 LTS"\n'),
+      { ID: 'ubuntu', VERSION_ID: '24.04', PRETTY_NAME: 'Ubuntu 24.04.3 LTS' }
+    )
+    assert.deepEqual(assessLinuxEncoderAcceptanceHost(validHost), { ok: true, problems: [] })
+  })
+
+  it('rejects CI/VM substitutes, anonymous boxes, and missing real devices', () => {
+    const assessment = assessLinuxEncoderAcceptanceHost({
+      ...validHost,
+      osRelease: { ID: 'debian', VERSION_ID: '13', PRETTY_NAME: 'Debian 13' },
+      testerName: '',
+      machineName: '',
+      physicalHardware: '',
+      videoDevices: [],
+      renderDevices: []
+    })
+    assert.equal(assessment.ok, false)
+    assert.match(assessment.problems.join('\n'), /Ubuntu 24.04/)
+    assert.match(assessment.problems.join('\n'), /TESTER_NAME/)
+    assert.match(assessment.problems.join('\n'), /TESTER_MACHINE/)
+    assert.match(assessment.problems.join('\n'), /PHYSICAL_HARDWARE/)
+    assert.match(assessment.problems.join('\n'), /webcam/)
+    assert.match(assessment.problems.join('\n'), /renderD/)
+  })
+})
+
+describe('Linux encoder acceptance evidence', () => {
+  function passingResult(encodeBackend) {
+    return [
+      {
+        combo: '1080p30',
+        outputPath: '/tmp/recording.mp4',
+        sizeBytes: 2048,
+        failures: [],
+        metrics: { width: 1920, height: 1080, observedFps: 30.0 },
+        bridgeDiagnostics: { encodeBackend }
+      }
+    ]
+  }
+
+  it('requires the artifact and truthful forced backend diagnostics', () => {
+    assert.equal(
+      assessLinuxEncoderMatrixResults({
+        backend: 'openh264',
+        results: passingResult('software-open-h264')
+      }).ok,
+      true
+    )
+    assert.equal(
+      assessLinuxEncoderMatrixResults({
+        backend: 'vaapi',
+        results: passingResult('hardware-vaapi')
+      }).ok,
+      true
+    )
+
+    const wrongBackend = assessLinuxEncoderMatrixResults({
+      backend: 'vaapi',
+      results: passingResult('software-open-h264')
+    })
+    assert.equal(wrongBackend.ok, false)
+    assert.match(wrongBackend.problems.join('\n'), /hardware-vaapi/)
+  })
+})

--- a/scripts/smoke-linux-encoder-acceptance.mjs
+++ b/scripts/smoke-linux-encoder-acceptance.mjs
@@ -1,0 +1,138 @@
+// Hardware-only L1.5 acceptance. This runs the real dev app's 1080p30
+// recording matrix once with forced OpenH264 and once with forced VAAPI, then
+// emits named-machine evidence. CI and VMs intentionally cannot satisfy it.
+
+import { spawnSync } from 'node:child_process'
+import { cpus, platform, release, tmpdir } from 'node:os'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  assessLinuxEncoderAcceptanceHost,
+  assessLinuxEncoderMatrixResults,
+  parseLinuxEncoderAcceptanceArgs,
+  parseOsRelease
+} from './lib/linux-encoder-acceptance.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const ffmpegPath = join(repoRoot, 'vendor', 'ffmpeg', 'linux-x64', 'bin', 'ffmpeg')
+const ffprobePath = join(repoRoot, 'vendor', 'ffmpeg', 'linux-x64', 'bin', 'ffprobe')
+const fetchScript = join(repoRoot, 'scripts', 'fetch-ffmpeg-linux.mjs')
+const matrixScript = join(repoRoot, 'scripts', 'smoke-recording-matrix-app.mjs')
+const pinPath = join(repoRoot, 'vendor', 'ffmpeg', 'linux-pin.json')
+const timestamp = new Date().toISOString().replaceAll(':', '-')
+const outputRoot = resolve(
+  process.env.VIDEORC_LINUX_ENCODER_EVIDENCE_DIR ??
+    join(tmpdir(), `videorc-linux-encoder-acceptance-${timestamp}`)
+)
+
+function fail(message) {
+  throw new Error(`linux-encoder-acceptance: ${message}`)
+}
+
+function runNode(script, env = process.env) {
+  const result = spawnSync(process.execPath, [script], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+    stdio: 'inherit'
+  })
+  if (result.error) fail(`could not run ${script}: ${result.error.message}`)
+  if (result.status !== 0) {
+    fail(`${script} exited with ${result.status ?? result.signal ?? 'unknown status'}`)
+  }
+}
+
+async function devicePaths(directory, pattern) {
+  const names = await readdir(directory).catch(() => [])
+  return names.filter((name) => pattern.test(name)).sort().map((name) => join(directory, name))
+}
+
+async function main() {
+  const { requested, backends } = parseLinuxEncoderAcceptanceArgs(process.argv.slice(2))
+  const osRelease = parseOsRelease(await readFile('/etc/os-release', 'utf8').catch(() => ''))
+  const videoDevices = await devicePaths('/dev', /^video\d+$/)
+  const renderDevices = await devicePaths('/dev/dri', /^renderD\d+$/)
+  const testerName = process.env.VIDEORC_LINUX_TESTER_NAME?.trim()
+  const machineName = process.env.VIDEORC_LINUX_TESTER_MACHINE?.trim()
+  const physicalHardware = process.env.VIDEORC_LINUX_PHYSICAL_HARDWARE
+  const hostAssessment = assessLinuxEncoderAcceptanceHost({
+    platform: platform(),
+    arch: process.arch,
+    osRelease,
+    testerName,
+    machineName,
+    physicalHardware,
+    videoDevices,
+    renderDevices,
+    backends
+  })
+  if (!hostAssessment.ok) fail(hostAssessment.problems.join('\n  - '))
+
+  await mkdir(outputRoot, { recursive: true })
+  runNode(fetchScript)
+  if (!existsSync(ffmpegPath) || !existsSync(ffprobePath)) {
+    fail('the verified Linux FFmpeg/FFprobe pair was not staged')
+  }
+
+  const pin = JSON.parse(await readFile(pinPath, 'utf8'))
+  const runs = []
+  for (const backend of backends) {
+    const outputDirectory = join(outputRoot, backend)
+    console.log(`\nLinux encoder acceptance: ${backend} -> ${outputDirectory}`)
+    runNode(matrixScript, {
+      ...process.env,
+      VIDEORC_LINUX_H264_ENCODER: backend,
+      VIDEORC_MATRIX_ONLY: '1080p30',
+      VIDEORC_MATRIX_RECORDING_MS: process.env.VIDEORC_MATRIX_RECORDING_MS ?? '6000',
+      VIDEORC_MATRIX_PRINT_BRIDGE_DIAGNOSTICS: '1',
+      VIDEORC_SMOKE_FFMPEG_PATH: ffmpegPath,
+      VIDEORC_SMOKE_OUTPUT_DIR: outputDirectory,
+      VIDEORC_SMOKE_TIMEOUT_MS: process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? '180000'
+    })
+
+    const resultsPath = join(outputDirectory, 'recording-matrix-results.json')
+    const results = JSON.parse(await readFile(resultsPath, 'utf8'))
+    const assessment = assessLinuxEncoderMatrixResults({ backend, results })
+    if (!assessment.ok) fail(`${backend}:\n  - ${assessment.problems.join('\n  - ')}`)
+    runs.push({ requestedBackend: backend, result: assessment.result })
+  }
+
+  const complete = requested === 'all' && runs.length === 2
+  const evidence = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    contract: 'linux-l1.5-1080p30',
+    complete,
+    tester: { name: testerName, machine: machineName },
+    host: {
+      distribution: osRelease.PRETTY_NAME,
+      kernel: release(),
+      architecture: process.arch,
+      physicalHardwareAttested: true,
+      cpu: cpus()[0]?.model ?? 'unknown',
+      displaySession: process.env.XDG_SESSION_TYPE ?? 'unknown',
+      waylandDisplayPresent: Boolean(process.env.WAYLAND_DISPLAY),
+      videoDevices,
+      renderDevices
+    },
+    ffmpeg: { path: ffmpegPath, url: pin.url, sha256: pin.sha256 },
+    runs
+  }
+  const evidencePath = join(outputRoot, 'linux-encoder-acceptance.json')
+  await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`)
+
+  if (!complete) {
+    console.log(`\nDiagnostic backend run passed; full two-backend acceptance remains incomplete.`)
+  } else {
+    console.log(`\nLinux L1.5 hardware acceptance PASS.`)
+  }
+  console.log(`Evidence: ${evidencePath}`)
+}
+
+main().catch((error) => {
+  console.error(error?.stack ?? String(error))
+  process.exitCode = 1
+})

--- a/scripts/smoke-recording-matrix-app.mjs
+++ b/scripts/smoke-recording-matrix-app.mjs
@@ -166,6 +166,7 @@ async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, st
   const diagnostics = await request(ws, timeoutMs, 'diagnostics.stats')
   const bridgeDiagnostics = Object.fromEntries(
     [
+      'encodeBackend',
       'encoderBridgeInputFps',
       'encoderBridgeQueueDepth',
       'encoderBridgeOutputQueueOldestFrameAgeMs',

--- a/vendor/ffmpeg/linux-pin.json
+++ b/vendor/ffmpeg/linux-pin.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-31-14-10/ffmpeg-n8.1.2-34-g9b6c8969e0-linux64-lgpl-8.1.tar.xz",
+  "sha256": "8c8b2897f2a8093ae2d985f7f1867d218451d4c567c1b2437f86a7c73a950b9f"
+}


### PR DESCRIPTION
## Summary

- pin and verify a durable Linux x64 LGPL FFmpeg bundle with VAAPI and OpenH264, explicitly rejecting x264/x265/fdk-aac, GPL, and nonfree builds
- probe `/dev/dri/renderD*` with a real `h264_vaapi` encode, bind the accepted render node to production FFmpeg commands, and use a named OpenH264 software fallback without a quality toast
- expose truthful VAAPI/OpenH264 diagnostics across Rust, the RPC schema, and the desktop UI
- extend the Linux workflow to execute the staged binary, verify its capabilities, and run a real OpenH264 encode
- add a hardware-only acceptance command that records real-app 1080p30 artifacts with forced OpenH264 and VAAPI, verifies the selected backend, and emits named Ubuntu-machine evidence
- document the L1.5 contract and the named-hardware stop before L2

## Hardware acceptance

Run this on the named physical Ubuntu 24.04 x64 tester box with a webcam and VAAPI render node:

```bash
VIDEORC_LINUX_TESTER_NAME="<person>" \
VIDEORC_LINUX_TESTER_MACHINE="<specific box>" \
VIDEORC_LINUX_PHYSICAL_HARDWARE=1 \
pnpm smoke:linux-encoder-acceptance
```

The default two-backend run must produce `linux-encoder-acceptance.json` with `complete: true`. Single-backend runs are diagnostic only. CI runners and VMs do not clear this gate.

## Verification

- `cargo fmt --check --all`
- `cargo clippy -p videorc-backend -- -D warnings`
- focused Rust tests: Linux selector/probe/args, H.264 platform args/backends, protocol wire parity, and Rust 1.98 compatibility sites
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @videorc/desktop test` — 1,372 passed, 1 skipped
- `pnpm test:scripts` — 1,055 passed
- `pnpm build`
- `pnpm smoke:recording-matrix` — 12/12 profiles passed, including 1080p60 and 4K30 hard-content passes
- Shadscan: baseline 41, enforced floor 41, final pre-commit 41 using `pnpm dlx @shadscan/cli@next --json`
- GitHub CI at `e462c1b1`: JavaScript, Linux L1.5, macOS Rust, Windows three-pass stability, Windows installer, and CodeRabbit draft-status checks all passed

`pnpm smoke:recording-studio` passed every unit/artifact/app/preview gate through detached native-surface reattach. Its final real ScreenCaptureKit smoke, and the Notes-window smoke run separately, are consistently blocked before recording by `preview.surface.create failed: This backend method is restricted to Electron main`. This is recorded as a host/authorization blocker; it is not presented as a media PASS.

## Merge blockers

- A named Ubuntu 24.04 x64 tester and real hardware are still required to run the acceptance command and prove 1080p30 with both VAAPI and OpenH264.
- Contributor attribution/DCO and the tester invitation are awaiting a response in #247. The commits carry privacy-preserving co-author credit but do not fabricate ForrestKnight's sign-off.

This PR intentionally stops at L1.5. It does not begin PipeWire audio, V4L2 camera, portal capture, Linux preview, packaging, or release work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux H.264 hardware encoding through VAAPI when supported.
  * Added automatic fallback to OpenH264 software encoding when hardware encoding is unavailable.
  * Added encoder selection preferences and clearer diagnostics showing the active backend and fallback reason.
  * Linux diagnostics now display hardware encoding as “Hardware (VAAPI).”

* **Quality Improvements**
  * Added Linux encoder acceptance checks covering recording output, frame rate, dimensions, and backend reporting.
  * Added verified, LGPL-compatible FFmpeg provisioning for Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->