### PR TITLE
docs: 0.9.66 release record

### DIFF
--- a/docs/releases/0.9.66.md
+++ b/docs/releases/0.9.66.md
@@ -1,0 +1,69 @@
+# Videorc 0.9.66 Beta 1
+
+Meet the co-host: a Premium, alpha-labelled AI producer for the Comments
+window that reads live chat during the stream, groups unanswered questions,
+drafts replies the streamer approves, and flags messages that need a
+moderator's eye. Nothing is ever sent without the streamer.
+
+## Scope
+
+- **Live chat co-host** (PR #245, plan: vault `2026-08-22 - Videorc Live
+  Chat Co-host Plan`): Rust `CohostEngine` inside the live-chat coordinator
+  (tick on ≥5 new messages or ≥1 new + 20 s, never <8 s apart, idle = no
+  ticks, delta cap 60, backoff 5–60 s, Retry-After honoured); one web call
+  per tick; session/generation guard; RPCs `cohost.*` + event
+  `cohost.state`; `liveChat.send` gains `inReplyToQuestionId` → auto
+  "answered". Renderer: Co-host pane in the Comments window (R / H / A / ⌫ /
+  ⌘J, footer action bar with key chips), status chip, Settings → Co-host
+  (Premium switch, tone, notes ≤ 4000, auto-highlight off), per-platform
+  draft caps, main↔window relay mirroring the highlight relay. Feature id
+  `live-cohost`, fail-closed; consent reuses the cloud-AI toggle; marked
+  **alpha** in the pane, notice badge, and Settings.
+- **Web** (videorc-web PR #11, deployed 2026-08-22): `POST
+  /api/ai/cohost/tick` with the full gate ladder (auth → schema → prompt
+  version → consent → Premium → kill switch → daily quota → gateway), zod
+  contract + prompt v1 + sanitizer, quota 1 200 ticks/day (Premium),
+  migration 0012 (`ai_usage_events.kind`, nullable `ai_job_id`) applied on
+  Neon, tier policy `liveCohostEnabled`, privacy-page disclosure. Model
+  falls back to `VIDEORC_AI_DEFAULT_TEXT_MODEL`; kill switch
+  `VIDEORC_AI_COHOST_DISABLED` is unset (enabled).
+- Release prep #246 (version bump + changelog).
+
+## Release status
+
+- [x] PRs merged: #245, #246 (admin-merged; local gates: typecheck / lint /
+      format, cargo fmt + clippy -D warnings, targeted cargo suites cohost 18
+      / live_chat 52 / protocol 31 / entitlements 18, 1 372 desktop tests,
+      1 045 script tests, `smoke:cohost-fake` PASS — 9 ticks / 44 messages;
+      `smoke:comment-highlight-stream` PASS on clean main); videorc-web #11
+      (386/387 tests, the 1 failure pre-existing; typecheck clean).
+- [x] macOS source commit `f114da4384543c064556a03d08284aaeac90333e`.
+- [x] Signed + notarized arm64 build; staple + Gatekeeper verified
+      (`release:validate:macos` PASS on .app and DMG).
+- [x] Uploaded to R2, all objects verified; `latest-mac.yml` serves
+      `version: 0.9.66`; zip 200 / 149 498 844 bytes; changelog.json carries
+      `0.9.66-beta.1`.
+- [x] Discord announcement posted (2026-08-23 00:2x CEST).
+- [ ] Owner acceptance: `docs/live-chat-live-smoke-checklist.md` → "Live
+      co-host" on a real Twitch + YouTube stream (grouping, R→send→cleared,
+      H card visible viewer-side, flags, sign-out/quota states, `cohost-tick`
+      usage rows).
+
+## Windows Alpha
+
+**Not released.** The `windows-alpha-release` lane cannot sign until the
+Azure Trusted Signing identity validation (`e450b194-…`, "Uros Miric")
+completes. No `0.9.66-alpha.1` changelog entry was added. Partial
+coordinated release per the release skill's completion contract.
+
+## Incident
+
+Upload was delayed 6.5 h (17:55 → 00:23 CEST, 2026-08-22/23): every TLS
+connection to the R2 bucket IPs returned a forged certificate
+(`CN=core1.netops.test, OU=Packetland`) on home fibre and on a 4G hotspot
+alike, while other Cloudflare IPs and `api.cloudflare.com` stayed clean —
+operator-level Cloudflare IP blocking on a LaLiga matchday (second
+occurrence after 0.9.53 on 2026-08-16). TLS verification was never bypassed;
+a 60 s issuer watcher ran the upload automatically when the genuine
+certificate returned. Follow-up: add a Cloudflare-API (`wrangler`) upload
+fallback to the release tooling and avoid Saturday-evening releases.


### PR DESCRIPTION
Release record for 0.9.66-beta.1 (co-host alpha). macOS live + verified; Windows Alpha explicitly not released (Azure validation); R2/LaLiga block incident documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Videorc 0.9.66 Beta 1.
  * Documented the Premium live-chat AI co-host alpha, web API deployment, release validation, Windows signing blocker, and R2 upload incident follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->