### PR TITLE
fix(ci): allow clippy::chunks_exact_to_as_chunks (Rust 1.98)

### DIFF
--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -1,3 +1,10 @@
+// Rust 1.98 clippy (CI `stable`) flags `chunks_exact(N)` with a constant N in
+// favour of `as_chunks::<N>()`. The pixel loops in the compositor/capture paths
+// are deliberately written with `chunks_exact`, which is the same speed and
+// keeps the row/pixel arithmetic explicit; silence the style lint crate-wide
+// rather than rewriting ten hot loops for a cosmetic suggestion.
+#![allow(clippy::chunks_exact_to_as_chunks)]
+
 mod account;
 mod ai;
 mod atomic_file;


### PR DESCRIPTION
Main's Rust job went red on 2a92fc0e because stable clippy moved to 1.98 and added `chunks_exact_to_as_chunks`; 10 sites, all deliberate pixel loops. Crate-wide documented allow. Verified clean with `cargo clippy -p videorc-backend -- -D warnings` on rustc 1.98.0 locally; fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to preserve existing performance-sensitive processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->