### PR TITLE
release: 0.9.66-alpha.1 Windows changelog

### DIFF
--- a/changelog/0.9.66-alpha.1.md
+++ b/changelog/0.9.66-alpha.1.md
@@ -1,0 +1,39 @@
+---
+version: 0.9.66-alpha.1
+date: 2026-08-23
+channel: alpha
+platforms:
+  - windows
+title: Windows catches up — fifteen macOS releases in one Alpha, plus the co-host
+summary: The Windows Alpha jumps from 0.9.51 to 0.9.66 in one update. Everything shipped on macOS since mid-August comes along — steadier cameras and scene changes, recording that recovers instead of refusing, Twitch connect that completes, X viewer counts — and the new Premium AI co-host for live chat (alpha).
+highlights:
+  - Meet the co-host (alpha, Premium) — the Comments window groups the questions your chat is actually asking, drafts replies you approve with one key, and flags messages that need a moderator's eye. Nothing is ever sent without you.
+  - Cameras stay steady through scene changes — switching layouts no longer restarts the camera, and the optional scene-motion glide is available (off by default).
+  - Record recovers a tired camera instead of refusing — a degraded-but-alive device is restarted once, then recording proceeds with a warning rather than a dead button.
+  - Connecting Twitch completes now — the device-code sign-in no longer authorizes into the void.
+  - Livestream lessons — takeover mute, window-only comments, notes-only capture privacy, a stop that actually stops, and X viewer counts in the Comments window.
+  - Notes-proof recording and real camera panning — the Notes window can't leak into a capture, and cover-crop camera scenes pan properly.
+---
+
+The Windows Alpha last shipped as 0.9.51 on 12 August. Since then macOS has
+had fifteen releases; this Alpha brings Windows level with 0.9.66 in a single
+update. The headline is the co-host: an AI producer for the Comments window
+that reads live chat during the stream, groups duplicate questions across
+Twitch and YouTube, ranks them, and drafts replies — you press R to take a
+draft into the composer, edit it, and ⌘/Ctrl+↩ sends it through the normal
+per-platform fan-out. It never posts on its own, it makes no AI calls while
+chat is quiet, and it is labelled alpha because grouping and tone will be
+tuned on real streams.
+
+Underneath, the camera and scene work from 0.9.63–0.9.65 lands on Windows:
+every scene captures the full canvas, so switching presets never restarts the
+camera, and the compositor holds the last good frame through device restarts
+instead of flashing placeholders. Recording no longer refuses a degraded
+camera; it restarts the device once and proceeds with a warning. Twitch's
+device-code sign-in completes, X viewer counts show next to the chat, and the
+stream stop path, takeover mute, notes-only capture privacy and cover-crop
+panning fixes from the August livestream batches are all included.
+
+As with 0.9.51, the installer and app are signed with Videorc's certificate;
+SmartScreen may still show a reputation notice while the certificate is
+young — the Windows Alpha page explains how to verify the download.


### PR DESCRIPTION
Adds `changelog/0.9.66-alpha.1.md` (channel alpha, platforms windows) on top of current main, no version change — the Windows Alpha has been stuck at 0.9.51 since Aug 12 (Windows-only compile break from 0.9.63, fixed in fa104246). Candidate build `release-windows-alpha.yml` is dispatched from main after this merges. `pnpm changelog:check`: 70 entries valid.