### PR TITLE
docs: 0.9.66 release record — Windows pilot live

### DIFF
--- a/docs/releases/0.9.66.md
+++ b/docs/releases/0.9.66.md
@@ -51,10 +51,33 @@ moderator's eye. Nothing is ever sent without the streamer.
 
 ## Windows Alpha
 
-**Not released.** The `windows-alpha-release` lane cannot sign until the
-Azure Trusted Signing identity validation (`e450b194-…`, "Uros Miric")
-completes. No `0.9.66-alpha.1` changelog entry was added. Partial
-coordinated release per the release skill's completion contract.
+**Pilot live (2026-08-23 00:41 CEST), public promotion pending physical
+acceptance.** The earlier statement that the lane was blocked on Azure identity
+validation was wrong — validation had completed on 2026-08-10; the real blocker
+was a Windows-only compile break introduced with scene transitions (0.9.63,
+`SceneConfigParams.transition_ms`), fixed in `fa104246` (via #248), plus the
+Rust 1.98 clippy lint on the Linux job (#250). Windows had been stuck at
+0.9.51-alpha.1 (pilot) since 2026-08-12.
+
+- Changelog `0.9.66-alpha.1` added on `main` (#251) → source commit
+  `91cceebae42e43dd5916fc486011f8e69388b600`.
+- Candidate: https://github.com/TheOrcDev/videorc/actions/runs/32606637547 —
+  unsigned gates PASS, protected sign job approved by the release owner,
+  Trusted Signing publisher `Uros Miric`, `windows-release-artifact: PASS`,
+  installer SHA-256
+  `74c443af0fda15f581633393ff5a572dd333573b03742e9f5e5cc9cfcde89cf1`, stored at
+  `candidates/windows/0.9.66-alpha.1/91cceeba…/`.
+- Pilot promotion: https://github.com/TheOrcDev/videorc/actions/runs/32608389639
+  — candidate download/verify PASS, `windows-alpha-release-upload: PASS`;
+  published `releases/windows/0.9.66-alpha.1/*`, `updates/windows/pilot/*`,
+  `releases/windows/pilot/release.json`. Stable Windows feed, accepted manifest
+  and global changelog withheld (pending manifest preserved).
+- [ ] Physical acceptance on clean Windows 11 x64 (`docs/releases/windows-alpha-runbook.md` §3)
+      with the identity above; Alpha-to-Alpha update from 0.9.51 via the pilot
+      feed (§4). No committed record exists for 0.9.51 (it never left pilot), so
+      this record may use the `first-public-alpha` sequence if the promotion
+      script accepts it; otherwise record 0.9.51 as the pilot predecessor.
+- [ ] Sanitized PASS record `docs/acceptance/windows-alpha/0.9.66-alpha.1.json` → public promotion → web state `public` → production smoke.
 
 ## Incident
 


### PR DESCRIPTION
Windows 0.9.66-alpha.1: candidate run 32606637547, pilot promotion 32608389639 (PASS). Corrects the earlier 'blocked on Azure validation' statement. Public promotion still gated on physical acceptance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Windows Alpha release status from “Not released” to “Pilot live.”
  * Added release notes for Windows Alpha 0.9.66-alpha.1.
  * Documented the signed candidate build and installer verification details.
  * Clarified that stable Windows distribution remains withheld during pilot validation.
  * Added acceptance checks for clean Windows 11 installation, upgrades, and production smoke testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->