### PR TITLE
feat(cohost): error code + message in toast/chip, 12s tick timeout

### DIFF
--- a/apps/desktop/src/renderer/src/components/cohost-pane.test.ts
+++ b/apps/desktop/src/renderer/src/components/cohost-pane.test.ts
@@ -220,4 +220,30 @@ describe('CohostPane', () => {
     expect(markup).toContain('Partial')
     expect(markup).toContain('Chat is hyped')
   })
+
+  it("names the failed tick in the server's words as the chip tooltip and a secondary line", () => {
+    const detail = 'ai-gateway-error (HTTP 502): The co-host tick failed on every configured model.'
+    const markup = renderPane({
+      state: state({
+        status: 'error',
+        reason: 'gateway-error',
+        detail: {
+          code: 'ai-gateway-error',
+          message: 'The co-host tick failed on every configured model.',
+          status: 502
+        }
+      })
+    })
+    expect(markup).toContain('error · AI error')
+    expect(markup).toContain(`title="${detail}"`)
+    expect(markup).toContain('data-slot="cohost-error-detail"')
+    expect(markup).toContain('once co-host is listening again')
+    expect(markup).not.toContain('Listening — questions')
+    // Monochrome: the detail line is muted copy, never a destructive accent.
+    expect(markup).not.toContain('text-destructive')
+
+    const healthy = renderPane({ state: state() })
+    expect(healthy).not.toContain('data-slot="cohost-error-detail"')
+    expect(healthy).toContain('Listening — questions from chat will appear here.')
+  })
 })

--- a/apps/desktop/src/renderer/src/components/cohost-pane.tsx
+++ b/apps/desktop/src/renderer/src/components/cohost-pane.tsx
@@ -224,6 +224,7 @@ export function CohostPane({
               'truncate text-[11px]',
               chip.tone === 'live' ? 'text-success' : 'text-muted-foreground'
             )}
+            title={chip.detail ?? undefined}
           >
             {chip.label.replace(/^Co-host: /, '')}
           </span>
@@ -241,6 +242,17 @@ export function CohostPane({
 
       <CollapsibleContent>
         <Separator />
+        {chip?.detail ? (
+          // The failed tick in the server's own words, so "AI error" is never
+          // the whole story. Monochrome; the chip already carries the state.
+          <p
+            className="truncate px-2.5 py-1 text-[11px] text-subtle"
+            data-slot="cohost-error-detail"
+            title={chip.detail}
+          >
+            {chip.detail}
+          </p>
+        ) : null}
         <Command
           ref={rootRef}
           aria-label="Co-host questions and flags"
@@ -254,7 +266,9 @@ export function CohostPane({
           <CommandList className="max-h-48 px-1 py-1">
             {rows.length === 0 ? (
               <p className="px-2 py-3 text-xs text-subtle">
-                Listening — questions from chat will appear here.
+                {state?.status === 'listening'
+                  ? 'Listening — questions from chat will appear here.'
+                  : 'Questions from chat will appear here once co-host is listening again.'}
               </p>
             ) : (
               <>

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -274,10 +274,9 @@ import {
 import { commentCanHighlight } from '@/components/comment-row'
 import {
   applyCohostState,
-  cohostErrorToastReason,
+  cohostErrorToast,
   cohostHighlightMessageId,
-  sortedCohostQuestions,
-  COHOST_ERROR_TOAST_MESSAGES
+  sortedCohostQuestions
 } from '@/lib/cohost-view'
 import { entitlementDisabledReason } from '@/lib/entitlements'
 import { upsertNoiseCleanupJob } from '@/lib/noise-cleanup-view'
@@ -2668,10 +2667,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     cohostStateRef.current = merged
     setCohostState(merged)
     // Toast discipline: the pane and the destination chip already show every
-    // co-host state. Only a NEW error reason is news.
-    const reason = cohostErrorToastReason(previous, merged)
-    if (reason) {
-      toast.error(COHOST_ERROR_TOAST_MESSAGES[reason], { id: 'cohost-error' })
+    // co-host state. Only a NEW failure (reason + server error code) is news;
+    // backoff retries of the same failure stay silent.
+    const errorToast = cohostErrorToast(previous, merged)
+    if (errorToast) {
+      toast.error(errorToast.message, { id: 'cohost-error' })
     }
   }, [])
 

--- a/apps/desktop/src/renderer/src/lib/cohost-view.test.ts
+++ b/apps/desktop/src/renderer/src/lib/cohost-view.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, it } from 'vitest'
 
-import type { CohostFlag, CohostQuestion, CohostReason, CohostState } from '@/lib/backend'
+import type {
+  CohostErrorDetail,
+  CohostFlag,
+  CohostQuestion,
+  CohostReason,
+  CohostState
+} from '@/lib/backend'
 import {
   applyCohostState,
   cohostAgeLabel,
   cohostAskersLabel,
   cohostChipView,
-  cohostErrorToastReason,
+  cohostErrorDetailText,
+  cohostErrorToast,
+  cohostErrorToastKey,
+  cohostErrorToastMessage,
   cohostFlagRowKey,
   cohostHighlightMessageId,
   cohostPaneMode,
@@ -58,6 +67,19 @@ function state(overrides: Partial<CohostState> = {}): CohostState {
     tickSeq: 4,
     ...overrides
   }
+}
+
+/** The 2026-08-23 incident envelope: web answered 502 `ai-gateway-error`. */
+const GATEWAY_502: CohostErrorDetail = {
+  code: 'ai-gateway-error',
+  message: 'The co-host tick failed on every configured model.',
+  status: 502
+}
+
+const TIMEOUT: CohostErrorDetail = {
+  code: 'timeout',
+  message: 'The co-host service did not answer within 12 s.',
+  status: null
 }
 
 describe('applyCohostState', () => {
@@ -122,11 +144,13 @@ describe('cohostChipView', () => {
   it('is the only chip that earns the live accent while listening', () => {
     expect(cohostChipView(state({ questions: [question(), question({ id: 'q-2' })] }))).toEqual({
       label: 'Co-host: listening · 2 q',
-      tone: 'live'
+      tone: 'live',
+      detail: null
     })
     expect(cohostChipView(state({ questions: [] }))).toEqual({
       label: 'Co-host: listening',
-      tone: 'live'
+      tone: 'live',
+      detail: null
     })
   })
 
@@ -142,23 +166,77 @@ describe('cohostChipView', () => {
       ['gateway-error', 'Co-host: paused · AI error']
     ]
     for (const [reason, label] of cases) {
-      expect(cohostChipView(state({ status: 'paused', reason }))).toEqual({ label, tone: 'muted' })
+      expect(cohostChipView(state({ status: 'paused', reason }))).toEqual({
+        label,
+        tone: 'muted',
+        detail: null
+      })
     }
   })
 
   it('stays monochrome for off and error', () => {
     expect(cohostChipView(state({ status: 'off', reason: null }))).toEqual({
       label: 'Co-host: off',
-      tone: 'muted'
+      tone: 'muted',
+      detail: null
     })
     expect(cohostChipView(state({ status: 'error', reason: 'gateway-error' }))).toEqual({
       label: 'Co-host: error · AI error',
-      tone: 'muted'
+      tone: 'muted',
+      detail: null
     })
     expect(cohostChipView(state({ status: 'error', reason: null }))).toEqual({
       label: 'Co-host: error',
-      tone: 'muted'
+      tone: 'muted',
+      detail: null
     })
+  })
+
+  it("carries the failed tick in the server's own words as the chip detail", () => {
+    expect(
+      cohostChipView(state({ status: 'error', reason: 'gateway-error', detail: GATEWAY_502 }))
+    ).toEqual({
+      label: 'Co-host: error · AI error',
+      tone: 'muted',
+      detail: 'ai-gateway-error (HTTP 502): The co-host tick failed on every configured model.'
+    })
+    // No HTTP status for a desktop-side failure.
+    expect(
+      cohostChipView(state({ status: 'error', reason: 'network', detail: TIMEOUT }))?.detail
+    ).toBe('timeout: The co-host service did not answer within 12 s.')
+    // A server-side pause (quota) carries its detail too...
+    expect(
+      cohostChipView(
+        state({
+          status: 'paused',
+          reason: 'quota-exhausted',
+          detail: { code: 'quota-exhausted', message: 'Resets at midnight UTC.', status: 429 }
+        })
+      )?.detail
+    ).toBe('quota-exhausted (HTTP 429): Resets at midnight UTC.')
+    // ...but a stale detail never leaks onto a listening or off chip.
+    expect(cohostChipView(state({ detail: GATEWAY_502 }))?.detail).toBeNull()
+    expect(cohostChipView(state({ status: 'off', detail: GATEWAY_502 }))?.detail).toBeNull()
+    // Optional on the wire: an older backend omits the key entirely.
+    const { detail: _omitted, ...legacy } = state({ status: 'error', reason: 'gateway-error' })
+    expect(cohostChipView(legacy as CohostState)?.detail).toBeNull()
+  })
+})
+
+describe('cohostErrorDetailText', () => {
+  it('formats code, status and message, degrading when parts are missing', () => {
+    expect(cohostErrorDetailText(null)).toBeNull()
+    expect(cohostErrorDetailText(undefined)).toBeNull()
+    expect(cohostErrorDetailText(GATEWAY_502)).toBe(
+      'ai-gateway-error (HTTP 502): The co-host tick failed on every configured model.'
+    )
+    expect(cohostErrorDetailText({ code: 'ai-gateway-error', message: '  ', status: 502 })).toBe(
+      'ai-gateway-error (HTTP 502)'
+    )
+    expect(cohostErrorDetailText({ code: 'network', message: 'dns', status: null })).toBe(
+      'network: dns'
+    )
+    expect(cohostErrorDetailText({ code: '  ', message: 'x', status: 500 })).toBeNull()
   })
 })
 
@@ -293,23 +371,92 @@ describe('row copy', () => {
   })
 })
 
-describe('cohostErrorToastReason', () => {
+describe('cohostErrorToast', () => {
   it('says nothing for states the pane already shows', () => {
-    expect(cohostErrorToastReason(null, state())).toBeNull()
+    expect(cohostErrorToast(null, state())).toBeNull()
     expect(
-      cohostErrorToastReason(null, state({ status: 'paused', reason: 'quota-exhausted' }))
+      cohostErrorToast(null, state({ status: 'paused', reason: 'quota-exhausted' }))
     ).toBeNull()
+    expect(cohostErrorToastKey(state())).toBeNull()
+    expect(cohostErrorToastKey(state({ status: 'error', reason: null }))).toBeNull()
   })
 
   it('toasts a NEW error reason exactly once', () => {
     const errored = state({ status: 'error', reason: 'gateway-error' })
-    expect(cohostErrorToastReason(state(), errored)).toBe('gateway-error')
-    expect(cohostErrorToastReason(errored, errored)).toBeNull()
+    expect(cohostErrorToast(state(), errored)).toEqual({
+      reason: 'gateway-error',
+      key: 'gateway-error:',
+      message: 'Co-host stopped: Videorc AI returned an error.'
+    })
+    expect(cohostErrorToast(errored, errored)).toBeNull()
   })
 
   it('toasts again when the error reason changes', () => {
     const first = state({ status: 'error', reason: 'gateway-error' })
     const second = state({ status: 'error', reason: 'network' })
-    expect(cohostErrorToastReason(first, second)).toBe('network')
+    expect(cohostErrorToast(first, second)?.reason).toBe('network')
+  })
+
+  it("puts the server's code and message in the toast copy", () => {
+    const errored = state({ status: 'error', reason: 'gateway-error', detail: GATEWAY_502 })
+    expect(cohostErrorToast(state(), errored)).toEqual({
+      reason: 'gateway-error',
+      key: 'gateway-error:ai-gateway-error',
+      message:
+        'Co-host stopped: Videorc AI returned an error (ai-gateway-error: The co-host tick failed on every configured model).'
+    })
+    expect(cohostErrorToastMessage('network', TIMEOUT)).toBe(
+      'Co-host stopped: no connection to Videorc AI (timeout: The co-host service did not answer within 12 s).'
+    )
+    // A code without a message still names itself; no detail keeps the base copy.
+    expect(
+      cohostErrorToastMessage('gateway-error', {
+        code: 'ai-gateway-error',
+        message: '',
+        status: 502
+      })
+    ).toBe('Co-host stopped: Videorc AI returned an error (ai-gateway-error).')
+    expect(cohostErrorToastMessage('gateway-error', null)).toBe(
+      'Co-host stopped: Videorc AI returned an error.'
+    )
+    expect(cohostErrorToastMessage('gateway-error', undefined)).toBe(
+      'Co-host stopped: Videorc AI returned an error.'
+    )
+  })
+
+  it('dedupes on the (reason, code) pair, not per tick', () => {
+    const tick5 = state({
+      status: 'error',
+      reason: 'gateway-error',
+      detail: GATEWAY_502,
+      tickSeq: 5
+    })
+    const tick6 = { ...tick5, tickSeq: 6 }
+    const tick7 = { ...tick5, tickSeq: 7 }
+    expect(cohostErrorToast(state(), tick5)).not.toBeNull()
+    // Backoff retries of the same failure are silent...
+    expect(cohostErrorToast(tick5, tick6)).toBeNull()
+    expect(cohostErrorToast(tick6, tick7)).toBeNull()
+    // ...even when the server's sentence changes but the code does not.
+    expect(
+      cohostErrorToast(tick7, {
+        ...tick7,
+        tickSeq: 8,
+        detail: { ...GATEWAY_502, message: 'Model ladder exhausted (3 tried).' }
+      })
+    ).toBeNull()
+    // A different code under the same reason is news.
+    const upstream = {
+      ...tick7,
+      tickSeq: 9,
+      detail: { code: 'upstream-timeout', message: 'Gateway timed out.', status: 504 }
+    }
+    expect(cohostErrorToast(tick7, upstream)?.key).toBe('gateway-error:upstream-timeout')
+    // Recovery then the same failure again is news again.
+    const recovered = state({ tickSeq: 10 })
+    expect(cohostErrorToast(upstream, recovered)).toBeNull()
+    expect(cohostErrorToast(recovered, { ...tick5, tickSeq: 11 })?.key).toBe(
+      'gateway-error:ai-gateway-error'
+    )
   })
 })

--- a/apps/desktop/src/renderer/src/lib/cohost-view.ts
+++ b/apps/desktop/src/renderer/src/lib/cohost-view.ts
@@ -1,4 +1,5 @@
 import type {
+  CohostErrorDetail,
   CohostFlag,
   CohostPriority,
   CohostQuestion,
@@ -18,6 +19,7 @@ export const EMPTY_COHOST_STATE: CohostState = {
   sessionId: null,
   status: 'off',
   reason: null,
+  detail: null,
   questions: [],
   flags: [],
   mood: null,
@@ -69,6 +71,35 @@ export interface CohostChipView {
   label: string
   /** Only `listening` earns the live accent; every other state is monochrome. */
   tone: 'live' | 'muted'
+  /**
+   * What the failed tick actually said — "ai-gateway-error (HTTP 502): The
+   * co-host tick failed on every configured model." — for the chip's tooltip
+   * or a secondary line. Null while listening, off, or when the engine paused
+   * itself locally (signed out, Basic, consent).
+   */
+  detail: string | null
+}
+
+/** `state.detail` is optional on the wire (older backend); absent means null. */
+export function cohostErrorDetail(state: CohostState | null): CohostErrorDetail | null {
+  return state?.detail ?? null
+}
+
+function withoutTrailingPeriod(text: string): string {
+  return text.trim().replace(/\.+$/, '')
+}
+
+/**
+ * One line a streamer can paste into a bug report: the server's envelope code,
+ * the HTTP status when there was a response, and the server's own sentence.
+ */
+export function cohostErrorDetailText(detail: CohostErrorDetail | null | undefined): string | null {
+  if (!detail) return null
+  const code = detail.code.trim()
+  if (!code) return null
+  const head = detail.status !== null ? `${code} (HTTP ${detail.status})` : code
+  const message = detail.message.trim()
+  return message ? `${head}: ${message}` : head
 }
 
 const REASON_LABELS: Record<CohostReason, string> = {
@@ -90,20 +121,35 @@ export function cohostReasonLabel(reason: CohostReason | null): string | null {
 export function cohostChipView(state: CohostState | null): CohostChipView | null {
   if (!state) return null
   const reason = cohostReasonLabel(state.reason)
+  // The engine only sets `detail` on a failed tick, and clears it the moment
+  // it listens again; a stale detail on a listening/off state is never shown.
+  const detail =
+    state.status === 'error' || state.status === 'paused'
+      ? cohostErrorDetailText(cohostErrorDetail(state))
+      : null
   switch (state.status) {
     case 'off':
-      return { label: 'Co-host: off', tone: 'muted' }
+      return { label: 'Co-host: off', tone: 'muted', detail: null }
     case 'listening': {
       const count = state.questions.length
       return {
         label: count > 0 ? `Co-host: listening · ${count} q` : 'Co-host: listening',
-        tone: 'live'
+        tone: 'live',
+        detail: null
       }
     }
     case 'paused':
-      return { label: reason ? `Co-host: paused · ${reason}` : 'Co-host: paused', tone: 'muted' }
+      return {
+        label: reason ? `Co-host: paused · ${reason}` : 'Co-host: paused',
+        tone: 'muted',
+        detail
+      }
     case 'error':
-      return { label: reason ? `Co-host: error · ${reason}` : 'Co-host: error', tone: 'muted' }
+      return {
+        label: reason ? `Co-host: error · ${reason}` : 'Co-host: error',
+        tone: 'muted',
+        detail
+      }
   }
 }
 
@@ -291,17 +337,21 @@ export function cohostHighlightMessageId(
 
 // --- Error toast -----------------------------------------------------------
 
+export interface CohostErrorToast {
+  reason: CohostReason
+  /** `${reason}:${detail.code}` — the dedupe identity of this failure. */
+  key: string
+  message: string
+}
+
 /**
- * Toast discipline: the pane and the chip already show every co-host state, so
- * only a NEW error reason is news. Returns the reason to toast, or null.
+ * The identity a toast is deduplicated on: the reason AND the server's error
+ * code. A 502 `ai-gateway-error` followed by a 502 `upstream-timeout` is news
+ * twice; the same 502 on five backoff retries is news once.
  */
-export function cohostErrorToastReason(
-  previous: CohostState | null,
-  next: CohostState
-): CohostReason | null {
-  if (next.status !== 'error' || !next.reason) return null
-  if (previous?.status === 'error' && previous.reason === next.reason) return null
-  return next.reason
+export function cohostErrorToastKey(state: CohostState | null): string | null {
+  if (!state || state.status !== 'error' || !state.reason) return null
+  return `${state.reason}:${cohostErrorDetail(state)?.code ?? ''}`
 }
 
 export const COHOST_ERROR_TOAST_MESSAGES: Record<CohostReason, string> = {
@@ -313,4 +363,37 @@ export const COHOST_ERROR_TOAST_MESSAGES: Record<CohostReason, string> = {
   'server-unconfigured': 'Co-host stopped: Videorc AI is unavailable right now.',
   network: 'Co-host stopped: no connection to Videorc AI.',
   'gateway-error': 'Co-host stopped: Videorc AI returned an error.'
+}
+
+/**
+ * Toast copy with the server's words attached:
+ * "Co-host stopped: Videorc AI returned an error (ai-gateway-error: The
+ * co-host tick failed on every configured model)." The HTTP status stays in
+ * the chip tooltip — a toast is read in a second, not debugged.
+ */
+export function cohostErrorToastMessage(
+  reason: CohostReason,
+  detail: CohostErrorDetail | null | undefined
+): string {
+  const base = COHOST_ERROR_TOAST_MESSAGES[reason]
+  const code = detail?.code.trim() ?? ''
+  if (!code) return base
+  const message = detail ? withoutTrailingPeriod(detail.message) : ''
+  const suffix = message ? `${code}: ${message}` : code
+  return `${withoutTrailingPeriod(base)} (${suffix}).`
+}
+
+/**
+ * Toast discipline: the pane and the chip already show every co-host state, so
+ * only a NEW failure — a new (reason, code) pair — is news. Backoff retries of
+ * the same failure return null. Returns the toast to raise, or null.
+ */
+export function cohostErrorToast(
+  previous: CohostState | null,
+  next: CohostState
+): CohostErrorToast | null {
+  const key = cohostErrorToastKey(next)
+  if (!key || !next.reason) return null
+  if (previous?.status === 'error' && cohostErrorToastKey(previous) === key) return null
+  return { reason: next.reason, key, message: cohostErrorToastMessage(next.reason, next.detail) }
 }

--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -934,6 +934,43 @@ describe('backend RPC contract', () => {
       'cohost.state'
     )
 
+    // `detail` names the failed tick; it is optional (older backend), nullable,
+    // and closed: a bad code/status shape fails the event like any other.
+    const detail = {
+      code: 'ai-gateway-error',
+      message: 'The co-host tick failed on every configured model.',
+      status: 502
+    }
+    const errored = { ...state, status: 'error', reason: 'gateway-error', detail }
+    expect(validateBackendEventPayload('cohost.state', errored)).toEqual(errored)
+    expect(validateBackendRpcResult('cohost.status', errored)).toEqual(errored)
+    const timedOut = {
+      ...state,
+      status: 'error',
+      reason: 'network',
+      detail: { code: 'timeout', message: 'No answer within 12 s.', status: null }
+    }
+    expect(validateBackendEventPayload('cohost.state', timedOut)).toEqual(timedOut)
+    expect(validateBackendEventPayload('cohost.state', { ...state, detail: null })).toEqual({
+      ...state,
+      detail: null
+    })
+    expect(() =>
+      validateBackendEventPayload('cohost.state', { ...errored, detail: { ...detail, code: '' } })
+    ).toThrow('cohost.state')
+    expect(() =>
+      validateBackendEventPayload('cohost.state', {
+        ...errored,
+        detail: { ...detail, status: '502' }
+      })
+    ).toThrow('cohost.state')
+    expect(() =>
+      validateBackendEventPayload('cohost.state', {
+        ...errored,
+        detail: { ...detail, extra: true }
+      })
+    ).toThrow('cohost.state')
+
     const start = { sessionId: 'session-1', consentToProcessChat: true, streamTitle: 'Rust night' }
     expect(validateBackendRpcParams('cohost.start', start)).toEqual(start)
     expect(validateBackendRpcParams('cohost.start', { sessionId: 'session-1' })).toEqual({

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -1363,6 +1363,14 @@ const cohostFlagSchema = objectSchema(
   },
   { allowUnknown: false }
 )
+const cohostErrorDetailSchema = objectSchema(
+  {
+    code: stringSchema({ minLength: 1, maxLength: 128 }),
+    message: stringSchema({ maxLength: 2000 }),
+    status: nullableSchema(numberSchema({ integer: true, min: 100, max: 599 }))
+  },
+  { allowUnknown: false }
+)
 const cohostStateSchema = objectSchema(
   {
     sessionId: nullableSchema(boundedString),
@@ -1379,6 +1387,8 @@ const cohostStateSchema = objectSchema(
         'gateway-error'
       ])
     ),
+    // Optional on the wire: a backend from before `detail` existed omits it.
+    detail: optionalSchema(nullableSchema(cohostErrorDetailSchema)),
     questions: arraySchema(cohostQuestionSchema, { maxLength: 40 }),
     flags: arraySchema(cohostFlagSchema, { maxLength: 50 }),
     mood: nullableSchema(enumSchema(['hype', 'calm', 'tense', 'mixed'])),

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -3530,11 +3530,29 @@ export interface CohostFlag {
   at: string
 }
 
+/**
+ * What the last failed tick actually said. `code` is the server's error
+ * envelope code verbatim (`ai-gateway-error`, `quota-exhausted`, ...) or a
+ * desktop-assigned `network` / `timeout` / `malformed-response`; `status` is
+ * the HTTP status when a response arrived. Cleared as soon as the engine is
+ * listening again.
+ */
+export interface CohostErrorDetail {
+  code: string
+  message: string
+  status: number | null
+}
+
 /** The `cohost.state` event payload and every `cohost.*` RPC result. */
 export interface CohostState {
   sessionId: string | null
   status: CohostStatus
   reason: CohostReason | null
+  /**
+   * Present only while `reason` describes a failed tick. Optional on the wire
+   * so a backend from before the field still validates; absent means null.
+   */
+  detail?: CohostErrorDetail | null
   questions: CohostQuestion[]
   flags: CohostFlag[]
   mood: CohostMood | null

--- a/apps/desktop/src/shared/protocol-contract-fixtures.test.ts
+++ b/apps/desktop/src/shared/protocol-contract-fixtures.test.ts
@@ -69,6 +69,9 @@ interface HighRiskContractFixtures {
     settings: CohostSettings
     state: CohostState
     offState: CohostState
+    errorState: CohostState
+    timeoutState: CohostState
+    legacyState: CohostState
   }
 }
 
@@ -184,7 +187,33 @@ describe('shared high-risk protocol fixture', () => {
     expect(validateBackendEventPayload('cohost.state', fixtures.cohost.offState)).toStrictEqual(
       fixtures.cohost.offState
     )
-    expect(fixtures.cohost.offState).toMatchObject({ sessionId: null, reason: null, mood: null })
+    expect(fixtures.cohost.offState).toMatchObject({
+      sessionId: null,
+      reason: null,
+      detail: null,
+      mood: null
+    })
+    // `detail` carries the failed tick's envelope verbatim, or a desktop code
+    // with no HTTP status; a pre-`detail` payload validates unchanged.
+    for (const shape of ['errorState', 'timeoutState', 'legacyState'] as const) {
+      expect(validateBackendEventPayload('cohost.state', fixtures.cohost[shape])).toStrictEqual(
+        fixtures.cohost[shape]
+      )
+      expect(validateBackendRpcResult('cohost.status', fixtures.cohost[shape])).toStrictEqual(
+        fixtures.cohost[shape]
+      )
+    }
+    expect(fixtures.cohost.errorState.detail).toStrictEqual({
+      code: 'ai-gateway-error',
+      message: 'The co-host tick failed on every configured model.',
+      status: 502
+    })
+    expect(fixtures.cohost.timeoutState.detail).toStrictEqual({
+      code: 'timeout',
+      message: 'The co-host service did not answer within 12 s.',
+      status: null
+    })
+    expect('detail' in fixtures.cohost.legacyState).toBe(false)
   })
 
   it('keeps comment pagination defaults and deletion DTOs identical', () => {

--- a/crates/videorc-backend/src/cohost.rs
+++ b/crates/videorc-backend/src/cohost.rs
@@ -24,8 +24,8 @@ use crate::state::AppState;
 use crate::storage::Database;
 use crate::streaming::StreamPlatform;
 use crate::videorc_api::{
-    CohostApiError, CohostTickMessage, CohostTickOpenQuestion, CohostTickRequest,
-    CohostTickResponse, VideorcApiClient,
+    CohostApiError, CohostApiErrorKind, CohostTickMessage, CohostTickOpenQuestion,
+    CohostTickRequest, CohostTickResponse, VideorcApiClient,
 };
 
 pub const COHOST_STATE_EVENT: &str = "cohost.state";
@@ -42,7 +42,13 @@ const TICK_DELTA_CAP: usize = 60;
 const TICK_OPEN_QUESTIONS_CAP: usize = 40;
 const TICK_BURST_THRESHOLD: usize = 5;
 const TICK_IDLE_INTERVAL: Duration = Duration::from_secs(20);
-const TICK_MIN_GAP: Duration = Duration::from_secs(8);
+/// Contract floor between two tick requests. Independent of the HTTP timeout:
+/// ticks never overlap, so a slow tick delays the next one rather than
+/// shortening the gap.
+pub(crate) const TICK_MIN_GAP: Duration = Duration::from_secs(8);
+/// Hard cap on the detail message carried on the wire; server envelope
+/// messages are one sentence, and a proxy error page must not become a toast.
+const ERROR_DETAIL_MESSAGE_MAX_CHARS: usize = 400;
 const BACKOFF_STEPS_SECS: [u64; 5] = [5, 10, 20, 40, 60];
 const QUOTA_DEFAULT_RETRY: Duration = Duration::from_secs(3600);
 /// How often a paused precondition (signed out, Basic, no consent) is re-read.
@@ -209,15 +215,44 @@ pub struct CohostFlag {
     pub at: String,
 }
 
+/// What the last failed tick actually said, so the toast, the chip and a bug
+/// report can name the error instead of "AI returned an error". `code` is the
+/// server's envelope code verbatim (or a desktop-assigned `network` /
+/// `timeout` / `malformed-response`), `status` the HTTP status when one was
+/// received. Cleared the moment the engine is listening again.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CohostErrorDetail {
+    pub code: String,
+    pub message: String,
+    pub status: Option<u16>,
+}
+
+impl CohostErrorDetail {
+    pub fn new(code: impl Into<String>, message: impl Into<String>, status: Option<u16>) -> Self {
+        let message: String = message.into();
+        Self {
+            code: code.into(),
+            message: truncate_chars(message.trim(), ERROR_DETAIL_MESSAGE_MAX_CHARS),
+            status,
+        }
+    }
+}
+
 /// The `cohost.state` event payload and the result of every `cohost.*` RPC.
 /// Nullable fields serialize as explicit `null` (the renderer reducer keys on
-/// them), never as absent keys.
+/// them), never as absent keys. `detail` is additionally `default` on read so
+/// a payload from before it existed still parses.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CohostState {
     pub session_id: Option<String>,
     pub status: CohostStatus,
     pub reason: Option<CohostReason>,
+    /// Present only while `reason` describes a failed tick (status `error`, or
+    /// `paused` by the server: quota, Premium, consent).
+    #[serde(default)]
+    pub detail: Option<CohostErrorDetail>,
     pub questions: Vec<CohostQuestion>,
     pub flags: Vec<CohostFlag>,
     pub mood: Option<CohostMood>,
@@ -232,6 +267,7 @@ impl CohostState {
             session_id: None,
             status: CohostStatus::Off,
             reason: None,
+            detail: None,
             questions: Vec::new(),
             flags: Vec::new(),
             mood: None,
@@ -297,6 +333,7 @@ struct CohostSession {
     stream_title: Option<String>,
     status: CohostStatus,
     reason: Option<CohostReason>,
+    detail: Option<CohostErrorDetail>,
     questions: Vec<CohostQuestion>,
     flags: Vec<CohostFlag>,
     mood: Option<CohostMood>,
@@ -336,6 +373,7 @@ impl CohostSession {
             stream_title,
             status: CohostStatus::Listening,
             reason: None,
+            detail: None,
             questions: Vec::new(),
             flags: Vec::new(),
             mood: None,
@@ -362,6 +400,7 @@ impl CohostSession {
             session_id: Some(self.session_id.clone()),
             status: self.status,
             reason: self.reason,
+            detail: self.detail.clone(),
             questions: self.questions.clone(),
             flags: self.flags.clone(),
             mood: self.mood,
@@ -472,6 +511,7 @@ impl CohostSession {
         self.next_attempt_at = None;
         self.status = CohostStatus::Listening;
         self.reason = None;
+        self.detail = None;
         self.last_tick_iso = Some(now_iso.to_string());
         self.partial = dropped > 0;
         self.mood = response.mood;
@@ -546,12 +586,12 @@ impl CohostSession {
     fn apply_failure(&mut self, error: &CohostApiError, now: Instant) {
         self.in_flight = false;
         let reason = error.reason();
-        match error {
-            CohostApiError::QuotaExhausted { retry_after, .. } => {
+        match error.kind {
+            CohostApiErrorKind::QuotaExhausted { retry_after } => {
                 self.status = CohostStatus::Paused;
                 self.next_attempt_at = Some(now + retry_after.unwrap_or(QUOTA_DEFAULT_RETRY));
             }
-            CohostApiError::PremiumRequired { .. } | CohostApiError::ConsentRequired { .. } => {
+            CohostApiErrorKind::PremiumRequired | CohostApiErrorKind::ConsentRequired => {
                 self.status = CohostStatus::Paused;
                 self.next_attempt_at = Some(now + PRECONDITION_RECHECK);
             }
@@ -563,12 +603,18 @@ impl CohostSession {
             }
         }
         self.reason = Some(reason);
+        // Every failed tick carries what the server (or the transport) said;
+        // the renderer decides how much of it to show per reason.
+        self.detail = Some(error.detail.clone());
     }
 
+    /// A local precondition pause (signed out, Basic, no consent). Not a tick
+    /// failure, so any earlier tick detail is stale and leaves with it.
     fn pause(&mut self, reason: CohostReason, now: Instant) -> bool {
         let changed = self.status != CohostStatus::Paused || self.reason != Some(reason);
         self.status = CohostStatus::Paused;
         self.reason = Some(reason);
+        self.detail = None;
         self.next_attempt_at = Some(now + PRECONDITION_RECHECK);
         changed
     }
@@ -1049,9 +1095,7 @@ async fn run_scheduler_pass(state: &AppState, generation: u64) -> bool {
     let message_count = prepared.request.messages.len();
     let result = match VideorcApiClient::new() {
         Ok(client) => client.post_cohost_tick(&token, &prepared.request).await,
-        Err(error) => Err(CohostApiError::Network {
-            message: error.to_string(),
-        }),
+        Err(error) => Err(CohostApiError::network(error.to_string())),
     };
     let log = match &result {
         Ok(response) => Some((
@@ -1067,9 +1111,15 @@ async fn run_scheduler_pass(state: &AppState, generation: u64) -> bool {
         Err(error) => Some((
             "warn",
             format!(
-                "Co-host tick {} failed ({}): {}",
+                "Co-host tick {} failed ({}, {}{}): {}",
                 prepared.request.tick_seq,
                 serde_json::to_string(&error.reason()).unwrap_or_default(),
+                error.detail.code,
+                error
+                    .detail
+                    .status
+                    .map(|status| format!(", HTTP {status}"))
+                    .unwrap_or_default(),
                 error.message()
             ),
         )),
@@ -1144,6 +1194,12 @@ mod tests {
             is_deleted: false,
             raw_provider_type: Some("twitch".to_string()),
         }
+    }
+
+    /// A classified server failure with its envelope, as `post_cohost_tick`
+    /// would return it.
+    fn server_error(status: u16, code: &str, message: &str) -> CohostApiError {
+        crate::videorc_api::classify_cohost_failure(status, code, message.to_string(), None)
     }
 
     fn enabled_settings() -> CohostSettings {
@@ -1246,9 +1302,7 @@ mod tests {
             Some(TickGate::Idle)
         );
         // A network failure schedules a 5 s backoff before the next attempt.
-        let failure = Err(CohostApiError::Network {
-            message: "offline".to_string(),
-        });
+        let failure = Err(CohostApiError::network("offline"));
         assert!(engine.apply_tick_result(generation, 0, failure, start + secs(2), "now"));
         let snapshot = engine.snapshot();
         assert_eq!(snapshot.status, CohostStatus::Error);
@@ -1289,10 +1343,7 @@ mod tests {
             engine.apply_tick_result(
                 generation,
                 0,
-                Err(CohostApiError::GatewayError {
-                    code: "ai-gateway-error".to_string(),
-                    message: "boom".to_string(),
-                }),
+                Err(server_error(502, "ai-gateway-error", "boom")),
                 now,
                 "now",
             );
@@ -1573,93 +1624,78 @@ mod tests {
         let start = Instant::now();
         let cases = [
             (
-                CohostApiError::Unauthorized {
-                    message: "x".into(),
-                },
+                server_error(401, "unauthorized", "x"),
                 CohostStatus::Error,
                 CohostReason::SessionExpired,
                 5,
             ),
             (
-                CohostApiError::PremiumRequired {
-                    message: "x".into(),
-                },
+                server_error(403, "premium-required", "x"),
                 CohostStatus::Paused,
                 CohostReason::PremiumRequired,
                 5,
             ),
             (
-                CohostApiError::ConsentRequired {
-                    message: "x".into(),
-                },
+                server_error(400, "consent-required", "x"),
                 CohostStatus::Paused,
                 CohostReason::ConsentRequired,
                 5,
             ),
             (
-                CohostApiError::QuotaExhausted {
-                    retry_after: Some(secs(120)),
-                    message: "x".into(),
-                },
+                crate::videorc_api::classify_cohost_failure(
+                    429,
+                    "quota-exhausted",
+                    "x".into(),
+                    Some("120"),
+                ),
                 CohostStatus::Paused,
                 CohostReason::QuotaExhausted,
                 120,
             ),
             (
-                CohostApiError::QuotaExhausted {
-                    retry_after: None,
-                    message: "x".into(),
-                },
+                server_error(429, "quota-exhausted", "x"),
                 CohostStatus::Paused,
                 CohostReason::QuotaExhausted,
                 3600,
             ),
             (
-                CohostApiError::ServerUnconfigured {
-                    code: "cohost-disabled".into(),
-                    message: "x".into(),
-                },
+                server_error(503, "cohost-disabled", "x"),
                 CohostStatus::Error,
                 CohostReason::ServerUnconfigured,
                 5,
             ),
             (
-                CohostApiError::PromptVersionUnsupported {
-                    message: "x".into(),
-                },
+                server_error(400, "prompt-version-unsupported", "x"),
                 CohostStatus::Error,
                 CohostReason::ServerUnconfigured,
                 5,
             ),
             (
-                CohostApiError::GatewayError {
-                    code: "ai-gateway-error".into(),
-                    message: "x".into(),
-                },
+                server_error(502, "ai-gateway-error", "x"),
                 CohostStatus::Error,
                 CohostReason::GatewayError,
                 5,
             ),
             (
-                CohostApiError::InvalidRequest {
-                    message: "x".into(),
-                },
+                server_error(400, "invalid-request", "x"),
                 CohostStatus::Error,
                 CohostReason::GatewayError,
                 5,
             ),
             (
-                CohostApiError::MalformedResponse {
-                    message: "x".into(),
-                },
+                CohostApiError::malformed_response(200, "x"),
                 CohostStatus::Error,
                 CohostReason::GatewayError,
                 5,
             ),
             (
-                CohostApiError::Network {
-                    message: "x".into(),
-                },
+                CohostApiError::network("x"),
+                CohostStatus::Error,
+                CohostReason::Network,
+                5,
+            ),
+            (
+                CohostApiError::timeout("x"),
                 CohostStatus::Error,
                 CohostReason::Network,
                 5,
@@ -1675,6 +1711,8 @@ mod tests {
             let snapshot = engine.snapshot();
             assert_eq!(snapshot.status, status, "{error:?}");
             assert_eq!(snapshot.reason, Some(reason), "{error:?}");
+            // Every failed tick exposes what was actually said.
+            assert_eq!(snapshot.detail, Some(error.detail.clone()), "{error:?}");
             let next = engine.session.as_ref().unwrap().next_attempt_at.unwrap();
             assert_eq!(
                 next.duration_since(start).as_secs(),
@@ -1682,6 +1720,225 @@ mod tests {
                 "{error:?}"
             );
         }
+    }
+
+    #[test]
+    fn failed_tick_detail_is_captured_and_cleared_on_recovery() {
+        let start = Instant::now();
+        let (mut engine, generation) = running_engine(start);
+        assert_eq!(engine.snapshot().detail, None);
+
+        // 502 from the 2026-08-23 incident: code + message + status all ride
+        // the snapshot.
+        engine.note_messages(&messages("session-1", 0..5));
+        engine
+            .prepare_tick(generation, true, true, start + secs(1))
+            .unwrap();
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Err(server_error(
+                502,
+                "ai-gateway-error",
+                "The co-host tick failed on every configured model."
+            )),
+            start + secs(2),
+            "t1"
+        ));
+        let snapshot = engine.snapshot();
+        assert_eq!(snapshot.status, CohostStatus::Error);
+        assert_eq!(snapshot.reason, Some(CohostReason::GatewayError));
+        assert_eq!(
+            snapshot.detail,
+            Some(CohostErrorDetail {
+                code: "ai-gateway-error".to_string(),
+                message: "The co-host tick failed on every configured model.".to_string(),
+                status: Some(502),
+            })
+        );
+
+        // A later 400 replaces it wholesale (no stale status from the 502).
+        engine.note_messages(&messages("session-1", 5..10));
+        engine
+            .prepare_tick(generation, true, true, start + secs(10))
+            .unwrap();
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Err(server_error(400, "invalid-request", "messages: too long")),
+            start + secs(11),
+            "t2"
+        ));
+        assert_eq!(
+            engine.snapshot().detail,
+            Some(CohostErrorDetail {
+                code: "invalid-request".to_string(),
+                message: "messages: too long".to_string(),
+                status: Some(400),
+            })
+        );
+
+        // A timeout has no HTTP status and the desktop's own code.
+        engine.note_messages(&messages("session-1", 10..15));
+        engine
+            .prepare_tick(generation, true, true, start + secs(30))
+            .unwrap();
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Err(CohostApiError::timeout(
+                "The co-host service did not answer within 12 s."
+            )),
+            start + secs(42),
+            "t3"
+        ));
+        let snapshot = engine.snapshot();
+        assert_eq!(snapshot.reason, Some(CohostReason::Network));
+        assert_eq!(
+            snapshot.detail,
+            Some(CohostErrorDetail {
+                code: "timeout".to_string(),
+                message: "The co-host service did not answer within 12 s.".to_string(),
+                status: None,
+            })
+        );
+
+        // Recovery: a merged tick clears reason and detail together.
+        engine.note_messages(&messages("session-1", 15..20));
+        engine
+            .prepare_tick(generation, true, true, start + secs(80))
+            .unwrap();
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Ok(response(Vec::new())),
+            start + secs(81),
+            "t4"
+        ));
+        let snapshot = engine.snapshot();
+        assert_eq!(snapshot.status, CohostStatus::Listening);
+        assert_eq!(snapshot.reason, None);
+        assert_eq!(snapshot.detail, None);
+    }
+
+    #[test]
+    fn precondition_pause_drops_stale_tick_detail() {
+        let start = Instant::now();
+        let (mut engine, generation) = running_engine(start);
+        engine.note_messages(&messages("session-1", 0..5));
+        engine
+            .prepare_tick(generation, true, true, start + secs(1))
+            .unwrap();
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Err(server_error(502, "ai-gateway-error", "boom")),
+            start + secs(2),
+            "t1"
+        ));
+        assert!(engine.snapshot().detail.is_some());
+        // Signed out while backing off: the pause is local, not a tick result.
+        assert_eq!(
+            engine.prepare_tick(generation, false, true, start + secs(10)),
+            Err(TickGate::Paused(CohostReason::SignedOut))
+        );
+        let snapshot = engine.snapshot();
+        assert_eq!(snapshot.status, CohostStatus::Paused);
+        assert_eq!(snapshot.detail, None);
+    }
+
+    #[test]
+    fn error_detail_message_is_trimmed_and_capped() {
+        let long = "x".repeat(1000);
+        let detail = CohostErrorDetail::new("ai-gateway-error", format!("  {long}  "), Some(502));
+        assert_eq!(
+            detail.message.chars().count(),
+            ERROR_DETAIL_MESSAGE_MAX_CHARS
+        );
+        assert_eq!(detail.code, "ai-gateway-error");
+        assert_eq!(detail.status, Some(502));
+    }
+
+    #[test]
+    fn state_without_detail_key_still_parses_and_serializes_explicit_null() {
+        let legacy: CohostState = serde_json::from_value(serde_json::json!({
+            "sessionId": null,
+            "status": "off",
+            "reason": null,
+            "questions": [],
+            "flags": [],
+            "mood": null,
+            "lastTickAt": null,
+            "tickSeq": 0,
+            "partial": false
+        }))
+        .unwrap();
+        assert_eq!(legacy, CohostState::off());
+        let wire = serde_json::to_value(CohostState::off()).unwrap();
+        assert_eq!(wire["detail"], serde_json::Value::Null);
+        let errored = CohostState {
+            status: CohostStatus::Error,
+            reason: Some(CohostReason::GatewayError),
+            detail: Some(CohostErrorDetail::new(
+                "ai-gateway-error",
+                "boom",
+                Some(502),
+            )),
+            ..CohostState::off()
+        };
+        assert_eq!(
+            serde_json::to_value(&errored).unwrap()["detail"],
+            serde_json::json!({ "code": "ai-gateway-error", "message": "boom", "status": 502 })
+        );
+        let timed_out = CohostState {
+            detail: Some(CohostErrorDetail::new("timeout", "slow", None)),
+            ..CohostState::off()
+        };
+        assert_eq!(
+            serde_json::to_value(&timed_out).unwrap()["detail"]["status"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn tick_timeout_exceeds_min_gap_and_an_in_flight_tick_only_delays_the_next() {
+        // The HTTP timeout (12 s) is headroom; the cadence floor stays 8 s.
+        assert!(crate::videorc_api::COHOST_TICK_TIMEOUT > TICK_MIN_GAP);
+        assert_eq!(TICK_MIN_GAP.as_secs(), 8);
+
+        let start = Instant::now();
+        let (mut engine, generation) = running_engine(start);
+        engine.note_messages(&messages("session-1", 0..5));
+        let sent_at = start + secs(1);
+        engine
+            .prepare_tick(generation, true, true, sent_at)
+            .unwrap();
+        // A burst arrives while the request is still out: never a second
+        // request in flight, even once the 8 s gap has passed.
+        engine.note_messages(&messages("session-1", 5..10));
+        for offset in [2, 8, 9, 12] {
+            assert_eq!(
+                engine
+                    .prepare_tick(generation, true, true, sent_at + secs(offset))
+                    .err(),
+                Some(TickGate::Idle),
+                "+{offset}s"
+            );
+        }
+        // The slow tick lands at +12 s: the gap since it was SENT is already
+        // ≥ 8 s, so the delayed next tick goes out right away.
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Ok(response(Vec::new())),
+            sent_at + secs(12),
+            "t1"
+        ));
+        let next = engine
+            .prepare_tick(generation, true, true, sent_at + secs(12))
+            .unwrap();
+        assert_eq!(next.request.tick_seq, 2);
+        assert_eq!(next.request.messages.len(), 5);
     }
 
     #[test]

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -4400,6 +4400,39 @@ mod tests {
         let off: crate::cohost::CohostState = serde_json::from_value(off_wire.clone()).unwrap();
         assert_eq!(off, crate::cohost::CohostState::off());
         assert_eq!(serde_json::to_value(off).unwrap(), off_wire);
+
+        // `detail` rides a failed tick: server envelope code + message + HTTP
+        // status, or a desktop-assigned code with no status.
+        let error_wire = shared_high_risk_contract_fixture_value("/cohost/errorState");
+        let errored: crate::cohost::CohostState =
+            serde_json::from_value(error_wire.clone()).unwrap();
+        assert_eq!(
+            errored.detail,
+            Some(crate::cohost::CohostErrorDetail {
+                code: "ai-gateway-error".to_string(),
+                message: "The co-host tick failed on every configured model.".to_string(),
+                status: Some(502),
+            })
+        );
+        assert_eq!(serde_json::to_value(errored).unwrap(), error_wire);
+        let timeout_wire = shared_high_risk_contract_fixture_value("/cohost/timeoutState");
+        let timed_out: crate::cohost::CohostState =
+            serde_json::from_value(timeout_wire.clone()).unwrap();
+        assert_eq!(
+            timed_out.detail.as_ref().map(|detail| detail.code.as_str()),
+            Some("timeout")
+        );
+        assert_eq!(
+            timed_out.detail.as_ref().and_then(|detail| detail.status),
+            None
+        );
+        assert_eq!(serde_json::to_value(timed_out).unwrap(), timeout_wire);
+
+        // A payload from before `detail` existed still parses (serde default).
+        let legacy_wire = shared_high_risk_contract_fixture_value("/cohost/legacyState");
+        assert!(legacy_wire.get("detail").is_none());
+        let legacy: crate::cohost::CohostState = serde_json::from_value(legacy_wire).unwrap();
+        assert_eq!(legacy, crate::cohost::CohostState::off());
     }
 
     #[test]

--- a/crates/videorc-backend/src/videorc_api.rs
+++ b/crates/videorc-backend/src/videorc_api.rs
@@ -20,13 +20,17 @@ pub(crate) const CAPTION_CHUNK_UPLOAD_TIMEOUT: std::time::Duration =
 pub(crate) const AI_CAPABILITIES_REQUEST_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(8);
 const DESKTOP_AUTH_EXCHANGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-/// Co-host ticks are synchronous and small; a hung tick must become a
-/// retryable failure before the next cadence window, never a stalled engine.
-pub(crate) const COHOST_TICK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+/// Co-host ticks are synchronous and small, but the server fans one tick out
+/// across a model ladder: a slow-but-alive gateway needs headroom beyond the
+/// 8 s cadence floor, while a hung tick must still become a retryable failure,
+/// never a stalled engine. The scheduler never overlaps ticks, so a 12 s tick
+/// simply delays the next one.
+pub(crate) const COHOST_TICK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(12);
 const COHOST_TICK_PATH: &str = "/api/ai/cohost/tick";
 
 use crate::cohost::{
-    CohostFlagKind, CohostFlagSeverity, CohostMood, CohostPriority, CohostReason, CohostTone,
+    CohostErrorDetail, CohostFlagKind, CohostFlagSeverity, CohostMood, CohostPriority,
+    CohostReason, CohostTone,
 };
 use crate::streaming::StreamPlatform;
 
@@ -214,64 +218,104 @@ pub struct CohostTickUsage {
     pub model: String,
 }
 
-/// Every non-200 tick outcome, classified from the error envelope code first
-/// and the HTTP status second. `reason()` is the renderer-facing mapping.
+/// Every failed tick outcome: the classification the engine acts on
+/// (`kind` → status/backoff, `reason()` → renderer reason) plus the server's
+/// own diagnosis (`detail`) that rides `cohost.state` so "AI returned an
+/// error" is never the whole story.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CohostApiError {
+pub struct CohostApiError {
+    pub kind: CohostApiErrorKind,
+    pub detail: CohostErrorDetail,
+}
+
+/// Classified from the error envelope code first and the HTTP status second.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CohostApiErrorKind {
     /// 401: the stored bearer no longer works (session expired/rotated).
-    Unauthorized { message: String },
-    /// 403 `premium-required`.
-    PremiumRequired { message: String },
+    Unauthorized,
+    /// 403 `premium-required` (and any other 403: ops blocklist).
+    PremiumRequired,
     /// 400 `consent-required`.
-    ConsentRequired { message: String },
+    ConsentRequired,
     /// 400 `prompt-version-unsupported`: this build is behind the server.
-    PromptVersionUnsupported { message: String },
+    PromptVersionUnsupported,
     /// 400 `invalid-request`: a desktop-side request bug (zod rejection).
-    InvalidRequest { message: String },
+    InvalidRequest,
     /// 429 `quota-exhausted` (+ Retry-After seconds when the server sent one).
     QuotaExhausted {
         retry_after: Option<std::time::Duration>,
-        message: String,
     },
     /// 503 `ai-gateway-not-configured` | `cohost-disabled`.
-    ServerUnconfigured { code: String, message: String },
+    ServerUnconfigured,
     /// 502 `ai-gateway-error` and any other server failure.
-    GatewayError { code: String, message: String },
-    /// Transport failure or the 8 s timeout.
-    Network { message: String },
+    GatewayError,
+    /// Transport failure (`network`) or the tick timeout (`timeout`).
+    Network,
     /// 200 with a body that does not match the contract.
-    MalformedResponse { message: String },
+    MalformedResponse,
 }
+
+/// Detail codes the desktop assigns itself when no server envelope exists.
+pub const COHOST_DETAIL_CODE_NETWORK: &str = "network";
+pub const COHOST_DETAIL_CODE_TIMEOUT: &str = "timeout";
+pub const COHOST_DETAIL_CODE_MALFORMED_RESPONSE: &str = "malformed-response";
 
 impl CohostApiError {
     pub fn reason(&self) -> CohostReason {
-        match self {
-            Self::Unauthorized { .. } => CohostReason::SessionExpired,
-            Self::PremiumRequired { .. } => CohostReason::PremiumRequired,
-            Self::ConsentRequired { .. } => CohostReason::ConsentRequired,
-            Self::PromptVersionUnsupported { .. } | Self::ServerUnconfigured { .. } => {
-                CohostReason::ServerUnconfigured
-            }
-            Self::QuotaExhausted { .. } => CohostReason::QuotaExhausted,
-            Self::InvalidRequest { .. }
-            | Self::GatewayError { .. }
-            | Self::MalformedResponse { .. } => CohostReason::GatewayError,
-            Self::Network { .. } => CohostReason::Network,
+        match self.kind {
+            CohostApiErrorKind::Unauthorized => CohostReason::SessionExpired,
+            CohostApiErrorKind::PremiumRequired => CohostReason::PremiumRequired,
+            CohostApiErrorKind::ConsentRequired => CohostReason::ConsentRequired,
+            CohostApiErrorKind::PromptVersionUnsupported
+            | CohostApiErrorKind::ServerUnconfigured => CohostReason::ServerUnconfigured,
+            CohostApiErrorKind::QuotaExhausted { .. } => CohostReason::QuotaExhausted,
+            CohostApiErrorKind::InvalidRequest
+            | CohostApiErrorKind::GatewayError
+            | CohostApiErrorKind::MalformedResponse => CohostReason::GatewayError,
+            CohostApiErrorKind::Network => CohostReason::Network,
         }
     }
 
     pub fn message(&self) -> &str {
-        match self {
-            Self::Unauthorized { message }
-            | Self::PremiumRequired { message }
-            | Self::ConsentRequired { message }
-            | Self::PromptVersionUnsupported { message }
-            | Self::InvalidRequest { message }
-            | Self::QuotaExhausted { message, .. }
-            | Self::ServerUnconfigured { message, .. }
-            | Self::GatewayError { message, .. }
-            | Self::Network { message }
-            | Self::MalformedResponse { message } => message,
+        &self.detail.message
+    }
+
+    /// A transport failure before any HTTP status existed.
+    pub fn network(message: impl Into<String>) -> Self {
+        Self {
+            kind: CohostApiErrorKind::Network,
+            detail: CohostErrorDetail::new(COHOST_DETAIL_CODE_NETWORK, message, None),
+        }
+    }
+
+    /// The request outlived `COHOST_TICK_TIMEOUT`.
+    pub fn timeout(message: impl Into<String>) -> Self {
+        Self {
+            kind: CohostApiErrorKind::Network,
+            detail: CohostErrorDetail::new(COHOST_DETAIL_CODE_TIMEOUT, message, None),
+        }
+    }
+
+    /// A success status whose body does not match the tick contract.
+    pub fn malformed_response(status: u16, message: impl Into<String>) -> Self {
+        Self {
+            kind: CohostApiErrorKind::MalformedResponse,
+            detail: CohostErrorDetail::new(
+                COHOST_DETAIL_CODE_MALFORMED_RESPONSE,
+                message,
+                Some(status),
+            ),
+        }
+    }
+
+    pub(crate) fn from_transport(error: reqwest::Error) -> Self {
+        if error.is_timeout() {
+            Self::timeout(format!(
+                "The co-host service did not answer within {} s.",
+                COHOST_TICK_TIMEOUT.as_secs()
+            ))
+        } else {
+            Self::network(format!("Could not reach the co-host service: {error}"))
         }
     }
 }
@@ -291,44 +335,30 @@ pub(crate) fn classify_cohost_failure(
     message: String,
     retry_after: Option<&str>,
 ) -> CohostApiError {
-    match code {
-        "unauthorized" => return CohostApiError::Unauthorized { message },
-        "premium-required" => return CohostApiError::PremiumRequired { message },
-        "consent-required" => return CohostApiError::ConsentRequired { message },
-        "prompt-version-unsupported" => {
-            return CohostApiError::PromptVersionUnsupported { message };
-        }
-        "invalid-request" => return CohostApiError::InvalidRequest { message },
-        "quota-exhausted" => {
-            return CohostApiError::QuotaExhausted {
-                retry_after: parse_retry_after_seconds(retry_after),
-                message,
-            };
-        }
-        "ai-gateway-not-configured" | "cohost-disabled" => {
-            return CohostApiError::ServerUnconfigured {
-                code: code.to_string(),
-                message,
-            };
-        }
-        _ => {}
-    }
-    match status {
-        401 => CohostApiError::Unauthorized { message },
-        403 => CohostApiError::PremiumRequired { message },
-        400 => CohostApiError::InvalidRequest { message },
-        429 => CohostApiError::QuotaExhausted {
+    let kind = match code {
+        "unauthorized" => CohostApiErrorKind::Unauthorized,
+        "premium-required" => CohostApiErrorKind::PremiumRequired,
+        "consent-required" => CohostApiErrorKind::ConsentRequired,
+        "prompt-version-unsupported" => CohostApiErrorKind::PromptVersionUnsupported,
+        "invalid-request" => CohostApiErrorKind::InvalidRequest,
+        "quota-exhausted" => CohostApiErrorKind::QuotaExhausted {
             retry_after: parse_retry_after_seconds(retry_after),
-            message,
         },
-        503 => CohostApiError::ServerUnconfigured {
-            code: code.to_string(),
-            message,
+        "ai-gateway-not-configured" | "cohost-disabled" => CohostApiErrorKind::ServerUnconfigured,
+        _ => match status {
+            401 => CohostApiErrorKind::Unauthorized,
+            403 => CohostApiErrorKind::PremiumRequired,
+            400 => CohostApiErrorKind::InvalidRequest,
+            429 => CohostApiErrorKind::QuotaExhausted {
+                retry_after: parse_retry_after_seconds(retry_after),
+            },
+            503 => CohostApiErrorKind::ServerUnconfigured,
+            _ => CohostApiErrorKind::GatewayError,
         },
-        _ => CohostApiError::GatewayError {
-            code: code.to_string(),
-            message: format!("cohost tick failed ({status}): {message}"),
-        },
+    };
+    CohostApiError {
+        kind,
+        detail: CohostErrorDetail::new(code, message, Some(status)),
     }
 }
 
@@ -544,18 +574,16 @@ impl VideorcApiClient {
             .timeout(COHOST_TICK_TIMEOUT)
             .send()
             .await
-            .map_err(|error| CohostApiError::Network {
-                message: format!("Could not reach the co-host service: {error}"),
-            })?;
+            .map_err(CohostApiError::from_transport)?;
 
         let status = response.status();
         if status.is_success() {
-            return response
-                .json()
-                .await
-                .map_err(|error| CohostApiError::MalformedResponse {
-                    message: format!("Could not read the co-host response: {error}"),
-                });
+            return response.json().await.map_err(|error| {
+                CohostApiError::malformed_response(
+                    status.as_u16(),
+                    format!("Could not read the co-host response: {error}"),
+                )
+            });
         }
         let retry_after = response
             .headers()
@@ -872,6 +900,14 @@ fn classify_caption_failure(status: u16, code: String, message: String) -> Capti
 }
 
 async fn read_error_code_and_message(response: reqwest::Response) -> (String, String) {
+    let text = response.text().await.unwrap_or_default();
+    parse_error_envelope(&text)
+}
+
+/// `{ error: { code, message } }` → `(code, message)` with honest fallbacks:
+/// `unknown` / `request failed` when the body is not the envelope (HTML from
+/// a proxy, an empty body, a different JSON shape) or a part is blank.
+pub(crate) fn parse_error_envelope(text: &str) -> (String, String) {
     #[derive(Deserialize)]
     struct ErrorEnvelope {
         error: Option<ErrorBody>,
@@ -883,17 +919,19 @@ async fn read_error_code_and_message(response: reqwest::Response) -> (String, St
         message: Option<String>,
     }
 
-    let parsed = match response.text().await {
-        Ok(text) => serde_json::from_str::<ErrorEnvelope>(&text).ok(),
-        Err(_) => None,
-    };
-    let body = parsed.and_then(|envelope| envelope.error);
+    let body = serde_json::from_str::<ErrorEnvelope>(text)
+        .ok()
+        .and_then(|envelope| envelope.error);
     (
         body.as_ref()
-            .and_then(|error| error.code.clone())
+            .and_then(|error| error.code.as_deref())
+            .map(str::trim)
+            .filter(|code| !code.is_empty())
+            .map(str::to_string)
             .unwrap_or_else(|| "unknown".to_string()),
         body.and_then(|error| error.message)
-            .filter(|message| !message.trim().is_empty())
+            .map(|message| message.trim().to_string())
+            .filter(|message| !message.is_empty())
             .unwrap_or_else(|| "request failed".to_string()),
     )
 }
@@ -970,7 +1008,10 @@ mod tests {
     #[test]
     fn entitlement_capability_request_finishes_before_the_rpc_deadline() {
         assert!(!AI_CAPABILITIES_REQUEST_TIMEOUT.is_zero());
-        assert_eq!(COHOST_TICK_TIMEOUT.as_secs(), 8);
+        // Headroom over the 8 s cadence floor (a model ladder can take longer),
+        // but well under the updater/RPC deadlines; see cohost.rs for the
+        // min-gap interaction test.
+        assert_eq!(COHOST_TICK_TIMEOUT.as_secs(), 12);
         assert!(AI_CAPABILITIES_REQUEST_TIMEOUT < std::time::Duration::from_secs(10));
     }
 
@@ -1182,59 +1223,49 @@ mod tests {
 
     #[test]
     fn cohost_failures_classify_by_envelope_code_then_status() {
-        let cases: Vec<(u16, &str, Option<&str>, CohostApiError, CohostReason)> = vec![
+        use CohostApiErrorKind as Kind;
+        let cases: Vec<(u16, &str, Option<&str>, Kind, CohostReason)> = vec![
             (
                 401,
                 "unauthorized",
                 None,
-                CohostApiError::Unauthorized {
-                    message: "m".into(),
-                },
+                Kind::Unauthorized,
                 CohostReason::SessionExpired,
             ),
             (
                 403,
                 "premium-required",
                 None,
-                CohostApiError::PremiumRequired {
-                    message: "m".into(),
-                },
+                Kind::PremiumRequired,
                 CohostReason::PremiumRequired,
             ),
             (
                 400,
                 "consent-required",
                 None,
-                CohostApiError::ConsentRequired {
-                    message: "m".into(),
-                },
+                Kind::ConsentRequired,
                 CohostReason::ConsentRequired,
             ),
             (
                 400,
                 "prompt-version-unsupported",
                 None,
-                CohostApiError::PromptVersionUnsupported {
-                    message: "m".into(),
-                },
+                Kind::PromptVersionUnsupported,
                 CohostReason::ServerUnconfigured,
             ),
             (
                 400,
                 "invalid-request",
                 None,
-                CohostApiError::InvalidRequest {
-                    message: "m".into(),
-                },
+                Kind::InvalidRequest,
                 CohostReason::GatewayError,
             ),
             (
                 429,
                 "quota-exhausted",
                 Some("120"),
-                CohostApiError::QuotaExhausted {
+                Kind::QuotaExhausted {
                     retry_after: Some(std::time::Duration::from_secs(120)),
-                    message: "m".into(),
                 },
                 CohostReason::QuotaExhausted,
             ),
@@ -1242,50 +1273,35 @@ mod tests {
                 429,
                 "unknown",
                 Some("Wed, 21 Oct 2026 07:28:00 GMT"),
-                CohostApiError::QuotaExhausted {
-                    retry_after: None,
-                    message: "m".into(),
-                },
+                Kind::QuotaExhausted { retry_after: None },
                 CohostReason::QuotaExhausted,
             ),
             (
                 503,
                 "ai-gateway-not-configured",
                 None,
-                CohostApiError::ServerUnconfigured {
-                    code: "ai-gateway-not-configured".into(),
-                    message: "m".into(),
-                },
+                Kind::ServerUnconfigured,
                 CohostReason::ServerUnconfigured,
             ),
             (
                 503,
                 "cohost-disabled",
                 None,
-                CohostApiError::ServerUnconfigured {
-                    code: "cohost-disabled".into(),
-                    message: "m".into(),
-                },
+                Kind::ServerUnconfigured,
                 CohostReason::ServerUnconfigured,
             ),
             (
                 502,
                 "ai-gateway-error",
                 None,
-                CohostApiError::GatewayError {
-                    code: "ai-gateway-error".into(),
-                    message: "cohost tick failed (502): m".into(),
-                },
+                Kind::GatewayError,
                 CohostReason::GatewayError,
             ),
             (
                 500,
                 "unknown",
                 None,
-                CohostApiError::GatewayError {
-                    code: "unknown".into(),
-                    message: "cohost tick failed (500): m".into(),
-                },
+                Kind::GatewayError,
                 CohostReason::GatewayError,
             ),
             // Ops blocklist: any unknown 403 code is the premium-required class.
@@ -1293,9 +1309,7 @@ mod tests {
                 403,
                 "ai-user-disabled",
                 None,
-                CohostApiError::PremiumRequired {
-                    message: "m".into(),
-                },
+                Kind::PremiumRequired,
                 CohostReason::PremiumRequired,
             ),
             // Status-only fallbacks when the envelope carries no known code.
@@ -1303,25 +1317,34 @@ mod tests {
                 401,
                 "unknown",
                 None,
-                CohostApiError::Unauthorized {
-                    message: "m".into(),
-                },
+                Kind::Unauthorized,
                 CohostReason::SessionExpired,
             ),
             (
                 403,
                 "unknown",
                 None,
-                CohostApiError::PremiumRequired {
-                    message: "m".into(),
-                },
+                Kind::PremiumRequired,
                 CohostReason::PremiumRequired,
             ),
         ];
-        for (status, code, retry_after, expected, reason) in cases {
+        for (status, code, retry_after, kind, reason) in cases {
             let actual = classify_cohost_failure(status, code, "m".to_string(), retry_after);
-            assert_eq!(actual, expected, "{status} {code}");
+            assert_eq!(actual.kind, kind, "{status} {code}");
             assert_eq!(actual.reason(), reason, "{status} {code}");
+            // The server's own words survive classification verbatim: the
+            // raw envelope code (even when the class came from the status),
+            // the message, and the HTTP status.
+            assert_eq!(
+                actual.detail,
+                CohostErrorDetail {
+                    code: code.to_string(),
+                    message: "m".to_string(),
+                    status: Some(status),
+                },
+                "{status} {code}"
+            );
+            assert_eq!(actual.message(), "m");
         }
         assert_eq!(
             parse_retry_after_seconds(Some(" 42 ")),
@@ -1329,6 +1352,74 @@ mod tests {
         );
         assert_eq!(parse_retry_after_seconds(Some("soon")), None);
         assert_eq!(parse_retry_after_seconds(None), None);
+    }
+
+    #[test]
+    fn cohost_error_envelope_parse_keeps_code_and_message_with_honest_fallbacks() {
+        // The 2026-08-23 incident shape: web mis-parsed the gateway reply and
+        // answered 502 with this envelope; the desktop must carry both parts.
+        assert_eq!(
+            parse_error_envelope(
+                r#"{"error":{"code":"ai-gateway-error","message":"The co-host tick failed on every configured model."}}"#
+            ),
+            (
+                "ai-gateway-error".to_string(),
+                "The co-host tick failed on every configured model.".to_string()
+            )
+        );
+        assert_eq!(
+            parse_error_envelope(
+                r#"{"error":{"code":"quota-exhausted","message":"  Try later. "}}"#
+            ),
+            ("quota-exhausted".to_string(), "Try later.".to_string())
+        );
+        // Missing or blank parts fall back one at a time.
+        assert_eq!(
+            parse_error_envelope(r#"{"error":{"code":"ai-gateway-error"}}"#),
+            ("ai-gateway-error".to_string(), "request failed".to_string())
+        );
+        assert_eq!(
+            parse_error_envelope(r#"{"error":{"code":"  ","message":"Upstream exploded."}}"#),
+            ("unknown".to_string(), "Upstream exploded.".to_string())
+        );
+        assert_eq!(
+            parse_error_envelope(r#"{"error":{"message":""}}"#),
+            ("unknown".to_string(), "request failed".to_string())
+        );
+        // Not the envelope at all: a proxy HTML page, an empty body, other JSON.
+        for body in ["<html>502 Bad Gateway</html>", "", r#"{"ok":false}"#, "[]"] {
+            assert_eq!(
+                parse_error_envelope(body),
+                ("unknown".to_string(), "request failed".to_string()),
+                "{body:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cohost_desktop_side_failures_carry_their_own_detail_codes() {
+        let network = CohostApiError::network("Could not reach the co-host service: dns");
+        assert_eq!(network.kind, CohostApiErrorKind::Network);
+        assert_eq!(network.reason(), CohostReason::Network);
+        assert_eq!(network.detail.code, COHOST_DETAIL_CODE_NETWORK);
+        assert_eq!(network.detail.status, None);
+
+        let timeout = CohostApiError::timeout("The co-host service did not answer within 12 s.");
+        assert_eq!(timeout.kind, CohostApiErrorKind::Network);
+        assert_eq!(timeout.reason(), CohostReason::Network);
+        assert_eq!(timeout.detail.code, COHOST_DETAIL_CODE_TIMEOUT);
+        assert_eq!(timeout.detail.status, None);
+        assert_eq!(
+            timeout.message(),
+            "The co-host service did not answer within 12 s."
+        );
+
+        let malformed =
+            CohostApiError::malformed_response(200, "Could not read the co-host response: EOF");
+        assert_eq!(malformed.kind, CohostApiErrorKind::MalformedResponse);
+        assert_eq!(malformed.reason(), CohostReason::GatewayError);
+        assert_eq!(malformed.detail.code, COHOST_DETAIL_CODE_MALFORMED_RESPONSE);
+        assert_eq!(malformed.detail.status, Some(200));
     }
 
     #[test]

--- a/protocol-fixtures/high-risk-contracts.json
+++ b/protocol-fixtures/high-risk-contracts.json
@@ -264,6 +264,7 @@
       "sessionId": "session-fixture",
       "status": "listening",
       "reason": null,
+      "detail": null,
       "questions": [
         {
           "id": "q_fixture",
@@ -293,6 +294,50 @@
       "partial": false
     },
     "offState": {
+      "sessionId": null,
+      "status": "off",
+      "reason": null,
+      "detail": null,
+      "questions": [],
+      "flags": [],
+      "mood": null,
+      "lastTickAt": null,
+      "tickSeq": 0,
+      "partial": false
+    },
+    "errorState": {
+      "sessionId": "session-fixture",
+      "status": "error",
+      "reason": "gateway-error",
+      "detail": {
+        "code": "ai-gateway-error",
+        "message": "The co-host tick failed on every configured model.",
+        "status": 502
+      },
+      "questions": [],
+      "flags": [],
+      "mood": null,
+      "lastTickAt": "2026-08-22T10:00:20Z",
+      "tickSeq": 3,
+      "partial": false
+    },
+    "timeoutState": {
+      "sessionId": "session-fixture",
+      "status": "error",
+      "reason": "network",
+      "detail": {
+        "code": "timeout",
+        "message": "The co-host service did not answer within 12 s.",
+        "status": null
+      },
+      "questions": [],
+      "flags": [],
+      "mood": null,
+      "lastTickAt": "2026-08-22T10:00:20Z",
+      "tickSeq": 3,
+      "partial": false
+    },
+    "legacyState": {
       "sessionId": null,
       "status": "off",
       "reason": null,


### PR DESCRIPTION
Follow-up to last night's co-host incident (server side fixed in videorc-web #13/#14). `cohost.state.detail {code,message,status}` on every failed tick; toast + chip show it; one toast per (reason, code); tick timeout 8→12s. Gates: cohost 25 / videorc_api 15 / protocol 31, clippy+fmt clean, desktop 1377 tests, typecheck/lint/format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Co-host failures now display specific error codes, messages, and HTTP status details.
  - Error details are available in status tooltips and directly within the co-host panel.
  - Recovery guidance replaces the normal listening message when co-host operation is paused.
  - Network, timeout, gateway, and malformed-response failures now provide clearer diagnostics.
  - Co-host requests allow additional time before timing out.

- **Bug Fixes**
  - Repeated identical failures no longer produce duplicate notifications.
  - Error details clear automatically when co-hosting recovers or enters a non-error state.
  - Older co-host states remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->