### PR TITLE
release: 0.9.67-beta.1 — the co-host says why it stopped

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.66",
+  "version": "0.9.67",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.67-beta.1.md
+++ b/changelog/0.9.67-beta.1.md
@@ -1,0 +1,30 @@
+---
+version: 0.9.67-beta.1
+date: 2026-08-23
+channel: beta
+platforms:
+  - macos
+title: The co-host says why it stopped — and it stops less
+summary: Last night the co-host could fail mid-stream with a bare "Videorc AI returned an error". The cause was on our servers and is fixed there; this update makes the app tell you exactly what went wrong, gives each AI pass more time before giving up, and confirms the Publish tab's AI works end to end again.
+highlights:
+  - When the co-host pauses on an error, the toast and the status chip now carry the reason and the server's message — "ai-gateway-error: …" instead of a mystery.
+  - Each co-host pass gets 12 seconds before the app gives up (was 8), matched by a longer budget on the server, so a slow moment at the AI provider no longer reads as a failure.
+  - One error toast per distinct cause, not one per retry — a flapping provider can't spam you while you're live.
+  - Server side (already live): our AI gateway client read the model's answer from the wrong field, so every structured AI call — co-host ticks and the Publish pack alike — was failing. Fixed, and the co-host now runs on a fast model that fits its budget.
+  - Publish-tab AI (transcript → titles, description, chapters) is verified working again end to end.
+---
+
+The first live night of the co-host surfaced a server bug: our AI gateway
+client looked for the model's answer in a field that the API never sends,
+so every structured AI call failed — the co-host saw "AI returned an error"
+on every pass, and the Publish tab's pack generation had been silently
+broken by the same line. That is fixed on the server and needs nothing
+from you.
+
+What this update changes in the app is the experience around failures.
+The toast and the co-host chip now say exactly why it stopped, using the
+server's own error code and message, so the next time something breaks
+you (and we) know within seconds. Each AI pass is also given 12 seconds
+instead of 8, with the server's budget raised to match, so a slow provider
+response no longer counts as a failure. And a provider that flaps produces
+one toast per distinct cause rather than one per retry.


### PR DESCRIPTION
Version bump + macOS changelog. Ships #253 (cohost error detail + 12s timeout) on top of the server-side fixes (videorc-web #13/#14).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publish-tab AI generation now works reliably for transcripts, including titles, descriptions, and chapters.
* **Bug Fixes**
  * Improved reporting for AI failures by displaying the server’s error code and message.
  * Increased the AI processing timeout from 8 to 12 seconds.
  * Reduced repeated error notifications by showing one toast per distinct failure cause.
* **Release**
  * Updated the desktop application to version 0.9.67 beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->