### PR TITLE
release: 0.9.67-alpha.1 Windows changelog

### DIFF
--- a/changelog/0.9.67-alpha.1.md
+++ b/changelog/0.9.67-alpha.1.md
@@ -1,0 +1,19 @@
+---
+version: 0.9.67-alpha.1
+date: 2026-08-23
+channel: alpha
+platforms:
+  - windows
+title: Co-host errors explained, and more time per AI pass
+summary: The Windows Alpha picks up the co-host reliability update — error toasts now carry the real reason, each AI pass gets 12 seconds, and the server-side gateway fix that broke last night's co-host and the Publish pack is already live.
+highlights:
+  - Co-host error toasts and the status chip now show the server's error code and message instead of a bare "AI returned an error".
+  - Each co-host pass has 12 seconds (was 8) before the app gives up, with a matching server budget.
+  - One toast per distinct cause while live, not one per retry.
+  - Server fix (already live): structured AI calls — co-host and Publish pack — read the model's answer correctly again.
+---
+
+Same change set as the macOS 0.9.67 Beta: the co-host tells you why it
+stopped, AI passes get more time, and the server-side gateway parsing bug
+that broke last night's co-host ticks and the Publish pack is fixed for
+every build.


### PR DESCRIPTION
Windows Alpha entry for the co-host reliability update (same change set as 0.9.67-beta.1). Candidate dispatched from the merge commit.