### PR TITLE
docs: 0.9.67 release record

### DIFF
--- a/docs/releases/0.9.67.md
+++ b/docs/releases/0.9.67.md
@@ -1,0 +1,43 @@
+# Videorc 0.9.67 Beta 1 / Windows Alpha 1
+
+Co-host reliability follow-up to the first live night (2026-08-22/23): the
+server-side AI Gateway parsing bug is fixed on the web, the app now says
+exactly why the co-host stopped, and each AI pass gets more time.
+
+## Scope
+
+- **Web (videorc-web #13, #14, deployed 2026-08-23):** `generateStructuredJson`
+  read `payload.output_text`, an SDK-only field the raw Responses API never
+  sends → every structured generation failed (co-host 502 `ai-gateway-error`,
+  Publish pack too). Fixed (`responsesApiOutputText` reads
+  `output[].content[]`). Tick budget 7 s → 10 s (attempt 6.5 → 9 s). Failed
+  ticks metered as `cohost-tick-failed` with `error_code` (migration 0013,
+  applied on Neon), visible in the ops dashboard, excluded from quota.
+  `smoke:ai-cohost-live` hits the real gateway (3.5 s, PASS). Production
+  `VIDEORC_AI_COHOST_TEXT_MODEL=openai/gpt-5.4-mini-fast`, fallback
+  `google/gemini-3.5-flash-lite` (gpt-5.5 class exceeds the budget).
+- **Desktop (#253):** `cohost.state.detail {code,message,status}` on every
+  failed tick; toast + chip show it; one toast per (reason, code); tick HTTP
+  timeout 8 s → 12 s. Release prep #254 (macOS) / #255 (Windows changelog).
+- Publish pack verified end to end against the real gateway after the fix
+  (gpt-5.5 4.0 s; gpt-5.4-mini-fast 2.6 s).
+
+## Release status
+
+- [x] macOS source commit `e31e9ec652502df56ae06c3f977c8d3c2cddba9b`; signed +
+      notarized + stapled; `release:validate:macos` PASS; uploaded and
+      verified (`latest-mac.yml` → 0.9.67, zip 200); Discord posted.
+- [x] Windows source commit `ac7f431a90a01b8f2d2c8717bf282b5a2e69ceaf`;
+      candidate https://github.com/TheOrcDev/videorc/actions/runs/32637500182
+      (publisher `Uros Miric`, installer SHA-256
+      `351bb9c35b328a79326f834dcea244283ba4f937de35dbd08959b9b96ba83aa6`);
+      pilot promotion https://github.com/TheOrcDev/videorc/actions/runs/32639350433
+      PASS — `releases/windows/pilot/release.json` + `updates/windows/pilot/`
+      now serve 0.9.67-alpha.1 (account-gated download).
+- [ ] Owner co-host acceptance on a real stream (questions grouped, R→send→cleared,
+      error toast shows a reason if anything fails).
+- [ ] Windows physical acceptance + public promotion (unchanged from 0.9.66;
+      see `docs/releases/windows-alpha-runbook.md` §3–6). A Windows 0.9.66
+      tester reported "Backend crashed, restarting (attempt 3)" — cause not
+      recoverable from the bundle; crash capture is slice B1 of the batch-3
+      plan and targets 0.9.68.


### PR DESCRIPTION
macOS 0.9.67-beta.1 live + verified; Windows 0.9.67-alpha.1 candidate + pilot PASS.