### PR TITLE
fix(account): refresh avatar on launch, cache avatars in the Comments window, log cache rejections

### DIFF
--- a/apps/desktop/src/main/avatar-cache.test.ts
+++ b/apps/desktop/src/main/avatar-cache.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { avatarCacheFileName, avatarHostAllowed } from './avatar-cache'
+import {
+  AVATAR_MAX_BYTES,
+  avatarCacheFileName,
+  avatarCacheRejectionKey,
+  avatarCacheRejectionMessage,
+  avatarHostAllowed,
+  avatarUrlDecision,
+  httpStatusClass,
+  redactAvatarFetchError,
+  type AvatarCacheRejection
+} from './avatar-cache'
 
 describe('avatarHostAllowed', () => {
   it('allows the platform CDNs over https only', () => {
@@ -10,12 +20,117 @@ describe('avatarHostAllowed', () => {
     expect(avatarHostAllowed('http://yt3.ggpht.com/abc')).toBe(false)
   })
 
+  it('allows every Vercel Blob store the web may upload account avatars to', () => {
+    // Parity with the web's isAccountAvatarBlobUrl: bare host or any subdomain.
+    expect(avatarHostAllowed('https://blob.vercel-storage.com/avatars/u.png')).toBe(true)
+    expect(avatarHostAllowed('https://abc123.public.blob.vercel-storage.com/avatars/u.png')).toBe(
+      true
+    )
+    expect(avatarHostAllowed('https://abc123.blob.vercel-storage.com/avatars/u.png')).toBe(true)
+    expect(avatarHostAllowed('http://abc123.public.blob.vercel-storage.com/avatars/u.png')).toBe(
+      false
+    )
+    expect(avatarHostAllowed('https://blob.vercel-storage.com.attacker.dev/u.png')).toBe(false)
+    expect(avatarHostAllowed('https://notblob.vercel-storage.com/u.png')).toBe(false)
+  })
+
   it('rejects lookalike hosts, other origins, and garbage', () => {
     expect(avatarHostAllowed('https://evil-yt3.ggpht.com.attacker.dev/x.png')).toBe(false)
     expect(avatarHostAllowed('https://notgoogleusercontent.com/x.png')).toBe(false)
     expect(avatarHostAllowed('https://example.com/avatar.png')).toBe(false)
     expect(avatarHostAllowed('file:///etc/passwd')).toBe(false)
     expect(avatarHostAllowed('not a url')).toBe(false)
+  })
+})
+
+describe('avatarUrlDecision', () => {
+  it('names the host for an allowed URL', () => {
+    expect(avatarUrlDecision('https://LH3.googleusercontent.com/a/user=s96')).toEqual({
+      allowed: true,
+      host: 'lh3.googleusercontent.com'
+    })
+  })
+
+  it('explains each rejection with host and scheme only', () => {
+    expect(avatarUrlDecision(42)).toEqual({
+      allowed: false,
+      rejection: { kind: 'not-a-url' }
+    })
+    expect(avatarUrlDecision('not a url')).toEqual({
+      allowed: false,
+      rejection: { kind: 'not-a-url' }
+    })
+    expect(avatarUrlDecision('http://yt3.ggpht.com/abc?token=secret')).toEqual({
+      allowed: false,
+      rejection: { kind: 'scheme', scheme: 'http', host: 'yt3.ggpht.com' }
+    })
+    expect(avatarUrlDecision('https://cdn.example.com/u.png?sig=secret')).toEqual({
+      allowed: false,
+      rejection: { kind: 'host', scheme: 'https', host: 'cdn.example.com' }
+    })
+  })
+})
+
+describe('avatar cache rejection diagnostics', () => {
+  const rejections: AvatarCacheRejection[] = [
+    { kind: 'not-a-url' },
+    { kind: 'scheme', scheme: 'http', host: 'yt3.ggpht.com' },
+    { kind: 'host', scheme: 'https', host: 'cdn.example.com' },
+    { kind: 'http-status', host: 'static-cdn.jtvnw.net', statusClass: '4xx' },
+    { kind: 'empty-body', host: 'yt3.ggpht.com' },
+    { kind: 'too-large', host: 'lh3.googleusercontent.com', bytes: AVATAR_MAX_BYTES + 1 },
+    { kind: 'fetch-error', host: 'yt3.ggpht.com', message: 'net::ERR_NAME_NOT_RESOLVED' }
+  ]
+
+  it('writes one readable line per rejection, never a path or query', () => {
+    for (const rejection of rejections) {
+      const message = avatarCacheRejectionMessage(rejection)
+      expect(message.startsWith('Chat avatar not cached:')).toBe(true)
+      expect(message).not.toMatch(/[?&]\w+=|\/\w+\.(png|jpg)/)
+      if ('host' in rejection) {
+        expect(message).toContain(rejection.host)
+      }
+    }
+    expect(
+      avatarCacheRejectionMessage({ kind: 'http-status', host: 'h.example', statusClass: '5xx' })
+    ).toBe('Chat avatar not cached: h.example answered 5xx.')
+    expect(
+      avatarCacheRejectionMessage({ kind: 'too-large', host: 'h.example', bytes: 3_000_000 })
+    ).toBe(`Chat avatar not cached: h.example returned 3000000 bytes (cap ${AVATAR_MAX_BYTES}).`)
+  })
+
+  it('dedupes by host and reason so a busy chat logs each cause once', () => {
+    const keys = rejections.map(avatarCacheRejectionKey)
+    expect(new Set(keys).size).toBe(rejections.length)
+    expect(avatarCacheRejectionKey({ kind: 'too-large', host: 'h.example', bytes: 1 })).toBe(
+      avatarCacheRejectionKey({ kind: 'too-large', host: 'h.example', bytes: 2 })
+    )
+    expect(avatarCacheRejectionKey({ kind: 'fetch-error', host: 'h.example', message: 'a' })).toBe(
+      avatarCacheRejectionKey({ kind: 'fetch-error', host: 'h.example', message: 'b' })
+    )
+    expect(
+      avatarCacheRejectionKey({ kind: 'http-status', host: 'h.example', statusClass: '4xx' })
+    ).not.toBe(
+      avatarCacheRejectionKey({ kind: 'http-status', host: 'h.example', statusClass: '5xx' })
+    )
+  })
+
+  it('classifies HTTP statuses without leaking the exact code', () => {
+    expect(httpStatusClass(200)).toBe('2xx')
+    expect(httpStatusClass(403)).toBe('4xx')
+    expect(httpStatusClass(503)).toBe('5xx')
+    expect(httpStatusClass(Number.NaN)).toBe('unknown')
+    expect(httpStatusClass(0)).toBe('unknown')
+  })
+
+  it('redacts URL-shaped text from fetch errors and bounds the length', () => {
+    expect(
+      redactAvatarFetchError(
+        new Error('request to https://yt3.ggpht.com/abc?token=secret failed, reason: ECONNRESET')
+      )
+    ).toBe('request to <url> failed, reason: ECONNRESET')
+    expect(redactAvatarFetchError('net::ERR_NAME_NOT_RESOLVED')).toBe('net::ERR_NAME_NOT_RESOLVED')
+    expect(redactAvatarFetchError(new Error('x'.repeat(500)))).toHaveLength(160)
   })
 })
 

--- a/apps/desktop/src/main/avatar-cache.ts
+++ b/apps/desktop/src/main/avatar-cache.ts
@@ -14,9 +14,10 @@ const AVATAR_ALLOWED_HOST_SUFFIXES = [
   'googleusercontent.com',
   // Twitch profile images
   'static-cdn.jtvnw.net',
-  // Videorc account avatars uploaded on videorc.com (Vercel Blob storage);
+  // Videorc account avatars uploaded on videorc.com (Vercel Blob storage).
+  // Any store subdomain, matching the web's own isAccountAvatarBlobUrl check;
   // Google account photos are covered by googleusercontent.com above.
-  'public.blob.vercel-storage.com'
+  'blob.vercel-storage.com'
 ]
 
 /** Keep the cache bounded; oldest files (by mtime) are pruned past this. */
@@ -27,20 +28,107 @@ export const AVATAR_CACHE_MAX_FILES = 200
  * avatar the web happily accepted. */
 export const AVATAR_MAX_BYTES = 2 * 1024 * 1024
 
-export function avatarHostAllowed(rawUrl: string): boolean {
+/**
+ * Why an avatar was not cached. Carries only what support needs to see (host,
+ * scheme, size / status class) — never the path or query, which on platform
+ * CDNs can embed per-user tokens.
+ */
+export type AvatarCacheRejection =
+  | { kind: 'not-a-url' }
+  | { kind: 'scheme'; scheme: string; host: string }
+  | { kind: 'host'; scheme: string; host: string }
+  | { kind: 'http-status'; host: string; statusClass: string }
+  | { kind: 'empty-body'; host: string }
+  | { kind: 'too-large'; host: string; bytes: number }
+  | { kind: 'fetch-error'; host: string; message: string }
+
+export type AvatarUrlDecision =
+  | { allowed: true; host: string }
+  | { allowed: false; rejection: AvatarCacheRejection }
+
+export function avatarUrlDecision(rawUrl: unknown): AvatarUrlDecision {
+  if (typeof rawUrl !== 'string') {
+    return { allowed: false, rejection: { kind: 'not-a-url' } }
+  }
   let url: URL
   try {
     url = new URL(rawUrl)
   } catch {
-    return false
-  }
-  if (url.protocol !== 'https:') {
-    return false
+    return { allowed: false, rejection: { kind: 'not-a-url' } }
   }
   const host = url.hostname.toLowerCase()
-  return AVATAR_ALLOWED_HOST_SUFFIXES.some(
+  const scheme = url.protocol.replace(/:$/, '')
+  if (url.protocol !== 'https:') {
+    return { allowed: false, rejection: { kind: 'scheme', scheme, host } }
+  }
+  const allowed = AVATAR_ALLOWED_HOST_SUFFIXES.some(
     (suffix) => host === suffix || host.endsWith(`.${suffix}`)
   )
+  return allowed
+    ? { allowed: true, host }
+    : { allowed: false, rejection: { kind: 'host', scheme, host } }
+}
+
+export function avatarHostAllowed(rawUrl: string): boolean {
+  return avatarUrlDecision(rawUrl).allowed
+}
+
+/** `2xx` / `4xx` / `5xx` style class; enough to tell auth from outage. */
+export function httpStatusClass(status: number): string {
+  if (!Number.isFinite(status) || status < 100 || status > 999) {
+    return 'unknown'
+  }
+  return `${Math.floor(status / 100)}xx`
+}
+
+// Platform fetch errors occasionally quote the request URL; strip anything
+// URL-shaped so the log line never carries a token-bearing path.
+export function redactAvatarFetchError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  return raw.replace(/[a-z][a-z0-9+.-]*:\/\/\S+/gi, '<url>').slice(0, 160)
+}
+
+/**
+ * One line per distinct (host, reason) so a busy chat from one blocked CDN
+ * does not flood the 200-line backend log ring.
+ */
+export function avatarCacheRejectionKey(rejection: AvatarCacheRejection): string {
+  switch (rejection.kind) {
+    case 'not-a-url':
+      return 'not-a-url'
+    case 'scheme':
+      return `scheme:${rejection.scheme}:${rejection.host}`
+    case 'host':
+      return `host:${rejection.host}`
+    case 'http-status':
+      return `http-status:${rejection.host}:${rejection.statusClass}`
+    case 'empty-body':
+      return `empty-body:${rejection.host}`
+    case 'too-large':
+      return `too-large:${rejection.host}`
+    case 'fetch-error':
+      return `fetch-error:${rejection.host}`
+  }
+}
+
+export function avatarCacheRejectionMessage(rejection: AvatarCacheRejection): string {
+  const prefix = 'Chat avatar not cached:'
+  switch (rejection.kind) {
+    case 'not-a-url':
+      return `${prefix} value is not a URL.`
+    case 'scheme':
+      return `${prefix} scheme ${rejection.scheme} is not https (host ${rejection.host}).`
+    case 'host':
+      return `${prefix} host ${rejection.host} is not an allowlisted avatar CDN.`
+    case 'http-status':
+      return `${prefix} ${rejection.host} answered ${rejection.statusClass}.`
+    case 'empty-body':
+      return `${prefix} ${rejection.host} returned an empty body.`
+    case 'too-large':
+      return `${prefix} ${rejection.host} returned ${rejection.bytes} bytes (cap ${AVATAR_MAX_BYTES}).`
+    case 'fetch-error':
+      return `${prefix} fetching from ${rejection.host} failed (${rejection.message}).`
+  }
 }
 
 /**

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -203,8 +203,13 @@ import { backendIsolationEnv } from './backend-isolation'
 import {
   AVATAR_CACHE_MAX_FILES,
   AVATAR_MAX_BYTES,
+  type AvatarCacheRejection,
   avatarCacheFileName,
-  avatarHostAllowed
+  avatarCacheRejectionKey,
+  avatarCacheRejectionMessage,
+  avatarUrlDecision,
+  httpStatusClass,
+  redactAvatarFetchError
 } from './avatar-cache'
 import { DARK_WINDOW_PALETTE, windowPalette } from './window-palette'
 import {
@@ -11355,11 +11360,29 @@ function avatarCacheDirectory(): string {
 
 const avatarFetchesInFlight = new Map<string, Promise<string | null>>()
 
-async function cacheChatAvatar(rawUrl: unknown): Promise<string | null> {
-  if (typeof rawUrl !== 'string' || !avatarHostAllowed(rawUrl)) {
-    return null
+// Rejections used to be silent, so a monogram-only sidebar or Comments window
+// left nothing in a support bundle. Log each distinct (host, reason) once per
+// process — host/scheme/size/status class only, never the URL (CDN paths can
+// carry per-user tokens).
+const avatarRejectionsLogged = new Set<string>()
+
+function rejectChatAvatar(rejection: AvatarCacheRejection): null {
+  const key = avatarCacheRejectionKey(rejection)
+  if (!avatarRejectionsLogged.has(key)) {
+    avatarRejectionsLogged.add(key)
+    logBackend('warn', avatarCacheRejectionMessage(rejection))
   }
-  const fileName = avatarCacheFileName(rawUrl)
+  return null
+}
+
+async function cacheChatAvatar(rawUrl: unknown): Promise<string | null> {
+  const decision = avatarUrlDecision(rawUrl)
+  if (!decision.allowed) {
+    return rejectChatAvatar(decision.rejection)
+  }
+  const { host } = decision
+  const avatarUrl = rawUrl as string
+  const fileName = avatarCacheFileName(avatarUrl)
   const localUrl = `${MANAGED_ASSET_SCHEME}://avatar/${fileName}`
   const filePath = join(avatarCacheDirectory(), fileName)
   if (existsSync(filePath)) {
@@ -11371,20 +11394,31 @@ async function cacheChatAvatar(rawUrl: unknown): Promise<string | null> {
   }
   const fetchPromise = (async () => {
     try {
-      const response = await net.fetch(rawUrl)
+      const response = await net.fetch(avatarUrl)
       if (!response.ok) {
-        return null
+        return rejectChatAvatar({
+          kind: 'http-status',
+          host,
+          statusClass: httpStatusClass(response.status)
+        })
       }
       const bytes = Buffer.from(await response.arrayBuffer())
-      if (bytes.length === 0 || bytes.length > AVATAR_MAX_BYTES) {
-        return null
+      if (bytes.length === 0) {
+        return rejectChatAvatar({ kind: 'empty-body', host })
+      }
+      if (bytes.length > AVATAR_MAX_BYTES) {
+        return rejectChatAvatar({ kind: 'too-large', host, bytes: bytes.length })
       }
       mkdirSync(avatarCacheDirectory(), { recursive: true })
       writeFileSync(filePath, bytes)
       pruneAvatarCache()
       return localUrl
-    } catch {
-      return null
+    } catch (error) {
+      return rejectChatAvatar({
+        kind: 'fetch-error',
+        host,
+        message: redactAvatarFetchError(error)
+      })
     } finally {
       avatarFetchesInFlight.delete(fileName)
     }

--- a/apps/desktop/src/main/renderer-security-policy.test.ts
+++ b/apps/desktop/src/main/renderer-security-policy.test.ts
@@ -16,6 +16,7 @@ import {
   trustedRendererDevServerUrl
 } from '../shared/renderer-security-policy'
 import { electronInvokeApiMethods } from '../shared/electron-ipc-contract'
+import { AUXILIARY_API_KEYS } from '../preload/api-policy'
 import {
   installRendererSessionPermissions,
   rendererWebPermissionAllowed,
@@ -255,6 +256,33 @@ describe('renderer security policy', () => {
     expect(roleCanInvokeChannel('comments', 'comments-window:push-snapshot')).toBe(false)
     expect(roleCanInvokeChannel('captions', 'captions-window:get-snapshot')).toBe(true)
     expect(roleCanInvokeChannel('captions', 'captions-window:push-snapshot')).toBe(false)
+  })
+
+  it('lets only the Comments window join main in caching chat avatars', () => {
+    // The detached Comments window draws the same chat rows as Studio; the
+    // host allowlist and the on-disk cache stay main-owned (avatar-cache.ts).
+    expect(roleCanInvokeChannel('main', 'avatars:cache')).toBe(true)
+    expect(roleCanInvokeChannel('comments', 'avatars:cache')).toBe(true)
+    expect(roleCanInvokeChannel('notes', 'avatars:cache')).toBe(false)
+    expect(roleCanInvokeChannel('captions', 'avatars:cache')).toBe(false)
+    expect(AUXILIARY_API_KEYS.comments).toContain('cacheChatAvatar')
+    expect(AUXILIARY_API_KEYS.notes).not.toContain('cacheChatAvatar')
+    expect(AUXILIARY_API_KEYS.captions).not.toContain('cacheChatAvatar')
+  })
+
+  it('exposes an invoke to an auxiliary preload only when the channel policy admits that role', () => {
+    const channelByApiMethod = new Map<string, string>(
+      Object.entries(electronInvokeApiMethods).map(([channel, method]) => [method, channel])
+    )
+    for (const role of ['notes', 'comments', 'captions'] as const) {
+      for (const key of AUXILIARY_API_KEYS[role]) {
+        const channel = channelByApiMethod.get(key as string)
+        if (!channel) {
+          continue // event subscription, not an invoke
+        }
+        expect(roleCanInvokeChannel(role, channel), `${role} -> ${channel}`).toBe(true)
+      }
+    }
   })
 
   it('applies a restrictive CSP to every bundled renderer and a nonce to Notes', () => {

--- a/apps/desktop/src/preload/api-policy.ts
+++ b/apps/desktop/src/preload/api-policy.ts
@@ -12,6 +12,7 @@ export const AUXILIARY_API_KEYS = {
     'onNotesWindowState'
   ],
   comments: [
+    'cacheChatAvatar',
     'sendCommentHighlight',
     'getCommentHighlightState',
     'onCommentHighlightState',

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -98,6 +98,11 @@ import {
 import { providerOAuthRetryDelayMs } from '@/lib/provider-oauth-retry'
 import { accountCallbackRetryDelayMs } from '@/lib/account-callback-retry'
 import {
+  INITIAL_ACCOUNT_READY_REFRESH_STATE,
+  reduceAccountReadyRefresh,
+  type AccountReadyRefreshState
+} from '@/lib/account-ready-refresh'
+import {
   LatestRequestByKey,
   SingleFlightByKey,
   SingleFlightGeneration
@@ -5551,26 +5556,48 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     await refreshEntitlementsForClient(client)
   }, [client, refreshEntitlementsForClient])
 
-  // Purchases and token expiry must not remain stale. Focus covers return from
-  // the Premium browser; the bounded signed-in timer covers an app left open.
+  // Purchases and token expiry must not remain stale. App ready (first connect)
+  // covers a cold launch, focus covers return from the Premium browser, and
+  // the bounded signed-in timer covers an app left open.
+  const accountReadyRefreshRef = useRef<AccountReadyRefreshState>(
+    INITIAL_ACCOUNT_READY_REFRESH_STATE
+  )
   useEffect(() => {
     if (!client || wsStatus !== 'connected') {
+      accountReadyRefreshRef.current = reduceAccountReadyRefresh(accountReadyRefreshRef.current, {
+        type: 'disconnected'
+      }).state
       return
+    }
+    // The identity snapshot was otherwise frozen at the last interactive
+    // sign-in — account.refresh existed backend-side but was never wired,
+    // so a web-side avatar/name change never reached the app (owner
+    // report, 2026-08-19). Failures keep the current snapshot.
+    const refreshAccountSnapshot = (): void => {
+      void client
+        .requestTyped('account.refresh', undefined)
+        .then((snapshot) => setAccount(snapshot))
+        .catch(() => {})
     }
     const refreshOnFocus = (): void => {
       void refreshEntitlementsForClient(client).catch(() => {
         // Preserve the current fail-closed snapshot on transport failure.
       })
-      // The identity snapshot was otherwise frozen at the last interactive
-      // sign-in — account.refresh existed backend-side but was never wired,
-      // so a web-side avatar/name change never reached the app (owner
-      // report, 2026-08-19). Failures keep the current snapshot.
       if (account?.status === 'signed-in') {
-        void client
-          .requestTyped('account.refresh', undefined)
-          .then((snapshot) => setAccount(snapshot))
-          .catch(() => {})
+        refreshAccountSnapshot()
       }
+    }
+    // Cold launch: account.get returns the persisted snapshot, which for a
+    // Google-linked account may predate the avatar the web now serves. One
+    // refresh per connection, so the snapshot it sets does not re-trigger it.
+    const onReady = reduceAccountReadyRefresh(accountReadyRefreshRef.current, {
+      type: 'connected',
+      client,
+      signedIn: account?.status === 'signed-in'
+    })
+    accountReadyRefreshRef.current = onReady.state
+    if (onReady.refresh) {
+      refreshAccountSnapshot()
     }
     window.addEventListener('focus', refreshOnFocus)
     const timer =

--- a/apps/desktop/src/renderer/src/lib/account-ready-refresh.test.ts
+++ b/apps/desktop/src/renderer/src/lib/account-ready-refresh.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  INITIAL_ACCOUNT_READY_REFRESH_STATE,
+  reduceAccountReadyRefresh
+} from './account-ready-refresh'
+
+describe('account refresh on app ready', () => {
+  it('refreshes once per backend connection while signed in', () => {
+    const client = {}
+    const first = reduceAccountReadyRefresh(INITIAL_ACCOUNT_READY_REFRESH_STATE, {
+      type: 'connected',
+      client,
+      signedIn: true
+    })
+    expect(first.refresh).toBe(true)
+
+    // The refreshed snapshot re-runs the effect for the same connection: no loop.
+    const again = reduceAccountReadyRefresh(first.state, {
+      type: 'connected',
+      client,
+      signedIn: true
+    })
+    expect(again.refresh).toBe(false)
+    expect(again.state).toBe(first.state)
+  })
+
+  it('does not refresh a signed-out snapshot, but does once sign-in lands', () => {
+    const client = {}
+    const signedOut = reduceAccountReadyRefresh(INITIAL_ACCOUNT_READY_REFRESH_STATE, {
+      type: 'connected',
+      client,
+      signedIn: false
+    })
+    expect(signedOut.refresh).toBe(false)
+    expect(signedOut.state).toBe(INITIAL_ACCOUNT_READY_REFRESH_STATE)
+
+    const signedIn = reduceAccountReadyRefresh(signedOut.state, {
+      type: 'connected',
+      client,
+      signedIn: true
+    })
+    expect(signedIn.refresh).toBe(true)
+  })
+
+  it('refreshes again on a new connection, and after an explicit disconnect', () => {
+    const firstClient = {}
+    const secondClient = {}
+    const first = reduceAccountReadyRefresh(INITIAL_ACCOUNT_READY_REFRESH_STATE, {
+      type: 'connected',
+      client: firstClient,
+      signedIn: true
+    })
+    const reconnect = reduceAccountReadyRefresh(first.state, {
+      type: 'connected',
+      client: secondClient,
+      signedIn: true
+    })
+    expect(reconnect.refresh).toBe(true)
+
+    const disconnected = reduceAccountReadyRefresh(reconnect.state, { type: 'disconnected' })
+    expect(disconnected.refresh).toBe(false)
+    expect(disconnected.state).toBe(INITIAL_ACCOUNT_READY_REFRESH_STATE)
+    expect(
+      reduceAccountReadyRefresh(disconnected.state, {
+        type: 'connected',
+        client: secondClient,
+        signedIn: true
+      }).refresh
+    ).toBe(true)
+  })
+
+  it('keeps the idle state identity stable across no-op disconnects', () => {
+    const idle = reduceAccountReadyRefresh(INITIAL_ACCOUNT_READY_REFRESH_STATE, {
+      type: 'disconnected'
+    })
+    expect(idle.state).toBe(INITIAL_ACCOUNT_READY_REFRESH_STATE)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/account-ready-refresh.ts
+++ b/apps/desktop/src/renderer/src/lib/account-ready-refresh.ts
@@ -1,0 +1,52 @@
+// Account refresh on app ready (live feedback batch 3, B3).
+//
+// `account.get` hands the renderer the snapshot persisted at the last
+// interactive sign-in. Until now it was only re-validated against the web on
+// window focus and on a 5-minute timer, so a cold launch showed whatever the
+// last sign-in stored — for Google-linked accounts, no avatar at all — until
+// the user alt-tabbed away and back. This reducer decides when the renderer
+// owes the web one `account.refresh` for the current backend connection:
+// exactly once per connection, and only while signed in.
+
+export interface AccountReadyRefreshState {
+  /** The backend client this connection's refresh was already issued for. */
+  readonly refreshedFor: object | null
+}
+
+export const INITIAL_ACCOUNT_READY_REFRESH_STATE: AccountReadyRefreshState = {
+  refreshedFor: null
+}
+
+export type AccountReadyRefreshEvent =
+  | { type: 'connected'; client: object; signedIn: boolean }
+  | { type: 'disconnected' }
+
+export interface AccountReadyRefreshResult {
+  state: AccountReadyRefreshState
+  /** Issue `account.refresh` now. */
+  refresh: boolean
+}
+
+export function reduceAccountReadyRefresh(
+  state: AccountReadyRefreshState,
+  event: AccountReadyRefreshEvent
+): AccountReadyRefreshResult {
+  switch (event.type) {
+    case 'disconnected':
+      return {
+        state: state.refreshedFor === null ? state : INITIAL_ACCOUNT_READY_REFRESH_STATE,
+        refresh: false
+      }
+    case 'connected': {
+      if (!event.signedIn) {
+        // Signed-out snapshots have nothing to refresh; an interactive sign-in
+        // later in this connection re-enters here as signedIn and refreshes.
+        return { state, refresh: false }
+      }
+      if (state.refreshedFor === event.client) {
+        return { state, refresh: false }
+      }
+      return { state: { refreshedFor: event.client }, refresh: true }
+    }
+  }
+}

--- a/apps/desktop/src/shared/renderer-security-policy.ts
+++ b/apps/desktop/src/shared/renderer-security-policy.ts
@@ -41,7 +41,9 @@ export const IPC_INVOKE_ROLES = {
   'backgrounds:import-image': MAIN_ONLY,
   'backgrounds:bundled-assets': MAIN_ONLY,
   'backgrounds:asset-exists': MAIN_ONLY,
-  'avatars:cache': MAIN_ONLY,
+  // The detached Comments window renders the same chat rows as Studio; without
+  // this it could only ever draw monograms. Main still owns the host allowlist.
+  'avatars:cache': MAIN_AND_COMMENTS,
   'oauth:open-url': MAIN_ONLY,
   'oauth:callback-redirect-uri': MAIN_ONLY,
   'oauth:callbacks-list': MAIN_ONLY,


### PR DESCRIPTION
## Why

Live feedback batch 3, B3 (desktop half). The web side (TheOrcDev/videorc-web#15) makes `/api/auth/get-session` (Bearer) and `/api/desktop/session/verify` return the resolved avatar (uploaded image, else the linked Google picture). These are the desktop hygiene items that kept the photo from showing even once it arrives:

- cold launch rendered the snapshot persisted at the last sign-in until the window lost and regained focus;
- the detached Comments window could only ever draw monograms (`avatars:cache` was main-only);
- the blob allowlist accepted only `*.public.blob.vercel-storage.com`, not every store the web's own `isAccountAvatarBlobUrl` accepts;
- cache rejections were silent, so a support bundle showed nothing.

## What

- `renderer/src/lib/account-ready-refresh.ts` (new) + `hooks/use-studio.tsx`: one `account.refresh` per backend connection on app ready (keyed on the client identity, so the snapshot it sets does not re-trigger it), in the same effect as the existing focus / 5-min refresh. No new `useEffect`.
- `shared/renderer-security-policy.ts`: `'avatars:cache': MAIN_AND_COMMENTS`. `preload/api-policy.ts`: `cacheChatAvatar` exposed to the comments role. Host allowlist and on-disk cache stay main-owned; `comments.html` CSP already allows `img-src videorc-asset:`.
- `main/avatar-cache.ts`: suffix `blob.vercel-storage.com` (bare host or any subdomain, https only). New pure helpers: `avatarUrlDecision`, `httpStatusClass`, `redactAvatarFetchError`, `avatarCacheRejectionKey`, `avatarCacheRejectionMessage`.
- `main/index.ts` `cacheChatAvatar`: every rejection (not a URL / scheme / host / HTTP status class / empty body / too large / fetch error) emits one `logBackend('warn', ...)` line per (host, reason) per process, e.g. `Chat avatar not cached: host cdn.example.com is not an allowlisted avatar CDN.` Host, scheme, byte count or status class only; never the URL (CDN paths can carry per-user tokens; fetch error text is URL-redacted and bounded).

## Tests

- `main/avatar-cache.test.ts`: blob-suffix matrix (bare, `.public.`, other store subdomains, http, lookalike), decision reasons, message never carries path/query, dedupe keys, status classes, error redaction.
- `main/renderer-security-policy.test.ts`: `avatars:cache` role matrix (main + comments only) and a new cross-check that every invoke an auxiliary preload exposes is admitted by the channel policy for that role.
- `renderer/src/lib/account-ready-refresh.test.ts`: once per connection, signed-out then sign-in, reconnect, disconnect reset.

## Gates

- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm format:check` clean (`Tracked text integrity OK (1139 files)`)
- `pnpm --filter @videorc/desktop test` 151 files, 1390 passed | 1 skipped

## Acceptance (owner)

Google-linked account shows the photo in the sidebar on a cold launch (needs videorc-web#15 deployed); detached Comments window shows chat avatars; a rejected host appears in Health > backend logs as `Chat avatar not cached: ...`.

## Noted, out of scope

`IPC_INVOKE_ROLES` admits `comments-window:cohost-get` / `cohost-action` for the comments role but `AUXILIARY_API_KEYS.comments` never exposes `getCohostWindowState` / `sendCohostAction` (no renderer calls them). Dead allowance, not a privilege gap; the cross-check test is deliberately one-directional because of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved avatar caching with support for additional approved storage hosts.
  * Added safer handling and clearer reporting for invalid URLs, failed downloads, HTTP errors, empty responses, and oversized images.
  * Enabled comment experiences to use avatar caching.
  * Added reliable account refresh behavior when connections are established, restored, or refreshed.

* **Bug Fixes**
  * Prevented unnecessary account refreshes while signed out and duplicate refreshes during a single connection.
  * Sensitive URL and fetch-error details are now redacted from diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->