### PR TITLE
fix(recording): record-with-warning on unsteady startup cadence; persistent start-failure UX

### DIFF
--- a/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
@@ -6,6 +6,7 @@ import {
   Info,
   Record,
   StopCircle,
+  WarningCircle,
   type Icon
 } from '@phosphor-icons/react'
 import type { ReactElement, ReactNode } from 'react'
@@ -15,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import { Kbd } from '@/components/ui/kbd'
 import { useWorkspaceNav } from '@/components/workspace-nav'
 import { useStudioCore } from '@/hooks/use-studio'
+import type { SessionStartFailure } from '@/lib/session-start-failure'
 import { outputSummary, streamingSummary } from '@/lib/studio-session-view'
 
 // The session's primary actions rendered as a matched pair of glassy hero
@@ -36,11 +38,14 @@ export function SessionPanel({
   liveStreamBlockedReason,
   blockedReason = null,
   blockedJump = null,
+  startFailure = null,
   canStop,
   stopLabel,
   onRecord,
   onLiveStream,
-  onStop
+  onStop,
+  onRetryStart,
+  onDismissStartFailure
 }: {
   active: boolean
   startRequestPending: boolean
@@ -54,11 +59,16 @@ export function SessionPanel({
     label: string
     to: Parameters<ReturnType<typeof useWorkspaceNav>['setActive']>[0]
   } | null
+  /** The last refused Record / Go Live (B0): stays under the controls until
+   * the user starts again or dismisses it — a 4s toast was the only signal. */
+  startFailure?: SessionStartFailure | null
   canStop: boolean
   stopLabel: string
   onRecord: () => void
   onLiveStream: () => void
   onStop: () => void
+  onRetryStart?: () => void
+  onDismissStartFailure?: () => void
 }): ReactElement {
   const { captureConfig } = useStudioCore()
   const { openStudioPanel, setActive } = useWorkspaceNav()
@@ -132,6 +142,46 @@ export function SessionPanel({
                 {blockedJump.label}
               </button>
             ) : null}
+          </div>
+        ) : null}
+        {/* A refused start is the ONE place destructive red is allowed on chrome:
+            it is status, it persists, and it carries the backend's reason
+            verbatim (the toast can be missed mid-stream; this line cannot). */}
+        {!active && startFailure ? (
+          <div
+            className="flex items-start gap-1.5 text-xs"
+            data-testid="session-start-failure"
+            key={startFailure.at}
+            role="alert"
+          >
+            <WarningCircle className="mt-px size-3.5 shrink-0 text-destructive" weight="fill" />
+            <p
+              className="line-clamp-3 min-w-0 flex-1 text-destructive"
+              title={startFailure.message}
+            >
+              <span className="font-medium">Could not start.</span> {startFailure.message}
+            </p>
+            <span className="flex shrink-0 items-center gap-2">
+              {onRetryStart ? (
+                <button
+                  className="font-medium text-foreground underline-offset-2 hover:underline"
+                  disabled={startRequestPending}
+                  type="button"
+                  onClick={onRetryStart}
+                >
+                  Retry
+                </button>
+              ) : null}
+              {onDismissStartFailure ? (
+                <button
+                  className="text-muted-foreground underline-offset-2 hover:underline"
+                  type="button"
+                  onClick={onDismissStartFailure}
+                >
+                  Dismiss
+                </button>
+              ) : null}
+            </span>
           </div>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -59,7 +59,10 @@ export function StudioTab(): ReactElement {
     confirmGoLive,
     continueGoLiveWithReadyDestinations,
     continueGoLiveWithoutCaptions,
-    resolveGoLiveBlocker
+    resolveGoLiveBlocker,
+    sessionStartFailure,
+    dismissSessionStartFailure,
+    retrySessionStart
   } = studio
 
   const active = isSessionTransportActive(recording.state)
@@ -169,10 +172,13 @@ export function StudioTab(): ReactElement {
               canStop={canStop}
               liveStreamBlockedReason={liveStreamBlockedReason}
               recordBlockedReason={recordBlockedReason}
+              startFailure={sessionStartFailure}
               startRequestPending={startRequestPending}
               stopLabel={stopLabel}
+              onDismissStartFailure={dismissSessionStartFailure}
               onLiveStream={handleLiveStream}
               onRecord={handleRecord}
+              onRetryStart={retrySessionStart}
               onStop={stopSession}
             />
           </div>

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -314,6 +314,14 @@ import {
   premiumRequiredIssueMessage,
   VIDEORC_PREMIUM_URL
 } from '@/lib/premium-upgrade'
+import {
+  reduceSessionStartFailure,
+  SESSION_START_FAILED_TOAST_ID,
+  sessionStartFailureMessage,
+  sessionStartFailureToastOptions,
+  type SessionStartFailure
+} from '@/lib/session-start-failure'
+import { recordingStartupHealthToast } from '@/lib/studio-health'
 import { assertYouTubeTransitionConfirmed } from '@/lib/youtube-transition'
 import { effectiveSceneBackground } from '@/lib/background-assets'
 import { useBackgroundAssets } from '@/hooks/use-background-assets'
@@ -981,6 +989,12 @@ export type StudioContextValue = {
   cancelGoLiveConfirmation: () => void
   confirmGoLive: () => Promise<void>
   continueGoLiveWithReadyDestinations: () => Promise<void>
+  /** Why the last Record / Go Live was refused; null once the user starts
+   * again or dismisses it. Rendered next to the Record control (B0). */
+  sessionStartFailure: SessionStartFailure | null
+  dismissSessionStartFailure: () => void
+  /** Re-run the exact start that failed (same streaming override). */
+  retrySessionStart: () => void
   refreshScreens: () => Promise<void>
   importScreenImage: () => Promise<void>
   renameScreen: (screenId: string, name: string) => Promise<void>
@@ -2645,6 +2659,60 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     }
     toast.error(message)
   }, [])
+
+  // --- Session-start failures are unmissable (B0) ----------------------------
+  // A refused Record / Go Live used to be one default 4s toast while the user
+  // was watching the stream. Now: one keyed persistent toast with Retry, plus a
+  // failure state the Session panel renders beside the Record control until the
+  // user starts again or dismisses it. The retry closure is held in a ref so the
+  // toast action (created once) always re-runs the LATEST failed start.
+  const [sessionStartFailure, setSessionStartFailure] = useState<SessionStartFailure | null>(null)
+  const sessionStartRetryRef = useRef<(() => void) | null>(null)
+  const dismissSessionStartFailure = useCallback(() => {
+    sessionStartRetryRef.current = null
+    setSessionStartFailure((current) => reduceSessionStartFailure(current, { type: 'dismissed' }))
+    toast.dismiss(SESSION_START_FAILED_TOAST_ID)
+  }, [])
+  const retrySessionStart = useCallback(() => {
+    const retry = sessionStartRetryRef.current
+    if (!retry) {
+      return
+    }
+    retry()
+  }, [])
+  const noteSessionStartAttempt = useCallback(() => {
+    setSessionStartFailure((current) =>
+      reduceSessionStartFailure(current, { type: 'start-attempted' })
+    )
+    toast.dismiss(SESSION_START_FAILED_TOAST_ID)
+  }, [])
+  const reportSessionStartFailure = useCallback(
+    (error: unknown, retry: () => void) => {
+      const message = sessionStartFailureMessage(error)
+      setLastError(message)
+      sessionStartRetryRef.current = retry
+      setSessionStartFailure((current) =>
+        reduceSessionStartFailure(current, { type: 'failed', message, at: Date.now() })
+      )
+      if (isPremiumUpgradeMessage(message)) {
+        // Premium gate: the upgrade link is the only useful action, and the
+        // Session-panel line still carries the reason persistently.
+        toast.error(message, premiumUpgradeToastOptions())
+        return
+      }
+      toast.error(
+        message,
+        sessionStartFailureToastOptions(retrySessionStart, () => {
+          // The user closed the toast: the Session-panel line goes with it.
+          sessionStartRetryRef.current = null
+          setSessionStartFailure((current) =>
+            reduceSessionStartFailure(current, { type: 'dismissed' })
+          )
+        })
+      )
+    },
+    [retrySessionStart]
+  )
 
   // --- Live Chat Co-host (Premium cloud AI) --------------------------------
   // The BACKEND owns the engine: the tick scheduler, the open-question set,
@@ -4619,6 +4687,18 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         }
         if (isRecordingQualityEvent(event.code)) {
           void refreshSessions(nextClient)
+        }
+        // Recording startup barrier (B0): an unsteady start is a keyed warning
+        // (the session DID start); a refusal shares the start-failure toast key
+        // so the RPC rejection that follows updates it in place with Retry.
+        const startupToast = recordingStartupHealthToast(event)
+        if (startupToast) {
+          const show = startupToast.variant === 'warning' ? toast.warning : toast.error
+          show(startupToast.title, {
+            id: startupToast.id,
+            description: startupToast.description,
+            duration: startupToast.duration
+          })
         }
         // Quality-gate toast policy: only interrupt for verdicts the user would
         // notice and can act on — the backend marks those warn-level (e.g. a
@@ -8969,6 +9049,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     [captureConfig.streaming, client, endPreparedXBroadcasts]
   )
 
+  const runStartSessionRef = useRef<
+    ((streamingOverride?: StreamingSettings) => Promise<void>) | null
+  >(null)
   const runStartSession = useCallback(
     async (streamingOverride?: StreamingSettings) => {
       if (!client || startBlockedReason) {
@@ -8981,6 +9064,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       let streamingForStart: StreamingSettings | null = null
       try {
         setLastError(null)
+        noteSessionStartAttempt()
         streamingForStart = streamingOverride ?? null
         if (streamingForStart) {
           await probeStreamOutputTopology(
@@ -9109,7 +9193,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           await completePreparedPlatformBroadcasts(streamingForStart)
         }
         platformLifecycleStreamingRef.current = null
-        reportError(error)
+        // Every start rejection — the compositor startup barrier, topology
+        // probe, platform activation, the RPC itself — is unmissable: keyed
+        // persistent toast + Session-panel line, Retry re-runs this exact start.
+        reportSessionStartFailure(error, () => {
+          void runStartSessionRef.current?.(streamingOverride)
+        })
         if (recordingRef.current.state === 'starting' && !recordingRef.current.sessionId) {
           applyRecordingStatus({ state: 'idle', message: 'Ready to start a capture session.' })
         }
@@ -9125,9 +9214,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       client,
       completePreparedPlatformBroadcasts,
       isSessionActive,
+      noteSessionStartAttempt,
       probeStreamOutputTopology,
       refreshSessions,
       reportError,
+      reportSessionStartFailure,
       sceneEditMode,
       sceneWithBackground,
       settings,
@@ -9136,6 +9227,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       validatePlatformAccountsForClient
     ]
   )
+  runStartSessionRef.current = runStartSession
 
   const prepareOauthTargetsForGoLive = useCallback(async (): Promise<GoLivePartialSetup> => {
     if (!client) {
@@ -9380,6 +9472,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     startRequestPending
   ])
 
+  const confirmGoLiveRef = useRef<(() => Promise<void>) | null>(null)
   const confirmGoLive = useCallback(async () => {
     if (!client || goLiveConfirmationPending || startRequestPending) {
       return
@@ -9441,7 +9534,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       setGoLiveConfirmationOpen(false)
       await runStartSession(setupDecision.streaming)
     } catch (error) {
-      reportError(error)
+      // A Go Live that dies BEFORE the start RPC (metadata, preflight, platform
+      // setup) is just as silent as a refused start: same persistent surface.
+      // The dialog stays open, so Retry re-runs the confirmation.
+      reportSessionStartFailure(error, () => {
+        void confirmGoLiveRef.current?.()
+      })
     } finally {
       setGoLiveConfirmationPending(false)
     }
@@ -9451,11 +9549,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     goLiveConfirmationPending,
     goLiveCaptionsReadiness,
     prepareOauthTargetsForGoLive,
-    reportError,
+    reportSessionStartFailure,
     runStartSession,
     startRequestPending,
     streamMetadataDraft
   ])
+  confirmGoLiveRef.current = confirmGoLive
 
   const continueGoLiveWithReadyDestinations = useCallback(async () => {
     if (goLiveCaptionsReadiness.blocksStart) {
@@ -10698,6 +10797,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       cancelGoLiveConfirmation,
       confirmGoLive,
       continueGoLiveWithReadyDestinations,
+      sessionStartFailure,
+      dismissSessionStartFailure,
+      retrySessionStart,
       refreshScreens,
       importScreenImage,
       renameScreen,
@@ -10889,6 +10991,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       cancelGoLiveConfirmation,
       confirmGoLive,
       continueGoLiveWithReadyDestinations,
+      sessionStartFailure,
+      dismissSessionStartFailure,
+      retrySessionStart,
       refreshScreens,
       importScreenImage,
       renameScreen,

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -317,6 +317,7 @@ import {
 import {
   reduceSessionStartFailure,
   SESSION_START_FAILED_TOAST_ID,
+  SESSION_START_FAILED_TOAST_TITLE,
   sessionStartFailureMessage,
   sessionStartFailureToastOptions,
   type SessionStartFailure
@@ -2701,8 +2702,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         return
       }
       toast.error(
-        message,
-        sessionStartFailureToastOptions(retrySessionStart, () => {
+        SESSION_START_FAILED_TOAST_TITLE,
+        sessionStartFailureToastOptions(message, retrySessionStart, () => {
           // The user closed the toast: the Session-panel line goes with it.
           sessionStartRetryRef.current = null
           setSessionStartFailure((current) =>

--- a/apps/desktop/src/renderer/src/lib/session-start-failure.test.ts
+++ b/apps/desktop/src/renderer/src/lib/session-start-failure.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  reduceSessionStartFailure,
+  SESSION_START_FAILED_TOAST_ID,
+  sessionStartFailureMessage,
+  sessionStartFailureToastOptions
+} from './session-start-failure'
+
+const BARRIER_MESSAGE =
+  'Recording startup blocked before encoding: latest compositor frame gap 700ms exceeds startup cadence budget 200ms (recent gaps 700/690/710 ms; 4 fresh frame(s) in 2500ms); cadence budget 200ms.'
+
+describe('sessionStartFailureMessage', () => {
+  it('keeps the backend reason verbatim', () => {
+    expect(sessionStartFailureMessage(new Error(BARRIER_MESSAGE))).toBe(BARRIER_MESSAGE)
+  })
+
+  it('stringifies non-Error rejections and never yields an empty line', () => {
+    expect(sessionStartFailureMessage('No livestream destinations are ready.')).toBe(
+      'No livestream destinations are ready.'
+    )
+    expect(sessionStartFailureMessage(new Error('   '))).toBe('The session could not start.')
+  })
+})
+
+describe('reduceSessionStartFailure', () => {
+  it('records a failure with its timestamp', () => {
+    expect(
+      reduceSessionStartFailure(null, { type: 'failed', message: BARRIER_MESSAGE, at: 1700 })
+    ).toEqual({ message: BARRIER_MESSAGE, at: 1700 })
+  })
+
+  it('replaces an earlier failure so a repeat of the same reason still re-renders', () => {
+    const first = reduceSessionStartFailure(null, {
+      type: 'failed',
+      message: BARRIER_MESSAGE,
+      at: 1
+    })
+    const second = reduceSessionStartFailure(first, {
+      type: 'failed',
+      message: BARRIER_MESSAGE,
+      at: 2
+    })
+    expect(second).toEqual({ message: BARRIER_MESSAGE, at: 2 })
+    expect(second).not.toBe(first)
+  })
+
+  it('clears when the user starts again', () => {
+    const failed = reduceSessionStartFailure(null, {
+      type: 'failed',
+      message: BARRIER_MESSAGE,
+      at: 1
+    })
+    expect(reduceSessionStartFailure(failed, { type: 'start-attempted' })).toBeNull()
+  })
+
+  it('clears when the user dismisses it', () => {
+    const failed = reduceSessionStartFailure(null, {
+      type: 'failed',
+      message: BARRIER_MESSAGE,
+      at: 1
+    })
+    expect(reduceSessionStartFailure(failed, { type: 'dismissed' })).toBeNull()
+  })
+
+  it('is a no-op to dismiss or start with nothing pending', () => {
+    expect(reduceSessionStartFailure(null, { type: 'dismissed' })).toBeNull()
+    expect(reduceSessionStartFailure(null, { type: 'start-attempted' })).toBeNull()
+  })
+})
+
+describe('sessionStartFailureToastOptions', () => {
+  it('is persistent, keyed so it cannot stack, and carries a Retry action', () => {
+    const retry = vi.fn()
+    const dismiss = vi.fn()
+    const options = sessionStartFailureToastOptions(retry, dismiss)
+
+    expect(options.id).toBe(SESSION_START_FAILED_TOAST_ID)
+    expect(options.id).toBe('session-start-failed')
+    expect(options.duration).toBe(Infinity)
+    expect(options.action.label).toBe('Retry')
+
+    options.action.onClick()
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(dismiss).not.toHaveBeenCalled()
+
+    options.onDismiss()
+    expect(dismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/session-start-failure.test.ts
+++ b/apps/desktop/src/renderer/src/lib/session-start-failure.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   reduceSessionStartFailure,
   SESSION_START_FAILED_TOAST_ID,
+  SESSION_START_FAILED_TOAST_TITLE,
   sessionStartFailureMessage,
   sessionStartFailureToastOptions
 } from './session-start-failure'
@@ -73,10 +74,12 @@ describe('sessionStartFailureToastOptions', () => {
   it('is persistent, keyed so it cannot stack, and carries a Retry action', () => {
     const retry = vi.fn()
     const dismiss = vi.fn()
-    const options = sessionStartFailureToastOptions(retry, dismiss)
+    const options = sessionStartFailureToastOptions(BARRIER_MESSAGE, retry, dismiss)
 
     expect(options.id).toBe(SESSION_START_FAILED_TOAST_ID)
     expect(options.id).toBe('session-start-failed')
+    expect(SESSION_START_FAILED_TOAST_TITLE).toBe('Could not start')
+    expect(options.description).toBe(BARRIER_MESSAGE)
     expect(options.duration).toBe(Infinity)
     expect(options.action.label).toBe('Retry')
 

--- a/apps/desktop/src/renderer/src/lib/session-start-failure.ts
+++ b/apps/desktop/src/renderer/src/lib/session-start-failure.ts
@@ -12,6 +12,10 @@
 
 /** Sonner key for the start-failure toast: re-reporting updates it in place. */
 export const SESSION_START_FAILED_TOAST_ID = 'session-start-failed'
+/** Shared title: sonner merges an update over the existing toast by id, so the
+ * health-event toast and the RPC-rejection toast must use the same shape
+ * (title + description) or the older description lingers under a new title. */
+export const SESSION_START_FAILED_TOAST_TITLE = 'Could not start'
 
 export interface SessionStartFailure {
   /** Backend / preflight reason, verbatim — it already reads as a sentence. */
@@ -47,6 +51,7 @@ export function reduceSessionStartFailure(
 
 export interface SessionStartFailureToastOptions {
   id: string
+  description: string
   duration: number
   action: { label: string; onClick: () => void }
   onDismiss: () => void
@@ -55,14 +60,17 @@ export interface SessionStartFailureToastOptions {
 /**
  * Persistent (`duration: Infinity`) and keyed so repeated failures never stack;
  * Retry re-runs the exact start that failed. Dismissing the toast also clears
- * the Session-panel line so the two surfaces never disagree.
+ * the Session-panel line so the two surfaces never disagree. Render with
+ * `toast.error(SESSION_START_FAILED_TOAST_TITLE, options)`.
  */
 export function sessionStartFailureToastOptions(
+  message: string,
   retry: () => void,
   dismiss: () => void
 ): SessionStartFailureToastOptions {
   return {
     id: SESSION_START_FAILED_TOAST_ID,
+    description: message,
     duration: Infinity,
     action: { label: 'Retry', onClick: retry },
     onDismiss: dismiss

--- a/apps/desktop/src/renderer/src/lib/session-start-failure.ts
+++ b/apps/desktop/src/renderer/src/lib/session-start-failure.ts
@@ -1,0 +1,70 @@
+/**
+ * Session-start failures must be unmissable (live feedback batch 3, B0).
+ *
+ * Before this, a refused Record / Go Live surfaced as ONE default 4-second
+ * toast while the user was looking at the stream, and the Record control just
+ * went back to idle. Now every start rejection — the compositor startup
+ * barrier, a Go Live preflight, platform setup, the start RPC itself — lands
+ * in one keyed, persistent toast with a Retry action, and in a Studio-context
+ * failure state the Session panel renders next to the Record button until the
+ * user starts again or dismisses it.
+ */
+
+/** Sonner key for the start-failure toast: re-reporting updates it in place. */
+export const SESSION_START_FAILED_TOAST_ID = 'session-start-failed'
+
+export interface SessionStartFailure {
+  /** Backend / preflight reason, verbatim — it already reads as a sentence. */
+  message: string
+  /** `Date.now()` at the failure, so a repeat of the same message still re-renders. */
+  at: number
+}
+
+export type SessionStartFailureAction =
+  | { type: 'failed'; message: string; at: number }
+  /** A new start attempt began (Record, Stream, Retry): the old reason is stale. */
+  | { type: 'start-attempted' }
+  /** The user dismissed the line or the toast. */
+  | { type: 'dismissed' }
+
+export function sessionStartFailureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.trim() || 'The session could not start.'
+}
+
+export function reduceSessionStartFailure(
+  current: SessionStartFailure | null,
+  action: SessionStartFailureAction
+): SessionStartFailure | null {
+  switch (action.type) {
+    case 'failed':
+      return { message: action.message, at: action.at }
+    case 'start-attempted':
+    case 'dismissed':
+      return null
+  }
+}
+
+export interface SessionStartFailureToastOptions {
+  id: string
+  duration: number
+  action: { label: string; onClick: () => void }
+  onDismiss: () => void
+}
+
+/**
+ * Persistent (`duration: Infinity`) and keyed so repeated failures never stack;
+ * Retry re-runs the exact start that failed. Dismissing the toast also clears
+ * the Session-panel line so the two surfaces never disagree.
+ */
+export function sessionStartFailureToastOptions(
+  retry: () => void,
+  dismiss: () => void
+): SessionStartFailureToastOptions {
+  return {
+    id: SESSION_START_FAILED_TOAST_ID,
+    duration: Infinity,
+    action: { label: 'Retry', onClick: retry },
+    onDismiss: dismiss
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/studio-health.test.ts
+++ b/apps/desktop/src/renderer/src/lib/studio-health.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { SESSION_START_FAILED_TOAST_ID } from './session-start-failure'
+import {
+  SESSION_START_FAILED_TOAST_ID,
+  SESSION_START_FAILED_TOAST_TITLE,
+  sessionStartFailureToastOptions
+} from './session-start-failure'
 import {
   RECORDING_STARTUP_BARRIER_TIMEOUT_CODE,
   RECORDING_STARTUP_CADENCE_UNSTEADY_CODE,
@@ -195,12 +199,23 @@ describe('recordingStartupHealthToast', () => {
       level: 'error',
       message: REFUSED_MESSAGE
     })
+    // Same title + description shape as the RPC-rejection toast: sonner merges
+    // an update over the existing toast by id, so this is what lets the
+    // rejection add Retry in place instead of stacking a second red toast.
     expect(result).toEqual({
       variant: 'error',
       id: SESSION_START_FAILED_TOAST_ID,
-      title: 'Recording could not start',
+      title: SESSION_START_FAILED_TOAST_TITLE,
       description: REFUSED_MESSAGE,
       duration: Infinity
+    })
+    expect(result).toMatchObject({
+      title: 'Could not start',
+      description: sessionStartFailureToastOptions(
+        REFUSED_MESSAGE,
+        () => {},
+        () => {}
+      ).description
     })
   })
 

--- a/apps/desktop/src/renderer/src/lib/studio-health.test.ts
+++ b/apps/desktop/src/renderer/src/lib/studio-health.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { studioHealth, type StudioHealthInput } from './studio-health'
+import { SESSION_START_FAILED_TOAST_ID } from './session-start-failure'
+import {
+  RECORDING_STARTUP_BARRIER_TIMEOUT_CODE,
+  RECORDING_STARTUP_CADENCE_UNSTEADY_CODE,
+  RECORDING_STARTUP_UNSTEADY_TOAST_ID,
+  recordingStartupHealthToast,
+  studioHealth,
+  type StudioHealthInput
+} from './studio-health'
 
 function stats(overrides: Partial<StudioHealthInput> = {}): StudioHealthInput {
   return {
@@ -156,5 +164,70 @@ describe('studioHealth', () => {
     expect(studioHealth(stats({ compositorBackend: 'cpu-fallback' }), true, 'darwin').tone).toBe(
       'error'
     )
+  })
+})
+
+describe('recordingStartupHealthToast', () => {
+  const UNSTEADY_MESSAGE =
+    'Recording started with an unsteady compositor at start: gaps 166/120/98 ms vs 300 ms budget (5 fresh 1920x1080 frame(s) in 5000ms); check the first seconds of the file.'
+  const REFUSED_MESSAGE =
+    'Recording startup blocked before encoding: waiting for compositor frame (recent gaps none ms; 0 fresh frame(s) in 2500ms); cadence budget 200ms.'
+
+  it('maps the unsteady-start WARN to a keyed warning toast carrying the backend copy', () => {
+    const result = recordingStartupHealthToast({
+      code: RECORDING_STARTUP_CADENCE_UNSTEADY_CODE,
+      level: 'warn',
+      message: UNSTEADY_MESSAGE
+    })
+    expect(result).toEqual({
+      variant: 'warning',
+      id: RECORDING_STARTUP_UNSTEADY_TOAST_ID,
+      title: 'Recording started on an unsteady compositor',
+      description: UNSTEADY_MESSAGE,
+      duration: 15000
+    })
+    expect(result?.id).toBe('recording-startup-cadence-unsteady')
+  })
+
+  it('maps the barrier refusal to a persistent error toast on the start-failure key', () => {
+    const result = recordingStartupHealthToast({
+      code: RECORDING_STARTUP_BARRIER_TIMEOUT_CODE,
+      level: 'error',
+      message: REFUSED_MESSAGE
+    })
+    expect(result).toEqual({
+      variant: 'error',
+      id: SESSION_START_FAILED_TOAST_ID,
+      title: 'Recording could not start',
+      description: REFUSED_MESSAGE,
+      duration: Infinity
+    })
+  })
+
+  it('ignores every other health event, including non-error barrier levels', () => {
+    expect(
+      recordingStartupHealthToast({
+        code: 'recording-startup-barrier-ready',
+        level: 'info',
+        message: 'Recording startup waited 120ms for 3 fresh compositor frame(s).'
+      })
+    ).toBeNull()
+    expect(
+      recordingStartupHealthToast({
+        code: 'recording-startup-cadence-retry',
+        level: 'info',
+        message: 'retrying the startup barrier once with a 300ms budget.'
+      })
+    ).toBeNull()
+    expect(
+      recordingStartupHealthToast({
+        code: RECORDING_STARTUP_BARRIER_TIMEOUT_CODE,
+        level: 'warn',
+        message: REFUSED_MESSAGE
+      })
+    ).toBeNull()
+    expect(
+      recordingStartupHealthToast({ code: 'mic-silent', level: 'warn', message: 'quiet' })
+    ).toBeNull()
   })
 })

--- a/apps/desktop/src/renderer/src/lib/studio-health.ts
+++ b/apps/desktop/src/renderer/src/lib/studio-health.ts
@@ -1,6 +1,9 @@
 import type { StatusTone } from '@/components/status-badge'
 import type { DiagnosticStats, HealthEvent } from '@/lib/backend'
-import { SESSION_START_FAILED_TOAST_ID } from '@/lib/session-start-failure'
+import {
+  SESSION_START_FAILED_TOAST_ID,
+  SESSION_START_FAILED_TOAST_TITLE
+} from '@/lib/session-start-failure'
 import type { NativePreviewHostKind } from '../../../shared/backend'
 import { isNativePreviewCapability } from '../../../shared/native-preview-capability'
 
@@ -49,7 +52,7 @@ export function recordingStartupHealthToast(
     return {
       variant: 'error',
       id: SESSION_START_FAILED_TOAST_ID,
-      title: 'Recording could not start',
+      title: SESSION_START_FAILED_TOAST_TITLE,
       description: event.message,
       duration: Infinity
     }

--- a/apps/desktop/src/renderer/src/lib/studio-health.ts
+++ b/apps/desktop/src/renderer/src/lib/studio-health.ts
@@ -1,7 +1,61 @@
 import type { StatusTone } from '@/components/status-badge'
-import type { DiagnosticStats } from '@/lib/backend'
+import type { DiagnosticStats, HealthEvent } from '@/lib/backend'
+import { SESSION_START_FAILED_TOAST_ID } from '@/lib/session-start-failure'
 import type { NativePreviewHostKind } from '../../../shared/backend'
 import { isNativePreviewCapability } from '../../../shared/native-preview-capability'
+
+/** Backend health-event codes for the recording startup barrier (recording.rs). */
+export const RECORDING_STARTUP_BARRIER_TIMEOUT_CODE = 'recording-startup-barrier-timeout'
+export const RECORDING_STARTUP_CADENCE_UNSTEADY_CODE = 'recording-startup-cadence-unsteady'
+/** Sonner key for the unsteady-start warning: one per start, never a stack. */
+export const RECORDING_STARTUP_UNSTEADY_TOAST_ID = 'recording-startup-cadence-unsteady'
+
+export interface HealthEventToast {
+  variant: 'warning' | 'error'
+  /** Sonner id — keyed so a repeat updates in place instead of stacking. */
+  id: string
+  title: string
+  description: string
+  duration: number
+}
+
+/**
+ * Toast copy for the two recording-startup health events (B0). Both used to be
+ * stored in the session record and shown nowhere persistent.
+ *
+ * - `recording-startup-cadence-unsteady` (warn): the session STARTED, but the
+ *   compositor never settled during the startup barrier and its retry — the
+ *   first seconds of the file deserve a look. Warning variant, 15s.
+ * - `recording-startup-barrier-timeout` (error): the session was refused. It
+ *   shares the start-failure toast key, so the start RPC rejection that
+ *   follows updates this toast in place (adding Retry) instead of stacking a
+ *   second red toast for the same failure. Persistent.
+ *
+ * Returns null for every other event; the caller keeps its own policies.
+ */
+export function recordingStartupHealthToast(
+  event: Pick<HealthEvent, 'code' | 'level' | 'message'>
+): HealthEventToast | null {
+  if (event.code === RECORDING_STARTUP_CADENCE_UNSTEADY_CODE) {
+    return {
+      variant: 'warning',
+      id: RECORDING_STARTUP_UNSTEADY_TOAST_ID,
+      title: 'Recording started on an unsteady compositor',
+      description: event.message,
+      duration: 15000
+    }
+  }
+  if (event.code === RECORDING_STARTUP_BARRIER_TIMEOUT_CODE && event.level === 'error') {
+    return {
+      variant: 'error',
+      id: SESSION_START_FAILED_TOAST_ID,
+      title: 'Recording could not start',
+      description: event.message,
+      duration: Infinity
+    }
+  }
+  return null
+}
 
 /** The slice of diagnostics the compact Studio health badge reads. Full stats live in the
  * Diagnostics tab; this is the at-a-glance "is the live program healthy" signal. */

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -422,10 +422,60 @@ pub struct CompositorStartupSourceRequirements {
 pub struct CompositorStartupBarrierResult {
     pub ready: bool,
     pub wait_ms: u64,
+    /// Current streak of consecutive accepted frames (reset by any block or
+    /// cadence violation) — the value the readiness threshold is judged on.
     pub frames_observed: u32,
+    /// Total fresh target-resolution frames with advancing required sources
+    /// seen during the wait, regardless of streak resets. Zero means the
+    /// compositor never produced a usable frame (a true stall).
+    pub fresh_frames_seen: u32,
+    /// Publish gaps (ms) between the last few accepted fresh frames, oldest
+    /// first, including the gaps that exceeded the cadence budget.
+    pub gap_history_ms: Vec<u64>,
+    /// True when the wait timed out on the cadence budget ALONE: at least one
+    /// fresh frame was observed, a gap exceeded the budget, and the latest
+    /// observation was not a resolution / scene-revision / missing-source
+    /// block. False for every structural block and for zero-frame stalls.
+    pub cadence_only: bool,
     pub first_source_frame_ms: Option<u64>,
     pub first_full_resolution_frame_ms: Option<u64>,
     pub timeout_reason: Option<String>,
+}
+
+/// How many recent inter-frame gaps the startup barrier remembers for its
+/// diagnostics; enough to tell one hiccup from a pattern.
+pub const COMPOSITOR_STARTUP_GAP_HISTORY_LEN: usize = 3;
+
+impl CompositorStartupBarrierResult {
+    pub fn empty() -> Self {
+        Self {
+            ready: false,
+            wait_ms: 0,
+            frames_observed: 0,
+            fresh_frames_seen: 0,
+            gap_history_ms: Vec::new(),
+            cadence_only: false,
+            first_source_frame_ms: None,
+            first_full_resolution_frame_ms: None,
+            timeout_reason: None,
+        }
+    }
+
+    /// `166/120/98` style rendering of the recent gap ring, oldest first.
+    pub fn gap_history_label(&self) -> String {
+        startup_gap_history_label(&self.gap_history_ms)
+    }
+}
+
+fn startup_gap_history_label(history: &[u64]) -> String {
+    if history.is_empty() {
+        return "none".to_string();
+    }
+    history
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 #[derive(Debug, Clone)]
@@ -1369,6 +1419,12 @@ pub async fn wait_for_compositor_startup_frames(
     let started_at = Instant::now();
     let min_consecutive = params.min_consecutive_frames.max(1);
     let mut frames_observed = 0_u32;
+    let mut fresh_frames_seen = 0_u32;
+    let mut gap_history_ms: Vec<u64> = Vec::with_capacity(COMPOSITOR_STARTUP_GAP_HISTORY_LEN);
+    let mut cadence_violations = 0_u32;
+    // The latest observation was a structural block (resolution, scene
+    // revision, missing source). Cleared by the next usable frame.
+    let mut blocked_structurally = false;
     let mut last_sequence = None;
     let mut last_accepted_evidence = None;
     let mut last_accepted_published_at = None;
@@ -1384,11 +1440,13 @@ pub async fn wait_for_compositor_startup_frames(
 
             if let Some(reason) = startup_frame_block_reason(evidence, params) {
                 frames_observed = 0;
+                blocked_structurally = true;
                 last_sequence = None;
                 last_accepted_evidence = None;
                 last_accepted_published_at = None;
                 timeout_reason = reason;
             } else {
+                blocked_structurally = false;
                 if first_full_resolution_frame_ms.is_none() {
                     first_full_resolution_frame_ms = Some(started_at.elapsed().as_millis() as u64);
                 }
@@ -1400,13 +1458,16 @@ pub async fn wait_for_compositor_startup_frames(
                         params.requirements,
                     )
                 {
-                    if let Some(max_frame_gap) = params.max_frame_gap
-                        && let Some(previous_published_at) = last_accepted_published_at
-                    {
+                    fresh_frames_seen = fresh_frames_seen.saturating_add(1);
+                    if let Some(previous_published_at) = last_accepted_published_at {
                         let frame_gap = evidence
                             .published_at
                             .saturating_duration_since(previous_published_at);
-                        if frame_gap > max_frame_gap {
+                        push_startup_gap(&mut gap_history_ms, frame_gap.as_millis() as u64);
+                        if let Some(max_frame_gap) = params.max_frame_gap
+                            && frame_gap > max_frame_gap
+                        {
+                            cadence_violations = cadence_violations.saturating_add(1);
                             frames_observed = 1;
                             last_sequence = Some(evidence.sequence);
                             last_accepted_evidence = Some(evidence);
@@ -1431,6 +1492,9 @@ pub async fn wait_for_compositor_startup_frames(
                         ready: true,
                         wait_ms: started_at.elapsed().as_millis() as u64,
                         frames_observed,
+                        fresh_frames_seen,
+                        gap_history_ms,
+                        cadence_only: false,
                         first_source_frame_ms,
                         first_full_resolution_frame_ms,
                         timeout_reason: None,
@@ -1445,10 +1509,23 @@ pub async fn wait_for_compositor_startup_frames(
         }
 
         if started_at.elapsed() >= params.timeout {
+            let wait_ms = started_at.elapsed().as_millis() as u64;
+            // Cadence-only: the compositor IS producing usable frames, just
+            // not three in a row inside the budget. Anything structural, or
+            // a wait that never saw a usable frame, is a real block.
+            let cadence_only =
+                !blocked_structurally && fresh_frames_seen > 0 && cadence_violations > 0;
+            let timeout_reason = format!(
+                "{timeout_reason} (recent gaps {} ms; {fresh_frames_seen} fresh frame(s) in {wait_ms}ms)",
+                startup_gap_history_label(&gap_history_ms)
+            );
             return CompositorStartupBarrierResult {
                 ready: false,
-                wait_ms: started_at.elapsed().as_millis() as u64,
+                wait_ms,
                 frames_observed,
+                fresh_frames_seen,
+                gap_history_ms,
+                cadence_only,
                 first_source_frame_ms,
                 first_full_resolution_frame_ms,
                 timeout_reason: Some(timeout_reason),
@@ -1457,6 +1534,24 @@ pub async fn wait_for_compositor_startup_frames(
 
         sleep(Duration::from_millis(10)).await;
     }
+}
+
+/// Keep only the most recent `COMPOSITOR_STARTUP_GAP_HISTORY_LEN` gaps, oldest first.
+fn push_startup_gap(history: &mut Vec<u64>, gap_ms: u64) {
+    if history.len() >= COMPOSITOR_STARTUP_GAP_HISTORY_LEN {
+        history.remove(0);
+    }
+    history.push(gap_ms);
+}
+
+/// Test seam: inject one compositor frame-evidence sample without running a
+/// compositor, so startup-barrier callers in other modules can drive cadence.
+#[cfg(test)]
+pub(crate) async fn set_latest_frame_evidence_for_tests(
+    state: &AppState,
+    evidence: CompositorFrameEvidence,
+) {
+    state.compositor.lock().await.latest_frame_evidence = Some(evidence);
 }
 
 fn startup_frame_advances_required_sources(
@@ -7680,6 +7775,233 @@ mod tests {
                 .is_some_and(|reason| reason.contains("startup cadence budget")),
             "{result:?}"
         );
+        // Usable frames arrived, only the cadence missed: the caller may
+        // retry or record with a warning instead of refusing.
+        assert!(result.cadence_only, "{result:?}");
+        assert_eq!(result.fresh_frames_seen, 2, "{result:?}");
+        assert_eq!(result.gap_history_ms.len(), 1, "{result:?}");
+        assert!(result.gap_history_ms[0] >= 100, "{result:?}");
+        assert!(
+            result
+                .timeout_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("2 fresh frame(s) in")),
+            "{result:?}"
+        );
+    }
+
+    /// Cadence matrix: the owner's 166/100/90ms hiccup pattern is unsteady
+    /// under a tight budget (cadence-only, with the last three gaps on record)
+    /// and clean under the 200ms production budget, at 30 and at 60fps.
+    #[tokio::test]
+    async fn startup_barrier_reports_gap_history_and_cadence_only_for_hiccups() {
+        for (label, budget_ms, expect_ready) in [
+            ("30fps/tight", 71_u64, false),
+            ("60fps/tight", 36, false),
+            ("30fps/production", 200, true),
+            ("60fps/production", 200, true),
+        ] {
+            let state = test_state();
+            let writer_state = state.clone();
+            let writer = tokio::spawn(async move {
+                sleep(Duration::from_millis(10)).await;
+                let mut sequence = 1_u64;
+                set_latest_frame_evidence(&writer_state, 1, 1920, 1080, Some(1), None, false).await;
+                for gap in [166_u64, 100, 90, 100, 90, 100] {
+                    sleep(Duration::from_millis(gap)).await;
+                    sequence += 1;
+                    set_latest_frame_evidence(
+                        &writer_state,
+                        sequence,
+                        1920,
+                        1080,
+                        Some(sequence),
+                        None,
+                        false,
+                    )
+                    .await;
+                }
+            });
+
+            let result = wait_for_compositor_startup_frames(
+                &state,
+                CompositorStartupBarrierParams {
+                    width: 1920,
+                    height: 1080,
+                    required_scene_revision: Some(1),
+                    min_consecutive_frames: 3,
+                    max_frame_gap: Some(Duration::from_millis(budget_ms)),
+                    timeout: Duration::from_millis(750),
+                    requirements: CompositorStartupSourceRequirements {
+                        require_real_source: true,
+                        require_camera_source: true,
+                        require_screen_source: false,
+                    },
+                },
+            )
+            .await;
+            writer.abort();
+
+            assert_eq!(result.ready, expect_ready, "{label}: {result:?}");
+            assert!(result.fresh_frames_seen >= 3, "{label}: {result:?}");
+            // Ready after exactly three frames = two gaps; a timeout has seen
+            // the whole pattern and keeps only the last three.
+            assert_eq!(
+                result.gap_history_ms.len(),
+                if expect_ready {
+                    2
+                } else {
+                    COMPOSITOR_STARTUP_GAP_HISTORY_LEN
+                },
+                "{label}: {result:?}"
+            );
+            assert!(
+                result
+                    .gap_history_ms
+                    .iter()
+                    .all(|gap| (80..=230).contains(gap)),
+                "{label}: {result:?}"
+            );
+            if expect_ready {
+                assert!(!result.cadence_only, "{label}: {result:?}");
+                assert_eq!(result.timeout_reason, None, "{label}: {result:?}");
+            } else {
+                assert!(result.cadence_only, "{label}: {result:?}");
+                let reason = result.timeout_reason.clone().unwrap_or_default();
+                assert!(
+                    reason.contains("startup cadence budget")
+                        && reason
+                            .contains(&format!("recent gaps {} ms", result.gap_history_label())),
+                    "{label}: {reason}"
+                );
+            }
+        }
+    }
+
+    /// A stall is never cadence-only: no frame at all, or frames that stop
+    /// advancing the required camera, report zero/one fresh frame and no
+    /// cadence violation so the caller refuses instead of recording.
+    #[tokio::test]
+    async fn startup_barrier_stalls_are_not_cadence_only() {
+        let silent = wait_for_compositor_startup_frames(
+            &test_state(),
+            CompositorStartupBarrierParams {
+                width: 1920,
+                height: 1080,
+                required_scene_revision: Some(1),
+                min_consecutive_frames: 3,
+                max_frame_gap: Some(Duration::from_millis(200)),
+                timeout: Duration::from_millis(120),
+                requirements: any_real_source_requirements(),
+            },
+        )
+        .await;
+        assert!(!silent.ready && !silent.cadence_only, "{silent:?}");
+        assert_eq!(silent.fresh_frames_seen, 0);
+        assert_eq!(silent.gap_history_label(), "none");
+        assert!(
+            silent
+                .timeout_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("0 fresh frame(s)")),
+            "{silent:?}"
+        );
+
+        // One frame, then the camera freezes (sequence advances, camera does
+        // not): 700ms later the barrier has one fresh frame and no gaps.
+        let state = test_state();
+        set_latest_frame_evidence(&state, 1, 1920, 1080, Some(4), None, false).await;
+        let writer_state = state.clone();
+        let writer = tokio::spawn(async move {
+            let mut sequence = 2_u64;
+            loop {
+                sleep(Duration::from_millis(700)).await;
+                set_latest_frame_evidence(
+                    &writer_state,
+                    sequence,
+                    1920,
+                    1080,
+                    Some(4),
+                    None,
+                    false,
+                )
+                .await;
+                sequence += 1;
+            }
+        });
+        let frozen = wait_for_compositor_startup_frames(
+            &state,
+            CompositorStartupBarrierParams {
+                width: 1920,
+                height: 1080,
+                required_scene_revision: Some(1),
+                min_consecutive_frames: 3,
+                max_frame_gap: Some(Duration::from_millis(200)),
+                timeout: Duration::from_millis(1500),
+                requirements: CompositorStartupSourceRequirements {
+                    require_real_source: true,
+                    require_camera_source: true,
+                    require_screen_source: false,
+                },
+            },
+        )
+        .await;
+        writer.abort();
+        assert!(!frozen.ready && !frozen.cadence_only, "{frozen:?}");
+        assert_eq!(frozen.fresh_frames_seen, 1, "{frozen:?}");
+        assert!(frozen.gap_history_ms.is_empty(), "{frozen:?}");
+    }
+
+    /// A resolution block AFTER usable frames wins over earlier cadence
+    /// misses: the latest observation decides, so this is never cadence-only.
+    #[tokio::test]
+    async fn startup_barrier_structural_block_after_hiccups_is_not_cadence_only() {
+        let state = test_state();
+        let writer_state = state.clone();
+        let writer = tokio::spawn(async move {
+            sleep(Duration::from_millis(10)).await;
+            set_latest_frame_evidence(&writer_state, 1, 1920, 1080, Some(1), None, false).await;
+            sleep(Duration::from_millis(120)).await;
+            set_latest_frame_evidence(&writer_state, 2, 1920, 1080, Some(2), None, false).await;
+            sleep(Duration::from_millis(30)).await;
+            set_latest_frame_evidence(&writer_state, 3, 640, 360, Some(3), None, false).await;
+        });
+
+        let result = wait_for_compositor_startup_frames(
+            &state,
+            CompositorStartupBarrierParams {
+                width: 1920,
+                height: 1080,
+                required_scene_revision: Some(1),
+                min_consecutive_frames: 3,
+                max_frame_gap: Some(Duration::from_millis(50)),
+                timeout: Duration::from_millis(300),
+                requirements: any_real_source_requirements(),
+            },
+        )
+        .await;
+        writer.abort();
+
+        assert!(!result.ready && !result.cadence_only, "{result:?}");
+        assert_eq!(result.fresh_frames_seen, 2, "{result:?}");
+        assert!(
+            result
+                .timeout_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("640x360, expected 1920x1080")),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn startup_gap_history_keeps_the_last_three_gaps_oldest_first() {
+        let mut history = Vec::new();
+        for gap in [166_u64, 120, 98, 33, 34] {
+            push_startup_gap(&mut history, gap);
+        }
+        assert_eq!(history, vec![98, 33, 34]);
+        assert_eq!(startup_gap_history_label(&history), "98/33/34");
+        assert_eq!(startup_gap_history_label(&[]), "none");
     }
 
     #[tokio::test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -6987,20 +6987,31 @@ const RECORDING_STARTUP_BARRIER_TIMEOUT: Duration = Duration::from_millis(2500);
 /// Consecutive target-resolution real-source compositor frames required before encoding.
 const RECORDING_STARTUP_BARRIER_MIN_FRAMES: u32 = 3;
 /// How many frame intervals the startup barrier allows between consecutive
-/// accepted compositor publishes. macOS Metal stays near the interval; Windows
-/// CPU compose + dshow delivery routinely lands 100–180ms gaps at session start
-/// (on-box: 130ms then 172ms over earlier 71ms/150ms budgets), so non-macOS uses
-/// a looser factor (~200ms at 30fps) plus a floor. Stalled pipelines still fail
-/// at multi-hundred-ms.
+/// accepted compositor publishes. Under live load (co-host ticks, chat, 1080p
+/// compose, FFmpeg spawn) the macOS Metal compositor hiccups to 100–170ms at
+/// session start — a 2.1× factor (71ms at 30fps) refused a real recording on
+/// 2026-08-23 for a single 166ms gap. macOS now uses 4.0× with the shared
+/// 200ms floor; Windows CPU compose + dshow delivery lands 100–180ms gaps
+/// routinely (on-box: 130ms then 172ms), so it keeps the looser 6.0×. Stalled
+/// pipelines still fail at multi-hundred-ms, and a cadence-only miss no longer
+/// refuses the session (see `await_recording_startup_barrier`).
 #[cfg(target_os = "macos")]
-const RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR: f64 = 2.1;
+const RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR: f64 = 4.0;
 #[cfg(not(target_os = "macos"))]
 const RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR: f64 = 6.0;
-/// Windows compose/dshow startup gaps are often wall-clock-bound rather than
-/// pure multiples of the target frame interval; keep a hard floor so 60fps
-/// sessions do not inherit an unrealistically tight cadence budget.
-#[cfg(not(target_os = "macos"))]
+/// Startup gaps are wall-clock-bound (scheduler, spawn, GPU queue) rather than
+/// pure multiples of the frame interval; keep a hard floor on every platform so
+/// 60fps sessions do not inherit an unrealistically tight cadence budget.
 const RECORDING_STARTUP_CADENCE_MIN_FRAME_GAP: Duration = Duration::from_millis(200);
+/// When the first barrier pass times out on cadence alone, one in-place retry
+/// runs with this much more budget before the session proceeds with a warning.
+const RECORDING_STARTUP_CADENCE_RETRY_BUDGET_FACTOR: f64 = 1.5;
+/// Emitted (WARN) when encoding starts on a compositor that never settled at
+/// start; the renderer turns it into a keyed warning toast.
+pub const RECORDING_STARTUP_CADENCE_UNSTEADY_CODE: &str = "recording-startup-cadence-unsteady";
+/// Emitted (ERROR) when the barrier refuses the session: no usable frame, or a
+/// resolution / scene-revision / missing-source block.
+pub const RECORDING_STARTUP_BARRIER_TIMEOUT_CODE: &str = "recording-startup-barrier-timeout";
 const RECORDING_CAMERA_CADENCE_READY_TIMEOUT: Duration = Duration::from_millis(3000);
 /// When the cadence has not settled by this point, the session is presumed to
 /// have drifted into degraded delivery (long-uptime capture cards do this) and
@@ -7047,6 +7058,40 @@ async fn await_microphone_warmup(state: &AppState, stats: Arc<AudioCaptureStats>
     true
 }
 
+/// What one startup-barrier pass means for the session, decided by a pure
+/// function so the record-with-warning ladder is testable without a compositor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordingStartupBarrierVerdict {
+    /// Consecutive fresh frames inside the budget: encode now.
+    Ready,
+    /// Usable frames arrived but not steadily enough. Never a refusal on its
+    /// own: retry once with a looser budget, then record with a warning.
+    CadenceOnly,
+    /// No usable frame at all, or a resolution / scene-revision / missing
+    /// source block: the barrier exists for exactly this, refuse the start.
+    Blocked,
+}
+
+fn classify_recording_startup_barrier(
+    result: &CompositorStartupBarrierResult,
+) -> RecordingStartupBarrierVerdict {
+    if result.ready {
+        RecordingStartupBarrierVerdict::Ready
+    } else if result.cadence_only && result.fresh_frames_seen > 0 {
+        RecordingStartupBarrierVerdict::CadenceOnly
+    } else {
+        RecordingStartupBarrierVerdict::Blocked
+    }
+}
+
+/// The cadence budget a cadence-only retry runs with (1.5× the first pass).
+fn recording_startup_retry_frame_gap_budget(max_frame_gap: Duration) -> Duration {
+    Duration::from_millis(
+        (max_frame_gap.as_millis() as f64 * RECORDING_STARTUP_CADENCE_RETRY_BUDGET_FACTOR).ceil()
+            as u64,
+    )
+}
+
 async fn await_recording_startup_barrier(
     state: &AppState,
     session_id: &str,
@@ -7056,69 +7101,199 @@ async fn await_recording_startup_barrier(
     required_scene_revision: Option<u64>,
     requirements: CompositorStartupSourceRequirements,
 ) -> Result<CompositorStartupBarrierResult> {
+    await_recording_startup_barrier_with_budget(
+        state,
+        session_id,
+        width,
+        height,
+        required_scene_revision,
+        requirements,
+        recording_startup_frame_gap_budget(target_fps),
+        RECORDING_STARTUP_BARRIER_TIMEOUT,
+    )
+    .await
+}
+
+/// Record-with-warning ladder for compositor cadence at session start
+/// (mirrors the 0.9.56 camera-cadence ladder):
+///
+/// 1. one barrier pass with the platform budget;
+/// 2. on a cadence-only timeout, one in-place retry with a 1.5× budget;
+/// 3. if that is still cadence-only, proceed to encode with a WARN health
+///    event and the `ready-unsteady` diagnostics state.
+///
+/// Only a structural block or a zero-frame stall refuses the session.
+#[allow(clippy::too_many_arguments)]
+async fn await_recording_startup_barrier_with_budget(
+    state: &AppState,
+    session_id: &str,
+    width: u32,
+    height: u32,
+    required_scene_revision: Option<u64>,
+    requirements: CompositorStartupSourceRequirements,
+    max_frame_gap: Duration,
+    timeout: Duration,
+) -> Result<CompositorStartupBarrierResult> {
     publish_recording_startup_barrier_diagnostics(
         state,
         "waiting",
-        &CompositorStartupBarrierResult {
-            ready: false,
-            wait_ms: 0,
-            frames_observed: 0,
-            first_source_frame_ms: None,
-            first_full_resolution_frame_ms: None,
-            timeout_reason: None,
-        },
+        &CompositorStartupBarrierResult::empty(),
         None,
     )
     .await;
 
-    let max_frame_gap = recording_startup_frame_gap_budget(target_fps);
-    let result = wait_for_compositor_startup_frames(
-        state,
-        CompositorStartupBarrierParams {
-            width,
-            height,
-            required_scene_revision,
-            min_consecutive_frames: RECORDING_STARTUP_BARRIER_MIN_FRAMES,
-            max_frame_gap: Some(max_frame_gap),
-            timeout: RECORDING_STARTUP_BARRIER_TIMEOUT,
-            requirements,
-        },
-    )
-    .await;
-
-    if result.ready {
-        publish_recording_startup_barrier_diagnostics(state, "ready", &result, None).await;
-        let _ = emit_health_event(
+    let run_pass = |frame_gap: Duration| {
+        wait_for_compositor_startup_frames(
             state,
-            Some(session_id),
-            HealthLevel::Info,
-            "recording-startup-barrier-ready",
-            &format!(
-                "Recording startup waited {}ms for {} fresh {}x{} compositor frame(s) with frame gaps at or below {}ms.",
-                result.wait_ms,
-                result.frames_observed,
+            CompositorStartupBarrierParams {
                 width,
                 height,
-                max_frame_gap.as_millis()
-            ),
-        );
-        return Ok(result);
+                required_scene_revision,
+                min_consecutive_frames: RECORDING_STARTUP_BARRIER_MIN_FRAMES,
+                max_frame_gap: Some(frame_gap),
+                timeout,
+                requirements,
+            },
+        )
+    };
+
+    let first = run_pass(max_frame_gap).await;
+    match classify_recording_startup_barrier(&first) {
+        RecordingStartupBarrierVerdict::Ready => {
+            publish_recording_startup_barrier_diagnostics(state, "ready", &first, None).await;
+            emit_recording_startup_barrier_ready(
+                state,
+                session_id,
+                &first,
+                width,
+                height,
+                max_frame_gap,
+                false,
+            );
+            return Ok(first);
+        }
+        RecordingStartupBarrierVerdict::Blocked => {
+            return Err(refuse_recording_startup(state, session_id, &first, max_frame_gap).await);
+        }
+        RecordingStartupBarrierVerdict::CadenceOnly => {}
     }
 
-    publish_recording_startup_barrier_diagnostics(state, "timed-out", &result, None).await;
+    let retry_frame_gap = recording_startup_retry_frame_gap_budget(max_frame_gap);
+    publish_recording_startup_barrier_diagnostics(state, "retrying", &first, None).await;
+    let _ = emit_health_event(
+        state,
+        Some(session_id),
+        HealthLevel::Info,
+        "recording-startup-cadence-retry",
+        &format!(
+            "Compositor cadence was unsteady at start (gaps {} ms vs {}ms budget, {} fresh frame(s) in {}ms); retrying the startup barrier once with a {}ms budget.",
+            first.gap_history_label(),
+            max_frame_gap.as_millis(),
+            first.fresh_frames_seen,
+            first.wait_ms,
+            retry_frame_gap.as_millis()
+        ),
+    );
+
+    let mut second = run_pass(retry_frame_gap).await;
+    second.wait_ms = second.wait_ms.saturating_add(first.wait_ms);
+    match classify_recording_startup_barrier(&second) {
+        RecordingStartupBarrierVerdict::Ready => {
+            publish_recording_startup_barrier_diagnostics(state, "ready", &second, None).await;
+            emit_recording_startup_barrier_ready(
+                state,
+                session_id,
+                &second,
+                width,
+                height,
+                retry_frame_gap,
+                true,
+            );
+            Ok(second)
+        }
+        RecordingStartupBarrierVerdict::CadenceOnly => {
+            publish_recording_startup_barrier_diagnostics(state, "ready-unsteady", &second, None)
+                .await;
+            let _ = emit_health_event(
+                state,
+                Some(session_id),
+                HealthLevel::Warn,
+                RECORDING_STARTUP_CADENCE_UNSTEADY_CODE,
+                &format!(
+                    "Recording started with an unsteady compositor at start: gaps {} ms vs {} ms budget ({} fresh {}x{} frame(s) in {}ms); check the first seconds of the file.",
+                    second.gap_history_label(),
+                    retry_frame_gap.as_millis(),
+                    second.fresh_frames_seen,
+                    width,
+                    height,
+                    second.wait_ms
+                ),
+            );
+            Ok(second)
+        }
+        RecordingStartupBarrierVerdict::Blocked => {
+            Err(refuse_recording_startup(state, session_id, &second, retry_frame_gap).await)
+        }
+    }
+}
+
+fn emit_recording_startup_barrier_ready(
+    state: &AppState,
+    session_id: &str,
+    result: &CompositorStartupBarrierResult,
+    width: u32,
+    height: u32,
+    max_frame_gap: Duration,
+    after_retry: bool,
+) {
+    let suffix = if after_retry {
+        " after one cadence retry"
+    } else {
+        ""
+    };
+    let _ = emit_health_event(
+        state,
+        Some(session_id),
+        HealthLevel::Info,
+        "recording-startup-barrier-ready",
+        &format!(
+            "Recording startup waited {}ms for {} fresh {}x{} compositor frame(s) with frame gaps at or below {}ms{suffix}.",
+            result.wait_ms,
+            result.frames_observed,
+            width,
+            height,
+            max_frame_gap.as_millis()
+        ),
+    );
+}
+
+/// Publish the refusal (diagnostics + ERROR health event) and build the error
+/// the start RPC returns. The compositor's reason already carries the recent
+/// gap history, the fresh-frame count and the wall time; the budget is added
+/// here so a refusal can be read without the support bundle.
+async fn refuse_recording_startup(
+    state: &AppState,
+    session_id: &str,
+    result: &CompositorStartupBarrierResult,
+    max_frame_gap: Duration,
+) -> anyhow::Error {
+    publish_recording_startup_barrier_diagnostics(state, "timed-out", result, None).await;
     let reason = result
         .timeout_reason
         .clone()
         .unwrap_or_else(|| "compositor did not produce ready frames".to_string());
-    let message = format!("Recording startup blocked before encoding: {reason}.");
+    let message = format!(
+        "Recording startup blocked before encoding: {reason}; cadence budget {}ms.",
+        max_frame_gap.as_millis()
+    );
     let _ = emit_health_event(
         state,
         Some(session_id),
         HealthLevel::Error,
-        "recording-startup-barrier-timeout",
+        RECORDING_STARTUP_BARRIER_TIMEOUT_CODE,
         &message,
     );
-    bail!(message)
+    anyhow::anyhow!(message)
 }
 
 async fn await_recording_camera_cadence_ready(
@@ -7354,20 +7529,14 @@ fn camera_cadence_mismatch_warning(measured_fps: Option<f64>, target_fps: u32) -
     ))
 }
 
+/// `max(frame_interval × factor, 200ms)` on every platform (factor 4.0 on
+/// macOS, 6.0 elsewhere). At 30 and 60fps the floor wins, so the budget is
+/// 200ms everywhere; the factor only matters below 20fps.
 fn recording_startup_frame_gap_budget(target_fps: u32) -> Duration {
     let frame_interval_ms =
         1000.0 / f64::from(target_fps.max(1)) * RECORDING_STARTUP_CADENCE_FRAME_INTERVAL_FACTOR;
-    let budget = Duration::from_millis(frame_interval_ms.ceil() as u64);
-    // Exactly one arm survives cfg-stripping and becomes the tail expression;
-    // `return` here would trip clippy::needless_return on that platform.
-    #[cfg(not(target_os = "macos"))]
-    {
-        budget.max(RECORDING_STARTUP_CADENCE_MIN_FRAME_GAP)
-    }
-    #[cfg(target_os = "macos")]
-    {
-        budget
-    }
+    Duration::from_millis(frame_interval_ms.ceil() as u64)
+        .max(RECORDING_STARTUP_CADENCE_MIN_FRAME_GAP)
 }
 
 fn optional_ms(value: Option<f64>) -> String {
@@ -16251,33 +16420,493 @@ mod tests {
 
     #[test]
     fn recording_startup_frame_gap_budget_scales_with_target_fps() {
+        // The 200ms floor wins at every shipping frame rate on every platform:
+        // macOS 4.0 × 33.3ms = 134ms → 200ms; Windows 6.0 × 33.3ms = 200ms.
+        assert_eq!(
+            recording_startup_frame_gap_budget(30),
+            Duration::from_millis(200)
+        );
+        // 60fps: 67ms (macOS) / 100ms (Windows) → the floor (gaps are wall-clock).
+        assert_eq!(
+            recording_startup_frame_gap_budget(60),
+            Duration::from_millis(200)
+        );
+        assert_eq!(
+            recording_startup_frame_gap_budget(24),
+            Duration::from_millis(200)
+        );
+        // The owner's 166ms live hiccup (2026-08-23, refused under the 71ms
+        // macOS budget) and the Windows tester's 172ms compose gap both pass.
+        assert!(recording_startup_frame_gap_budget(30) > Duration::from_millis(166));
+        assert!(recording_startup_frame_gap_budget(30) > Duration::from_millis(172));
+        // Below 20fps the factor takes over: 4.0 × 100ms (macOS) / 6.0 × 100ms.
         #[cfg(target_os = "macos")]
-        {
-            // 2.1 × 33.3ms ≈ 70 → 71ms ceil
-            assert_eq!(
-                recording_startup_frame_gap_budget(30),
-                Duration::from_millis(71)
-            );
-            assert_eq!(
-                recording_startup_frame_gap_budget(60),
-                Duration::from_millis(36)
-            );
-        }
+        assert_eq!(
+            recording_startup_frame_gap_budget(10),
+            Duration::from_millis(400)
+        );
         #[cfg(not(target_os = "macos"))]
-        {
-            // 6.0 × 33.3ms = 200ms — covers on-box Windows 172ms compose gaps
-            assert_eq!(
-                recording_startup_frame_gap_budget(30),
-                Duration::from_millis(200)
-            );
-            // 6.0 × 16.7ms ≈ 100ms, but the 200ms floor wins (gaps are wall-clock).
-            assert_eq!(
-                recording_startup_frame_gap_budget(60),
-                Duration::from_millis(200)
-            );
-            // The exact tester numbers that used to fail under the 71ms/150ms budgets.
-            assert!(recording_startup_frame_gap_budget(30) > Duration::from_millis(172));
+        assert_eq!(
+            recording_startup_frame_gap_budget(10),
+            Duration::from_millis(600)
+        );
+        // A stalled pipeline at multi-hundred-ms still trips the budget.
+        assert!(recording_startup_frame_gap_budget(30) < Duration::from_millis(700));
+    }
+
+    #[test]
+    fn recording_startup_retry_budget_is_one_and_a_half_times_the_first_pass() {
+        assert_eq!(
+            recording_startup_retry_frame_gap_budget(Duration::from_millis(200)),
+            Duration::from_millis(300)
+        );
+        assert_eq!(
+            recording_startup_retry_frame_gap_budget(Duration::from_millis(71)),
+            Duration::from_millis(107)
+        );
+    }
+
+    #[test]
+    fn recording_startup_barrier_verdict_splits_cadence_from_structural_blocks() {
+        let mut result = CompositorStartupBarrierResult::empty();
+        result.ready = true;
+        assert_eq!(
+            classify_recording_startup_barrier(&result),
+            RecordingStartupBarrierVerdict::Ready
+        );
+
+        // Cadence-only with usable frames: never a refusal on its own.
+        let mut unsteady = CompositorStartupBarrierResult::empty();
+        unsteady.cadence_only = true;
+        unsteady.fresh_frames_seen = 4;
+        unsteady.gap_history_ms = vec![166, 120, 98];
+        unsteady.timeout_reason = Some("latest compositor frame gap 166ms".to_string());
+        assert_eq!(
+            classify_recording_startup_barrier(&unsteady),
+            RecordingStartupBarrierVerdict::CadenceOnly
+        );
+        assert_eq!(unsteady.gap_history_label(), "166/120/98");
+
+        // Zero fresh frames is a stall even if the flag were set.
+        let mut stalled = CompositorStartupBarrierResult::empty();
+        stalled.cadence_only = true;
+        stalled.fresh_frames_seen = 0;
+        assert_eq!(
+            classify_recording_startup_barrier(&stalled),
+            RecordingStartupBarrierVerdict::Blocked
+        );
+
+        // Structural blocks (resolution, scene revision, missing source).
+        let mut blocked = CompositorStartupBarrierResult::empty();
+        blocked.fresh_frames_seen = 2;
+        blocked.cadence_only = false;
+        blocked.timeout_reason =
+            Some("latest compositor frame is 640x360, expected 1920x1080".to_string());
+        assert_eq!(
+            classify_recording_startup_barrier(&blocked),
+            RecordingStartupBarrierVerdict::Blocked
+        );
+        assert_eq!(blocked.gap_history_label(), "none");
+    }
+
+    fn startup_frame_evidence(
+        sequence: u64,
+        width: u32,
+        height: u32,
+        camera_sequence: Option<u64>,
+    ) -> crate::compositor::CompositorFrameEvidence {
+        crate::compositor::CompositorFrameEvidence {
+            sequence,
+            scene_revision: Some(1),
+            width,
+            height,
+            has_real_source: true,
+            camera_sequence,
+            screen_sequence: None,
+            has_image_source: false,
+            published_at: Instant::now(),
         }
+    }
+
+    fn startup_barrier_test_state(session_id: &str) -> AppState {
+        let state = test_state();
+        state
+            .database
+            .ensure_fake_live_chat_session(session_id)
+            .unwrap();
+        state
+    }
+
+    /// Publishes 1920x1080 frames with an advancing camera: the first after
+    /// 10ms, then one per entry of `gaps_ms`, then one every `tail_period_ms`
+    /// until aborted (`None` = go quiet after the pattern).
+    fn spawn_startup_frame_writer(
+        state: AppState,
+        gaps_ms: Vec<u64>,
+        tail_period_ms: Option<u64>,
+    ) -> tokio::task::JoinHandle<()> {
+        spawn_startup_frame_writer_sized(state, 1920, 1080, gaps_ms, tail_period_ms)
+    }
+
+    fn spawn_startup_frame_writer_sized(
+        state: AppState,
+        width: u32,
+        height: u32,
+        gaps_ms: Vec<u64>,
+        tail_period_ms: Option<u64>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut sequence = 1_u64;
+            sleep(Duration::from_millis(10)).await;
+            crate::compositor::set_latest_frame_evidence_for_tests(
+                &state,
+                startup_frame_evidence(sequence, width, height, Some(sequence)),
+            )
+            .await;
+            for gap in gaps_ms {
+                sleep(Duration::from_millis(gap)).await;
+                sequence += 1;
+                crate::compositor::set_latest_frame_evidence_for_tests(
+                    &state,
+                    startup_frame_evidence(sequence, width, height, Some(sequence)),
+                )
+                .await;
+            }
+            let Some(period) = tail_period_ms else {
+                return;
+            };
+            loop {
+                sleep(Duration::from_millis(period)).await;
+                sequence += 1;
+                crate::compositor::set_latest_frame_evidence_for_tests(
+                    &state,
+                    startup_frame_evidence(sequence, width, height, Some(sequence)),
+                )
+                .await;
+            }
+        })
+    }
+
+    fn camera_startup_requirements() -> CompositorStartupSourceRequirements {
+        CompositorStartupSourceRequirements {
+            require_real_source: true,
+            require_camera_source: true,
+            require_screen_source: false,
+        }
+    }
+
+    async fn startup_barrier_diagnostics_state(state: &AppState) -> Option<String> {
+        state
+            .diagnostics
+            .lock()
+            .await
+            .recording_startup_barrier_state
+            .clone()
+    }
+
+    fn health_event_codes(state: &AppState, session_id: &str) -> Vec<String> {
+        state
+            .database
+            .list_health_events(session_id)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.code)
+            .collect()
+    }
+
+    /// The owner's live incident: 166ms then ~100ms hiccups at 30fps used to
+    /// refuse the whole session under the 71ms budget. Under the production
+    /// budget (200ms at 30 and 60fps) the same pattern records cleanly.
+    #[tokio::test]
+    async fn recording_startup_barrier_records_owner_hiccup_pattern_at_30_and_60_fps() {
+        for target_fps in [30_u32, 60] {
+            let session_id = format!("session-startup-hiccups-{target_fps}");
+            let state = startup_barrier_test_state(&session_id);
+            let writer = spawn_startup_frame_writer(state.clone(), vec![166, 100, 90], Some(33));
+
+            let result = await_recording_startup_barrier(
+                &state,
+                &session_id,
+                1920,
+                1080,
+                target_fps,
+                Some(1),
+                camera_startup_requirements(),
+            )
+            .await;
+            writer.abort();
+
+            let result = result.unwrap_or_else(|error| {
+                panic!("{target_fps}fps: 166/100/90ms hiccups must record, not refuse: {error}")
+            });
+            assert!(result.ready, "{target_fps}fps: {result:?}");
+            assert_eq!(
+                startup_barrier_diagnostics_state(&state).await.as_deref(),
+                Some("ready")
+            );
+            let codes = health_event_codes(&state, &session_id);
+            assert!(
+                codes
+                    .iter()
+                    .any(|code| code == "recording-startup-barrier-ready"),
+                "{target_fps}fps: {codes:?}"
+            );
+            assert!(
+                !codes
+                    .iter()
+                    .any(|code| code == RECORDING_STARTUP_BARRIER_TIMEOUT_CODE),
+                "{target_fps}fps: {codes:?}"
+            );
+        }
+    }
+
+    /// Cadence-only miss on the first pass, clean on the 1.5× retry: the
+    /// session records with no warning, and the retry is logged once.
+    #[tokio::test]
+    async fn recording_startup_barrier_retries_once_with_a_looser_budget() {
+        let session_id = "session-startup-retry";
+        let state = startup_barrier_test_state(session_id);
+        // 250ms gaps: over the 200ms budget, under the 300ms retry budget.
+        let writer = spawn_startup_frame_writer(state.clone(), Vec::new(), Some(250));
+
+        let result = await_recording_startup_barrier_with_budget(
+            &state,
+            session_id,
+            1920,
+            1080,
+            Some(1),
+            camera_startup_requirements(),
+            Duration::from_millis(200),
+            Duration::from_millis(700),
+        )
+        .await;
+        writer.abort();
+
+        let result = result.expect("a cadence-only first pass must not refuse the session");
+        assert!(result.ready, "{result:?}");
+        assert_eq!(
+            startup_barrier_diagnostics_state(&state).await.as_deref(),
+            Some("ready")
+        );
+        let codes = health_event_codes(&state, session_id);
+        assert_eq!(
+            codes
+                .iter()
+                .filter(|code| *code == "recording-startup-cadence-retry")
+                .count(),
+            1,
+            "exactly one retry: {codes:?}"
+        );
+        assert!(
+            codes
+                .iter()
+                .any(|code| code == "recording-startup-barrier-ready"),
+            "{codes:?}"
+        );
+        assert!(
+            !codes
+                .iter()
+                .any(|code| code == RECORDING_STARTUP_CADENCE_UNSTEADY_CODE),
+            "the retry settled, no warning due: {codes:?}"
+        );
+    }
+
+    /// Still cadence-only after the retry: record with the WARN event and the
+    /// `ready-unsteady` diagnostics state instead of refusing.
+    #[tokio::test]
+    async fn recording_startup_barrier_records_with_warning_when_cadence_never_settles() {
+        let session_id = "session-startup-unsteady";
+        let state = startup_barrier_test_state(session_id);
+        // 350ms gaps: over both the 200ms budget and the 300ms retry budget,
+        // but fresh frames keep arriving — an unsteady compositor, not a stall.
+        let writer = spawn_startup_frame_writer(state.clone(), Vec::new(), Some(350));
+
+        let result = await_recording_startup_barrier_with_budget(
+            &state,
+            session_id,
+            1920,
+            1080,
+            Some(1),
+            camera_startup_requirements(),
+            Duration::from_millis(200),
+            Duration::from_millis(900),
+        )
+        .await;
+        writer.abort();
+
+        let result = result.expect("cadence alone must never refuse a recording");
+        assert!(!result.ready, "{result:?}");
+        assert!(result.cadence_only, "{result:?}");
+        assert!(result.fresh_frames_seen >= 2, "{result:?}");
+        assert!(
+            result.gap_history_ms.iter().all(|gap| *gap >= 300),
+            "{result:?}"
+        );
+        assert_eq!(
+            startup_barrier_diagnostics_state(&state).await.as_deref(),
+            Some("ready-unsteady")
+        );
+        let events = state.database.list_health_events(session_id).unwrap();
+        let unsteady = events
+            .iter()
+            .find(|event| event.code == RECORDING_STARTUP_CADENCE_UNSTEADY_CODE)
+            .unwrap_or_else(|| panic!("missing unsteady warning: {events:?}"));
+        assert!(matches!(unsteady.level, HealthLevel::Warn), "{unsteady:?}");
+        assert!(
+            unsteady.message.contains("unsteady compositor")
+                && unsteady.message.contains("300 ms budget")
+                && unsteady
+                    .message
+                    .contains("check the first seconds of the file"),
+            "{}",
+            unsteady.message
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| event.code == RECORDING_STARTUP_BARRIER_TIMEOUT_CODE),
+            "{events:?}"
+        );
+    }
+
+    /// A true stall — no compositor frame at all — still refuses, with the
+    /// frame count in the message and a persistent ERROR health event.
+    #[tokio::test]
+    async fn recording_startup_barrier_refuses_a_zero_frame_stall() {
+        let session_id = "session-startup-stall";
+        let state = startup_barrier_test_state(session_id);
+
+        let error = await_recording_startup_barrier_with_budget(
+            &state,
+            session_id,
+            1920,
+            1080,
+            Some(1),
+            camera_startup_requirements(),
+            Duration::from_millis(200),
+            Duration::from_millis(300),
+        )
+        .await
+        .expect_err("a zero-frame stall must refuse the session");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("Recording startup blocked before encoding")
+                && message.contains("waiting for compositor frame")
+                && message.contains("0 fresh frame(s)")
+                && message.contains("recent gaps none")
+                && message.contains("cadence budget 200ms"),
+            "{message}"
+        );
+        assert_eq!(
+            startup_barrier_diagnostics_state(&state).await.as_deref(),
+            Some("timed-out")
+        );
+        let events = state.database.list_health_events(session_id).unwrap();
+        let refusal = events
+            .iter()
+            .find(|event| event.code == RECORDING_STARTUP_BARRIER_TIMEOUT_CODE)
+            .unwrap_or_else(|| panic!("missing refusal event: {events:?}"));
+        assert!(matches!(refusal.level, HealthLevel::Error), "{refusal:?}");
+        assert!(
+            !events
+                .iter()
+                .any(|event| event.code == "recording-startup-cadence-retry"),
+            "a stall must not burn a cadence retry: {events:?}"
+        );
+    }
+
+    /// Frames 700ms apart that never advance the required camera are not
+    /// fresh frames: the barrier refuses instead of recording a frozen feed.
+    #[tokio::test]
+    async fn recording_startup_barrier_refuses_slow_frames_that_never_advance() {
+        let session_id = "session-startup-frozen";
+        let state = startup_barrier_test_state(session_id);
+        let writer_state = state.clone();
+        let writer = tokio::spawn(async move {
+            let mut sequence = 1_u64;
+            loop {
+                crate::compositor::set_latest_frame_evidence_for_tests(
+                    &writer_state,
+                    startup_frame_evidence(sequence, 1920, 1080, Some(7)),
+                )
+                .await;
+                sequence += 1;
+                sleep(Duration::from_millis(700)).await;
+            }
+        });
+
+        let error = await_recording_startup_barrier_with_budget(
+            &state,
+            session_id,
+            1920,
+            1080,
+            Some(1),
+            camera_startup_requirements(),
+            Duration::from_millis(200),
+            Duration::from_millis(1500),
+        )
+        .await
+        .expect_err("a camera that never advances must refuse the session");
+        writer.abort();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("advancing required sources") && message.contains("1 fresh frame(s)"),
+            "{message}"
+        );
+        assert_eq!(
+            startup_barrier_diagnostics_state(&state).await.as_deref(),
+            Some("timed-out")
+        );
+        assert!(
+            health_event_codes(&state, session_id)
+                .iter()
+                .any(|code| code == RECORDING_STARTUP_BARRIER_TIMEOUT_CODE)
+        );
+    }
+
+    /// Wrong-resolution frames are a structural block even when they arrive
+    /// steadily: hard fail with the observed resolution in the message.
+    #[tokio::test]
+    async fn recording_startup_barrier_refuses_wrong_resolution_frames() {
+        let session_id = "session-startup-resolution";
+        let state = startup_barrier_test_state(session_id);
+        let writer =
+            spawn_startup_frame_writer_sized(state.clone(), 640, 360, Vec::new(), Some(33));
+
+        let error = await_recording_startup_barrier_with_budget(
+            &state,
+            session_id,
+            1920,
+            1080,
+            Some(1),
+            camera_startup_requirements(),
+            Duration::from_millis(200),
+            Duration::from_millis(300),
+        )
+        .await
+        .expect_err("preview-sized frames must refuse the session");
+        writer.abort();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("latest compositor frame is 640x360, expected 1920x1080"),
+            "{message}"
+        );
+        let codes = health_event_codes(&state, session_id);
+        assert!(
+            codes
+                .iter()
+                .any(|code| code == RECORDING_STARTUP_BARRIER_TIMEOUT_CODE),
+            "{codes:?}"
+        );
+        assert!(
+            !codes
+                .iter()
+                .any(|code| code == RECORDING_STARTUP_CADENCE_UNSTEADY_CODE),
+            "{codes:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

Owner incident (2026-08-23, live, macOS): **"Recording startup blocked before encoding: latest compositor frame gap 166ms exceeds startup cadence budget 71ms"** refused the whole session start, and the only signal was a 4-second toast. Batch 3 slice **B0** (plan `2026-08-23 - Videorc Live Feedback Batch 3 Plan`).

Two root causes:
1. macOS kept the 2.1x startup cadence factor (71ms at 30fps, 36ms at 60fps) that Windows was relieved from in aec0a404; under live load one 166ms hiccup reset the 3-frame streak and 2.5s later the barrier `bail!`ed.
2. A start rejection surfaced as one default `toast.error(message)` and the Record control returned to idle; the Error-level health event was stored but shown nowhere persistent.

## Backend (`crates/videorc-backend`)

**`compositor.rs` — `wait_for_compositor_startup_frames`**
- Keeps a ring of the last 3 observed inter-frame gaps and a `fresh_frames_seen` counter.
- `CompositorStartupBarrierResult` gains `gap_history_ms`, `fresh_frames_seen`, `cadence_only` (+ `empty()` / `gap_history_label()`). `cadence_only` is true only when ≥1 fresh target-resolution frame with advancing required sources was seen, a gap exceeded the budget, and the *latest* observation was not a resolution / scene-revision / missing-source block.
- Timeout reasons now end with `(recent gaps 166/120/98 ms; N fresh frame(s) in Wms)`.

**`recording.rs`**
- Budget unified: `max(frame_interval × factor, 200ms)` on every platform — macOS factor 2.1 → **4.0**, Windows keeps 6.0, the 200ms floor is now shared.
  **Final numbers: 30fps → 200ms, 60fps → 200ms, 24fps → 200ms (both platforms); 10fps → 400ms macOS / 600ms Windows. Retry budget = 1.5× → 300ms at 30/60fps.**
- `await_recording_startup_barrier` is now a ladder (mirrors the 0.9.56 camera ladder):
  1. one pass with the platform budget;
  2. cadence-only timeout → `recording-startup-cadence-retry` (info) + one in-place retry at 1.5× budget;
  3. still cadence-only → **return Ok**, emit WARN `recording-startup-cadence-unsteady` ("Recording started with an unsteady compositor at start: gaps … ms vs 300 ms budget (… fresh 1920x1080 frame(s) in …ms); check the first seconds of the file.") and publish diagnostics state `ready-unsteady`.
  4. `Blocked` (zero fresh frames, non-advancing required source, wrong resolution / scene revision / missing source) → ERROR `recording-startup-barrier-timeout` + bail; the message carries the gap history, frames observed, wall time and budget.
- Worst-case added start latency for an unsteady compositor: one extra 2.5s pass before encoding begins (the session starts instead of failing).

## Renderer (`apps/desktop/src/renderer`)

- `lib/session-start-failure.ts` (new): `SESSION_START_FAILED_TOAST_ID = 'session-start-failed'`, `reduceSessionStartFailure`, `sessionStartFailureToastOptions` (`duration: Infinity`, `action: Retry`, `onDismiss`).
- `hooks/use-studio.tsx`: `reportSessionStartFailure(error, retry)` replaces `reportError` for every start rejection (`runStartSession` catch, `confirmGoLive` catch) — keyed persistent toast with **Retry** that re-runs the exact failed start (same streaming override) + `sessionStartFailure: { message, at } | null` exposed through the studio context with `dismissSessionStartFailure` / `retrySessionStart`. A new start attempt clears it. Premium-gate messages keep the upgrade toast but still set the state.
- `components/studio/session-panel.tsx`: the Record / Stream control shows a `role="alert"` line under the buttons — destructive icon + "Could not start. {reason}" (clamped, full text in title) + Retry / Dismiss — until the user starts again or dismisses. Monochrome chrome; destructive red only on the status line, per `videorc-design`.
- `lib/studio-health.ts`: `recordingStartupHealthToast(event)` — WARN `recording-startup-cadence-unsteady` → keyed warning toast (15s); ERROR `recording-startup-barrier-timeout` → error toast on the **same** `session-start-failed` key, so the RPC rejection that follows updates it in place (adds Retry) instead of stacking. Both surfaces share one shape (title `Could not start` + description = backend reason) because sonner merges `{...toast, ...data}` on an id update — a message-as-title update would have left the older description under it (second commit).

## Tests

Rust: `recording_startup_barrier_records_owner_hiccup_pattern_at_30_and_60_fps`, `…_retries_once_with_a_looser_budget`, `…_records_with_warning_when_cadence_never_settles`, `…_refuses_a_zero_frame_stall`, `…_refuses_slow_frames_that_never_advance`, `…_refuses_wrong_resolution_frames`, budget/retry-budget/verdict unit tests; compositor `startup_barrier_reports_gap_history_and_cadence_only_for_hiccups` (30/60fps × tight/production budget), `startup_barrier_stalls_are_not_cadence_only`, `startup_barrier_structural_block_after_hiccups_is_not_cadence_only`, gap-ring test.
TS: `session-start-failure.test.ts` (8), `studio-health.test.ts` (+3 mapping tests).

## Gates

- `cargo fmt --all` — clean
- `cargo test -p videorc-backend -- recording::tests::recording_startup compositor::tests::startup` — **24 passed; 0 failed** (2.13s)
- `cargo clippy -p videorc-backend -- -D warnings` — Finished, no warnings
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm format:check` — All matched files use Prettier code style
- `pnpm --filter @videorc/desktop test` — **Test Files 151 passed; Tests 1388 passed | 1 skipped** (re-run after the toast-shape commit: same)
- `pnpm smoke:recording-studio` (26-step gate, run from the isolated worktree; box load average 50–130 from parallel agent runs):
  - Run 3 (warm cache): **steps 1–14 PASS** — desktop unit gates, `test:scripts`, live-audio probe, `live_layout::`/`scene::`/`recording::` (263 passed, 1 ignored)/`audio::`/`noise_cleanup::`, captions contract, captions-live record+stream artifact, noise-cleanup artifact, **`smoke:dev` all 7 layouts quality PASS**, `smoke:screens`, `smoke:preview-real-launch`.
  - **Step 15 `smoke:layout-source-loop` FAILED: `Error: No camera device available to select.`** — the dev app launched from this worktree's Electron binary has no camera TCC grant (per-binary TCC; known for isolated worktrees), so 15/17/18–24 (camera-driven preview smokes) cannot run here. Step 18 confirmed standalone with the same error.
  - Closest focused gates run standalone instead: **step 16 `smoke:live-layout-switch-recording` PASS** (synthetic record + record-and-stream artifacts, RTMP listener received 915 KB) — exercises the real startup barrier through the app; `smoke:dev` PASS (above).
  - Step 25 `smoke:screen-recording-real` fails standalone **before recording starts** in the harness: `real-source baseline failed: preview.surface.create failed: This backend method is restricted to Electron main.` — a backend-authority role check this PR does not touch.
  - Run 1 (cold cache) timed out at step 10 compiling the native preview addon inside the 240s launch budget; run 2 (warm) passed steps 1–11 and hit a load flake at step 12 (`[Screen + camera]` 1.43s/2.00s: "FFmpeg did not stop promptly after stdin quit command; sending SIGTERM" — the session's health log shows `recording-startup-barrier-ready` 467ms, no retry/unsteady), which passed cleanly standalone and in run 3.

Not done here (plan B0 item 4b): the new *startup-under-load* smoke — worth its own slice once the owner confirms the by-eye behaviour.

