### PR TITLE
fix(audio): honest mixer levels, real ballistics, no idle mic analyser without Monitor input

### DIFF
--- a/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
@@ -5,6 +5,9 @@ import { PanelSection } from '@/components/panel-section'
 import { StatusBadge } from '@/components/status-badge'
 import { BarVisualizer, paintBarVisualizer } from '@/components/ui/bar-visualizer'
 import { Button } from '@/components/ui/button'
+import { Kbd } from '@/components/ui/kbd'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { useWorkspaceNav } from '@/components/workspace-nav'
 import { useStudioAudio, useStudioCore, useStudioDiagnostics } from '@/hooks/use-studio'
 import {
@@ -15,6 +18,11 @@ import {
 import type { AudioMeterStatus } from '@/lib/backend'
 import { formatDb } from '@/lib/format'
 import { resampleMicVisualLevelsInto } from '@/lib/mic-visual-frame'
+import {
+  audioMixerMonitorLabel,
+  audioMixerMonitorWhenIdle,
+  withAudioMixerMonitorWhenIdle
+} from '@/lib/mic-visual-gate'
 import { advanceClipHoldDeadline, fallbackBandLevels } from '@/lib/mic-meter'
 import { systemAccessAction, systemAccessRows, type SystemAccessAction } from '@/lib/system-access'
 import { cn } from '@/lib/utils'
@@ -41,15 +49,19 @@ export function audioMixerSignalLive(
 
 /**
  * Audio mixer (SD4 + post-0.9.4 fix F7 + 2026-07-10 live-meter fix + Studio
- * audio ElevenLabs rework S3). The VISUAL is a multi-band bar visualizer over
- * the shared renderer mic pipeline at display rate. The provider's WebAudio
- * frame also supplies the peak-dB label and clip hold. The
- * backend stays the capture/health authority: its 1 Hz `micLiveLevel` and the
- * on-demand 700 ms "Check level" sample drive a deterministic coarse-band
- * fallback whenever the analyser cannot open the selected device. The stream
- * releases while the document is hidden (idle-CPU discipline). System audio
- * shows its honest "unavailable — pending native adapter" state; real capture
- * is Phase-2 (F3).
+ * audio ElevenLabs rework S3 + live feedback batch 3 B2). The VISUAL is a
+ * multi-band bar visualizer over the shared renderer mic pipeline at display
+ * rate: per-band dBFS over -60..0, gated at -55, 15 ms attack / 350 ms decay.
+ * The provider's WebAudio frame also supplies the peak-dB label and clip
+ * hold. The backend stays the capture/health authority: its 1 Hz
+ * `micLiveLevel` and the on-demand 700 ms "Check level" sample drive a
+ * deterministic coarse-band fallback (same dBFS scale) whenever the analyser
+ * cannot open the selected device. The analyser is armed by a running
+ * session or by the persisted "Monitor input" toggle (M); an idle Studio with
+ * monitoring off never opens the microphone, so the bars sit at floor and
+ * the OS shows no mic indicator. The stream also releases while the document
+ * is hidden (idle-CPU discipline). System audio shows its honest
+ * "unavailable — pending native adapter" state; real capture is Phase-2 (F3).
  */
 export function AudioMixer(): ReactElement {
   const {
@@ -60,7 +72,10 @@ export function AudioMixer(): ReactElement {
     deviceList,
     handleSystemPermission,
     mediaAccess,
-    runtimeInfo
+    runtimeInfo,
+    isSessionActive,
+    settings,
+    setSettings
   } = useStudioCore()
   const { audioMeter, audioMeterLoading } = useStudioAudio()
   const { diagnosticStats } = useStudioDiagnostics()
@@ -109,6 +124,12 @@ export function AudioMixer(): ReactElement {
   )
   const analyserDriven = micVisual.active && !muted
   const signalLive = audioMixerSignalLive(muted, micVisual.active, liveLevel)
+  const monitorWhenIdle = audioMixerMonitorWhenIdle(settings)
+  const monitorLabel = audioMixerMonitorLabel({ sessionActive: isSessionActive, signalLive })
+  // The M shortcut lives in StudioMicVisualProvider (one home for Studio and
+  // Sources); this switch is the pointer surface for the same setting.
+  const setMonitorWhenIdle = (next: boolean): void =>
+    setSettings((current) => withAudioMixerMonitorWhenIdle(current, next))
   const fallbackLevels = fallbackBandLevels(
     muted || !selectedMicrophone ? 0 : level,
     MIXER_BAR_COUNT
@@ -171,20 +192,48 @@ export function AudioMixer(): ReactElement {
             fallbackLevels={fallbackLevels}
             meterTone={meterTone}
           />
-          {signalLive ? (
-            <span className="shrink-0 text-xs text-muted-foreground">Live</span>
-          ) : (
-            <Button
-              className="shrink-0"
-              disabled={!selectedMicrophone || audioMeterLoading}
-              size="xs"
-              variant="outline"
-              onClick={() => void sampleAudioMeter()}
-            >
-              {audioMeterLoading ? 'Checking…' : 'Check level'}
-            </Button>
-          )}
+          <span
+            className={cn(
+              'min-w-16 shrink-0 text-right text-xs',
+              signalLive ? 'text-muted-foreground' : 'text-muted-foreground/60'
+            )}
+            data-videorc-mic-monitor-state={monitorLabel.toLowerCase()}
+          >
+            {monitorLabel}
+          </span>
         </div>
+        {/* Idle only: a session arms the meter by itself, so the toggle has
+            nothing to say while one runs. "Check level" stays as the
+            backend's one-shot reading for people who keep monitoring off. */}
+        {!isSessionActive ? (
+          <div className="flex items-center justify-between gap-2">
+            <Label
+              className="gap-2 text-xs font-normal text-muted-foreground"
+              htmlFor="audio-mixer-monitor-input"
+            >
+              <Switch
+                checked={monitorWhenIdle}
+                disabled={!selectedMicrophone}
+                id="audio-mixer-monitor-input"
+                size="sm"
+                onCheckedChange={setMonitorWhenIdle}
+              />
+              Monitor input
+              <Kbd>M</Kbd>
+            </Label>
+            {!signalLive ? (
+              <Button
+                className="shrink-0"
+                disabled={!selectedMicrophone || audioMeterLoading}
+                size="xs"
+                variant="outline"
+                onClick={() => void sampleAudioMeter()}
+              >
+                {audioMeterLoading ? 'Checking…' : 'Check level'}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
         {notice === 'permission' ? (
           <div className="flex items-center justify-between gap-2 text-xs text-warning">
             <span>Microphone permission is required before levels can be read.</span>

--- a/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
@@ -1,10 +1,14 @@
 import { useRef, type ReactElement, type RefObject } from 'react'
 
+import { Button } from '@/components/ui/button'
+import { Kbd } from '@/components/ui/kbd'
 import { LiveWaveform, type LiveWaveformHandle } from '@/components/ui/live-waveform'
+import { useStudioCore } from '@/hooks/use-studio'
 import {
   useStudioMicVisualLifecycle,
   useStudioMicVisualPainter
 } from '@/hooks/use-studio-mic-visual'
+import { audioMixerMonitorWhenIdle, withAudioMixerMonitorWhenIdle } from '@/lib/mic-visual-gate'
 
 /**
  * See-before-you-pick mic preview (Studio audio rework S4): a scrolling live
@@ -13,6 +17,8 @@ import {
  * (Quick Settings popover, Sources panel). The workspace provider owns the
  * sole stream, analyser, and frame clock; this surface only paints its rolling
  * snapshots. Failures show an honest inline reason, never a fake wave or toast.
+ * While no session runs the analyser only opens with "Monitor input" on
+ * (live feedback batch 3, B2), so the idle line offers that toggle inline.
  */
 export function MicPickerPreview({
   deviceName
@@ -21,9 +27,15 @@ export function MicPickerPreview({
   deviceName: string | undefined
 }): ReactElement {
   const lifecycle = useStudioMicVisualLifecycle()
+  const { captureConfig, isSessionActive, settings, setSettings } = useStudioCore()
   const waveformRef = useRef<LiveWaveformHandle>(null)
   useMicPickerFramePainter(waveformRef)
   const enabled = Boolean(deviceName)
+  const monitoringOff =
+    enabled &&
+    !isSessionActive &&
+    !captureConfig.audio.microphoneMuted &&
+    !audioMixerMonitorWhenIdle(settings)
 
   return (
     <div className="flex flex-col gap-1" data-videorc-mic-preview>
@@ -42,6 +54,19 @@ export function MicPickerPreview({
         <span className="text-xs text-muted-foreground">
           Live preview unavailable — the mic may be in use or needs permission. Recording is
           unaffected.
+        </span>
+      ) : monitoringOff ? (
+        <span className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span>Input monitoring is off while idle.</span>
+          <Button
+            className="shrink-0"
+            size="xs"
+            variant="ghost"
+            onClick={() => setSettings((current) => withAudioMixerMonitorWhenIdle(current, true))}
+          >
+            Monitor input
+            <Kbd>M</Kbd>
+          </Button>
         </span>
       ) : null}
     </div>

--- a/apps/desktop/src/renderer/src/hooks/studio-mic-visual-provider.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-mic-visual-provider.test.ts
@@ -2,14 +2,35 @@ import { StrictMode, act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const providerState = vi.hoisted(() => ({ microphoneMuted: false }))
+// Existing lifecycle cases run with idle monitoring ON so the gate is not
+// what they exercise; the gate cases below flip these explicitly.
+const providerState = vi.hoisted(() => ({
+  microphoneMuted: false,
+  sessionActive: false,
+  monitorWhenIdle: true,
+  setSettingsCalls: 0
+}))
 
 vi.mock('@/hooks/use-document-visible', () => ({ useDocumentVisible: () => true }))
 vi.mock('@/hooks/use-studio', () => ({
   useStudioCore: () => ({
     captureConfig: { audio: { microphoneMuted: providerState.microphoneMuted } },
     mediaAccess: { microphone: 'granted' },
-    selectedMicrophone: { id: 'backend-mic-1', name: 'Studio microphone' }
+    selectedMicrophone: { id: 'backend-mic-1', name: 'Studio microphone' },
+    isSessionActive: providerState.sessionActive,
+    settings: { audioMixer: { monitorWhenIdle: providerState.monitorWhenIdle } },
+    setSettings: (
+      update:
+        | { audioMixer?: { monitorWhenIdle?: boolean } }
+        | ((current: { audioMixer?: { monitorWhenIdle?: boolean } }) => {
+            audioMixer?: { monitorWhenIdle?: boolean }
+          })
+    ) => {
+      providerState.setSettingsCalls += 1
+      const current = { audioMixer: { monitorWhenIdle: providerState.monitorWhenIdle } }
+      const next = typeof update === 'function' ? update(current) : update
+      providerState.monitorWhenIdle = next.audioMixer?.monitorWhenIdle === true
+    }
   })
 }))
 
@@ -42,6 +63,118 @@ describe('StudioMicVisualProvider', () => {
     restoreEnvironment?.()
     restoreEnvironment = undefined
     providerState.microphoneMuted = false
+    providerState.sessionActive = false
+    providerState.monitorWhenIdle = true
+    providerState.setSettingsCalls = 0
+  })
+
+  it('keeps the microphone closed while idle and arms it for a session automatically', async () => {
+    const environment = installBrowserAudioEnvironment()
+    restoreEnvironment = environment.restore
+    const lifecycleStates: boolean[] = []
+    providerState.monitorWhenIdle = false
+    const renderProvider = async (): Promise<void> => {
+      await act(async () => {
+        root?.render(
+          createElement(
+            StrictMode,
+            null,
+            createElement(StudioMicVisualProvider, {
+              enabled: true,
+              children: createElement(VisualConsumer, {
+                onLifecycle: (active) => lifecycleStates.push(active)
+              })
+            })
+          )
+        )
+        await import('../lib/browser-mic-visual-pipeline')
+        await Promise.resolve()
+      })
+    }
+
+    // Idle Studio, monitoring off: no getUserMedia, no AudioContext, no clock —
+    // the OS shows no mic indicator and the bars sit at floor.
+    root = createRoot(environment.container)
+    await renderProvider()
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(environment.getUserMedia).not.toHaveBeenCalled()
+    expect(environment.contexts).toHaveLength(0)
+    expect(environment.scheduledFrames.size).toBe(0)
+    expect(lifecycleStates.at(-1)).toBe(false)
+
+    // A session starts (recording or streaming): the meter arms itself.
+    providerState.sessionActive = true
+    await renderProvider()
+    await vi.waitFor(() => expect(environment.contexts).toHaveLength(1))
+    expect(environment.getUserMedia).toHaveBeenCalledTimes(1)
+    expect(environment.scheduledFrames.size).toBe(1)
+    expect(lifecycleStates.at(-1)).toBe(true)
+
+    // Session ends with monitoring still off: the microphone is released.
+    providerState.sessionActive = false
+    await renderProvider()
+    await vi.waitFor(() => expect(environment.contexts[0].close).toHaveBeenCalledTimes(1))
+    expect(environment.stopTrack).toHaveBeenCalledTimes(1)
+    expect(environment.scheduledFrames.size).toBe(0)
+    expect(lifecycleStates.at(-1)).toBe(false)
+
+    // Monitor input on (the M shortcut flips the persisted setting): idle
+    // monitoring opens the analyser again.
+    environment.pressKey('m')
+    expect(providerState.setSettingsCalls).toBe(1)
+    expect(providerState.monitorWhenIdle).toBe(true)
+    await renderProvider()
+    await vi.waitFor(() => expect(environment.contexts).toHaveLength(2))
+    expect(environment.getUserMedia).toHaveBeenCalledTimes(2)
+    expect(lifecycleStates.at(-1)).toBe(true)
+  })
+
+  it('ignores the M shortcut while a session runs and inside editable fields', async () => {
+    const environment = installBrowserAudioEnvironment()
+    restoreEnvironment = environment.restore
+    providerState.monitorWhenIdle = false
+    providerState.sessionActive = true
+    root = createRoot(environment.container)
+    await act(async () => {
+      root?.render(
+        createElement(
+          StrictMode,
+          null,
+          createElement(StudioMicVisualProvider, {
+            enabled: true,
+            children: createElement(LifecycleObserver)
+          })
+        )
+      )
+      await Promise.resolve()
+    })
+    environment.pressKey('m')
+    expect(providerState.setSettingsCalls).toBe(0)
+
+    providerState.sessionActive = false
+    await act(async () => {
+      root?.render(
+        createElement(
+          StrictMode,
+          null,
+          createElement(StudioMicVisualProvider, {
+            enabled: true,
+            children: createElement(LifecycleObserver)
+          })
+        )
+      )
+      await Promise.resolve()
+    })
+    environment.pressKey('m', { editable: true })
+    environment.pressKey('m', { metaKey: true })
+    environment.pressKey('m', { repeat: true })
+    expect(providerState.setSettingsCalls).toBe(0)
+    environment.pressKey('M')
+    expect(providerState.setSettingsCalls).toBe(1)
+    expect(providerState.monitorWhenIdle).toBe(true)
   })
 
   it('tears down visual microphone resources and stops reporting live when muted', async () => {
@@ -138,9 +271,24 @@ function installBrowserAudioEnvironment(): {
   scheduledFrames: Map<number, FrameRequestCallback>
   getUserMedia: ReturnType<typeof vi.fn>
   stopTrack: ReturnType<typeof vi.fn>
+  /** Dispatch a document keydown the way the M shortcut listener sees it. */
+  pressKey: (
+    key: string,
+    options?: { editable?: boolean; metaKey?: boolean; repeat?: boolean }
+  ) => void
   restore: () => void
 } {
-  class FakeElement {}
+  class FakeElement {
+    closest(): FakeElement | null {
+      return null
+    }
+  }
+  class FakeInputElement extends FakeElement {
+    closest(): FakeElement {
+      return this
+    }
+  }
+  const documentTarget = new EventTarget()
   const contexts: Array<{ close: ReturnType<typeof vi.fn> }> = []
   const scheduledFrames = new Map<number, FrameRequestCallback>()
   const stopTrack = vi.fn()
@@ -172,8 +320,9 @@ function installBrowserAudioEnvironment(): {
     body: {},
     hidden: false,
     visibilityState: 'visible',
-    addEventListener: () => {},
-    removeEventListener: () => {}
+    addEventListener: documentTarget.addEventListener.bind(documentTarget),
+    removeEventListener: documentTarget.removeEventListener.bind(documentTarget),
+    dispatchEvent: documentTarget.dispatchEvent.bind(documentTarget)
   }
   const container = {
     nodeType: 1,
@@ -215,12 +364,17 @@ function installBrowserAudioEnvironment(): {
     }
   }
   const descriptors = new Map(
-    ['window', 'document', 'navigator', 'AudioContext', 'IS_REACT_ACT_ENVIRONMENT'].map((name) => [
-      name,
-      Object.getOwnPropertyDescriptor(globalThis, name)
-    ])
+    [
+      'window',
+      'document',
+      'navigator',
+      'AudioContext',
+      'HTMLElement',
+      'IS_REACT_ACT_ENVIRONMENT'
+    ].map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)])
   )
   Object.defineProperty(globalThis, 'window', { configurable: true, value: fakeWindow })
+  Object.defineProperty(globalThis, 'HTMLElement', { configurable: true, value: FakeElement })
   Object.defineProperty(globalThis, 'document', { configurable: true, value: fakeDocument })
   Object.defineProperty(globalThis, 'navigator', {
     configurable: true,
@@ -248,6 +402,25 @@ function installBrowserAudioEnvironment(): {
     scheduledFrames,
     getUserMedia,
     stopTrack,
+    pressKey: (key, options = {}) => {
+      const event = new Event('keydown', { cancelable: true }) as Event & {
+        key: string
+        metaKey: boolean
+        ctrlKey: boolean
+        altKey: boolean
+        repeat: boolean
+      }
+      Object.assign(event, {
+        key,
+        metaKey: options.metaKey === true,
+        ctrlKey: false,
+        altKey: false,
+        repeat: options.repeat === true
+      })
+      const target = options.editable ? new FakeInputElement() : new FakeElement()
+      Object.defineProperty(event, 'target', { value: target })
+      documentTarget.dispatchEvent(event)
+    },
     restore: () => {
       for (const [name, descriptor] of descriptors) {
         if (descriptor) Object.defineProperty(globalThis, name, descriptor)

--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -36,6 +36,11 @@ import type {
 } from '../../../shared/backend'
 import { BackgroundAssetsProvider } from './use-background-assets'
 import {
+  StudioMicVisualProvider,
+  useStudioMicVisualLifecycle,
+  useStudioMicVisualPainter
+} from './use-studio-mic-visual'
+import {
   StudioProvider,
   buildStreamOutputTopologyProbeParams,
   resolvedStreamingProfileEntitlementGate,
@@ -849,6 +854,14 @@ type StudioObservation = {
   chat: ReturnType<typeof useStudioChat>
   core: StudioCoreContextValue
   recording: StudioRecordingContextValue
+}
+
+/** A mixer-like consumer: paints frames (which retains analyser demand) and reports lifecycle. */
+function MicVisualProbe({ observe }: { observe: (active: boolean) => void }): null {
+  useStudioMicVisualPainter(() => undefined)
+  const lifecycle = useStudioMicVisualLifecycle()
+  useEffect(() => observe(lifecycle.active), [lifecycle.active, observe])
+  return null
 }
 
 function Probe({ observe }: { observe: (value: StudioObservation) => void }): null {
@@ -4210,7 +4223,191 @@ describe('real StudioProvider lifecycle', () => {
     expect(acknowledgedProviderCallbacks).toEqual([])
     expect(await api.getPendingOAuthCallbacks()).toEqual(pendingProviderCallbacks)
   })
+
+  it('arms the visual mic meter for a session and never opens the mic while idle', async () => {
+    // Live feedback batch 3, B2: the owner saw the mixer react while not
+    // recording. With Monitor input at its default (off), an idle Studio must
+    // not touch getUserMedia; starting a session arms the analyser by itself;
+    // stopping releases it again.
+    const backend = new StudioBackend()
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      platform: 'darwin',
+      getMediaAccessStatus: async () => ({ camera: 'granted', microphone: 'granted' })
+    })
+    const testDom = installProviderTestEnvironment(api)
+    const audio = installVisualMicAudioEnvironment()
+    restoreEnvironment = () => {
+      audio.restore()
+      testDom.restore()
+    }
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+    const micLifecycle: boolean[] = []
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(StudioMicVisualProvider, {
+              enabled: true,
+              children: [
+                createElement(Probe, {
+                  key: 'studio',
+                  observe: (value) => {
+                    observations.push(value)
+                  }
+                }),
+                createElement(MicVisualProbe, {
+                  key: 'mic',
+                  observe: (active) => {
+                    micLifecycle.push(active)
+                  }
+                })
+              ]
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.core.mediaAccess?.microphone === 'granted' &&
+        latest()?.core.selectedMicrophone?.id === 'mic:1'
+    )
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+    expect(latest()?.core.isSessionActive).toBe(false)
+    expect(latest()?.core.settings.audioMixer?.monitorWhenIdle).toBe(false)
+    expect(audio.getUserMedia).not.toHaveBeenCalled()
+    expect(audio.contexts).toHaveLength(0)
+    expect(micLifecycle.at(-1)).toBe(false)
+
+    await act(async () => {
+      await latest()?.core.startSession()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'recording')
+    await waitForObservation(() => micLifecycle.at(-1) === true)
+    expect(audio.getUserMedia).toHaveBeenCalledTimes(1)
+    expect(audio.getUserMedia.mock.calls[0]?.[0]).toMatchObject({
+      audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+      video: false
+    })
+    expect(audio.contexts).toHaveLength(1)
+
+    await act(async () => {
+      await latest()?.core.stopSession()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'idle')
+    await waitForObservation(() => micLifecycle.at(-1) === false)
+    expect(audio.contexts[0]?.close).toHaveBeenCalledTimes(1)
+    expect(audio.stopTrack).toHaveBeenCalledTimes(1)
+    expect(audio.getUserMedia).toHaveBeenCalledTimes(1)
+  }, 15_000)
 })
+
+/**
+ * navigator.mediaDevices + AudioContext fakes for the visual mic pipeline,
+ * layered over installProviderTestEnvironment (which supplies window/document).
+ */
+function installVisualMicAudioEnvironment(): {
+  contexts: Array<{ close: ReturnType<typeof vi.fn> }>
+  getUserMedia: ReturnType<typeof vi.fn>
+  stopTrack: ReturnType<typeof vi.fn>
+  restore: () => void
+} {
+  const contexts: Array<{ close: ReturnType<typeof vi.fn> }> = []
+  const stopTrack = vi.fn()
+  const getUserMedia = vi.fn(async () => ({ getTracks: () => [{ stop: stopTrack }] }))
+  class FakeAudioContext {
+    sampleRate = 48_000
+    close = vi.fn(async () => undefined)
+
+    constructor() {
+      contexts.push(this)
+    }
+
+    createAnalyser(): {
+      fftSize: number
+      frequencyBinCount: number
+      smoothingTimeConstant: number
+      getFloatFrequencyData: (samples: Float32Array) => void
+      getFloatTimeDomainData: (samples: Float32Array) => void
+    } {
+      return {
+        fftSize: 2048,
+        frequencyBinCount: 1024,
+        smoothingTimeConstant: 0,
+        getFloatFrequencyData: (samples) => samples.fill(Number.NEGATIVE_INFINITY),
+        getFloatTimeDomainData: (samples) => samples.fill(0)
+      }
+    }
+
+    createMediaStreamSource(): { connect: () => void; disconnect: () => void } {
+      return { connect: () => {}, disconnect: () => {} }
+    }
+  }
+  const descriptors = new Map(
+    ['navigator', 'AudioContext'].map((name) => [
+      name,
+      Object.getOwnPropertyDescriptor(globalThis, name)
+    ])
+  )
+  // The analyser clock is a held frame queue here: lifecycle (open/close) is
+  // what this environment proves, and the provider env's rAF-as-setTimeout(0)
+  // would spin the sampler at `at = 0` forever.
+  const fakeWindow = window as unknown as Record<string, unknown>
+  const previousRequestFrame = fakeWindow.requestAnimationFrame
+  const previousCancelFrame = fakeWindow.cancelAnimationFrame
+  const heldFrames = new Map<number, FrameRequestCallback>()
+  let nextFrameId = 0
+  fakeWindow.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    const id = ++nextFrameId
+    heldFrames.set(id, callback)
+    return id
+  }
+  fakeWindow.cancelAnimationFrame = (id: number): void => void heldFrames.delete(id)
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      mediaDevices: {
+        enumerateDevices: async () => [
+          { kind: 'audioinput', deviceId: 'mic-1', label: 'Microphone 1' }
+        ],
+        getUserMedia
+      }
+    }
+  })
+  Object.defineProperty(globalThis, 'AudioContext', {
+    configurable: true,
+    value: FakeAudioContext
+  })
+  return {
+    contexts,
+    getUserMedia,
+    stopTrack,
+    restore: () => {
+      fakeWindow.requestAnimationFrame = previousRequestFrame
+      fakeWindow.cancelAnimationFrame = previousCancelFrame
+      for (const [name, descriptor] of descriptors) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+        else Reflect.deleteProperty(globalThis, name)
+      }
+    }
+  }
+}
 
 function createVideorcApi(options: {
   pending: () => Promise<AccountCallbackEnvelope[]>

--- a/apps/desktop/src/renderer/src/hooks/use-studio-mic-visual.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio-mic-visual.tsx
@@ -11,6 +11,12 @@ import {
 
 import { useDocumentVisible } from '@/hooks/use-document-visible'
 import { useStudioCore } from '@/hooks/use-studio'
+import { isEditableTarget } from '@/lib/format'
+import {
+  audioMixerMonitorWhenIdle,
+  micVisualAnalyserEnabled,
+  withAudioMixerMonitorWhenIdle
+} from '@/lib/mic-visual-gate'
 import { createMicVisualFrameBuffer, type MicVisualFrameBuffer } from '@/lib/mic-visual-frame'
 import type {
   MicVisualLifecycleSnapshot,
@@ -20,6 +26,8 @@ import type {
 
 const StudioMicVisualContext = createContext<MicVisualPipeline | undefined>(undefined)
 const PEAK_LABEL_INTERVAL_MS = 250
+/** Single-key toggle for "Monitor input" (SHORTCUTS id `mic-monitor`). */
+const MONITOR_INPUT_KEY = 'm'
 const IDLE_LIFECYCLE: MicVisualLifecycleSnapshot = Object.freeze({
   status: 'idle',
   active: false
@@ -52,7 +60,10 @@ const IDLE_PIPELINE: MicVisualPipeline = Object.freeze({
 /**
  * Workspace-scoped owner for renderer microphone visuals. The backend remains
  * the recording/health authority; this provider opens one visual-only browser
- * stream only while Studio/Sources is visible and OS access is already granted.
+ * stream only while Studio/Sources is visible, OS access is already granted,
+ * and the meter is armed — by a running session, or by the persisted
+ * "Monitor input" setting while idle (micVisualAnalyserEnabled). An idle
+ * Studio with monitoring off never opens the microphone.
  */
 export function StudioMicVisualProvider({
   enabled,
@@ -61,7 +72,8 @@ export function StudioMicVisualProvider({
   enabled: boolean
   children: ReactNode
 }): ReactElement {
-  const { captureConfig, selectedMicrophone, mediaAccess } = useStudioCore()
+  const { captureConfig, selectedMicrophone, mediaAccess, isSessionActive, settings, setSettings } =
+    useStudioCore()
   const documentVisible = useDocumentVisible()
   const [pipeline, setPipeline] = useState<MicVisualPipeline | null>(null)
   const selectionKey = selectedMicrophone?.id
@@ -71,9 +83,16 @@ export function StudioMicVisualProvider({
     selectionKey,
     deviceName,
     permissionStatus,
-    enabled:
-      enabled && documentVisible && Boolean(selectionKey) && !captureConfig.audio.microphoneMuted
+    enabled: micVisualAnalyserEnabled({
+      workspaceVisible: enabled,
+      documentVisible,
+      microphoneSelected: Boolean(selectionKey),
+      muted: captureConfig.audio.microphoneMuted,
+      sessionActive: isSessionActive,
+      monitorWhenIdle: audioMixerMonitorWhenIdle(settings)
+    })
   }
+  useMonitorInputShortcut(enabled && Boolean(selectionKey) && !isSessionActive, setSettings)
 
   useEffect(() => {
     if (pipeline || !source.enabled) {
@@ -100,6 +119,37 @@ export function StudioMicVisualProvider({
       {children}
     </MicVisualPipelineProvider>
   )
+}
+
+/**
+ * M toggles "Monitor input" while Studio/Sources is on screen and no session
+ * runs (plain key, outside editable targets — same discipline as the D theme
+ * toggle and the Space session toggle). One home for both tabs; the mixer's
+ * switch and the picker's hint are the pointer surfaces of the same setting.
+ */
+function useMonitorInputShortcut(
+  armed: boolean,
+  setSettings: ReturnType<typeof useStudioCore>['setSettings']
+): void {
+  useEffect(() => {
+    if (!armed) {
+      return
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (event.key.toLowerCase() !== MONITOR_INPUT_KEY || isEditableTarget(event.target)) {
+        return
+      }
+      event.preventDefault()
+      setSettings((current) =>
+        withAudioMixerMonitorWhenIdle(current, !audioMixerMonitorWhenIdle(current))
+      )
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [armed, setSettings])
 }
 
 /** Public provider boundary used by the workspace and lifecycle integration tests. */

--- a/apps/desktop/src/renderer/src/lib/capture.ts
+++ b/apps/desktop/src/renderer/src/lib/capture.ts
@@ -48,6 +48,15 @@ export type SettingsState = {
    * the glide's interplay with idle camera restarts settles in the field.
    */
   animateSceneChanges?: boolean
+  /**
+   * Audio mixer (live feedback batch 3, B2). `monitorWhenIdle` keeps the
+   * visual-only analyser open while NO session runs; default OFF so an idle
+   * Studio never holds the microphone (no OS mic indicator) and the bars sit
+   * at floor. A running session always arms the meter regardless.
+   */
+  audioMixer?: {
+    monitorWhenIdle?: boolean
+  }
 }
 
 export type CaptionBurnTarget = 'off' | 'stream' | 'recording' | 'both'
@@ -326,7 +335,8 @@ export const defaultSettings: SettingsState = {
   outputDirectory: '',
   outputDirectoryHandle: undefined,
   keepOriginalRecording: false,
-  animateSceneChanges: false
+  animateSceneChanges: false,
+  audioMixer: { monitorWhenIdle: false }
 }
 
 export const rtmpDefaults: Record<RtmpPreset, string> = {

--- a/apps/desktop/src/renderer/src/lib/mic-meter.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-meter.test.ts
@@ -6,11 +6,15 @@ import {
   MIC_CLIP_HOLD_MS,
   MIC_CLIP_THRESHOLD_DB,
   MIC_METER_FLOOR_DB,
+  MIC_METER_GATE_DB,
   advanceClipHoldDeadline,
   advanceMeterBallistics,
   amplitudeToDb,
+  approachMeterLevel,
   dbToMeterLevel,
   fallbackBandLevels,
+  gateMeterLevel,
+  gatedDbToMeterLevel,
   matchMicrophoneDeviceId,
   samplesRmsAndPeak
 } from './mic-meter'
@@ -30,6 +34,49 @@ describe('mic meter math', () => {
     expect(dbToMeterLevel(0)).toBe(1)
     expect(dbToMeterLevel(MIC_METER_FLOOR_DB)).toBe(0)
     expect(dbToMeterLevel(-30)).toBeCloseTo(0.5, 5)
+  })
+
+  it('gates room tone to the floor and leaves the dBFS window above it untouched', () => {
+    expect(gatedDbToMeterLevel(0)).toBe(1)
+    expect(gatedDbToMeterLevel(-30)).toBeCloseTo(0.5, 5)
+    expect(gatedDbToMeterLevel(MIC_METER_GATE_DB)).toBeCloseTo(dbToMeterLevel(-55), 5)
+    // -70 dBFS room tone (the old mapping painted it as a 63 % bar) → floor.
+    expect(gatedDbToMeterLevel(-70)).toBe(0)
+    expect(gatedDbToMeterLevel(-56)).toBe(0)
+    expect(gatedDbToMeterLevel(MIC_METER_FLOOR_DB)).toBe(0)
+    expect(gatedDbToMeterLevel(Number.NEGATIVE_INFINITY)).toBe(0)
+    expect(gatedDbToMeterLevel(Number.NaN)).toBe(0)
+    // The same gate on an already-mapped backend level (audio.rs db_to_level).
+    expect(gateMeterLevel(dbToMeterLevel(-70))).toBe(0)
+    expect(gateMeterLevel(dbToMeterLevel(-56))).toBe(0)
+    expect(gateMeterLevel(dbToMeterLevel(-54))).toBeCloseTo(dbToMeterLevel(-54), 5)
+    expect(gateMeterLevel(1.5)).toBe(1)
+  })
+
+  it('approaches a target asymmetrically across the 48 ms analyser ticks', () => {
+    // Attack: one tick with the 15 ms tau is essentially there.
+    const risen = approachMeterLevel(0, 1, 48)
+    expect(risen).toBeGreaterThan(0.95)
+    expect(risen).toBeLessThanOrEqual(1)
+
+    // Decay: the 350 ms tau needs several ticks — the bar falls, it does not snap.
+    const decay: number[] = [risen]
+    for (let tick = 0; tick < 8; tick += 1) {
+      decay.push(approachMeterLevel(decay[decay.length - 1], 0, 48))
+    }
+    expect(decay[1]).toBeGreaterThan(0.8)
+    expect(decay[1]).toBeLessThan(decay[0])
+    for (let index = 1; index < decay.length; index += 1) {
+      expect(decay[index]).toBeLessThan(decay[index - 1])
+    }
+    // ~350 ms later (7 ticks) the bar is near e^-1 of where it started.
+    expect(decay[7]).toBeGreaterThan(0.3)
+    expect(decay[7]).toBeLessThan(0.45)
+    // Same distance, opposite direction, same elapsed: the rise is far larger.
+    expect(1 - approachMeterLevel(0, 1, 48)).toBeLessThan(approachMeterLevel(1, 0, 48) / 10)
+    // Out-of-range targets clamp; a zero tau snaps.
+    expect(approachMeterLevel(0, 2, 1000)).toBeLessThanOrEqual(1)
+    expect(approachMeterLevel(0.5, 1, 16, { ...DEFAULT_METER_BALLISTICS, attackMs: 0 })).toBe(1)
   })
 
   it('rises fast on attack and falls slower on decay', () => {
@@ -100,5 +147,12 @@ describe('fallback band levels', () => {
     expect(fallbackBandLevels(2, 1)).toEqual([1])
     expect(fallbackBandLevels(-1, 3)).toEqual([0, 0, 0])
     expect(fallbackBandLevels(0.5, 0)).toEqual([])
+  })
+
+  it('shares the analyser gate so a swap between paths never jumps in height', () => {
+    // Backend micLiveLevel for -70 dBFS room tone = (−70+60)/60 → 0 already;
+    // -57 dBFS = 0.05 would have painted a sliver the analyser no longer does.
+    expect(fallbackBandLevels(dbToMeterLevel(-57), 5)).toEqual([0, 0, 0, 0, 0])
+    expect(fallbackBandLevels(dbToMeterLevel(-40), 5)[2]).toBeCloseTo(gatedDbToMeterLevel(-40), 5)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/mic-meter.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-meter.ts
@@ -4,6 +4,13 @@
 // The WebAudio side lives in hooks/use-mic-level-meter.ts.
 
 export const MIC_METER_FLOOR_DB = -60
+/**
+ * Noise gate for every VISUAL meter path (analyser bands and the coarse
+ * fallback hump): room tone sits around -70..-55 dBFS on an ungated input and
+ * must paint as silence, not as a third of a bar. Below this the bar is at
+ * floor; at/above it the dBFS → level mapping is untouched.
+ */
+export const MIC_METER_GATE_DB = -55
 
 export function samplesRmsAndPeak(samples: Float32Array): { rms: number; peak: number } {
   if (samples.length === 0) {
@@ -31,6 +38,28 @@ export function amplitudeToDb(amplitude: number): number {
 /** Linear-in-dB meter position over the floor..0 dBFS window, clamped to 0..1. */
 export function dbToMeterLevel(db: number, floorDb: number = MIC_METER_FLOOR_DB): number {
   return Math.min(1, Math.max(0, (db - floorDb) / -floorDb))
+}
+
+/** dBFS → meter level with the shared noise gate: below the gate reads as floor. */
+export function gatedDbToMeterLevel(
+  db: number,
+  gateDb: number = MIC_METER_GATE_DB,
+  floorDb: number = MIC_METER_FLOOR_DB
+): number {
+  if (!Number.isFinite(db) || db < gateDb) {
+    return 0
+  }
+  return dbToMeterLevel(db, floorDb)
+}
+
+/** Meter level (floor..0 dBFS, linear-in-dB) back through the shared gate. */
+export function gateMeterLevel(
+  level: number,
+  gateDb: number = MIC_METER_GATE_DB,
+  floorDb: number = MIC_METER_FLOOR_DB
+): number {
+  const clamped = Math.min(1, Math.max(0, level))
+  return clamped < dbToMeterLevel(gateDb, floorDb) ? 0 : clamped
 }
 
 export type MeterBallisticsState = {
@@ -71,6 +100,23 @@ function approach(current: number, target: number, elapsedMs: number, tauMs: num
   return current + (target - current) * (1 - Math.exp(-elapsedMs / tauMs))
 }
 
+/**
+ * Bar-only ballistics (no peak state, no allocation): fast attack toward a
+ * louder target, slow decay toward a quieter one. The analyser pipeline runs
+ * this per band on its 48 ms clock; advanceMeterBallistics layers peak hold on
+ * top of the same curve.
+ */
+export function approachMeterLevel(
+  current: number,
+  targetLevel: number,
+  elapsedMs: number,
+  options: MeterBallisticsOptions = DEFAULT_METER_BALLISTICS
+): number {
+  const target = Math.min(1, Math.max(0, targetLevel))
+  const rising = target > current
+  return approach(current, target, elapsedMs, rising ? options.attackMs : options.decayMs)
+}
+
 export function advanceMeterBallistics(
   state: MeterBallisticsState,
   targetLevel: number,
@@ -79,13 +125,7 @@ export function advanceMeterBallistics(
   options: MeterBallisticsOptions = DEFAULT_METER_BALLISTICS
 ): MeterBallisticsState {
   const target = Math.min(1, Math.max(0, targetLevel))
-  const rising = target > state.level
-  const level = approach(
-    state.level,
-    target,
-    elapsedMs,
-    rising ? options.attackMs : options.decayMs
-  )
+  const level = approachMeterLevel(state.level, target, elapsedMs, options)
 
   let peakLevel = state.peakLevel
   let peakHeldUntilMs = state.peakHeldUntilMs
@@ -152,12 +192,17 @@ export function advanceClipHoldDeadline(
  * Deterministic band heights for the coarse fallback meter paths (backend
  * 1 Hz level, on-demand sample): a center-weighted hump scaled by the real
  * level — never fake noise. The center band equals the level exactly.
+ *
+ * `level` is the backend's linear-in-dB meter position over -60..0 dBFS
+ * (audio.rs db_to_level) — the SAME scale the analyser bands use
+ * (gatedDbToMeterLevel), so a swap between the two paths changes only the
+ * spectral shape, never the height. The shared gate applies here too.
  */
 export function fallbackBandLevels(level: number, bands: number): number[] {
   if (bands <= 0) {
     return []
   }
-  const clamped = Math.min(1, Math.max(0, level))
+  const clamped = gateMeterLevel(level)
   const center = (bands - 1) / 2
   return Array.from({ length: bands }, (_, index) => {
     const distance = center === 0 ? 0 : Math.abs(index - center) / center

--- a/apps/desktop/src/renderer/src/lib/mic-stream.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-stream.test.ts
@@ -46,7 +46,17 @@ describe('createMicStreamController', () => {
     })
 
     await expect(controller.open('MacBook Pro Microphone')).resolves.toBe(stream)
-    expect(requested).toEqual([{ audio: { deviceId: { exact: 'mic-1' } }, video: false }])
+    expect(requested).toEqual([
+      {
+        audio: {
+          deviceId: { exact: 'mic-1' },
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: false
+        },
+        video: false
+      }
+    ])
   })
 
   it('falls back to the default input when the name cannot be matched', async () => {
@@ -61,7 +71,13 @@ describe('createMicStreamController', () => {
     })
 
     await expect(controller.open('Ghost Device')).resolves.toBe(stream)
-    expect(requested).toEqual([{ audio: true, video: false }])
+    // Processing stays off on the default input too: AGC would pump silence.
+    expect(requested).toEqual([
+      {
+        audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+        video: false
+      }
+    ])
   })
 
   it('resolves null without throwing when acquisition fails or media is missing', async () => {

--- a/apps/desktop/src/renderer/src/lib/mic-stream.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-stream.ts
@@ -13,8 +13,25 @@ type MicTrackLike = { stop: () => void }
 
 export type MicMediaStreamLike = { getTracks: () => MicTrackLike[] }
 
+/**
+ * Meter-stream processing is OFF: Chromium's defaults (echo cancellation,
+ * noise suppression, and especially auto gain control) pump room tone up to
+ * speech level in silence, so the bars would show a signal the recording
+ * never contains. The RECORDING path is the backend's own capture and is
+ * untouched by these constraints.
+ */
+export const MIC_METER_STREAM_PROCESSING = Object.freeze({
+  echoCancellation: false,
+  noiseSuppression: false,
+  autoGainControl: false
+})
+
+export type MicStreamAudioConstraints = typeof MIC_METER_STREAM_PROCESSING & {
+  deviceId?: { exact: string }
+}
+
 export type MicStreamConstraints = {
-  audio: { deviceId: { exact: string } } | true
+  audio: MicStreamAudioConstraints
   video: false
 }
 
@@ -71,7 +88,9 @@ export function createMicStreamController<S extends MicMediaStreamLike>(
         }
         const deviceId = matchMicrophoneDeviceId(deviceName, inputs)
         const stream = await media.getUserMedia({
-          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+          audio: deviceId
+            ? { ...MIC_METER_STREAM_PROCESSING, deviceId: { exact: deviceId } }
+            : { ...MIC_METER_STREAM_PROCESSING },
           video: false
         })
         if (closed) {

--- a/apps/desktop/src/renderer/src/lib/mic-visual-gate.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-visual-gate.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { STORAGE_KEYS, defaultSettings, loadJson } from './capture'
+import {
+  audioMixerMonitorLabel,
+  audioMixerMonitorWhenIdle,
+  micVisualAnalyserEnabled,
+  withAudioMixerMonitorWhenIdle,
+  type MicVisualGateInput
+} from './mic-visual-gate'
+
+const ON_SCREEN: MicVisualGateInput = {
+  workspaceVisible: true,
+  documentVisible: true,
+  microphoneSelected: true,
+  muted: false,
+  sessionActive: false,
+  monitorWhenIdle: false
+}
+
+describe('micVisualAnalyserEnabled', () => {
+  it('keeps the microphone closed in an idle Studio with monitoring off', () => {
+    // The owner's complaint: bars reacting while not recording. Default OFF.
+    expect(micVisualAnalyserEnabled(ON_SCREEN)).toBe(false)
+  })
+
+  it('arms the analyser for the whole session without touching the toggle', () => {
+    expect(micVisualAnalyserEnabled({ ...ON_SCREEN, sessionActive: true })).toBe(true)
+  })
+
+  it('opens the analyser while idle only when the user asked to monitor input', () => {
+    expect(micVisualAnalyserEnabled({ ...ON_SCREEN, monitorWhenIdle: true })).toBe(true)
+  })
+
+  it.each<[string, Partial<MicVisualGateInput>]>([
+    ['the workspace tab is elsewhere', { workspaceVisible: false }],
+    ['the document is hidden', { documentVisible: false }],
+    ['no microphone is selected', { microphoneSelected: false }],
+    ['the microphone is muted', { muted: true }]
+  ])('stays closed when %s even if armed', (_label, overrides) => {
+    const armed = { ...ON_SCREEN, sessionActive: true, monitorWhenIdle: true }
+    expect(micVisualAnalyserEnabled({ ...armed, ...overrides })).toBe(false)
+  })
+})
+
+describe('audioMixerMonitorLabel', () => {
+  it('says Live only for a running session with a live signal path', () => {
+    expect(audioMixerMonitorLabel({ sessionActive: true, signalLive: true })).toBe('Live')
+  })
+
+  it('says Monitoring for idle input monitoring that is actually delivering', () => {
+    expect(audioMixerMonitorLabel({ sessionActive: false, signalLive: true })).toBe('Monitoring')
+  })
+
+  it('says Idle whenever nothing is being read, armed or not', () => {
+    expect(audioMixerMonitorLabel({ sessionActive: false, signalLive: false })).toBe('Idle')
+    // Muted mid-session: the path is not live, and the label must not claim it.
+    expect(audioMixerMonitorLabel({ sessionActive: true, signalLive: false })).toBe('Idle')
+  })
+})
+
+describe('audioMixer.monitorWhenIdle persistence', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('defaults to off, including for settings persisted before the key existed', () => {
+    expect(audioMixerMonitorWhenIdle(defaultSettings)).toBe(false)
+    expect(audioMixerMonitorWhenIdle(undefined)).toBe(false)
+    expect(audioMixerMonitorWhenIdle({ audioMixer: {} })).toBe(false)
+    vi.stubGlobal('localStorage', {
+      getItem: () => JSON.stringify({ outputDirectory: '/tmp/out', keepOriginalRecording: true }),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    })
+    expect(audioMixerMonitorWhenIdle(loadJson(STORAGE_KEYS.settings, defaultSettings))).toBe(false)
+  })
+
+  it('round-trips the toggle through the settings storage path', () => {
+    const updated = withAudioMixerMonitorWhenIdle(defaultSettings, true)
+    expect(updated).not.toBe(defaultSettings)
+    expect(defaultSettings.audioMixer?.monitorWhenIdle).toBe(false)
+
+    const stored = new Map<string, string>([[STORAGE_KEYS.settings, JSON.stringify(updated)]])
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => stored.get(key) ?? null,
+      setItem: (key: string, value: string) => stored.set(key, value),
+      removeItem: (key: string) => stored.delete(key)
+    })
+    const reloaded = loadJson(STORAGE_KEYS.settings, defaultSettings)
+    expect(audioMixerMonitorWhenIdle(reloaded)).toBe(true)
+    expect(audioMixerMonitorWhenIdle(withAudioMixerMonitorWhenIdle(reloaded, false))).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/mic-visual-gate.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-visual-gate.ts
@@ -1,0 +1,71 @@
+// Live feedback batch 3, B2 — the one place that decides whether the
+// renderer's visual-only microphone analyser may run. The owner's complaint
+// ("it's reacting while I'm not recording") was a meter that opened the mic
+// whenever Studio/Sources was on screen. Now: a running session always arms
+// it; an idle Studio only with the explicit "Monitor input" setting.
+
+import type { SettingsState } from './capture'
+
+export type MicVisualGateInput = Readonly<{
+  /** Studio or Sources tab is the active workspace tab. */
+  workspaceVisible: boolean
+  /** The document itself is visible (idle-CPU discipline while hidden). */
+  documentVisible: boolean
+  /** A backend microphone is selected. */
+  microphoneSelected: boolean
+  /** Capture config mute — dancing bars under a mute would lie. */
+  muted: boolean
+  /** Recording/streaming active OR a start/stop request in flight. */
+  sessionActive: boolean
+  /** Persisted settings.audioMixer.monitorWhenIdle. */
+  monitorWhenIdle: boolean
+}>
+
+/** Persisted preference with its default (OFF) applied. */
+export function audioMixerMonitorWhenIdle(
+  settings: Pick<SettingsState, 'audioMixer'> | undefined
+): boolean {
+  return settings?.audioMixer?.monitorWhenIdle === true
+}
+
+/** Settings updater for the Monitor input toggle (keeps sibling mixer prefs). */
+export function withAudioMixerMonitorWhenIdle<T extends Pick<SettingsState, 'audioMixer'>>(
+  settings: T,
+  monitorWhenIdle: boolean
+): T {
+  return { ...settings, audioMixer: { ...settings.audioMixer, monitorWhenIdle } }
+}
+
+/**
+ * Analyser demand: (session active OR monitor-when-idle) AND the visual is
+ * actually on screen for an unmuted, selected microphone. Starting a session
+ * arms the meter without touching the toggle; stopping it disarms unless the
+ * user opted into idle monitoring.
+ */
+export function micVisualAnalyserEnabled(input: MicVisualGateInput): boolean {
+  if (!input.workspaceVisible || !input.documentVisible) {
+    return false
+  }
+  if (!input.microphoneSelected || input.muted) {
+    return false
+  }
+  return input.sessionActive || input.monitorWhenIdle
+}
+
+export type AudioMixerMonitorLabel = 'Live' | 'Monitoring' | 'Idle'
+
+/**
+ * Chip copy beside the bars. "Live" = a session is running and the signal
+ * path is up; "Monitoring" = idle, the user asked for input monitoring, and
+ * the analyser is actually delivering; "Idle" = muted, off, or unavailable —
+ * the honest state when nothing is being read.
+ */
+export function audioMixerMonitorLabel(input: {
+  sessionActive: boolean
+  signalLive: boolean
+}): AudioMixerMonitorLabel {
+  if (!input.signalLive) {
+    return 'Idle'
+  }
+  return input.sessionActive ? 'Live' : 'Monitoring'
+}

--- a/apps/desktop/src/renderer/src/lib/mic-visual-pipeline.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-visual-pipeline.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { dbToMeterLevel } from './mic-meter'
 import {
+  advanceBandLevelsInto,
   createMicVisualFrameBuffer,
   createMicVisualPipeline,
   resampleMicVisualLevels,
   resampleMicVisualLevelsInto,
+  spectrumBandTargetsInto,
+  type MicVisualAnalyserLike,
   type MicVisualAudioContextLike,
   type MicVisualPipelineDependencies
 } from './mic-visual-pipeline'
@@ -13,16 +17,82 @@ type TestStream = {
   getTracks: () => Array<{ stop: () => void }>
 }
 
+const SAMPLE_RATE = 48_000
+const FFT_SIZE = 2048
+const BIN_COUNT = FFT_SIZE / 2
+const BIN_HZ = SAMPLE_RATE / FFT_SIZE
+const BAND_COUNT = 32
+
+/** Synthetic analyser content: a time-domain block plus a matching bin spectrum. */
+type AnalyserSignal = {
+  time: (index: number) => number
+  frequencyDb: (bin: number) => number
+}
+
+/** A pure sine at `hz` with peak amplitude `amplitude`, concentrated in one bin. */
+function sineSignal(amplitude: number, hz: number): AnalyserSignal {
+  const bin = Math.round(hz / BIN_HZ)
+  return {
+    time: (index) => amplitude * Math.sin((2 * Math.PI * hz * index) / SAMPLE_RATE),
+    // Any finite magnitude works: only the distribution is read from the FFT.
+    frequencyDb: (candidate) => (candidate === bin ? -13.6 : Number.NEGATIVE_INFINITY)
+  }
+}
+
+const SILENCE: AnalyserSignal = { time: () => 0, frequencyDb: () => Number.NEGATIVE_INFINITY }
+
+/** Index of the visual band that owns `hz` (same log spacing as the pipeline). */
+function bandFor(hz: number): number {
+  const ratio = Math.min(8000, SAMPLE_RATE / 2) / 80
+  return Math.min(BAND_COUNT - 1, Math.floor((Math.log(hz / 80) / Math.log(ratio)) * BAND_COUNT))
+}
+
+function fillFromSignal(signal: AnalyserSignal): {
+  frequency: Float32Array
+  time: Float32Array
+  rms: number
+} {
+  const frequency = new Float32Array(BIN_COUNT)
+  const time = new Float32Array(FFT_SIZE)
+  let sumSquares = 0
+  for (let bin = 0; bin < BIN_COUNT; bin += 1) frequency[bin] = signal.frequencyDb(bin)
+  for (let index = 0; index < FFT_SIZE; index += 1) {
+    time[index] = signal.time(index)
+    sumSquares += time[index] * time[index]
+  }
+  return { frequency, time, rms: Math.sqrt(sumSquares / FFT_SIZE) }
+}
+
+function bandTargets(signal: AnalyserSignal): number[] {
+  const { frequency, rms } = fillFromSignal(signal)
+  const targets: number[] = []
+  spectrumBandTargetsInto(
+    frequency,
+    rms,
+    SAMPLE_RATE,
+    FFT_SIZE,
+    targets,
+    new Float32Array(BIN_COUNT)
+  )
+  return targets
+}
+
 function pipelineHarness(): {
   dependencies: MicVisualPipelineDependencies<TestStream>
   getUserMedia: ReturnType<typeof vi.fn>
   contexts: Array<MicVisualAudioContextLike<TestStream> & { close: ReturnType<typeof vi.fn> }>
+  analysers: MicVisualAnalyserLike[]
   frames: Array<(at: number) => void>
   microtasks: Array<() => void>
   cancelFrame: ReturnType<typeof vi.fn>
   stoppedTracks: ReturnType<typeof vi.fn>
+  setSignal: (signal: AnalyserSignal) => void
 } {
   const stoppedTracks = vi.fn()
+  // Default content: a -12 dBFS DC block over a flat spectrum — every band
+  // carries energy, which the lifecycle tests lean on (bands > 0).
+  let signal: AnalyserSignal = { time: () => 0.25, frequencyDb: () => -60 }
+  const analysers: MicVisualAnalyserLike[] = []
   const stream: TestStream = { getTracks: () => [{ stop: stoppedTracks }] }
   const getUserMedia = vi.fn(async () => stream)
   const contexts: Array<
@@ -35,10 +105,14 @@ function pipelineHarness(): {
   return {
     getUserMedia,
     contexts,
+    analysers,
     frames,
     microtasks,
     cancelFrame,
     stoppedTracks,
+    setSignal: (next) => {
+      signal = next
+    },
     dependencies: {
       mediaDevices: {
         enumerateDevices: async () => [
@@ -48,14 +122,23 @@ function pipelineHarness(): {
       },
       createAudioContext: () => {
         const analyser = {
-          fftSize: 2048,
-          frequencyBinCount: 1024,
+          fftSize: FFT_SIZE,
+          frequencyBinCount: BIN_COUNT,
           smoothingTimeConstant: 0,
-          getFloatFrequencyData: vi.fn((samples: Float32Array) => samples.fill(-60)),
-          getFloatTimeDomainData: vi.fn((samples: Float32Array) => samples.fill(0.25))
+          getFloatFrequencyData: vi.fn((samples: Float32Array) => {
+            for (let bin = 0; bin < samples.length; bin += 1) {
+              samples[bin] = signal.frequencyDb(bin)
+            }
+          }),
+          getFloatTimeDomainData: vi.fn((samples: Float32Array) => {
+            for (let index = 0; index < samples.length; index += 1) {
+              samples[index] = signal.time(index)
+            }
+          })
         }
+        analysers.push(analyser)
         const context = {
-          sampleRate: 48_000,
+          sampleRate: SAMPLE_RATE,
           createAnalyser: () => analyser,
           createMediaStreamSource: () => ({ connect: vi.fn(), disconnect: vi.fn() }),
           close: vi.fn(async () => undefined)
@@ -402,6 +485,124 @@ describe('createMicVisualPipeline', () => {
     expect(lateTrackStop).toHaveBeenCalledTimes(1)
     expect(harness.contexts).toHaveLength(0)
     expect(pipeline.getLifecycleSnapshot()).toEqual({ status: 'idle', active: false })
+  })
+})
+
+describe('spectrumBandTargetsInto', () => {
+  it('reads a full-scale sine as ~0 dBFS in its band and floor everywhere else', () => {
+    const targets = bandTargets(sineSignal(1, 1000))
+    expect(targets).toHaveLength(BAND_COUNT)
+    const band = bandFor(1000)
+    expect(targets[band]).toBeCloseTo(1, 2)
+    targets.forEach((level, index) => {
+      if (index !== band) expect(level).toBe(0)
+    })
+  })
+
+  it('maps a sine at N dBFS to the shared -60..0 dBFS window', () => {
+    // Peak amplitude -30 dBFS → bar at half height (linear-in-dB), exactly
+    // like the waveform history and the backend micLiveLevel scale.
+    const minus30 = bandTargets(sineSignal(10 ** (-30 / 20), 1000))
+    expect(minus30[bandFor(1000)]).toBeCloseTo(dbToMeterLevel(-30), 2)
+    const minus12 = bandTargets(sineSignal(10 ** (-12 / 20), 2500))
+    expect(minus12[bandFor(2500)]).toBeCloseTo(dbToMeterLevel(-12), 2)
+  })
+
+  it('gates -60 dBFS and -70 dBFS room tone to the floor', () => {
+    expect(bandTargets(sineSignal(10 ** (-60 / 20), 1000)).every((level) => level === 0)).toBe(true)
+    expect(bandTargets(sineSignal(10 ** (-70 / 20), 1000)).every((level) => level === 0)).toBe(true)
+    // Broadband noise at -70 dBFS (the old mapping's 63 % bars) is floor too.
+    const { frequency } = fillFromSignal({ time: () => 0, frequencyDb: () => -80 })
+    const targets: number[] = []
+    spectrumBandTargetsInto(
+      frequency,
+      10 ** (-70 / 20),
+      SAMPLE_RATE,
+      FFT_SIZE,
+      targets,
+      new Float32Array(BIN_COUNT)
+    )
+    expect(targets.every((level) => level === 0)).toBe(true)
+    expect(bandTargets(SILENCE).every((level) => level === 0)).toBe(true)
+  })
+
+  it('splits the broadband level across bands by their share of the spectrum', () => {
+    // Two equal tones in two bands: each band carries half the power (-3 dB).
+    const low = Math.round(300 / BIN_HZ)
+    const high = Math.round(3000 / BIN_HZ)
+    const amplitude = 10 ** (-20 / 20)
+    const signal: AnalyserSignal = {
+      time: (index) =>
+        amplitude * Math.sin((2 * Math.PI * 300 * index) / SAMPLE_RATE) +
+        amplitude * Math.sin((2 * Math.PI * 3000 * index) / SAMPLE_RATE),
+      frequencyDb: (bin) => (bin === low || bin === high ? -20 : Number.NEGATIVE_INFINITY)
+    }
+    const targets = bandTargets(signal)
+    expect(targets[bandFor(300)]).toBeCloseTo(dbToMeterLevel(-20), 1)
+    expect(targets[bandFor(3000)]).toBeCloseTo(dbToMeterLevel(-20), 1)
+    expect(targets[bandFor(300)]).toBeCloseTo(targets[bandFor(3000)], 1)
+  })
+})
+
+describe('advanceBandLevelsInto', () => {
+  it('rises within one 48 ms tick and falls over ~350 ms per band', () => {
+    const bands: number[] = []
+    advanceBandLevelsInto(bands, [1, 0.5, 0], 48)
+    expect(bands[0]).toBeGreaterThan(0.95)
+    expect(bands[1]).toBeGreaterThan(0.47)
+    expect(bands[2]).toBe(0)
+
+    advanceBandLevelsInto(bands, [0, 0, 0], 48)
+    expect(bands[0]).toBeGreaterThan(0.8)
+    expect(bands[1]).toBeGreaterThan(0.4)
+    for (let tick = 0; tick < 20; tick += 1) advanceBandLevelsInto(bands, [0, 0, 0], 48)
+    expect(bands[0]).toBeLessThan(0.1)
+    expect(bands[0]).toBeGreaterThan(0)
+  })
+})
+
+describe('createMicVisualPipeline level feel', () => {
+  it('paints silence at floor, speech on the next tick, and lets it fall slowly', async () => {
+    const harness = pipelineHarness()
+    harness.setSignal(SILENCE)
+    const pipeline = retainedPipeline(harness.dependencies)
+    pipeline.configure({
+      deviceName: 'Studio microphone',
+      enabled: true,
+      permissionStatus: 'granted'
+    })
+    await vi.waitFor(() => expect(harness.frames).toHaveLength(1))
+    expect(harness.analysers[0].smoothingTimeConstant).toBe(0.3)
+
+    let at = 0
+    const tick = (): void => {
+      at += 48
+      harness.frames.at(-1)?.(at)
+    }
+    tick()
+    expect(pipeline.getFrameSnapshot().bands.every((level) => level === 0)).toBe(true)
+    expect(pipeline.getFrameSnapshot().peakDb).toBe(-60)
+
+    // A -12 dBFS tone arrives: its band is up on the very next tick.
+    harness.setSignal(sineSignal(10 ** (-12 / 20), 1000))
+    tick()
+    const band = bandFor(1000)
+    const spoken = pipeline.getFrameSnapshot()
+    expect(spoken.bands[band]).toBeGreaterThan(dbToMeterLevel(-12) * 0.95)
+    expect(spoken.bands[band]).toBeLessThanOrEqual(dbToMeterLevel(-12))
+    expect(spoken.peakDb).toBeCloseTo(-12, 0)
+    expect(spoken.bands.filter((level) => level > 0)).toHaveLength(1)
+
+    // Back to silence: the bar decays instead of snapping — still most of the
+    // way up after one tick, near floor only after ~1 s.
+    harness.setSignal(SILENCE)
+    tick()
+    const falling = pipeline.getFrameSnapshot().bands[band]
+    expect(falling).toBeLessThan(spoken.bands[band])
+    expect(falling).toBeGreaterThan(spoken.bands[band] * 0.8)
+    for (let count = 0; count < 20; count += 1) tick()
+    expect(pipeline.getFrameSnapshot().bands[band]).toBeLessThan(0.05)
+    expect(pipeline.getFrameSnapshot().peakDb).toBe(-60)
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/mic-visual-pipeline.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-visual-pipeline.ts
@@ -1,6 +1,6 @@
 import type { MediaAccessStatus } from './backend'
 import type { MicVisualFrameBuffer } from './mic-visual-frame'
-import { amplitudeToDb, dbToMeterLevel } from './mic-meter'
+import { amplitudeToDb, approachMeterLevel, dbToMeterLevel, gatedDbToMeterLevel } from './mic-meter'
 import {
   createMicStreamController,
   microphoneStreamAcquisitionEnabled,
@@ -96,36 +96,80 @@ const VISUAL_UPDATE_INTERVAL_MS = 48
 const VISUAL_LOW_HZ = 80
 const VISUAL_HIGH_HZ = 8000
 const EMPTY_HISTORY_RING = new Float32Array(0)
+/**
+ * Analyser time smoothing. 0.8 read every 48 ms made a symmetric ~215 ms
+ * attack AND release (mush); 0.3 only takes the FFT flicker off and leaves
+ * the feel to the meter ballistics below (15 ms attack / 350 ms decay).
+ */
+const VISUAL_ANALYSER_SMOOTHING = 0.3
+/**
+ * Bars read dBFS the AES17 way: a full-scale sine is 0 dBFS (its RMS is
+ * -3.01 dBFS; the +3 dB offset is the sqrt(2) below). Band levels are then
+ * the same -60..0 dBFS window as the waveform history and the backend's
+ * micLiveLevel, gated at MIC_METER_GATE_DB.
+ */
+const BAND_RMS_TO_DBFS_GAIN = Math.SQRT2
 
-function normalizeSpectrumDb(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0
-  }
-  const normalized = (Math.max(-100, Math.min(-10, value)) + 100) / 90
-  return Math.sqrt(normalized)
-}
-
-function spectrumBandsInto(
-  samples: Float32Array,
+/**
+ * Per-band RMS from the FFT, calibrated by the time-domain broadband RMS.
+ *
+ * getFloatFrequencyData returns each bin's magnitude in dB under the
+ * analyser's own window and scaling (spec: Blackman, |X|/N). Instead of
+ * trusting those absolute numbers, only the DISTRIBUTION is taken from the
+ * spectrum (bandPower / totalPower, Parseval) and the absolute scale from the
+ * exact, unwindowed broadband RMS of the same block, so bandRms² sums to the
+ * broadband RMS² regardless of the engine's FFT scaling. The previous mapping
+ * (sqrt of a -100..-10 dB window over raw bin dB) painted -70 dB room tone as
+ * 63 % bars; this maps it to 0.
+ */
+export function spectrumBandTargetsInto(
+  frequencyDb: Float32Array,
+  broadbandRms: number,
   sampleRate: number,
   fftSize: number,
-  bands: number[]
+  targets: number[],
+  binPowerScratch: Float32Array
 ): void {
+  targets.length = VISUAL_BAND_COUNT
+  const binCount = Math.min(frequencyDb.length, binPowerScratch.length)
+  let totalPower = 0
+  for (let index = 1; index < binCount; index += 1) {
+    const db = frequencyDb[index]
+    const power = Number.isFinite(db) ? 10 ** (db / 10) : 0
+    binPowerScratch[index] = power
+    totalPower += power
+  }
+  if (!(totalPower > 0) || !(broadbandRms > 0) || binCount < 2) {
+    targets.fill(0)
+    return
+  }
+
   const binHz = sampleRate / fftSize
   const highHz = Math.min(VISUAL_HIGH_HZ, sampleRate / 2)
   const ratio = highHz / VISUAL_LOW_HZ
-  bands.length = VISUAL_BAND_COUNT
-
   for (let band = 0; band < VISUAL_BAND_COUNT; band += 1) {
     const startHz = VISUAL_LOW_HZ * ratio ** (band / VISUAL_BAND_COUNT)
     const endHz = VISUAL_LOW_HZ * ratio ** ((band + 1) / VISUAL_BAND_COUNT)
     const start = Math.max(1, Math.floor(startHz / binHz))
-    const end = Math.max(start + 1, Math.min(samples.length, Math.ceil(endHz / binHz)))
-    let total = 0
+    const end = Math.max(start + 1, Math.min(binCount, Math.ceil(endHz / binHz)))
+    let bandPower = 0
     for (let index = start; index < end; index += 1) {
-      total += normalizeSpectrumDb(samples[index])
+      bandPower += binPowerScratch[index]
     }
-    bands[band] = total / Math.max(1, end - start)
+    const bandRms = broadbandRms * Math.sqrt(bandPower / totalPower)
+    targets[band] = gatedDbToMeterLevel(amplitudeToDb(bandRms * BAND_RMS_TO_DBFS_GAIN))
+  }
+}
+
+/** Advance every band toward its target with the shared attack/decay curve. */
+export function advanceBandLevelsInto(
+  bands: number[],
+  targets: readonly number[],
+  elapsedMs: number
+): void {
+  bands.length = targets.length
+  for (let band = 0; band < targets.length; band += 1) {
+    bands[band] = approachMeterLevel(bands[band] ?? 0, targets[band], elapsedMs)
   }
 }
 
@@ -218,10 +262,12 @@ export function createMicVisualPipeline<S extends MicMediaStreamLike>(
       context = preparedContext
       const analyser = preparedContext.createAnalyser()
       analyser.fftSize = 2048
-      analyser.smoothingTimeConstant = 0.8
+      analyser.smoothingTimeConstant = VISUAL_ANALYSER_SMOOTHING
       mediaSource = preparedContext.createMediaStreamSource(stream)
       mediaSource.connect(analyser)
       const frequencySamples = new Float32Array(analyser.frequencyBinCount)
+      const binPowerScratch = new Float32Array(analyser.frequencyBinCount)
+      const bandTargets = new Array<number>(VISUAL_BAND_COUNT).fill(0)
       const timeSamples = new Float32Array(analyser.fftSize)
       let lastUpdateAt = Number.NEGATIVE_INFINITY
       const sessionFrame: SessionFrame = {
@@ -232,7 +278,7 @@ export function createMicVisualPipeline<S extends MicMediaStreamLike>(
         peakDb: null,
         hasData: false
       }
-      const sampleFrame = (): void => {
+      const sampleFrame = (elapsedMs: number): void => {
         analyser.getFloatFrequencyData(frequencySamples)
         analyser.getFloatTimeDomainData(timeSamples)
         let sumSquares = 0
@@ -251,12 +297,15 @@ export function createMicVisualPipeline<S extends MicMediaStreamLike>(
         } else {
           sessionFrame.historyStart = (sessionFrame.historyStart + 1) % VISUAL_HISTORY_SIZE
         }
-        spectrumBandsInto(
+        spectrumBandTargetsInto(
           frequencySamples,
+          rms,
           preparedContext.sampleRate,
           analyser.fftSize,
-          sessionFrame.bands
+          bandTargets,
+          binPowerScratch
         )
+        advanceBandLevelsInto(sessionFrame.bands, bandTargets, elapsedMs)
         sessionFrame.peakDb = amplitudeToDb(peak)
         sessionFrame.hasData = true
       }
@@ -274,9 +323,10 @@ export function createMicVisualPipeline<S extends MicMediaStreamLike>(
         if (disposed || activeSession !== session || session.stopped) {
           return
         }
-        if (at - lastUpdateAt >= VISUAL_UPDATE_INTERVAL_MS) {
+        const elapsedMs = at - lastUpdateAt
+        if (elapsedMs >= VISUAL_UPDATE_INTERVAL_MS) {
           lastUpdateAt = at
-          sampleFrame()
+          sampleFrame(Number.isFinite(elapsedMs) ? elapsedMs : VISUAL_UPDATE_INTERVAL_MS)
           publishFrame()
         }
         if (!disposed && activeSession === session && !session.stopped) {
@@ -285,7 +335,7 @@ export function createMicVisualPipeline<S extends MicMediaStreamLike>(
       }
       scheduledFrame = dependencies.requestFrame(tick)
       session.animationFrame = scheduledFrame
-      sampleFrame()
+      sampleFrame(VISUAL_UPDATE_INTERVAL_MS)
       return { session }
     } catch {
       if (scheduledFrame) {

--- a/apps/desktop/src/renderer/src/lib/shortcuts.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcuts.ts
@@ -26,6 +26,9 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
   { id: 'search', keys: ['⌘', 'K'], label: 'Search & commands', group: 'Navigation' },
 
   { id: 'record-toggle', keys: ['␣'], label: 'Start / stop the session', group: 'Session' },
+  // Audio mixer (Studio): arms the visual-only mic analyser while no session
+  // runs. A running session always arms it.
+  { id: 'mic-monitor', keys: ['M'], label: 'Monitor mic input while idle', group: 'Session' },
 
   { id: 'preview-window', keys: ['⌘', 'P'], label: 'Open preview window', group: 'Windows' },
   { id: 'notes-window', keys: ['⌘', '⇧', 'N'], label: 'Open notes window', group: 'Windows' },


### PR DESCRIPTION
Live feedback batch 3, slice **B2** (plan: `2026-08-23 - Videorc Live Feedback Batch 3 Plan.md`).

Owner: "audio mixer is not looking good, it's not natural with sound, and it's reacting while I'm not recording."

## Root causes (verified)

- `lib/mic-visual-pipeline.ts` mapped raw FFT bin dB through `sqrt((clamp(-100,-10)+100)/90)` — **−70 dB room tone painted 63 % bars**.
- `analyser.smoothingTimeConstant = 0.8` read every 48 ms = a symmetric ~215 ms attack **and** release; the 15/350 ms ballistics in `lib/mic-meter.ts` were dead code.
- `lib/mic-stream.ts` left `echoCancellation/noiseSuppression/autoGainControl` at Chromium defaults — AGC pumped silence up to speech level.
- The analyser ran whenever Studio/Sources was on screen (`app-shell.tsx` + `use-studio-mic-visual.tsx`): **no session gate**, so the mic opened (OS indicator on) and the bars reacted while idle.
- The backend fallback hump used a different mapping, so analyser ↔ fallback swaps were visible.

## Fix

**Math (`lib/mic-visual-pipeline.ts`, `lib/mic-meter.ts`)**
- Band level = dBFS over −60..0, the same `amplitudeToDb`/`dbToMeterLevel` window as the waveform history and the backend's `micLiveLevel`. The FFT only supplies each band's *share* of power (Parseval); the absolute scale comes from the exact time-domain broadband RMS of the same block, so the result does not depend on the engine's FFT scaling/window. AES17 calibration: a full-scale sine reads 0 dBFS.
- Noise gate: below **−55 dBFS → floor** (`MIC_METER_GATE_DB`, `gatedDbToMeterLevel`, `gateMeterLevel`).
- Real ballistics per band: `approachMeterLevel` (15 ms attack / 350 ms decay, the level-only half of `advanceMeterBallistics`) on the 48 ms tick. `smoothingTimeConstant` 0.8 → **0.3**.
- `fallbackBandLevels` applies the same gate on the same scale, so a swap changes only spectral shape, never height.

**Meter stream (`lib/mic-stream.ts`)**
- `echoCancellation: false, noiseSuppression: false, autoGainControl: false`. The recording path is the backend's own capture — untouched.

**Gate + control**
- New persisted setting `settings.audioMixer.monitorWhenIdle` (default **off**; `videorc.settings` localStorage like every other renderer pref).
- `lib/mic-visual-gate.ts`: analyser enabled = `(session active || monitorWhenIdle) && workspace visible && document visible && mic selected && unmuted`. Wired through `StudioMicVisualProvider` (the `app-shell.tsx:352` provider). **Starting a session arms the meter automatically; stopping releases the mic unless monitoring is on.**
- `components/studio/audio-mixer.tsx`: **Monitor input** shadcn `Switch` + `Kbd` **M** (rendered only while idle — a session arms the meter by itself); state label beside the bars: **Live / Monitoring / Idle**; "Check level" stays for people who keep monitoring off.
- The M shortcut lives in `StudioMicVisualProvider` (one home for Studio *and* Sources; `SHORTCUTS` id `mic-monitor`, group Session). The Sources/Quick-settings mic picker offers "Monitor input · M" inline on its idle line so picking a mic is not blind.

## What the bars should do now (owner by-eye)

- **Idle Studio, Monitor input off (default):** bars flat at floor, label "Idle", mic NOT opened — no orange mic indicator in the macOS menu bar. "Check level" still gives the backend's one-shot reading.
- **Idle, Monitor input on (switch or M):** label "Monitoring"; a silent room is flat (room tone gated); speech bars jump up within one tick (~50 ms) and fall over ~350 ms instead of mushing both ways; no AGC creep in the pauses.
- **Start recording / Go Live:** meter live without touching the toggle, label "Live"; on stop it goes back to "Idle" and the mic indicator disappears (unless monitoring is on).
- **Fallback path (analyser cannot open the device):** same height scale as the analyser, so a swap is not a jump.

## Tests

- `lib/mic-visual-pipeline.test.ts`: full-scale → ~1.0, −30 dBFS → 0.5, −12 → 0.8, −60/−70 → 0, broadband −70 → 0, two-tone spectral split, `advanceBandLevelsInto` asymmetry, pipeline feel (silence floor / next-tick rise / slow fall / smoothing 0.3).
- `lib/mic-meter.test.ts`: gate, `approachMeterLevel` asymmetry over 48 ms ticks, fallback parity.
- `lib/mic-stream.test.ts`: processing-off constraints on matched and default inputs.
- `lib/mic-visual-gate.test.ts`: gate reducer (idle/off → closed; session → armed; monitor → armed; tab/doc/mic/mute overrides), label copy, settings default + round-trip through `loadJson`.
- `hooks/studio-mic-visual-provider.test.ts`: idle keeps the mic closed → session auto-arms → stop releases → M re-arms; M ignored during a session / in editable fields / with modifiers / on repeat.
- `hooks/studio-provider.integration.test.ts`: real `StudioProvider` start/stop flow — no `getUserMedia` while idle, opened once with processing off after `session.start`, closed after `session.stop`.

## Gates

```
pnpm typecheck        → tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json  (exit 0)
pnpm lint             → eslint "apps/desktop/**/*.{ts,tsx}"  (exit 0)
pnpm format:check     → Tracked text integrity OK (1139 files). All matched files use Prettier code style!  (exit 0)
pnpm --filter @videorc/desktop test → Test Files 151 passed (151); Tests 1401 passed | 1 skipped (1402)
```

Full-suite note: 3 of 4 runs green; one run had `backendClient.test.ts > BackendClient request lifetime` time out (two cases, 1 s `waitFor` budgets under full-suite load) — that file is untouched here and the touched files were green on every run.

By-eye (silence / speech / idle / OS mic indicator) is the owner's; `smoke:recording-studio` is the B2/B5a regression gate for the 0.9.68 cut per the plan.
