### PR TITLE
feat(diagnostics): backend crash record + stderr tail survive restarts; Rust panic hook; backend.log

### DIFF
--- a/apps/desktop/src/main/backend-crash-log.test.ts
+++ b/apps/desktop/src/main/backend-crash-log.test.ts
@@ -1,0 +1,218 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  BACKEND_CRASH_LOG_LIMIT,
+  BACKEND_CRASH_STDERR_LINE_CHARS,
+  BACKEND_CRASH_STDERR_TAIL_LINES,
+  BackendStderrTail,
+  appendBackendCrashRecord,
+  backendCrashLogPath,
+  buildBackendCrashRecord,
+  describeBackendCrashRecord,
+  readBackendCrashLog,
+  shouldRecordBackendExit,
+  type BackendCrashRecord
+} from './backend-crash-log'
+
+const tempDirs: string[] = []
+
+function tempUserData(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'videorc-crash-log-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function record(overrides: Partial<BackendCrashRecord> = {}): BackendCrashRecord {
+  return buildBackendCrashRecord({
+    at: '2026-08-23T10:00:00.000Z',
+    generation: 2,
+    code: null,
+    signal: 'SIGKILL',
+    attempt: 1,
+    uptimeMs: 12_345,
+    intentional: false,
+    stderrTail: ['2026-08-23T10:00:00Z  INFO videorc_backend: ready', '{"panic":"boom"}'],
+    ...overrides
+  })
+}
+
+describe('shouldRecordBackendExit', () => {
+  it('records every non-intentional exit, even a clean-looking one', () => {
+    expect(shouldRecordBackendExit({ intentional: false, code: 0, signal: null })).toBe(true)
+    expect(shouldRecordBackendExit({ intentional: false, code: null, signal: 'SIGKILL' })).toBe(
+      true
+    )
+  })
+
+  it('skips intentional clean stops and signal-only intentional stops', () => {
+    expect(shouldRecordBackendExit({ intentional: true, code: 0, signal: null })).toBe(false)
+    expect(shouldRecordBackendExit({ intentional: true, code: null, signal: 'SIGTERM' })).toBe(
+      false
+    )
+  })
+
+  it('keeps intentional stops that still reported a non-zero code', () => {
+    expect(shouldRecordBackendExit({ intentional: true, code: 101, signal: null })).toBe(true)
+  })
+})
+
+describe('BackendStderrTail', () => {
+  it('keeps only the newest lines and truncates long ones', () => {
+    const tail = new BackendStderrTail()
+    for (let index = 0; index < BACKEND_CRASH_STDERR_TAIL_LINES + 10; index += 1) {
+      tail.push(`line ${index}`)
+    }
+    tail.push('')
+    tail.push('   ')
+    tail.push('x'.repeat(BACKEND_CRASH_STDERR_LINE_CHARS + 50))
+    const lines = tail.snapshot()
+    expect(lines).toHaveLength(BACKEND_CRASH_STDERR_TAIL_LINES)
+    expect(lines[0]).toBe('line 11')
+    expect(lines.at(-1)).toHaveLength(BACKEND_CRASH_STDERR_LINE_CHARS)
+    expect(lines.at(-1)?.endsWith('…')).toBe(true)
+  })
+
+  it('snapshots are copies', () => {
+    const tail = new BackendStderrTail()
+    tail.push('a')
+    const first = tail.snapshot()
+    tail.push('b')
+    expect(first).toEqual(['a'])
+    expect(tail.snapshot()).toEqual(['a', 'b'])
+  })
+})
+
+describe('backend crash log persistence', () => {
+  it('round-trips a record through the real file system, most recent first', () => {
+    const path = backendCrashLogPath(tempUserData())
+    expect(readBackendCrashLog(path)).toEqual([])
+
+    const first = record({ at: '2026-08-23T10:00:00.000Z', generation: 1 })
+    const second = record({
+      at: '2026-08-23T10:00:05.000Z',
+      generation: 2,
+      code: 101,
+      signal: null
+    })
+    let records = appendBackendCrashRecord(path, first, [])
+    records = appendBackendCrashRecord(path, second, records)
+
+    expect(records.map((entry) => entry.generation)).toEqual([2, 1])
+    expect(readBackendCrashLog(path)).toEqual(records)
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({ schemaVersion: 1 })
+  })
+
+  it('keeps only the newest BACKEND_CRASH_LOG_LIMIT records', () => {
+    const path = backendCrashLogPath(tempUserData())
+    let records: BackendCrashRecord[] = []
+    for (let generation = 1; generation <= BACKEND_CRASH_LOG_LIMIT + 3; generation += 1) {
+      records = appendBackendCrashRecord(path, record({ generation }), records)
+    }
+    expect(records).toHaveLength(BACKEND_CRASH_LOG_LIMIT)
+    expect(records[0].generation).toBe(BACKEND_CRASH_LOG_LIMIT + 3)
+    expect(readBackendCrashLog(path).map((entry) => entry.generation)).toEqual(
+      records.map((entry) => entry.generation)
+    )
+  })
+
+  it('writes atomically: temp file then rename, never a direct write', () => {
+    const writes: string[] = []
+    const renames: Array<[string, string]> = []
+    const made: string[] = []
+    appendBackendCrashRecord('/userData/backend-crashes.json', record(), [], {
+      writeFile: (target) => {
+        writes.push(target)
+      },
+      rename: (from, to) => {
+        renames.push([from, to])
+      },
+      makeDir: (target) => {
+        made.push(target)
+      }
+    })
+    expect(made).toEqual(['/userData'])
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).not.toBe('/userData/backend-crashes.json')
+    expect(writes[0].startsWith('/userData/backend-crashes.json.')).toBe(true)
+    expect(renames).toEqual([[writes[0], '/userData/backend-crashes.json']])
+  })
+
+  it('tolerates missing, corrupt, and foreign-shaped files', () => {
+    expect(readBackendCrashLog('/nope', { readFile: () => '{not json' })).toEqual([])
+    expect(
+      readBackendCrashLog('/nope', {
+        readFile: () => {
+          throw new Error('ENOENT')
+        }
+      })
+    ).toEqual([])
+    expect(readBackendCrashLog('/nope', { readFile: () => '{"records": 4}' })).toEqual([])
+    expect(readBackendCrashLog('/nope', { readFile: () => '[1, "x", null, {}]' })).toEqual([])
+  })
+
+  it('normalizes partial records and accepts a bare array', () => {
+    const records = readBackendCrashLog('/nope', {
+      readFile: () =>
+        JSON.stringify([
+          { at: '2026-08-23T10:00:00.000Z', code: 'bad', stderrTail: ['ok', 7, null] },
+          { at: '2026-08-23T09:00:00.000Z', generation: 3, signal: '', uptimeMs: -5 }
+        ])
+    })
+    expect(records).toEqual([
+      {
+        at: '2026-08-23T10:00:00.000Z',
+        generation: 0,
+        code: null,
+        signal: null,
+        attempt: null,
+        uptimeMs: 0,
+        intentional: false,
+        stderrTail: ['ok']
+      },
+      {
+        at: '2026-08-23T09:00:00.000Z',
+        generation: 3,
+        code: null,
+        signal: null,
+        attempt: null,
+        uptimeMs: 0,
+        intentional: false,
+        stderrTail: []
+      }
+    ])
+  })
+
+  it('caps the stderr tail inside a record on build and on read', () => {
+    const longTail = Array.from({ length: 80 }, (_, index) => `l${index}`)
+    const built = record({ stderrTail: longTail })
+    expect(built.stderrTail).toHaveLength(BACKEND_CRASH_STDERR_TAIL_LINES)
+    expect(built.stderrTail[0]).toBe('l30')
+    const read = readBackendCrashLog('/nope', {
+      readFile: () => JSON.stringify([{ at: 'x', stderrTail: longTail }])
+    })
+    expect(read[0].stderrTail).toHaveLength(BACKEND_CRASH_STDERR_TAIL_LINES)
+  })
+})
+
+describe('describeBackendCrashRecord', () => {
+  it('names the exit, uptime, and restart attempt', () => {
+    expect(describeBackendCrashRecord(record())).toBe(
+      'generation 2 exited (signal SIGKILL) after 12.3s, restart attempt 1'
+    )
+    expect(
+      describeBackendCrashRecord(
+        record({ code: 101, signal: null, attempt: null, intentional: true, uptimeMs: 500 })
+      )
+    ).toBe('generation 2 exited (code 101) after 500ms, intentional')
+  })
+})

--- a/apps/desktop/src/main/backend-crash-log.test.ts
+++ b/apps/desktop/src/main/backend-crash-log.test.ts
@@ -82,6 +82,12 @@ describe('BackendStderrTail', () => {
     expect(lines.at(-1)?.endsWith('…')).toBe(true)
   })
 
+  it('strips tracing ANSI colour codes so the record reads as plain text', () => {
+    const tail = new BackendStderrTail()
+    tail.push('\u001b[2m2026-08-23T14:13:03Z\u001b[0m \u001b[32m INFO\u001b[0m ready.')
+    expect(tail.snapshot()).toEqual(['2026-08-23T14:13:03Z  INFO ready.'])
+  })
+
   it('snapshots are copies', () => {
     const tail = new BackendStderrTail()
     tail.push('a')

--- a/apps/desktop/src/main/backend-crash-log.ts
+++ b/apps/desktop/src/main/backend-crash-log.ts
@@ -43,7 +43,7 @@ export class BackendStderrTail {
     if (!trimmed) {
       return
     }
-    this.lines.push(truncateStderrLine(trimmed, this.maxLineChars))
+    this.lines.push(truncateStderrLine(stripAnsi(trimmed), this.maxLineChars))
     if (this.lines.length > this.maxLines) {
       this.lines.splice(0, this.lines.length - this.maxLines)
     }
@@ -52,6 +52,15 @@ export class BackendStderrTail {
   snapshot(): string[] {
     return [...this.lines]
   }
+}
+
+// tracing's default fmt layer colours stderr (ANSI SGR sequences); a crash
+// record is read by humans in JSON, so keep the words and drop the paint.
+// eslint-disable-next-line no-control-regex -- the escape byte is the point.
+const ANSI_SGR_PATTERN = /\u001b\[[0-9;]*m/g
+
+export function stripAnsi(line: string): string {
+  return line.replace(ANSI_SGR_PATTERN, '')
 }
 
 export function truncateStderrLine(

--- a/apps/desktop/src/main/backend-crash-log.ts
+++ b/apps/desktop/src/main/backend-crash-log.ts
@@ -1,0 +1,222 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+import type { BackendCrashRecord } from '../shared/backend'
+
+// Backend crash evidence that survives supervisor restarts and app relaunches.
+//
+// Before this file the supervisor kept exit code/signal in memory and stderr
+// in a 200-line ring that died with the process, so a support bundle exported
+// after "Backend crashed, restarting (attempt 3)" started at the NEXT
+// generation's "backend ready" and said nothing about the crash. Every exit
+// worth keeping now lands in `userData/backend-crashes.json` (last 5, most
+// recent first) together with the dying process's last stderr lines, and
+// rides into the bundle via runtimeInfo.backendCrashes.
+//
+// Everything here is pure/injected so the policy is unit-testable; index.ts
+// wires it to the stderr handler and finalizeBackendRuntimeExit.
+
+export type { BackendCrashRecord } from '../shared/backend'
+
+/** Records kept on disk. Five covers the whole restart ladder (5 attempts). */
+export const BACKEND_CRASH_LOG_LIMIT = 5
+/** Stderr lines kept per generation for the record. */
+export const BACKEND_CRASH_STDERR_TAIL_LINES = 50
+/** Per-line cap so a runaway log line cannot bloat the record. */
+export const BACKEND_CRASH_STDERR_LINE_CHARS = 400
+
+export function backendCrashLogPath(userDataDir: string): string {
+  return join(userDataDir, 'backend-crashes.json')
+}
+
+/** Bounded ring of the newest stderr lines for ONE backend generation. */
+export class BackendStderrTail {
+  private readonly lines: string[] = []
+
+  constructor(
+    private readonly maxLines = BACKEND_CRASH_STDERR_TAIL_LINES,
+    private readonly maxLineChars = BACKEND_CRASH_STDERR_LINE_CHARS
+  ) {}
+
+  push(line: string): void {
+    const trimmed = line.trim()
+    if (!trimmed) {
+      return
+    }
+    this.lines.push(truncateStderrLine(trimmed, this.maxLineChars))
+    if (this.lines.length > this.maxLines) {
+      this.lines.splice(0, this.lines.length - this.maxLines)
+    }
+  }
+
+  snapshot(): string[] {
+    return [...this.lines]
+  }
+}
+
+export function truncateStderrLine(
+  line: string,
+  maxChars = BACKEND_CRASH_STDERR_LINE_CHARS
+): string {
+  if (line.length <= maxChars) {
+    return line
+  }
+  return `${line.slice(0, Math.max(0, maxChars - 1))}…`
+}
+
+/** Every non-intentional exit is a crash. An intentional stop that still
+ * reports a non-zero code is worth keeping too (the backend failed while we
+ * asked it to shut down); a clean or signal-only intentional stop is not —
+ * SIGTERM/SIGKILL is how the supervisor stops the process on purpose. */
+export function shouldRecordBackendExit({
+  intentional,
+  code
+}: {
+  intentional: boolean
+  code: number | null
+  signal?: string | null
+}): boolean {
+  if (!intentional) {
+    return true
+  }
+  return typeof code === 'number' && code !== 0
+}
+
+export interface BackendCrashLogStore {
+  readFile?: (path: string) => string
+  writeFile?: (path: string, contents: string) => void
+  rename?: (from: string, to: string) => void
+  makeDir?: (path: string) => void
+}
+
+export function readBackendCrashLog(
+  path: string,
+  { readFile = (target) => readFileSync(target, 'utf8') }: BackendCrashLogStore = {}
+): BackendCrashRecord[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFile(path))
+  } catch {
+    // Missing or corrupt evidence must never block startup or the bundle.
+    return []
+  }
+  const records = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.records)
+      ? parsed.records
+      : []
+  return records
+    .map((record) => normalizeBackendCrashRecord(record))
+    .filter((record): record is BackendCrashRecord => record !== null)
+    .slice(0, BACKEND_CRASH_LOG_LIMIT)
+}
+
+/** Prepend one record, keep the newest `BACKEND_CRASH_LOG_LIMIT`, and write the
+ * file atomically (temp file + rename) so a crash mid-write cannot leave a
+ * half-written JSON that hides all earlier evidence. Returns the new list
+ * (most recent first). Throws on write failure — the caller logs and keeps
+ * the in-memory copy. */
+export function appendBackendCrashRecord(
+  path: string,
+  record: BackendCrashRecord,
+  existing: readonly BackendCrashRecord[],
+  {
+    writeFile = (target, contents) => writeFileSync(target, contents),
+    rename = (from, to) => renameSync(from, to),
+    makeDir = (target) => mkdirSync(target, { recursive: true })
+  }: BackendCrashLogStore = {}
+): BackendCrashRecord[] {
+  const next = [record, ...existing].slice(0, BACKEND_CRASH_LOG_LIMIT)
+  makeDir(dirname(path))
+  const temp = `${path}.${process.pid}.${Date.now()}.tmp`
+  writeFile(temp, `${JSON.stringify({ schemaVersion: 1, records: next }, null, 2)}\n`)
+  rename(temp, path)
+  return next
+}
+
+export function buildBackendCrashRecord({
+  at,
+  generation,
+  code,
+  signal,
+  attempt,
+  uptimeMs,
+  intentional,
+  stderrTail
+}: {
+  at: string
+  generation: number
+  code: number | null
+  signal: string | null
+  attempt: number | null
+  uptimeMs: number
+  intentional: boolean
+  stderrTail: readonly string[]
+}): BackendCrashRecord {
+  return {
+    at,
+    generation,
+    code,
+    signal,
+    attempt,
+    uptimeMs: Math.max(0, Math.round(uptimeMs)),
+    intentional,
+    stderrTail: stderrTail
+      .slice(-BACKEND_CRASH_STDERR_TAIL_LINES)
+      .map((line) => truncateStderrLine(line))
+  }
+}
+
+/** One-line human summary for logs and the Diagnostics tab. */
+export function describeBackendCrashRecord(record: BackendCrashRecord): string {
+  const exit =
+    record.signal !== null
+      ? `signal ${record.signal}`
+      : record.code !== null
+        ? `code ${record.code}`
+        : 'unknown exit'
+  const attempt = record.attempt !== null ? `, restart attempt ${record.attempt}` : ''
+  return `generation ${record.generation} exited (${exit}) after ${formatUptime(record.uptimeMs)}${attempt}${record.intentional ? ', intentional' : ''}`
+}
+
+function formatUptime(uptimeMs: number): string {
+  if (uptimeMs < 1_000) {
+    return `${uptimeMs}ms`
+  }
+  if (uptimeMs < 60_000) {
+    return `${(uptimeMs / 1_000).toFixed(1)}s`
+  }
+  return `${Math.round(uptimeMs / 60_000)}min`
+}
+
+function normalizeBackendCrashRecord(value: unknown): BackendCrashRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  if (typeof value.at !== 'string' || !value.at) {
+    return null
+  }
+  return {
+    at: value.at,
+    generation: finiteInteger(value.generation) ?? 0,
+    code: finiteInteger(value.code),
+    signal: typeof value.signal === 'string' && value.signal ? value.signal : null,
+    attempt: finiteInteger(value.attempt),
+    uptimeMs: Math.max(0, finiteInteger(value.uptimeMs) ?? 0),
+    intentional: value.intentional === true,
+    stderrTail: Array.isArray(value.stderrTail)
+      ? value.stderrTail
+          .filter((line): line is string => typeof line === 'string')
+          .slice(-BACKEND_CRASH_STDERR_TAIL_LINES)
+          .map((line) => truncateStderrLine(line))
+      : []
+  }
+}
+
+function finiteInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) ? value : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/apps/desktop/src/main/backend-log-file.test.ts
+++ b/apps/desktop/src/main/backend-log-file.test.ts
@@ -31,6 +31,9 @@ describe('formatBackendLogFileLine', () => {
     expect(formatBackendLogFileLine('warn', 'a\nb', '2026-08-23T10:00:00.000Z')).toBe(
       '2026-08-23T10:00:00.000Z [warn] a\\nb\n'
     )
+    expect(formatBackendLogFileLine('info', '\u001b[32m INFO\u001b[0m ok', 'T')).toBe(
+      'T [info]  INFO ok\n'
+    )
   })
 })
 

--- a/apps/desktop/src/main/backend-log-file.test.ts
+++ b/apps/desktop/src/main/backend-log-file.test.ts
@@ -1,0 +1,140 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  BACKEND_LOG_FILE_MAX_BYTES,
+  BACKEND_LOG_FILE_MAX_FILES,
+  RotatingLogFile,
+  backendLogFilePath,
+  formatBackendLogFileLine
+} from './backend-log-file'
+
+const tempDirs: string[] = []
+
+function tempUserData(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'videorc-backend-log-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('formatBackendLogFileLine', () => {
+  it('is one line per entry with timestamp and level', () => {
+    expect(formatBackendLogFileLine('warn', 'a\nb', '2026-08-23T10:00:00.000Z')).toBe(
+      '2026-08-23T10:00:00.000Z [warn] a\\nb\n'
+    )
+  })
+})
+
+describe('RotatingLogFile', () => {
+  it('defaults to 2 files x 2 MB under userData/logs', () => {
+    expect(BACKEND_LOG_FILE_MAX_BYTES).toBe(2 * 1024 * 1024)
+    expect(BACKEND_LOG_FILE_MAX_FILES).toBe(2)
+    expect(backendLogFilePath('/ud')).toBe(join('/ud', 'logs', 'backend.log'))
+    const sink = new RotatingLogFile({ path: '/ud/logs/backend.log' })
+    expect(sink.rotatedPaths()).toEqual(['/ud/logs/backend.log', '/ud/logs/backend.log.1'])
+  })
+
+  it('creates the directory lazily and appends on the real file system', () => {
+    const path = backendLogFilePath(tempUserData())
+    const sink = new RotatingLogFile({ path })
+    expect(existsSync(path)).toBe(false)
+    sink.write('one\n')
+    sink.write('two\n')
+    expect(readFileSync(path, 'utf8')).toBe('one\ntwo\n')
+  })
+
+  it('rotates when the next line would exceed the budget and keeps only maxFiles', () => {
+    const path = backendLogFilePath(tempUserData())
+    const sink = new RotatingLogFile({ path, maxBytes: 20, maxFiles: 2 })
+    sink.write('aaaaaaaaaa\n') // 11 bytes
+    sink.write('bbbbbbbbbb\n') // would make 22 > 20 → rotate
+    expect(readFileSync(`${path}.1`, 'utf8')).toBe('aaaaaaaaaa\n')
+    expect(readFileSync(path, 'utf8')).toBe('bbbbbbbbbb\n')
+    sink.write('cccccccccc\n') // rotate again: .1 replaced, no .2
+    expect(readFileSync(`${path}.1`, 'utf8')).toBe('bbbbbbbbbb\n')
+    expect(readFileSync(path, 'utf8')).toBe('cccccccccc\n')
+    expect(existsSync(`${path}.2`)).toBe(false)
+    expect(statSync(path).size).toBeLessThanOrEqual(20)
+  })
+
+  it('resumes the byte count from an existing file across launches', () => {
+    const path = backendLogFilePath(tempUserData())
+    new RotatingLogFile({ path, maxBytes: 20 }).write('aaaaaaaaaa\n')
+    const relaunched = new RotatingLogFile({ path, maxBytes: 20 })
+    relaunched.write('bbbbbbbbbb\n')
+    expect(readFileSync(`${path}.1`, 'utf8')).toBe('aaaaaaaaaa\n')
+    expect(readFileSync(path, 'utf8')).toBe('bbbbbbbbbb\n')
+  })
+
+  it('never lets one oversized line block logging: it rotates then writes it', () => {
+    const path = backendLogFilePath(tempUserData())
+    const sink = new RotatingLogFile({ path, maxBytes: 8 })
+    sink.write('short\n')
+    sink.write('this line is longer than the budget\n')
+    expect(readFileSync(path, 'utf8')).toBe('this line is longer than the budget\n')
+    expect(readFileSync(`${path}.1`, 'utf8')).toBe('short\n')
+  })
+
+  it('disables itself after the first failure and reports it once', () => {
+    const errors: unknown[] = []
+    let attempts = 0
+    const sink = new RotatingLogFile({
+      path: '/ud/logs/backend.log',
+      fs: {
+        makeDir: () => {},
+        sizeOf: () => 0,
+        appendFile: () => {
+          attempts += 1
+          throw new Error('EACCES')
+        }
+      },
+      onError: (error) => {
+        errors.push(error)
+      }
+    })
+    sink.write('a\n')
+    sink.write('b\n')
+    sink.write('c\n')
+    expect(attempts).toBe(1)
+    expect(errors).toHaveLength(1)
+    expect((errors[0] as Error).message).toBe('EACCES')
+  })
+
+  it('disables itself explicitly when the live file cannot be rotated', () => {
+    const errors: unknown[] = []
+    const appended: string[] = []
+    const sink = new RotatingLogFile({
+      path: '/ud/logs/backend.log',
+      maxBytes: 4,
+      fs: {
+        makeDir: () => {},
+        sizeOf: () => 0,
+        remove: () => {},
+        rename: () => {
+          throw new Error('EBUSY')
+        },
+        appendFile: (_target, contents) => {
+          appended.push(contents)
+        }
+      },
+      onError: (error) => {
+        errors.push(error)
+      }
+    })
+    sink.write('abc\n')
+    sink.write('def\n')
+    sink.write('ghi\n')
+    expect(appended).toEqual(['abc\n'])
+    expect(errors).toHaveLength(1)
+    expect((errors[0] as Error).message).toBe('EBUSY')
+  })
+})

--- a/apps/desktop/src/main/backend-log-file.ts
+++ b/apps/desktop/src/main/backend-log-file.ts
@@ -1,0 +1,141 @@
+import { appendFileSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+// Rotating on-disk sink for backend stderr + supervisor lifecycle lines.
+//
+// Packaged builds have no terminal: before this file every backend stderr line
+// went to the main-process console (nowhere) and a 200-line in-memory ring
+// that died with the app, so a Windows tester's bundle after a crash loop
+// carried only the current generation's lines. `userData/logs/backend.log`
+// keeps the last ~4 MB (2 files × 2 MB) across restarts and relaunches.
+//
+// Writes are synchronous appends: the volume is log-line sized, the main
+// thread already serialises these lines to the console, and a sync write is
+// the only kind guaranteed to land before a crash takes the process down.
+
+export const BACKEND_LOG_FILE_MAX_BYTES = 2 * 1024 * 1024
+export const BACKEND_LOG_FILE_MAX_FILES = 2
+
+export function backendLogFilePath(userDataDir: string): string {
+  return join(userDataDir, 'logs', 'backend.log')
+}
+
+export function formatBackendLogFileLine(
+  level: string,
+  message: string,
+  timestamp: string
+): string {
+  return `${timestamp} [${level}] ${message.replace(/\r?\n/g, '\\n')}\n`
+}
+
+export interface RotatingLogFileFs {
+  appendFile?: (path: string, contents: string) => void
+  sizeOf?: (path: string) => number | null
+  rename?: (from: string, to: string) => void
+  remove?: (path: string) => void
+  makeDir?: (path: string) => void
+}
+
+export interface RotatingLogFileOptions {
+  path: string
+  maxBytes?: number
+  maxFiles?: number
+  fs?: RotatingLogFileFs
+  /** Called once, on the first failure; the sink then disables itself so a
+   * broken disk never turns every log line into a second error. */
+  onError?: (error: unknown) => void
+}
+
+export class RotatingLogFile {
+  private readonly path: string
+  private readonly maxBytes: number
+  private readonly maxFiles: number
+  private readonly appendFile: NonNullable<RotatingLogFileFs['appendFile']>
+  private readonly sizeOf: NonNullable<RotatingLogFileFs['sizeOf']>
+  private readonly rename: NonNullable<RotatingLogFileFs['rename']>
+  private readonly remove: NonNullable<RotatingLogFileFs['remove']>
+  private readonly makeDir: NonNullable<RotatingLogFileFs['makeDir']>
+  private readonly onError: (error: unknown) => void
+  private currentBytes: number | null = null
+  private disabled = false
+
+  constructor({
+    path,
+    maxBytes = BACKEND_LOG_FILE_MAX_BYTES,
+    maxFiles = BACKEND_LOG_FILE_MAX_FILES,
+    fs = {},
+    onError = () => {}
+  }: RotatingLogFileOptions) {
+    this.path = path
+    this.maxBytes = Math.max(1, maxBytes)
+    this.maxFiles = Math.max(1, maxFiles)
+    this.appendFile = fs.appendFile ?? ((target, contents) => appendFileSync(target, contents))
+    this.sizeOf =
+      fs.sizeOf ??
+      ((target) => {
+        try {
+          return statSync(target).size
+        } catch {
+          return null
+        }
+      })
+    this.rename = fs.rename ?? ((from, to) => renameSync(from, to))
+    this.remove = fs.remove ?? ((target) => rmSync(target, { force: true }))
+    this.makeDir = fs.makeDir ?? ((target) => mkdirSync(target, { recursive: true }))
+    this.onError = onError
+  }
+
+  get filePath(): string {
+    return this.path
+  }
+
+  /** Names of the files this sink owns, newest first. */
+  rotatedPaths(): string[] {
+    const paths = [this.path]
+    for (let index = 1; index < this.maxFiles; index += 1) {
+      paths.push(`${this.path}.${index}`)
+    }
+    return paths
+  }
+
+  write(line: string): void {
+    if (this.disabled || !line) {
+      return
+    }
+    try {
+      if (this.currentBytes === null) {
+        this.makeDir(dirname(this.path))
+        this.currentBytes = this.sizeOf(this.path) ?? 0
+      }
+      const bytes = Buffer.byteLength(line, 'utf8')
+      if (this.currentBytes > 0 && this.currentBytes + bytes > this.maxBytes) {
+        this.rotate()
+      }
+      this.appendFile(this.path, line)
+      this.currentBytes += bytes
+    } catch (error) {
+      this.disabled = true
+      this.onError(error)
+    }
+  }
+
+  private rotate(): void {
+    const paths = this.rotatedPaths()
+    // Drop the oldest, shift the rest up by one, then free the live name.
+    this.remove(paths[paths.length - 1])
+    for (let index = paths.length - 1; index >= 2; index -= 1) {
+      try {
+        this.rename(paths[index - 1], paths[index])
+      } catch {
+        // A missing intermediate file just means fewer rotations so far.
+      }
+    }
+    if (paths.length > 1) {
+      // The live file must move: a failed rename here (Windows lock, full
+      // disk) propagates so the sink disables itself explicitly instead of
+      // growing one file past the budget forever.
+      this.rename(paths[0], paths[1])
+    }
+    this.currentBytes = 0
+  }
+}

--- a/apps/desktop/src/main/backend-log-file.ts
+++ b/apps/desktop/src/main/backend-log-file.ts
@@ -1,6 +1,8 @@
 import { appendFileSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 
+import { stripAnsi } from './backend-crash-log'
+
 // Rotating on-disk sink for backend stderr + supervisor lifecycle lines.
 //
 // Packaged builds have no terminal: before this file every backend stderr line
@@ -25,7 +27,7 @@ export function formatBackendLogFileLine(
   message: string,
   timestamp: string
 ): string {
-  return `${timestamp} [${level}] ${message.replace(/\r?\n/g, '\\n')}\n`
+  return `${timestamp} [${level}] ${stripAnsi(message).replace(/\r?\n/g, '\\n')}\n`
 }
 
 export interface RotatingLogFileFs {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -161,6 +161,17 @@ import {
   type MediaAccessResult
 } from './media-access'
 import {
+  BACKEND_CRASH_LOG_LIMIT,
+  BackendStderrTail,
+  appendBackendCrashRecord,
+  backendCrashLogPath,
+  buildBackendCrashRecord,
+  describeBackendCrashRecord,
+  readBackendCrashLog,
+  shouldRecordBackendExit
+} from './backend-crash-log'
+import { RotatingLogFile, backendLogFilePath, formatBackendLogFileLine } from './backend-log-file'
+import {
   GPU_RETRY_STABILITY_MS,
   clearGpuFallbackState,
   decideGpuFallback,
@@ -856,6 +867,26 @@ app.on('child-process-gone', (_event, details) => {
     }
   }
 })
+// Backend crash evidence that survives restarts (live-feedback batch 3, B1).
+// The supervisor used to keep exit code/signal in memory and stderr in a ring
+// that died with the process, so a bundle exported after "Backend crashed,
+// restarting (attempt 3)" said nothing about the crash. Records live in
+// userData/backend-crashes.json (last 5) and ride into the bundle through
+// runtimeInfo.backendCrashes; every backend log line also lands in a rotating
+// userData/logs/backend.log so packaged Windows builds keep logs at all.
+const backendCrashLogFile = backendCrashLogPath(app.getPath('userData'))
+let backendCrashRecords = readBackendCrashLog(backendCrashLogFile)
+const backendLogFile = new RotatingLogFile({
+  path: backendLogFilePath(app.getPath('userData')),
+  onError: (error) => {
+    safeConsole.warn(`Backend log file disabled: ${errorMessageText(error)}`)
+  }
+})
+interface BackendGenerationEvidence {
+  startedAtMs: number
+  stderrTail: BackendStderrTail
+}
+const backendGenerationEvidence = new WeakMap<BackendRuntime, BackendGenerationEvidence>()
 // Keep the detached preview window live while it sits behind the main window.
 // A scene change is made in the main window, so the preview is occluded at that
 // moment — and macOS/Chromium stops compositing a fully-occluded window, which
@@ -7750,9 +7781,11 @@ let backendCrashTimestamps: number[] = []
 let backendRestartTimer: ReturnType<typeof setTimeout> | null = null
 let backendLastStartAt = 0
 
-function scheduleBackendRestart(code: number | null, signal: NodeJS.Signals | null): void {
+/** Returns the restart attempt number, or null when no restart was scheduled
+ * (the app is quitting, or the crash budget is exhausted). */
+function scheduleBackendRestart(code: number | null, signal: NodeJS.Signals | null): number | null {
   if (appIsQuitting || backendQuitInProgress || backendQuitComplete) {
-    return
+    return null
   }
   const now = Date.now()
   // A long stable run forgives earlier crashes (sleep/wake storms must not
@@ -7771,7 +7804,7 @@ function scheduleBackendRestart(code: number | null, signal: NodeJS.Signals | nu
       'Backend crashed repeatedly; automatic restarts stopped. Restart Videorc to recover.'
     )
     sendToWindows('backend:lifecycle', { state: 'failed', code, signal, attempt })
-    return
+    return attempt
   }
   const delayMs = BACKEND_RESTART_BACKOFF_MS[attempt - 1]
   logBackend(
@@ -7783,6 +7816,44 @@ function scheduleBackendRestart(code: number | null, signal: NodeJS.Signals | nu
     backendRestartTimer = null
     startBackend()
   }, delayMs)
+  return attempt
+}
+
+function recordBackendExit(
+  runtime: BackendRuntime,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  intentional: boolean,
+  attempt: number | null
+): void {
+  if (!shouldRecordBackendExit({ intentional, code, signal })) {
+    return
+  }
+  const evidence = backendGenerationEvidence.get(runtime)
+  const record = buildBackendCrashRecord({
+    at: new Date().toISOString(),
+    generation: runtime.generation,
+    code,
+    signal,
+    attempt,
+    uptimeMs: evidence ? Date.now() - evidence.startedAtMs : 0,
+    intentional,
+    stderrTail: evidence?.stderrTail.snapshot() ?? []
+  })
+  try {
+    backendCrashRecords = appendBackendCrashRecord(backendCrashLogFile, record, backendCrashRecords)
+    logBackend(
+      'warn',
+      `Recorded backend crash evidence: ${describeBackendCrashRecord(record)}; ${record.stderrTail.length} stderr line(s) kept in ${backendCrashLogFile}.`
+    )
+  } catch (error) {
+    // Keep the in-memory copy so this launch's bundle still carries it.
+    backendCrashRecords = [record, ...backendCrashRecords].slice(0, BACKEND_CRASH_LOG_LIMIT)
+    logBackend(
+      'error',
+      `Could not persist backend crash evidence to ${backendCrashLogFile}: ${errorMessageText(error)}`
+    )
+  }
 }
 
 function cancelBackendRestart(): void {
@@ -7840,9 +7911,8 @@ function finalizeBackendRuntimeExit(
     backendProcess = null
   }
   clearBackendConnectionState()
-  if (!settlement.wasIntentional) {
-    scheduleBackendRestart(code, signal)
-  }
+  const attempt = settlement.wasIntentional ? null : scheduleBackendRestart(code, signal)
+  recordBackendExit(runtime, code, signal, settlement.wasIntentional, attempt)
 }
 
 function startBackendWithRegistryLock(): void {
@@ -7896,14 +7966,22 @@ function startBackendWithRegistryLock(): void {
   })
   backendProcess = child
   const runtime = backendRuntimeOwner.start(child)
+  const stderrTail = new BackendStderrTail()
+  backendGenerationEvidence.set(runtime, { startedAtMs: backendLastStartAt, stderrTail })
+  logBackend(
+    'info',
+    `Backend generation ${runtime.generation} spawned as pid ${child.pid ?? 'unknown'}.`
+  )
   let runtimeStdoutBuffer = ''
   child.stdout.on('data', (chunk: Buffer) => {
     runtimeStdoutBuffer = handleBackendStdout(chunk.toString(), runtime, runtimeStdoutBuffer)
   })
   child.stderr.on('data', (chunk: Buffer) => {
     for (const line of chunk.toString().split(/\r?\n/)) {
-      if (line.trim()) {
-        logBackend(inferBackendLogLevel(line), line.trim())
+      const trimmed = line.trim()
+      if (trimmed) {
+        stderrTail.push(trimmed)
+        logBackend(inferBackendLogLevel(line), trimmed)
       }
     }
   })
@@ -8509,6 +8587,7 @@ function logBackend(level: BackendLogEvent['level'], message: string): void {
   if (backendLogs.length > 200) {
     backendLogs.shift()
   }
+  backendLogFile.write(formatBackendLogFileLine(level, message, log.timestamp))
 
   sendToWindows('backend:log', log)
 
@@ -11070,6 +11149,7 @@ async function runtimeInfo(): Promise<RuntimeInfo> {
       ),
       retryAttempts: gpuFallbackState?.retryAttempts ?? gpuFallbackLaunchState?.retryAttempts ?? 0
     },
+    backendCrashes: backendCrashRecords,
     env: process.env
   })
 }

--- a/apps/desktop/src/main/runtime-info.test.ts
+++ b/apps/desktop/src/main/runtime-info.test.ts
@@ -135,6 +135,50 @@ describe('runtime info helpers', () => {
     })
   })
 
+  it('carries persisted backend crash records into the bundle-bound runtime info', () => {
+    const crash = {
+      at: '2026-08-23T10:00:00.000Z',
+      generation: 2,
+      code: null,
+      signal: 'SIGKILL',
+      attempt: 1,
+      uptimeMs: 12_345,
+      intentional: false,
+      stderrTail: ['{"panic":"boom","location":"main.rs:1","thread":"main"}']
+    }
+    const info = buildRuntimeInfo({
+      appVersion: '9.9.9-test',
+      execPath: '/Applications/Videorc.app/Contents/MacOS/Videorc',
+      backendCrashes: [crash],
+      env: {}
+    })
+
+    // Contract pinned by the support bundle: rendererDiagnostics.runtimeInfo
+    // is forwarded verbatim, so the record shape IS the bundle shape.
+    expect(info.backendCrashes).toEqual([crash])
+    expect(info.backendCrashes).not.toBe([crash])
+    expect(JSON.parse(JSON.stringify(info)).backendCrashes).toEqual([crash])
+    expect(Object.keys(crash).sort()).toEqual([
+      'at',
+      'attempt',
+      'code',
+      'generation',
+      'intentional',
+      'signal',
+      'stderrTail',
+      'uptimeMs'
+    ])
+  })
+
+  it('defaults backendCrashes to an empty list so the bundle field is always present', () => {
+    const info = buildRuntimeInfo({
+      appVersion: '9.9.9-test',
+      execPath: '/Applications/Videorc.app/Contents/MacOS/Videorc',
+      env: {}
+    })
+    expect(info.backendCrashes).toEqual([])
+  })
+
   it('surfaces the running app version', () => {
     const info = buildRuntimeInfo({
       appVersion: '1.2.3',

--- a/apps/desktop/src/main/runtime-info.ts
+++ b/apps/desktop/src/main/runtime-info.ts
@@ -1,6 +1,11 @@
 import { release } from 'node:os'
 
-import type { RuntimeGpuDevice, RuntimeInfo, SystemPermissionPane } from '../shared/backend'
+import type {
+  BackendCrashRecord,
+  RuntimeGpuDevice,
+  RuntimeInfo,
+  SystemPermissionPane
+} from '../shared/backend'
 
 export const MACOS_PERMISSION_URLS: Record<SystemPermissionPane, string> = {
   privacy: 'x-apple.systempreferences:com.apple.preference.security',
@@ -29,6 +34,8 @@ export interface RuntimeInfoInput {
   gpuInfo?: unknown
   hardwareAccelerationDisabled?: boolean
   gpuFallback?: RuntimeInfo['gpuFallback']
+  /** Persisted crash evidence, most recent first (see backend-crash-log.ts). */
+  backendCrashes?: readonly BackendCrashRecord[]
   env: Partial<
     Pick<
       NodeJS.ProcessEnv,
@@ -97,6 +104,7 @@ export function buildRuntimeInfo({
     retryScheduled: false,
     retryAttempts: 0
   },
+  backendCrashes = [],
   env
 }: RuntimeInfoInput): RuntimeInfo {
   const targetPath = permissionTargetPath(execPath)
@@ -111,6 +119,7 @@ export function buildRuntimeInfo({
     gpuDevices: normalizeRuntimeGpuDevices(gpuInfo),
     hardwareAccelerationDisabled,
     gpuFallback,
+    backendCrashes: [...backendCrashes],
     isPackaged,
     permissionTargetName: isPackaged ? 'Videorc' : 'Electron',
     permissionTargetPath: targetPath,

--- a/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/diagnostics-tab.tsx
@@ -24,6 +24,7 @@ import {
   useStudioRecording
 } from '@/hooks/use-studio'
 import type {
+  BackendCrashRecord,
   DiagnosticBottleneck,
   DiagnosticStats,
   HealthEvent,
@@ -37,6 +38,7 @@ import type {
   SystemPermissionPane,
   WebSocketQueueDiagnosticStats
 } from '@/lib/backend'
+import { backendCrashView, latestBackendCrash } from '@/lib/backend-crash-view'
 import { compactTime, formatDroppedFrames, formatMetric } from '@/lib/format'
 import { systemAccessAction, systemAccessRows } from '@/lib/system-access'
 import { isNativePreviewCapability } from '../../../../shared/native-preview-capability'
@@ -700,6 +702,7 @@ export function DiagnosticsTab(): ReactElement {
         </PanelSection>
 
         <PanelSection icon={TerminalWindow} title="Backend logs">
+          <LastBackendCrash record={latestBackendCrash(runtimeInfo?.backendCrashes)} />
           <ScrollArea className="h-64 pr-3">
             <div className="flex flex-col gap-1.5">
               {logs.length ? (
@@ -814,6 +817,35 @@ function LogList({ entries }: { entries: SessionLogEntry[] }): ReactElement {
           sourceId={entry.sourceId ?? undefined}
         />
       ))}
+    </div>
+  )
+}
+
+// Persisted crash evidence (runtimeInfo.backendCrashes, written by main at
+// the moment of the exit). The live log list below starts at the CURRENT
+// generation, so without this row a crash that already restarted is invisible.
+function LastBackendCrash({ record }: { record: BackendCrashRecord | null }): ReactElement | null {
+  if (!record) {
+    return null
+  }
+  const view = backendCrashView(record)
+  return (
+    <div className="mb-2 rounded-row border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs">
+      <div className="mb-1 flex flex-wrap items-center gap-2">
+        <Badge variant="destructive">{view.intentional ? 'exit' : 'crash'}</Badge>
+        <span className="font-medium">
+          Backend generation {record.generation} · {view.exit} · after {view.uptime}
+          {view.attempt !== null ? ` · restart attempt ${view.attempt}` : ''}
+        </span>
+        <span className="ml-auto text-muted-foreground">{compactTime(record.at)}</span>
+      </div>
+      <p className="break-words font-mono text-muted-foreground">
+        {view.headline ?? 'No stderr output was captured before the exit.'}
+      </p>
+      <p className="mt-1 text-muted-foreground">
+        Kept with the last {record.stderrTail.length} stderr line(s); Export support bundle includes
+        it.
+      </p>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -4107,6 +4107,16 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     const offLog = window.videorc.onBackendLog(appendLog)
     // F-014: surface backend crashes instead of zombie-ing with a Ready badge.
     const offLifecycle = window.videorc.onBackendLifecycle?.((event) => {
+      // Crash evidence (runtimeInfo.backendCrashes) is written by main at the
+      // moment of the exit; re-read it so Diagnostics and the next bundle
+      // export carry the record without a relaunch.
+      if (event.state === 'restarting' || event.state === 'failed') {
+        window.videorc?.getRuntimeInfo?.().then((nextRuntimeInfo) => {
+          if (!disposed) {
+            setRuntimeInfo(nextRuntimeInfo)
+          }
+        })
+      }
       if (event.state === 'restarting') {
         toast.warning('Backend crashed', {
           id: 'backend-lifecycle',
@@ -7178,15 +7188,20 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     try {
       setLastError(null)
       setSupportBundleExportPending(true)
+      // Re-read runtime info at export time: backend crash records are
+      // appended by main while the app runs, and the startup snapshot would
+      // otherwise ship a bundle that predates the crash it is meant to explain.
+      const freshRuntimeInfo =
+        (await window.videorc?.getRuntimeInfo?.().catch(() => null)) ?? runtimeInfo
       const params: SupportBundleExportParams = {
         // S2 (plan 024): the backend only knows its crate version (stuck at
         // 0.9.0); forward the real Electron app version so the bundle
         // identifies the shipped build. Absent → backend degrades to crate.
-        appVersion: runtimeInfo?.version,
+        appVersion: freshRuntimeInfo?.version,
         rendererDiagnostics: {
           automaticSourceFallbacks: automaticSourceFallbacks.current,
           nativePreviewSurfaceStatus: previewSurfaceStatus,
-          runtimeInfo: runtimeInfo ?? undefined
+          runtimeInfo: freshRuntimeInfo ?? undefined
         }
       }
       const result = await client.request<SupportBundleExportResult>(

--- a/apps/desktop/src/renderer/src/lib/backend-crash-view.test.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-crash-view.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import type { BackendCrashRecord } from './backend'
+import {
+  backendCrashExitLabel,
+  backendCrashView,
+  formatBackendUptime,
+  latestBackendCrash,
+  parseBackendPanicLine
+} from './backend-crash-view'
+
+const record = (overrides: Partial<BackendCrashRecord> = {}): BackendCrashRecord => ({
+  at: '2026-08-23T10:00:00.000Z',
+  generation: 3,
+  code: null,
+  signal: 'SIGKILL',
+  attempt: 2,
+  uptimeMs: 4_200,
+  intentional: false,
+  stderrTail: ['INFO ready', 'WARN something'],
+  ...overrides
+})
+
+describe('backendCrashView', () => {
+  it('labels signal, code, and unknown exits', () => {
+    expect(backendCrashExitLabel({ code: null, signal: 'SIGKILL' })).toBe('signal SIGKILL')
+    expect(backendCrashExitLabel({ code: 101, signal: null })).toBe('code 101')
+    expect(backendCrashExitLabel({ code: null, signal: null })).toBe('unknown exit')
+  })
+
+  it('formats uptime at a glance', () => {
+    expect(formatBackendUptime(250)).toBe('250ms')
+    expect(formatBackendUptime(4_200)).toBe('4.2s')
+    expect(formatBackendUptime(150_000)).toBe('3min')
+    expect(formatBackendUptime(7_200_000)).toBe('2.0h')
+  })
+
+  it('prefers the Rust panic-hook line over the last stderr line', () => {
+    const view = backendCrashView(
+      record({
+        code: 101,
+        signal: null,
+        stderrTail: [
+          'INFO ready',
+          '{"panic":"ring starvation","location":"compositor.rs:42","thread":"compositor"}',
+          "thread 'compositor' panicked at compositor.rs:42",
+          'note: run with RUST_BACKTRACE=1'
+        ]
+      })
+    )
+    expect(view.exit).toBe('code 101')
+    expect(view.headline).toBe('panic: ring starvation (compositor.rs:42)')
+    expect(view.panic).toEqual({
+      message: 'ring starvation',
+      location: 'compositor.rs:42',
+      thread: 'compositor'
+    })
+  })
+
+  it('falls back to the last stderr line, then to null', () => {
+    expect(backendCrashView(record()).headline).toBe('WARN something')
+    expect(backendCrashView(record({ stderrTail: [] })).headline).toBeNull()
+    expect(backendCrashView(record()).attempt).toBe(2)
+    expect(backendCrashView(record()).uptime).toBe('4.2s')
+  })
+
+  it('ignores panic-looking lines that are not valid JSON', () => {
+    expect(parseBackendPanicLine('{"panic": oops')).toBeNull()
+    expect(parseBackendPanicLine('{"panic":5}')).toBeNull()
+    expect(parseBackendPanicLine('plain line')).toBeNull()
+  })
+
+  it('takes the first record as the latest (stored most recent first)', () => {
+    expect(latestBackendCrash(undefined)).toBeNull()
+    expect(latestBackendCrash([])).toBeNull()
+    expect(
+      latestBackendCrash([record({ generation: 9 }), record({ generation: 1 })])?.generation
+    ).toBe(9)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/backend-crash-view.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-crash-view.ts
@@ -1,0 +1,79 @@
+import type { BackendCrashRecord } from './backend'
+
+export interface BackendCrashView {
+  /** "code 101" / "signal SIGKILL" / "unknown exit". */
+  exit: string
+  /** Restart ladder position, or null when no restart was scheduled. */
+  attempt: number | null
+  uptime: string
+  /** The one stderr line most likely to explain the exit: a Rust panic-hook
+   * line when present, otherwise the last line the process printed. */
+  headline: string | null
+  /** Rust panic hook payload when the tail carries one. */
+  panic: { message: string; location: string | null; thread: string | null } | null
+  intentional: boolean
+}
+
+const PANIC_LINE_PREFIX = '{"panic":'
+
+export function backendCrashExitLabel(record: Pick<BackendCrashRecord, 'code' | 'signal'>): string {
+  if (record.signal) return `signal ${record.signal}`
+  if (record.code !== null) return `code ${record.code}`
+  return 'unknown exit'
+}
+
+export function formatBackendUptime(uptimeMs: number): string {
+  if (uptimeMs < 1_000) return `${Math.max(0, Math.round(uptimeMs))}ms`
+  if (uptimeMs < 60_000) return `${(uptimeMs / 1_000).toFixed(1)}s`
+  if (uptimeMs < 3_600_000) return `${Math.round(uptimeMs / 60_000)}min`
+  return `${(uptimeMs / 3_600_000).toFixed(1)}h`
+}
+
+export function parseBackendPanicLine(line: string): BackendCrashView['panic'] {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith(PANIC_LINE_PREFIX)) return null
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const value = parsed as Record<string, unknown>
+    if (typeof value.panic !== 'string') return null
+    return {
+      message: value.panic,
+      location: typeof value.location === 'string' ? value.location : null,
+      thread: typeof value.thread === 'string' ? value.thread : null
+    }
+  } catch {
+    return null
+  }
+}
+
+export function backendCrashView(record: BackendCrashRecord): BackendCrashView {
+  let panic: BackendCrashView['panic'] = null
+  let panicLine: string | null = null
+  for (let index = record.stderrTail.length - 1; index >= 0; index -= 1) {
+    const parsed = parseBackendPanicLine(record.stderrTail[index])
+    if (parsed) {
+      panic = parsed
+      panicLine = record.stderrTail[index]
+      break
+    }
+  }
+  const lastLine = record.stderrTail.at(-1) ?? null
+  return {
+    exit: backendCrashExitLabel(record),
+    attempt: record.attempt,
+    uptime: formatBackendUptime(record.uptimeMs),
+    headline: panic
+      ? `panic: ${panic.message}${panic.location ? ` (${panic.location})` : ''}`
+      : (panicLine ?? lastLine),
+    panic,
+    intentional: record.intentional
+  }
+}
+
+/** Most recent record, or null. Records are stored most recent first. */
+export function latestBackendCrash(
+  records: readonly BackendCrashRecord[] | undefined
+): BackendCrashRecord | null {
+  return records?.[0] ?? null
+}

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -2811,6 +2811,29 @@ export interface RuntimeInfo {
   disableAutoPreview?: boolean
   disableAutoSourcePreview?: boolean
   nativePreviewSurfaceStageSuspended?: boolean
+  /** Persisted backend crash evidence (most recent first, last 5). Survives
+   * supervisor restarts and app relaunches so a support bundle exported after
+   * "Backend crashed, restarting" still names the exit and its last stderr. */
+  backendCrashes?: BackendCrashRecord[]
+}
+
+/** One backend process exit worth keeping: every non-intentional exit plus
+ * intentional shutdowns that still reported a non-zero code. Written by the
+ * main-process supervisor to `userData/backend-crashes.json`. */
+export interface BackendCrashRecord {
+  /** ISO timestamp of the exit observation. */
+  at: string
+  /** Supervisor generation (1-based per app launch) of the process that died. */
+  generation: number
+  code: number | null
+  signal: string | null
+  /** Restart attempt number the supervisor assigned, or null when no restart
+   * was scheduled (app quitting, intentional stop with a non-zero code). */
+  attempt: number | null
+  uptimeMs: number
+  intentional: boolean
+  /** Last stderr lines of that process (each line truncated). */
+  stderrTail: string[]
 }
 
 export interface RuntimeGpuDevice {

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -39,6 +39,7 @@ mod mpeg_ts;
 mod native_preview_host;
 mod noise_cleanup;
 mod oauth;
+mod panic_hook;
 mod pipeline;
 mod posters;
 mod preflight;
@@ -197,6 +198,9 @@ use crate::youtube::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // One JSON line on stderr per panic so the supervisor's crash record
+    // (backend-crashes.json) names the cause; see panic_hook.rs.
+    panic_hook::install();
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::from_default_env().add_directive("videorc_backend=info".parse()?),

--- a/crates/videorc-backend/src/panic_hook.rs
+++ b/crates/videorc-backend/src/panic_hook.rs
@@ -1,0 +1,155 @@
+//! Structured panic reporting for the supervisor.
+//!
+//! Electron owns this process's stderr and keeps the last lines of a dying
+//! generation in `backend-crashes.json` (desktop `backend-crash-log.ts`). The
+//! default Rust hook prints a multi-line, human-shaped message; this hook
+//! prints ONE machine-readable JSON line first so the crash record carries
+//! the panic message, location, and thread even when everything after it is
+//! cut off, then defers to the default hook so unwind/abort semantics,
+//! `RUST_BACKTRACE`, and test harness output stay exactly as before.
+
+use std::io::Write;
+use std::panic::PanicHookInfo;
+
+/// Install the structured hook. Call once, before tracing is initialised, so
+/// a panic inside subscriber setup is still reported.
+pub fn install() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let line = format_panic_line(
+            &panic_message(info),
+            panic_location(info).as_deref(),
+            std::thread::current().name(),
+        );
+        {
+            // Bypass tracing/buffering: the line must be on the wire before
+            // anything else runs, and it must never itself panic.
+            let stderr = std::io::stderr();
+            let mut handle = stderr.lock();
+            let _ = writeln!(handle, "{line}");
+            let _ = handle.flush();
+        }
+        tracing::error!(target: "videorc_backend::panic", "{line}");
+        default_hook(info);
+    }));
+
+    #[cfg(debug_assertions)]
+    if std::env::var("VIDEORC_DEV_PANIC_ON_START").as_deref() == Ok("1") {
+        panic!("VIDEORC_DEV_PANIC_ON_START=1 requested a test panic");
+    }
+}
+
+/// One JSON object, no embedded newlines: `{"panic":…,"location":…,"thread":…}`.
+pub fn format_panic_line(message: &str, location: Option<&str>, thread: Option<&str>) -> String {
+    // Field order is part of the contract: the desktop Diagnostics view
+    // recognises a panic line by its `{"panic":` prefix, and serde_json's
+    // default map ordering is alphabetical, so the object is assembled by hand
+    // with serde_json doing only the string escaping.
+    let location = match location {
+        Some(location) => json_string(location),
+        None => "null".to_string(),
+    };
+    let line = format!(
+        "{{\"panic\":{},\"location\":{},\"thread\":{}}}",
+        json_string(message),
+        location,
+        json_string(thread.unwrap_or("unnamed"))
+    );
+    // serde_json never emits raw newlines inside strings, but the contract
+    // ("one line on stderr") is load-bearing for the supervisor's tail ring,
+    // so enforce it rather than trust it.
+    line.replace(['\n', '\r'], " ")
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"<unencodable>\"".to_string())
+}
+
+pub fn panic_message(info: &PanicHookInfo<'_>) -> String {
+    let payload = info.payload();
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "Box<dyn Any>".to_string()
+    }
+}
+
+pub fn panic_location(info: &PanicHookInfo<'_>) -> Option<String> {
+    info.location()
+        .map(|location| format!("{}:{}", location.file(), location.line()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panic_hook_line_is_one_json_object_with_the_contract_fields() {
+        let line = format_panic_line(
+            "ring starvation",
+            Some("crates/videorc-backend/src/compositor.rs:42"),
+            Some("compositor"),
+        );
+        assert!(!line.contains('\n'));
+        let parsed: serde_json::Value = serde_json::from_str(&line).expect("valid JSON");
+        assert_eq!(parsed["panic"], "ring starvation");
+        assert_eq!(
+            parsed["location"],
+            "crates/videorc-backend/src/compositor.rs:42"
+        );
+        assert_eq!(parsed["thread"], "compositor");
+        assert!(line.starts_with("{\"panic\":"), "{line}");
+    }
+
+    #[test]
+    fn panic_hook_line_escapes_newlines_and_quotes_in_the_message() {
+        let line = format_panic_line("first line\nsecond \"quoted\" line", None, None);
+        assert_eq!(line.lines().count(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(&line).expect("valid JSON");
+        assert_eq!(parsed["panic"], "first line\nsecond \"quoted\" line");
+        assert!(parsed["location"].is_null());
+        assert_eq!(parsed["thread"], "unnamed");
+    }
+
+    #[test]
+    fn panic_hook_message_reads_str_and_string_payloads() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let previous = std::panic::take_hook();
+        {
+            let captured = captured.clone();
+            std::panic::set_hook(Box::new(move |info| {
+                captured.lock().unwrap().push(format_panic_line(
+                    &panic_message(info),
+                    panic_location(info).as_deref(),
+                    std::thread::current().name(),
+                ));
+            }));
+        }
+        let _ = std::panic::catch_unwind(|| panic!("static str payload"));
+        let _ = std::panic::catch_unwind(|| panic!("formatted {} payload", 7));
+        std::panic::set_hook(previous);
+
+        // The hook is process-global: ignore anything another test thread
+        // happened to panic with while ours was installed.
+        let lines: Vec<String> = captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|line| line.contains("payload"))
+            .cloned()
+            .collect();
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        let first: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+        let second: serde_json::Value = serde_json::from_str(&lines[1]).unwrap();
+        assert_eq!(first["panic"], "static str payload");
+        assert_eq!(second["panic"], "formatted 7 payload");
+        assert!(
+            first["location"]
+                .as_str()
+                .is_some_and(|location| location.contains("panic_hook.rs:")),
+            "{first}"
+        );
+    }
+}

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -554,8 +554,29 @@ Included sections:
 - current recording status
 - latest diagnostic stats
 - recent backend logs and health events
+- persisted backend crash records (`rendererDiagnostics.runtimeInfo.backendCrashes`,
+  last 5, most recent first): exit code/signal, supervisor generation and
+  restart attempt, uptime, and the dying process's last stderr lines — this is
+  what explains a "Backend crashed, restarting" toast after the restart already
+  happened
 - recent session summaries with media paths reduced to redacted basenames
 - redaction summary counters
+
+Durable backend evidence outside the bundle (both under Electron's `userData`
+directory, `~/Library/Application Support/Videorc/` on macOS and
+`%APPDATA%\Videorc\` on Windows):
+
+- `backend-crashes.json` — the crash records above, written atomically at the
+  moment of each non-intentional backend exit (and intentional stops with a
+  non-zero code).
+- `logs/backend.log` (+ `backend.log.1`, 2 × 2 MB rotation) — every backend
+  stderr line and supervisor lifecycle line, so packaged builds without a
+  terminal keep logs across restarts. A Rust panic writes one structured line,
+  `{"panic":…,"location":…,"thread":…}`, before the default panic output;
+  debug builds can force one at startup with `VIDEORC_DEV_PANIC_ON_START=1`.
+
+`pnpm smoke:backend-resilience` kills the backend with SIGKILL and asserts the
+record, the log file, and `runtimeInfo.backendCrashes` all carry the crash.
 
 Excluded by default:
 

--- a/scripts/lib/support-bundle-verifier.mjs
+++ b/scripts/lib/support-bundle-verifier.mjs
@@ -107,6 +107,8 @@ export function validateSupportBundle(bundle, options = {}) {
     }
   }
 
+  inspectBackendCrashRecords(bundle, failures)
+
   inspectValue(bundle, [], failures, warnings)
   if (options.windowsAcceptance === true) {
     inspectWindowsAcceptance(bundle, failures, warnings)
@@ -117,6 +119,79 @@ export function validateSupportBundle(bundle, options = {}) {
     failures,
     warnings
   }
+}
+
+// Live-feedback batch 3 (B1): rendererDiagnostics.runtimeInfo.backendCrashes
+// carries the supervisor's persisted crash records (most recent first). The
+// field is optional (older apps omit it), but when present every record must
+// keep the shape the crash-capture flow promises, or the bundle is lying.
+const BACKEND_CRASH_RECORD_LIMIT = 5
+const BACKEND_CRASH_STDERR_TAIL_LIMIT = 50
+
+function inspectBackendCrashRecords(bundle, failures) {
+  const runtimeInfo = bundle.rendererDiagnostics?.runtimeInfo
+  if (!isPlainObject(runtimeInfo) || runtimeInfo.backendCrashes === undefined) {
+    return
+  }
+  const prefix = 'rendererDiagnostics.runtimeInfo.backendCrashes'
+  const records = runtimeInfo.backendCrashes
+  if (!Array.isArray(records)) {
+    failures.push(`${prefix} must be an array of crash records.`)
+    return
+  }
+  if (records.length > BACKEND_CRASH_RECORD_LIMIT) {
+    failures.push(`${prefix} must keep at most ${BACKEND_CRASH_RECORD_LIMIT} records.`)
+  }
+  let previousAt = null
+  records.forEach((record, index) => {
+    const label = `${prefix}.${index}`
+    if (!isPlainObject(record)) {
+      failures.push(`${label} must be an object.`)
+      return
+    }
+    if (typeof record.at !== 'string' || Number.isNaN(Date.parse(record.at))) {
+      failures.push(`${label}.at must be an ISO timestamp.`)
+    } else {
+      const at = Date.parse(record.at)
+      if (previousAt !== null && at > previousAt) {
+        failures.push(`${prefix} must be ordered most recent first (record ${index}).`)
+      }
+      previousAt = at
+    }
+    if (!Number.isInteger(record.generation) || record.generation < 0) {
+      failures.push(`${label}.generation must be a non-negative integer.`)
+    }
+    if (record.code !== null && !Number.isInteger(record.code)) {
+      failures.push(`${label}.code must be an integer or null.`)
+    }
+    if (record.signal !== null && (typeof record.signal !== 'string' || !record.signal)) {
+      failures.push(`${label}.signal must be a signal name or null.`)
+    }
+    if (record.code === null && record.signal === null && record.intentional !== true) {
+      failures.push(`${label} must name an exit code or a signal for a crash.`)
+    }
+    if (record.attempt !== null && (!Number.isInteger(record.attempt) || record.attempt < 1)) {
+      failures.push(`${label}.attempt must be a positive integer or null.`)
+    }
+    if (!Number.isInteger(record.uptimeMs) || record.uptimeMs < 0) {
+      failures.push(`${label}.uptimeMs must be a non-negative integer.`)
+    }
+    if (typeof record.intentional !== 'boolean') {
+      failures.push(`${label}.intentional must be a boolean.`)
+    }
+    if (!Array.isArray(record.stderrTail)) {
+      failures.push(`${label}.stderrTail must be an array of strings.`)
+    } else {
+      if (record.stderrTail.length > BACKEND_CRASH_STDERR_TAIL_LIMIT) {
+        failures.push(
+          `${label}.stderrTail must keep at most ${BACKEND_CRASH_STDERR_TAIL_LIMIT} lines.`
+        )
+      }
+      if (record.stderrTail.some((line) => typeof line !== 'string')) {
+        failures.push(`${label}.stderrTail must contain only strings.`)
+      }
+    }
+  })
 }
 
 function inspectWindowsAcceptance(bundle, failures, warnings) {

--- a/scripts/lib/support-bundle-verifier.test.mjs
+++ b/scripts/lib/support-bundle-verifier.test.mjs
@@ -483,6 +483,81 @@ describe('validateSupportBundle', () => {
     assert.match(result.failures.join('\n'), /gpuFallback/)
   })
 
+  it('accepts a bundle without backend crash records (older apps) and with valid ones', () => {
+    const bundle = validWindowsAcceptanceBundle()
+    assert.equal(validateSupportBundle(bundle, { windowsAcceptance: true }).ok, true)
+
+    bundle.rendererDiagnostics.runtimeInfo.backendCrashes = [
+      {
+        at: '2026-08-23T10:00:05.000Z',
+        generation: 2,
+        code: 101,
+        signal: null,
+        attempt: 2,
+        uptimeMs: 1200,
+        intentional: false,
+        stderrTail: ['{"panic":"boom","location":"main.rs:1","thread":"main"}']
+      },
+      {
+        at: '2026-08-23T10:00:00.000Z',
+        generation: 1,
+        code: null,
+        signal: 'SIGKILL',
+        attempt: 1,
+        uptimeMs: 65000,
+        intentional: false,
+        stderrTail: []
+      }
+    ]
+
+    const result = validateSupportBundle(bundle, { windowsAcceptance: true })
+
+    assert.deepEqual(result.failures, [])
+    assert.equal(result.ok, true)
+  })
+
+  it('rejects malformed backend crash records', () => {
+    const bundle = validBundle()
+    bundle.rendererDiagnostics.runtimeInfo.backendCrashes = [
+      {
+        at: '2026-08-23T10:00:00.000Z',
+        generation: 1,
+        code: null,
+        signal: null,
+        attempt: 0,
+        uptimeMs: -1,
+        intentional: false,
+        stderrTail: 'not-a-list'
+      },
+      {
+        at: '2026-08-23T10:00:05.000Z',
+        generation: 2,
+        code: 1,
+        signal: null,
+        attempt: null,
+        uptimeMs: 1,
+        intentional: false,
+        stderrTail: []
+      }
+    ]
+
+    const result = validateSupportBundle(bundle)
+
+    assert.equal(result.ok, false)
+    const failures = result.failures.join('\n')
+    assert.match(failures, /backendCrashes\.0 must name an exit code or a signal/)
+    assert.match(failures, /backendCrashes\.0\.attempt must be a positive integer or null/)
+    assert.match(failures, /backendCrashes\.0\.uptimeMs must be a non-negative integer/)
+    assert.match(failures, /backendCrashes\.0\.stderrTail must be an array of strings/)
+    assert.match(failures, /must be ordered most recent first \(record 1\)/)
+
+    bundle.rendererDiagnostics.runtimeInfo.backendCrashes = { at: 'x' }
+    assert.match(
+      validateSupportBundle(bundle).failures.join('\n'),
+      /backendCrashes must be an array of crash records/
+    )
+  })
+
   it('rejects software rendering without its persisted reason', () => {
     const bundle = validWindowsAcceptanceBundle()
     bundle.rendererDiagnostics.runtimeInfo.hardwareAccelerationDisabled = true

--- a/scripts/smoke-backend-resilience.mjs
+++ b/scripts/smoke-backend-resilience.mjs
@@ -3,14 +3,27 @@
 // "Backend offline", the supervisor restarts the process, and the badge heals
 // back to Ready with a working socket.
 //
+// Live-feedback batch 3 (B1): the crash must also leave durable evidence —
+// userData/backend-crashes.json gains a record naming the signal with the
+// dying generation's stderr tail, and userData/logs/backend.log exists — so a
+// support bundle exported AFTER the restart can still explain the crash.
+//
 // Run: pnpm smoke:backend-resilience
 
+import { existsSync, mkdtempSync, readFileSync, statSync } from 'node:fs'
 import { request as httpRequest } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { launchDevApp, stopProcess } from './lib/app-launcher.mjs'
 
 const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 120000)
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Pin the Electron userData dir so the crash evidence can be read back here.
+const userDataDir = mkdtempSync(join(tmpdir(), 'videorc-smoke-resilience-user-data-'))
+const crashLogPath = join(userDataDir, 'backend-crashes.json')
+const backendLogPath = join(userDataDir, 'logs', 'backend.log')
 
 const launched = await launchDevApp({
   requiredMarkers: ['backend-ready', 'preview-motion-ready'],
@@ -18,7 +31,8 @@ const launched = await launchDevApp({
   env: {
     VIDEORC_SMOKE_PRINT_BACKEND_READY: '1',
     VIDEORC_SMOKE_COMMAND_SERVER: '1',
-    VIDEORC_SMOKE_PREVIEW_MOTION: '1'
+    VIDEORC_SMOKE_PREVIEW_MOTION: '1',
+    VIDEORC_USER_DATA_DIR: userDataDir
   }
 })
 
@@ -40,17 +54,84 @@ try {
   console.log('Backend resilience: Session badge reports Backend offline.')
 
   await waitForBadge(smoke, 'Ready', 'Ready badge after supervisor restart', 60_000)
+  console.log('Backend resilience: supervisor restarted, badge healed to Ready.')
+
+  const record = await waitForCrashRecord(backend.pid)
   console.log(
-    'Backend resilience smoke OK — offline surfaced, supervisor restarted, badge healed to Ready.'
+    `Backend resilience: crash record persisted (generation ${record.generation}, signal ${record.signal}, attempt ${record.attempt}, ${record.stderrTail.length} stderr lines).`
+  )
+  if (!existsSync(backendLogPath) || statSync(backendLogPath).size === 0) {
+    throw new Error(`Expected a non-empty backend log at ${backendLogPath}.`)
+  }
+  const backendLog = readFileSync(backendLogPath, 'utf8')
+  if (!backendLog.includes('Recorded backend crash evidence')) {
+    throw new Error(`backend.log does not mention the crash record:\n${backendLog.slice(-2000)}`)
+  }
+  console.log(`Backend resilience: backend.log kept ${backendLog.split('\n').length} lines.`)
+
+  const runtimeInfo = await sendSmokeCommand(smoke, 'eval-js', {
+    code: 'return await window.videorc.getRuntimeInfo()'
+  })
+  const exported = runtimeInfo?.result?.backendCrashes
+  if (!Array.isArray(exported) || exported[0]?.at !== record.at) {
+    throw new Error(
+      `runtimeInfo.backendCrashes does not lead with the persisted record: ${JSON.stringify(exported)?.slice(0, 500)}`
+    )
+  }
+  console.log(
+    'Backend resilience smoke OK — offline surfaced, supervisor restarted, badge healed to Ready, crash evidence persisted and exported via runtimeInfo.'
   )
 } finally {
-  await stopProcess(launched.child, { timeoutMs: 15000 })
+  await stopProcess(launched.process, { timeoutMs: 15000 })
 }
 
 // The supervisor-restarted backend inherits the app's stdio pipes, which keeps
 // this script's event loop alive after the assertions pass — exit explicitly
 // (same pattern as preview-lifecycle-probe.mjs).
 process.exit(0)
+
+async function waitForCrashRecord(killedPid, budgetMs = 15_000) {
+  const deadline = Date.now() + budgetMs
+  let last = null
+  while (Date.now() < deadline) {
+    try {
+      const parsed = JSON.parse(readFileSync(crashLogPath, 'utf8'))
+      const records = Array.isArray(parsed?.records) ? parsed.records : []
+      last = records
+      const record = records.find((entry) => entry?.intentional === false)
+      if (record) {
+        // Packaged: the supervisor's child IS the backend → signal SIGKILL.
+        // Dev: the child is `cargo run`, which exits 101 and prints the
+        // backend's "(signal: 9, SIGKILL: kill)" line — captured in the tail.
+        const namesKill =
+          record.signal === 'SIGKILL' ||
+          (Array.isArray(record.stderrTail) &&
+            record.stderrTail.some((line) => /SIGKILL|signal: 9\b/.test(line)))
+        if (!namesKill) {
+          throw new Error(
+            `Crash record for the killed backend (pid ${killedPid}) must name SIGKILL (signal or stderr tail), saw ${JSON.stringify(record)}`
+          )
+        }
+        if (!Array.isArray(record.stderrTail) || record.stderrTail.length === 0) {
+          throw new Error(`Crash record carries no stderr tail: ${JSON.stringify(record)}`)
+        }
+        if (!Number.isInteger(record.attempt) || record.attempt < 1) {
+          throw new Error(`Crash record has no restart attempt: ${JSON.stringify(record)}`)
+        }
+        return record
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT' && !(error instanceof SyntaxError)) {
+        throw error
+      }
+      last = `read error: ${error.message}`
+    }
+    await sleep(300)
+  }
+  throw new Error(
+    `Timed out waiting for a crash record in ${crashLogPath}; last saw ${JSON.stringify(last)}.`
+  )
+}
 
 async function waitForBadge(smoke, expected, label, budgetMs = 30_000) {
   const deadline = Date.now() + budgetMs


### PR DESCRIPTION
Slice **B1** of the Live Feedback Batch 3 plan (2026-08-23).

## Why

A Windows tester's support bundle after "Backend crashed, restarting (attempt 3)" contained nothing about the crash: supervisor exit state lived in memory, stderr in a 200-line ring that died with the process, Rust had no panic hook, and packaged builds wrote no log file. The bundle started at the next generation's "backend ready".

## What

- **`apps/desktop/src/main/backend-crash-log.ts`** (new, modeled on `gpu-fallback.ts`): `userData/backend-crashes.json`, last 5 records `{ at, generation, code, signal, attempt, uptimeMs, intentional, stderrTail (≤50 lines × ≤400 chars, ANSI stripped) }`, atomic temp+rename write, tolerant read.
- **`apps/desktop/src/main/backend-log-file.ts`** (new): rotating `userData/logs/backend.log` (2 × 2 MB) for every backend stderr line + supervisor lifecycle line, so packaged Windows builds keep logs. Self-disables with one explicit warning on disk failure.
- **`main/index.ts`**: per-generation stderr tail ring fed from the existing stderr handler; `finalizeBackendRuntimeExit` records every non-intentional exit (plus intentional exits with a non-zero code) with the restart attempt from `scheduleBackendRestart` (now returns it); "generation N spawned as pid" line; all `logBackend` lines go to the file sink; `runtimeInfo.backendCrashes`.
- **`shared/backend.ts` + `main/runtime-info.ts`**: `RuntimeInfo.backendCrashes?: BackendCrashRecord[]` (most recent first, always emitted).
- **Renderer**: `use-studio.tsx` re-reads runtimeInfo on `restarting`/`failed` lifecycle events and again at support-bundle export time (the startup snapshot would otherwise predate the crash). Diagnostics tab → "Backend logs" panel leads with the last crash record (time, exit, uptime, attempt, panic/last stderr line) via `lib/backend-crash-view.ts`.
- **Rust `crates/videorc-backend/src/panic_hook.rs`**: `std::panic::set_hook` before tracing init writes ONE line `{"panic":…,"location":"file:line","thread":…}` to stderr (hand-assembled so field order is stable; serde_json escapes), then `tracing::error!`, then the default hook (unwind/abort unchanged). Debug-only `VIDEORC_DEV_PANIC_ON_START=1` forces one.
- **Support bundle**: schema stays 2; rides in `rendererDiagnostics.runtimeInfo`. `scripts/lib/support-bundle-verifier.mjs` validates the field shape when present (optional for older apps).
- **`scripts/smoke-backend-resilience.mjs`**: after the SIGKILL it now asserts the crash record (signal/tail/attempt), a non-empty `backend.log` that mentions the record, and `runtimeInfo.backendCrashes[0]` matching it. Also fixes the stale `launched.child` → `launched.process` stop call.
- `docs/distribution.md` Support Bundles section documents the new evidence.

## Gates

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm format:check` ✅
- `pnpm --filter @videorc/desktop test` ✅ 153 files, 1406 passed | 1 skipped (42 new tests across backend-crash-log / backend-log-file / runtime-info / backend-crash-view)
- `pnpm test:scripts` ✅ 1057 passed (verifier gains 2 tests)
- `cargo fmt --check --all` ✅
- `cargo clippy -p videorc-backend -- -D warnings` ✅
- `cargo test -p videorc-backend panic_hook` ✅ 3 passed

## Proof (kill -9)

`VIDEORC_SMOKE_TIMEOUT_MS=240000 pnpm smoke:backend-resilience` (dev app, isolated userData):

```
Backend resilience: initial badge Ready (backend pid 235).
Backend resilience: sent SIGKILL to the backend.
Backend resilience: Session badge reports Backend offline.
Backend resilience: supervisor restarted, badge healed to Ready.
Backend resilience: crash record persisted (generation 1, signal SIGKILL, attempt 1, 3 stderr lines).
Backend resilience: backend.log kept 22 lines.
Backend resilience smoke OK — offline surfaced, supervisor restarted, badge healed to Ready, crash evidence persisted and exported via runtimeInfo.
```

Resulting `backend-crashes.json` record: `{"at":"2026-08-23T14:13:04.274Z","generation":1,"code":null,"signal":"SIGKILL","attempt":1,"uptimeMs":2423,"intentional":false,"stderrTail":[…3 lines ending at "Videorc backend ready." / OAuth listener / entitlements warn]}`.

Note for the first run in a cold worktree: `cargo run --quiet` compiles silently, so launch the smoke only after `cargo build -p videorc-backend --bin videorc-backend` or raise `VIDEORC_SMOKE_TIMEOUT_MS`.

Not yet proven here: the forced Rust panic through the full app (unit-tested on the formatting helper + real `catch_unwind` payloads); Windows `backend.log` existence (tester).
