### PR TITLE
release: 0.9.68-beta.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.68-beta.1.md
+++ b/changelog/0.9.68-beta.1.md
@@ -1,0 +1,37 @@
+---
+version: 0.9.68-beta.1
+date: 2026-08-23
+channel: beta
+platforms:
+  - macos
+title: A recording that starts, a mixer that tells the truth, and crashes that leave a trace
+summary: Recording no longer refuses to start over a brief compositor hiccup — it starts and warns instead — and a start that does fail is now impossible to miss. The audio mixer finally shows real levels and stays quiet when you're not recording. Your avatar arrives from the web, Settings cards fit their content, and backend crashes leave a record in the support bundle.
+highlights:
+  - Recording starts even when the compositor stumbles for a moment at launch — a brief frame-gap hiccup now yields a recording with a warning instead of a refusal. If a start truly fails, you get a persistent error with Retry and a badge on the Record button, not a four-second toast.
+  - The audio mixer shows honest levels — room tone sits at the floor, speech rises fast and falls naturally — and it no longer opens your mic or dances while you're idle unless you turn on Monitor input. It arms itself the moment a session starts.
+  - Your account avatar now shows in the app, including for Google-linked accounts, and chat avatars render in the detached Comments window.
+  - Settings cards are sized to their content in two tidy columns; Remote control no longer stretches to fill an empty row.
+  - If the backend ever crashes, the support bundle now carries the exit code, signal and the last log lines from the crashed process, and a backend.log file is kept on disk.
+  - Windows groundwork: the capture pipeline resets cleanly after a session, the preview always comes back after stop, and every recording logs a frame-accounting summary so dropped frames can be traced to the stage that dropped them.
+---
+
+The headline is the startup barrier. Before encoding, Videorc checks that
+the compositor is delivering frames at a steady cadence; on macOS that
+budget was 71 ms at 30 fps — tight enough that a single busy moment at
+session start (chat, co-host, FFmpeg spawning) could fail the check and
+refuse the whole session, including a live stream, with only a brief
+toast to say so. The budget now matches what Windows already uses, a
+cadence-only stumble records with a warning instead of refusing, and a
+start that genuinely fails stays on screen with a Retry until you dismiss
+it.
+
+The mixer was mapping raw spectrum magnitudes through a curve that made
+silence look like sound; it now uses the same decibel scale as the rest
+of the app, real attack and release, and it no longer opens the
+microphone just because the Studio tab is open — a new Monitor input
+toggle does that on demand, and any session arms it automatically.
+
+Under the hood, backend crashes are finally diagnosable: the supervisor
+writes a crash record with the last log lines before restarting, a
+rotating backend.log is kept next to the app data, and support bundles
+include both.


### PR DESCRIPTION
Version bump + macOS changelog for batch 3 (#257 #258 #259 #260 #261 #262; web #15).