### PR TITLE
release: 0.9.69 — Windows budget-test fix + 0.9.69-alpha.1 entry

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.68",
+  "version": "0.9.69",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.69-alpha.1.md
+++ b/changelog/0.9.69-alpha.1.md
@@ -1,6 +1,6 @@
 ---
-version: 0.9.68-alpha.1
-date: 2026-08-23
+version: 0.9.69-alpha.1
+date: 2026-08-24
 channel: alpha
 platforms:
   - windows

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -16511,9 +16511,17 @@ mod tests {
             recording_startup_frame_gap_budget(60),
             Duration::from_millis(200)
         );
+        // 24fps: macOS 4.0 × 41.7ms = 167ms → floor 200ms; Windows 6.0 × 41.7ms
+        // = 250ms — the factor beats the floor there.
+        #[cfg(target_os = "macos")]
         assert_eq!(
             recording_startup_frame_gap_budget(24),
             Duration::from_millis(200)
+        );
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(
+            recording_startup_frame_gap_budget(24),
+            Duration::from_millis(250)
         );
         // The owner's 166ms live hiccup (2026-08-23, refused under the 71ms
         // macOS budget) and the Windows tester's 172ms compose gap both pass.


### PR DESCRIPTION
0.9.68-alpha.1 candidate failed on a Windows-only test assertion (24fps budget 250ms vs pinned 200ms). Runbook-compliant correction: entry removed, version bumped, replacement entry added. macOS remains 0.9.68.