### PR TITLE
docs: 0.9.68/0.9.69 release record

### DIFF
--- a/docs/releases/0.9.68.md
+++ b/docs/releases/0.9.68.md
@@ -1,0 +1,66 @@
+# Videorc 0.9.68 Beta 1 (macOS) / 0.9.69 Alpha 1 (Windows)
+
+Live-feedback batch 3: startup-cadence refusals become record-with-warning
+with unmissable start-failure UX, backend crashes leave a persistent record,
+the audio mixer shows honest levels with a session gate, avatars arrive from
+the web, Settings uses content-height columns, and the Windows capture
+pipeline gets hygiene + per-recording frame accounting.
+
+## Scope (PRs #257–#263, #265; videorc-web #15)
+
+- **B0 (#259, priority):** startup barrier budget unified to
+  `max(4×interval, 200ms)` (macOS was 71ms at 30fps); cadence-only stumbles
+  retry once then record with WARN `recording-startup-cadence-unsteady`;
+  hard failures only for stalls/resolution/scene/missing sources; every
+  start rejection is a persistent toast with Retry + an inline error under
+  Record/Go Live.
+- **B1 (#261):** `backend-crashes.json` (exit code, signal, attempt, uptime,
+  ≤50 stderr lines) written by the supervisor, surfaced in runtimeInfo +
+  support bundle + Diagnostics tab; rotating `userData/logs/backend.log`;
+  Rust panic hook emits one structured stderr line. Proven with a live
+  SIGKILL.
+- **B2 (#260):** mixer bands = dBFS over −60..0 (AES17), −55dBFS gate,
+  15/350ms ballistics, AGC/NS/EC off for the meter stream, **Monitor input**
+  toggle (M) — idle default off, mic not opened; sessions auto-arm.
+- **B3 (web #15 + #258):** desktop session endpoints return the resolved
+  avatar (Google id_token fallback); refresh on launch; Comments window may
+  cache chat avatars; `*.blob.vercel-storage.com` parity; cache rejections
+  logged.
+- **B4 (#257):** Settings upper region = two content-height columns
+  (`items-start`); Remote control shows an off-state line.
+- **B5 (#262):** Windows: D3D11 state resets after a session; suspended
+  preview compositor always restored (skips now logged); direct-D3D11
+  consumer released at stop; CPU-frame counter split; `MissedTickBehavior::
+  Skip` for the Windows record loop; MF input-credit wait capped with a
+  counter; INFO `recording-frame-accounting` event at every stop.
+
+## Release status
+
+- [x] macOS 0.9.68-beta.1: source `4426567cb2d6ea2a554de883b965522bef874fff`
+      (#263); signed/notarized/stapled, validate PASS; upload delayed ~7h by
+      the third LaLiga R2 block (Sun 17:10 → Mon 00:13 CEST), watcher
+      auto-uploaded; feed verified (`latest-mac.yml` → 0.9.68, zip 200);
+      Discord posted.
+- [x] Windows 0.9.69-alpha.1: the 0.9.68-alpha.1 candidate failed its
+      unsigned gates on one Windows-only test assertion (24fps budget 250ms
+      vs pinned 200ms) → runbook correction #265 (entry replaced, version
+      bumped; macOS stays 0.9.68). Candidate run 32671155204 (source
+      `3a422d4a5acc5bf93e53c289dca921c0d633921b`, installer SHA-256
+      `0ec4d38d273ed2dddb50b7fea0fafd4cd6bfa86bb9eedc857bc5be9d1208dd62`,
+      publisher `Uros Miric`); pilot promotion run 32672790605 PASS; pilot
+      manifest verified (177,779,432 bytes).
+- [ ] Owner by-eye: mixer feel, Settings layout, avatar on cold launch,
+      a refused start showing the persistent error.
+- [ ] Windows tester: repro the backend crash on 0.9.69 (crash record +
+      frame accounting now capture it); physical acceptance → public
+      promotion still pending (as since 0.9.51).
+
+## Watch items
+
+- `preview_surface` d3d11 suspend/restore tests flaked under load-24 on the
+  combined tree (6/7 pass; no code path in B0/B5 touches the stop timeout) —
+  keep an eye in CI.
+- Third LaLiga-matchday R2 interception (Sat + Sun). Follow-ups filed:
+  Cloudflare-API upload fallback (needs an owner-created API token) and a
+  Worker-fronted download/update path so Spanish users can update during
+  blocks.


### PR DESCRIPTION
Batch 3 record: macOS 0.9.68-beta.1 live+verified; Windows 0.9.69-alpha.1 pilot (runbook correction from the failed 0.9.68-alpha.1 candidate).