### PR TITLE
fix(windows): screen-camera direct D3D11 recording cadence + repair Windows compile and stable-clippy breakage

### DIFF
--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -823,7 +823,10 @@ describe('backend RPC contract', () => {
       adapterMismatches: 0,
       deviceResets: 0,
       synchronizationTimeouts: 0,
-      staleGenerationCallbacks: 0
+      staleGenerationCallbacks: 0,
+      renderTickOverruns: 2,
+      renderTickLagMaxMs: 4.5,
+      renderComposeStageMaxMs: 1.25
     }
     const diagnostics = {
       skippedFrames: 0,

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -976,6 +976,9 @@ const windowsD3d11MediaDiagnosticsSchema = objectSchema(
     deviceResets: nonNegativeInteger,
     synchronizationTimeouts: nonNegativeInteger,
     staleGenerationCallbacks: nonNegativeInteger,
+    renderTickOverruns: nonNegativeInteger,
+    renderTickLagMaxMs: optionalSchema(numberSchema({ min: 0 })),
+    renderComposeStageMaxMs: optionalSchema(numberSchema({ min: 0 })),
     fallbackReason: optionalSchema(stringSchema({ minLength: 1, maxLength: 16_384 }))
   },
   { allowUnknown: false }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -1341,6 +1341,9 @@ export interface WindowsD3d11MediaDiagnostics {
   deviceResets: number
   synchronizationTimeouts: number
   staleGenerationCallbacks: number
+  renderTickOverruns: number
+  renderTickLagMaxMs?: number
+  renderComposeStageMaxMs?: number
   fallbackReason?: string
 }
 

--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -134,6 +134,25 @@ const RAW_VIDEO_FIFO_STARTUP_PRIME_TIMEOUT: Duration = Duration::from_millis(250
 const WINDOWS_D3D11_GENERATION_RECOVERY_TIMEOUT: Duration = Duration::from_secs(8);
 #[cfg(target_os = "windows")]
 const WINDOWS_D3D11_GENERATION_RECOVERY_POLL: Duration = Duration::from_millis(50);
+/// Cadence of the encoder drain's bounded wait for a freshly published
+/// primary frame. Small enough to drain two-frame pump bursts within one
+/// clock period; large enough that the idle wait stays negligible.
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_D3D11_ENCODER_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Whether a newly published primary sequence must be drained before the next
+/// scheduled tick. `None` (no composition yet) is never newer.
+#[cfg(any(target_os = "windows", test))]
+const fn windows_d3d11_primary_sequence_is_newer(
+    published: Option<u64>,
+    last_seen: Option<u64>,
+) -> bool {
+    match (published, last_seen) {
+        (Some(published), Some(seen)) => published > seen,
+        (Some(_), None) => true,
+        (None, _) => false,
+    }
+}
 const FIFO_WRITE_PROGRESS_YIELD_BUDGET: u32 = 64;
 const FIFO_WRITE_STALL_BACKOFF: Duration = Duration::from_micros(250);
 const VIDEOTOOLBOX_OUTPUT_DRAIN_MAX_FRAMES_PER_TICK: usize = 8;
@@ -3948,6 +3967,11 @@ fn write_windows_d3d11_recording_frames(params: WindowsD3d11RecordingWriterParam
     let mut terminal_error = None;
     let mut current_input = input.current();
     let mut recovery_wait_started_at = None;
+    // The frame store is single-slot latest-wins: a publish that lands while
+    // this loop sleeps destroys the previous frame before it is read. Track
+    // the newest sequence we have seen published so the pacing wait below can
+    // wake the moment fresh work exists instead of one clock period late.
+    let mut last_seen_published = current_input.latest_published_sequence();
 
     if let Err(error) = validate_windows_d3d11_encoder_input(&current_input) {
         finish_windows_d3d11_writer_failure(
@@ -3976,6 +4000,7 @@ fn write_windows_d3d11_recording_frames(params: WindowsD3d11RecordingWriterParam
                 Ok(Some(replacement)) => {
                     current_input = replacement;
                     last_submitted_sequence = None;
+                    last_seen_published = current_input.latest_published_sequence();
                     recovery_wait_started_at = None;
                     generation_started_at = Instant::now();
                     next_frame_at = generation_started_at;
@@ -3992,7 +4017,27 @@ fn write_windows_d3d11_recording_frames(params: WindowsD3d11RecordingWriterParam
         }
         let now = Instant::now();
         if now < next_frame_at {
-            thread::sleep(next_frame_at - now);
+            // Bounded wait for the scheduled tick, cut short as soon as the
+            // pump publishes a sequence newer than the last one observed.
+            // Polling at 1ms costs at most ~33 wakeups per second while
+            // preserving the wall-anchored CFR schedule.
+            let mut wait_now = now;
+            while wait_now < next_frame_at {
+                let published = current_input.latest_published_sequence();
+                if windows_d3d11_primary_sequence_is_newer(published, last_seen_published) {
+                    last_seen_published = published;
+                    break;
+                }
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                thread::sleep(WINDOWS_D3D11_ENCODER_DRAIN_POLL_INTERVAL);
+                wait_now = Instant::now();
+            }
+            let published = current_input.latest_published_sequence();
+            if windows_d3d11_primary_sequence_is_newer(published, last_seen_published) {
+                last_seen_published = published;
+            }
         }
         next_frame_at += frame_interval;
         schedule_index = schedule_index.saturating_add(1);
@@ -4030,6 +4075,7 @@ fn write_windows_d3d11_recording_frames(params: WindowsD3d11RecordingWriterParam
                     Ok(Some(replacement)) => {
                         current_input = replacement;
                         last_submitted_sequence = None;
+                        last_seen_published = current_input.latest_published_sequence();
                         recovery_wait_started_at = None;
                         generation_started_at = Instant::now();
                         next_frame_at = generation_started_at;
@@ -5312,6 +5358,16 @@ mod tests {
             BridgeFrameSource::SyntheticFallback.accounting_kind(),
             BridgeInputKind::Synthetic
         );
+    }
+
+    #[test]
+    fn windows_d3d11_primary_sequence_newer_only_for_unseen_publications() {
+        assert!(!windows_d3d11_primary_sequence_is_newer(None, None));
+        assert!(!windows_d3d11_primary_sequence_is_newer(None, Some(7)));
+        assert!(windows_d3d11_primary_sequence_is_newer(Some(1), None));
+        assert!(windows_d3d11_primary_sequence_is_newer(Some(8), Some(7)));
+        assert!(!windows_d3d11_primary_sequence_is_newer(Some(7), Some(7)));
+        assert!(!windows_d3d11_primary_sequence_is_newer(Some(6), Some(7)));
     }
 
     #[test]

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1451,6 +1451,15 @@ pub struct WindowsD3d11MediaDiagnostics {
     pub synchronization_timeouts: u64,
     #[serde(default)]
     pub stale_generation_callbacks: u64,
+    /// Render-loop ticks whose work exceeded the frame interval before pacing.
+    #[serde(default)]
+    pub render_tick_overruns: u64,
+    /// Worst overshoot of any render tick beyond its frame interval.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub render_tick_lag_max_ms: Option<f64>,
+    /// Worst observed D3D11 compose_scene stage duration on the render thread.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub render_compose_stage_max_ms: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_reason: Option<String>,
 }

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -9781,6 +9781,15 @@ fn windows_d3d11_fallback_diagnostics(
 }
 
 #[cfg(target_os = "windows")]
+fn u64_ms_option(micros: u64) -> Option<f64> {
+    if micros == 0 {
+        None
+    } else {
+        Some(micros as f64 / 1_000.0)
+    }
+}
+
+#[cfg(target_os = "windows")]
 fn windows_d3d11_live_diagnostics(
     mode: WindowsD3d11MediaMode,
     snapshot: &WindowsD3d11SessionDiagnosticsSnapshot,
@@ -9898,6 +9907,9 @@ fn windows_d3d11_live_diagnostics(
             .saturating_add(u64::from(snapshot.device.device_loss_code.is_some())),
         synchronization_timeouts: snapshot.device.runtime.synchronization_timeouts,
         stale_generation_callbacks: snapshot.device.runtime.stale_generation_callbacks,
+        render_tick_overruns: snapshot.pump.render_tick_overruns,
+        render_tick_lag_max_ms: u64_ms_option(snapshot.pump.render_tick_lag_max_us),
+        render_compose_stage_max_ms: u64_ms_option(snapshot.pump.render_compose_stage_max_us),
         fallback_reason: terminal_error.or(capture_fallback),
     }
 }

--- a/crates/videorc-backend/src/windows_d3d11_session.rs
+++ b/crates/videorc-backend/src/windows_d3d11_session.rs
@@ -862,6 +862,17 @@ mod runtime {
             self.recovery_count
         }
 
+        /// Newest primary-output sequence the pump has published to the frame
+        /// store, or `None` before the first composition. The encoder drain
+        /// uses this to wake as soon as a fresh frame exists instead of
+        /// discovering it one clock period late.
+        pub(crate) fn latest_published_sequence(&self) -> Option<u64> {
+            self.snapshot
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .primary_sequence
+        }
+
         pub(crate) fn latest_ticket(
             &self,
         ) -> Option<(u64, Instant, WindowsD3d11TextureLeaseTicket)> {

--- a/crates/videorc-backend/src/windows_d3d11_session.rs
+++ b/crates/videorc-backend/src/windows_d3d11_session.rs
@@ -557,6 +557,11 @@ mod runtime {
         pub(crate) latest_capture_sequence: Option<u64>,
         pub(crate) repeated_capture_frames: u64,
         pub(crate) pressure_skips: u64,
+        pub(crate) render_ticks: u64,
+        pub(crate) render_tick_overruns: u64,
+        pub(crate) render_tick_lag_max_us: u64,
+        pub(crate) render_compose_stage_max_us: u64,
+        pub(crate) render_publish_stage_max_us: u64,
         pub(crate) preview_offered_sequence: Option<u64>,
         pub(crate) preview_offer_failures: u64,
         pub(crate) preview_sequence: Option<u64>,
@@ -1415,6 +1420,7 @@ mod runtime {
             let tick = match cfr.advance(new_capture_sequence) {
                 Ok(Some(tick)) => tick,
                 Ok(None) => {
+                    record_render_tick_overrun(&snapshot, frame_started_at, frame_interval);
                     pace_render_tick(frame_started_at, frame_interval);
                     continue;
                 }
@@ -1429,6 +1435,7 @@ mod runtime {
                 .clone();
             let camera_frame = latest_camera_frame(camera.as_ref(), &mut last_camera_frame);
             if plan.camera_required && camera_frame.is_none() {
+                record_render_tick_overrun(&snapshot, frame_started_at, frame_interval);
                 pace_render_tick(frame_started_at, frame_interval);
                 continue;
             }
@@ -1521,12 +1528,19 @@ mod runtime {
                     .map(|_| vec![WindowsD3d11MediaRole::Stream])
                     .unwrap_or_default(),
             };
+            let compose_started_at = Instant::now();
             let composition = match client.compose_scene(scene, sources, consumers) {
                 Ok(composition) => composition,
                 Err(error) if is_transient_pressure(&error) => {
                     update_snapshot(&snapshot, |current| {
                         current.pressure_skips = current.pressure_skips.saturating_add(1);
+                        current.render_compose_stage_max_us =
+                            current.render_compose_stage_max_us.max(
+                                u64::try_from(compose_started_at.elapsed().as_micros())
+                                    .unwrap_or(u64::MAX),
+                            );
                     });
+                    record_render_tick_overrun(&snapshot, frame_started_at, frame_interval);
                     pace_render_tick(frame_started_at, frame_interval);
                     continue;
                 }
@@ -1541,6 +1555,8 @@ mod runtime {
                     break;
                 }
             };
+            let compose_stage_us =
+                u64::try_from(compose_started_at.elapsed().as_micros()).unwrap_or(u64::MAX);
             if composition.diagnostics.production_readback_frames != 0 {
                 finish_with_error(
                     &snapshot,
@@ -1581,6 +1597,7 @@ mod runtime {
                     }
                 }
             }
+            let publish_started_at = Instant::now();
             let published = publish_composition(
                 composition.textures,
                 plan.primary_role,
@@ -1588,6 +1605,8 @@ mod runtime {
                 &primary_store,
                 auxiliary_store.as_ref(),
             );
+            let publish_stage_us =
+                u64::try_from(publish_started_at.elapsed().as_micros()).unwrap_or(u64::MAX);
             let (preview_sequence, primary_sequence, auxiliary_sequence) = match published {
                 Ok(published) => published,
                 Err(error) => {
@@ -1605,6 +1624,11 @@ mod runtime {
                 current.preview_sequence = preview_sequence;
                 current.primary_sequence = Some(primary_sequence);
                 current.auxiliary_sequence = auxiliary_sequence;
+                current.render_ticks = current.render_ticks.saturating_add(1);
+                current.render_compose_stage_max_us =
+                    current.render_compose_stage_max_us.max(compose_stage_us);
+                current.render_publish_stage_max_us =
+                    current.render_publish_stage_max_us.max(publish_stage_us);
             });
             if let Some(sender) = startup_tx.take() {
                 let _ = sender.send(Ok(WindowsD3d11StartupEvidence {
@@ -1618,6 +1642,7 @@ mod runtime {
                     auxiliary_encoder_attached: true,
                 }));
             }
+            record_render_tick_overrun(&snapshot, frame_started_at, frame_interval);
             pace_render_tick(frame_started_at, frame_interval);
         }
         let _ = client.stop_capture();
@@ -1656,6 +1681,28 @@ mod runtime {
         if let Some(remaining) = frame_interval.checked_sub(started_at.elapsed()) {
             thread::sleep(remaining);
         }
+    }
+
+    /// Overshoot of one render tick beyond its frame interval, in micros.
+    pub(crate) fn tick_overrun_micros(total: Duration, interval: Duration) -> Option<u64> {
+        total
+            .checked_sub(interval)
+            .filter(|overrun| !overrun.is_zero())
+            .map(|overrun| u64::try_from(overrun.as_micros()).unwrap_or(u64::MAX))
+    }
+
+    fn record_render_tick_overrun(
+        snapshot: &Arc<StdMutex<WindowsD3d11SessionPumpSnapshot>>,
+        started_at: Instant,
+        frame_interval: Duration,
+    ) {
+        let Some(overrun_us) = tick_overrun_micros(started_at.elapsed(), frame_interval) else {
+            return;
+        };
+        update_snapshot(snapshot, |current| {
+            current.render_tick_overruns = current.render_tick_overruns.saturating_add(1);
+            current.render_tick_lag_max_us = current.render_tick_lag_max_us.max(overrun_us);
+        });
     }
 
     fn is_transient_pressure(error: &WindowsD3d11Error) -> bool {
@@ -2065,6 +2112,38 @@ mod tests {
             Some("D3D11 session pump stopped without a terminal result")
         );
         assert_eq!(windows_d3d11_terminal_source_error(None, false), None);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_d3d11_render_tick_overrun_accounting_is_interval_relative() {
+        use std::time::Duration;
+
+        let interval = Duration::from_millis(33);
+        assert_eq!(
+            runtime::tick_overrun_micros(Duration::from_millis(20), interval),
+            None
+        );
+        assert_eq!(runtime::tick_overrun_micros(interval, interval), None);
+        assert_eq!(
+            runtime::tick_overrun_micros(Duration::from_millis(34), interval),
+            Some(1_000)
+        );
+        assert_eq!(
+            runtime::tick_overrun_micros(Duration::from_secs(3600), Duration::from_micros(1)),
+            Some(3_599_999_999)
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_d3d11_pump_snapshot_defaults_render_telemetry_to_zero() {
+        let snapshot = runtime::WindowsD3d11SessionPumpSnapshot::default();
+        assert_eq!(snapshot.render_ticks, 0);
+        assert_eq!(snapshot.render_tick_overruns, 0);
+        assert_eq!(snapshot.render_tick_lag_max_us, 0);
+        assert_eq!(snapshot.render_compose_stage_max_us, 0);
+        assert_eq!(snapshot.render_publish_stage_max_us, 0);
     }
 
     #[test]

--- a/crates/videorc-backend/src/windows_d3d11_session.rs
+++ b/crates/videorc-backend/src/windows_d3d11_session.rs
@@ -24,6 +24,16 @@ fn windows_d3d11_terminal_source_error(
     })
 }
 
+/// Screen-camera composition keeps one more full-frame layer in flight and
+/// stretches NV12/BGRA lease residency past the screen-only envelope. Size the
+/// capture and primary render pools so transient fence lag cannot starve a CFR
+/// tick into a silent single-frame skip (5 slots stays inside the per-format
+/// pool ceiling of 8 even for split screen-camera sessions).
+#[cfg(any(target_os = "windows", test))]
+const fn windows_d3d11_render_pool_slots(camera_required: bool) -> usize {
+    if camera_required { 5 } else { 3 }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WindowsD3d11MediaMode {
     Disabled,
@@ -918,13 +928,13 @@ mod runtime {
             let pool = WindowsD3d11TexturePoolConfig::dimension_keyed(
                 WindowsD3d11BgraTextureDescriptor::new(plan.source_width, plan.source_height)
                     .map_err(|error| error.to_string())?,
-                3,
+                super::windows_d3d11_render_pool_slots(plan.camera_required),
                 WindowsD3d11BgraTextureDescriptor::new(plan.primary.width, plan.primary.height)
                     .map_err(|error| error.to_string())?,
                 3,
                 WindowsD3d11Nv12TextureDescriptor::new(plan.primary.width, plan.primary.height)
                     .map_err(|error| error.to_string())?,
-                3,
+                super::windows_d3d11_render_pool_slots(plan.camera_required),
                 plan.auxiliary
                     .map(|auxiliary| {
                         Ok((
@@ -2144,6 +2154,12 @@ mod tests {
         assert_eq!(snapshot.render_tick_lag_max_us, 0);
         assert_eq!(snapshot.render_compose_stage_max_us, 0);
         assert_eq!(snapshot.render_publish_stage_max_us, 0);
+    }
+
+    #[test]
+    fn windows_d3d11_screen_camera_sessions_size_deeper_render_pools() {
+        assert_eq!(windows_d3d11_render_pool_slots(false), 3);
+        assert_eq!(windows_d3d11_render_pool_slots(true), 5);
     }
 
     #[test]

--- a/scripts/lib/windows-local-gates.mjs
+++ b/scripts/lib/windows-local-gates.mjs
@@ -1549,6 +1549,44 @@ export function buildWindowsLocalGateSteps({
       }
     },
     {
+      label: 'native Windows ScreenCamera D3D11 direct-record smoke 1080p30',
+      command: 'pnpm',
+      args: ['smoke:windows-native-screen', '--', '--d3d11', '--require-d3d11'],
+      env: {
+        VIDEORC_PERF_APP_EXECUTABLE: executable,
+        VIDEORC_SMOKE_OUTPUT_DIR: join(outputDir, 'native-screen-camera-1080p30'),
+        VIDEORC_SMOKE_FFMPEG_PATH: packagedFfmpeg,
+        VIDEORC_SMOKE_FFPROBE_PATH: packagedFfprobe,
+        VIDEORC_SMOKE_TIMEOUT_MS: '240000',
+        VIDEORC_WINDOWS_NATIVE_SCREEN_RECORDING_MS: '8000',
+        VIDEORC_WINDOWS_INCLUDE_CAMERA: '1',
+        VIDEORC_WINDOWS_REQUIRE_DIRECT_D3D11_RECORDING: '1',
+        VIDEORC_SMOKE_VIDEO_WIDTH: '1920',
+        VIDEORC_SMOKE_VIDEO_HEIGHT: '1080',
+        VIDEORC_SMOKE_VIDEO_FPS: '30',
+        VIDEORC_SMOKE_VIDEO_BITRATE_KBPS: '6000'
+      }
+    },
+    {
+      label: 'native Windows ScreenCamera D3D11 direct-record smoke 1080p60',
+      command: 'pnpm',
+      args: ['smoke:windows-native-screen', '--', '--d3d11', '--require-d3d11'],
+      env: {
+        VIDEORC_PERF_APP_EXECUTABLE: executable,
+        VIDEORC_SMOKE_OUTPUT_DIR: join(outputDir, 'native-screen-camera-1080p60'),
+        VIDEORC_SMOKE_FFMPEG_PATH: packagedFfmpeg,
+        VIDEORC_SMOKE_FFPROBE_PATH: packagedFfprobe,
+        VIDEORC_SMOKE_TIMEOUT_MS: '240000',
+        VIDEORC_WINDOWS_NATIVE_SCREEN_RECORDING_MS: '8000',
+        VIDEORC_WINDOWS_INCLUDE_CAMERA: '1',
+        VIDEORC_WINDOWS_REQUIRE_DIRECT_D3D11_RECORDING: '1',
+        VIDEORC_SMOKE_VIDEO_WIDTH: '1920',
+        VIDEORC_SMOKE_VIDEO_HEIGHT: '1080',
+        VIDEORC_SMOKE_VIDEO_FPS: '60',
+        VIDEORC_SMOKE_VIDEO_BITRATE_KBPS: '6000'
+      }
+    },
+    {
       label: 'native Windows D3D11 Media Foundation encoded-bridge matrix',
       command: 'pnpm',
       args: [

--- a/scripts/lib/windows-local-gates.test.mjs
+++ b/scripts/lib/windows-local-gates.test.mjs
@@ -914,6 +914,8 @@ describe('buildWindowsLocalGateSteps', () => {
       'package desktop Windows dir',
       'packaged recording and bundled-background smoke',
       'native Windows ScreenOnly D3D11 zero-copy smoke',
+      'native Windows ScreenCamera D3D11 direct-record smoke 1080p30',
+      'native Windows ScreenCamera D3D11 direct-record smoke 1080p60',
       'native Windows D3D11 Media Foundation encoded-bridge matrix',
       'recording-time Windows D3D11 native-preview smoke',
       'protected physical Windows RTMP matrix (forced D3D11/MF)',
@@ -937,6 +939,20 @@ describe('buildWindowsLocalGateSteps', () => {
       steps.find((step) => step.label === 'native Windows ScreenOnly D3D11 zero-copy smoke').args,
       ['smoke:windows-native-screen', '--', '--d3d11', '--require-d3d11']
     )
+    for (const [label, fps] of [
+      ['native Windows ScreenCamera D3D11 direct-record smoke 1080p30', '30'],
+      ['native Windows ScreenCamera D3D11 direct-record smoke 1080p60', '60']
+    ]) {
+      const step = steps.find((candidate) => candidate.label === label)
+      assert.ok(step, `missing protected-lane step: ${label}`)
+      assert.deepEqual(step.args, ['smoke:windows-native-screen', '--', '--d3d11', '--require-d3d11'])
+      assert.equal(step.env.VIDEORC_WINDOWS_INCLUDE_CAMERA, '1')
+      assert.equal(step.env.VIDEORC_WINDOWS_REQUIRE_DIRECT_D3D11_RECORDING, '1')
+      assert.equal(step.env.VIDEORC_SMOKE_VIDEO_WIDTH, '1920')
+      assert.equal(step.env.VIDEORC_SMOKE_VIDEO_HEIGHT, '1080')
+      assert.equal(step.env.VIDEORC_SMOKE_VIDEO_FPS, fps)
+      assert.equal(step.env.VIDEORC_SMOKE_VIDEO_BITRATE_KBPS, '6000')
+    }
     assert.deepEqual(
       steps.find(
         (step) => step.label === 'native Windows D3D11 Media Foundation encoded-bridge matrix'

--- a/scripts/lib/windows-native-screen-gates.mjs
+++ b/scripts/lib/windows-native-screen-gates.mjs
@@ -43,7 +43,7 @@ export function windowsNativeScreenRequiresFinalDiagnostics({
 
 export function evaluateWindowsNativeScreenD3d11Diagnostics(
   diagnostics,
-  { requireOutput = false, expectFallback = null } = {}
+  { requireOutput = false, expectFallback = null, requireZeroPoolPressure = false } = {}
 ) {
   const failures = []
   const media = diagnostics?.windowsD3d11Media
@@ -84,6 +84,9 @@ export function evaluateWindowsNativeScreenD3d11Diagnostics(
   }
   if ((media.adapterMismatches ?? 0) !== 0) {
     failures.push(`adapterMismatches=${media.adapterMismatches}`)
+  }
+  if (requireZeroPoolPressure && (media.texturePoolPressureEvents ?? 0) !== 0) {
+    failures.push(`texturePoolPressureEvents=${media.texturePoolPressureEvents}`)
   }
   if (typeof media.fallbackReason === 'string' && media.fallbackReason.trim()) {
     failures.push(`fallbackReason=${media.fallbackReason}`)

--- a/scripts/lib/windows-native-screen-gates.test.mjs
+++ b/scripts/lib/windows-native-screen-gates.test.mjs
@@ -102,6 +102,29 @@ test('native Windows D3D11 diagnostics prove zero-copy output and named fallback
   )
 })
 
+test('required D3D11 lanes fail closed on texture pool pressure', () => {
+  const pressured = {
+    windowsD3d11Media: {
+      state: 'live',
+      captureBackend: 'windows-graphics-capture',
+      captureReadbackFrames: 0,
+      compositorCpuFallbackFrames: 0,
+      encoderSystemMemorySamples: 0,
+      rawVideoCopiedFrames: 0,
+      previewBmpRequests: 0,
+      previewBmpBytes: 0,
+      adapterMismatches: 0,
+      texturePoolPressureEvents: 2,
+      fallbackReason: null
+    }
+  }
+  assert.deepEqual(evaluateWindowsNativeScreenD3d11Diagnostics(pressured), [])
+  assert.deepEqual(
+    evaluateWindowsNativeScreenD3d11Diagnostics(pressured, { requireZeroPoolPressure: true }),
+    ['texturePoolPressureEvents=2']
+  )
+})
+
 test('native Windows screen requests final diagnostics only for diagnostics-gated lanes', () => {
   assert.equal(windowsNativeScreenRequiresFinalDiagnostics(), false)
   assert.equal(

--- a/scripts/smoke-windows-native-screen-app.mjs
+++ b/scripts/smoke-windows-native-screen-app.mjs
@@ -777,7 +777,8 @@ async function monitorD3d11DuringRecording(ws, durationMs) {
 function assertD3d11Diagnostics(diagnostics, { requireOutput }) {
   const failures = evaluateWindowsNativeScreenD3d11Diagnostics(diagnostics, {
     requireOutput,
-    expectFallback: options.expectFallback
+    expectFallback: options.expectFallback,
+    requireZeroPoolPressure: options.requireD3d11
   })
   if (failures.length > 0) {
     throw new Error(`Windows D3D11 media diagnostics failed: ${failures.join('; ')}`)

--- a/scripts/smoke-windows-native-screen-app.mjs
+++ b/scripts/smoke-windows-native-screen-app.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
@@ -348,6 +348,35 @@ try {
     )
   }
 } finally {
+  let evidenceDiagnostics = null
+  try {
+    if (ws) {
+      evidenceDiagnostics = await request(ws, 10_000, 'diagnostics.stats')
+    }
+  } catch {
+    // Best effort only; the original failure must keep propagating.
+  }
+  try {
+    writeFileSync(
+      join(outputDirectory, 'native-screen-diagnostics-evidence.json'),
+      JSON.stringify(
+        {
+          includeCamera,
+          video,
+          requireDirectD3D11Recording,
+          d3d11Monitor: bmpEvidence,
+          finalDiagnostics: evidenceDiagnostics,
+          cameraEvidence,
+          recordingEvidence,
+          collectorHardFailures
+        },
+        null,
+        2
+      )
+    )
+  } catch (error) {
+    console.log(`Windows native screen smoke could not retain diagnostics evidence: ${error}`)
+  }
   if (ws) {
     if (includeCamera) {
       try {
@@ -716,19 +745,19 @@ async function monitorD3d11DuringRecording(ws, durationMs) {
   while (Date.now() - startedAt < durationMs) {
     const diagnostics = await request(ws, timeoutMs, 'diagnostics.stats')
     assertD3d11Diagnostics(diagnostics, { requireOutput: false })
-    samples.push(diagnostics.windowsD3d11Media)
+    samples.push({
+      elapsedMs: Date.now() - startedAt,
+      media: diagnostics.windowsD3d11Media
+    })
     await sleep(Math.min(250, Math.max(1, durationMs - (Date.now() - startedAt))))
   }
   const first = samples[0] ?? {}
   const last = samples.at(-1) ?? {}
-  const textureAdvances = Math.max(
-    0,
-    Number(last.textureImportFrames ?? 0) - Number(first.textureImportFrames ?? 0)
-  )
-  const encoderAdvances = Math.max(
-    0,
-    Number(last.encoderGpuSamples ?? 0) - Number(first.encoderGpuSamples ?? 0)
-  )
+  const mediaAt = (sample) => sample?.media ?? {}
+  const counterDelta = (name) =>
+    Math.max(0, Number(mediaAt(last)[name] ?? 0) - Number(mediaAt(first)[name] ?? 0))
+  const textureAdvances = counterDelta('textureImportFrames')
+  const encoderAdvances = counterDelta('encoderGpuSamples')
   return {
     mode: 'disabled-d3d11',
     requests: 0,
@@ -737,7 +766,11 @@ async function monitorD3d11DuringRecording(ws, durationMs) {
     nonblankFrames: 0,
     sampleCount: samples.length,
     textureAdvances,
-    encoderAdvances
+    encoderAdvances,
+    texturePoolPressureEvents: counterDelta('texturePoolPressureEvents'),
+    previewPresents: counterDelta('previewPresents'),
+    synchronizationTimeouts: counterDelta('synchronizationTimeouts'),
+    samples
   }
 }
 


### PR DESCRIPTION
Closes the code work for the #173 screen+camera completion gate. Rebased on current main (supersedes main's own `transition_ms` and clippy-1.98 fixes; those were dropped from this branch).

## Summary

The direct WGC-texture → D3D11 VideoProcessor → NV12 → Media Foundation path now holds 1080p30 screen+camera cadence with a decoupled 15fps webcam. Two loss mechanisms were isolated with new per-tick diagnostics and fixed:

1. **Texture-pool exhaustion** — camera-layer fence residency transiently drained the 3-slot capture-BGRA/NV12 pools; screen-camera sessions now size them to 5 (`windows_d3d11_render_pool_slots`, per-format ceiling of 8 respected for split sessions), and any `texturePoolPressureEvents > 0` hard-fails `--require-d3d11` smokes.
2. **Silent latest-wins frame loss** — the encoder drain ran on its own clock against a single-slot store, so two-frame pump bursts destroyed frames before read. The drain's bounded wait now wakes when the pump publishes a newer primary sequence (1ms poll inside the wait window); wall-anchored CFR schedule, stop-drain accounting from #262, and backpressure handling unchanged.

## Changes

- Protected-lane ScreenCamera 1080p30/60 direct-record smokes wired into `smoke:local-gates:windows` (`VIDEORC_WINDOWS_INCLUDE_CAMERA=1`, `VIDEORC_WINDOWS_REQUIRE_DIRECT_D3D11_RECORDING=1`, shipping-profile video shapes)
- New wire diagnostics (Rust protocol + TS mirrors + contract fixture): `renderTickOverruns`, `renderTickLagMaxMs`, `renderComposeStageMaxMs`
- Native-screen smoke retains `native-screen-diagnostics-evidence.json` (per-sample media counters + final diagnostics) even when a later gate fails

## Physical evidence (win11-x64-i5-8400-gtx1650-super, packaged)

Screen+camera 1080p30 direct-record, C920 reporting real ~15fps while the screen clock holds:

| Build | Recorded | Observed FPS | Overruns | Pool pressure |
|---|---|---|---|---|
| pre-fix | 167 | 27.52 | n/a | 2 (silent) |
| post pool fix | 180 | ~29.6 | 0 | 0 |
| final | 178 / 179 / 177 | 29.5 / 29.5 / 29.01 | 0 | 0 |

Worst case 29.01fps clears the issue's 28.5fps floor for 1080p30. Residual ≤3-frame deficit is startup-boundary coalescing (drain attaches one beat after first publish); follow-up slice identified.

## Gates

Fork PR https://github.com/petercr/videorc/pull/17 all lanes green (Linux gates, Rust test/clippy/fmt, JS format/lint/tests, Windows gates, installer artifact). Locally on the rebased stack: `cargo test -p videorc-backend` 1509/0, fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Linux VAAPI hardware encoding, with automatic fallback to software encoding when needed.
  - Expanded runtime diagnostics with encoder, compositor, rendering, timeout, and backend-crash information.
  - Added detailed co-host error reporting.

- **Bug Fixes**
  - Improved recording startup reliability with cadence checks, retry handling, and clearer warnings.
  - Improved Windows screen-camera recording synchronization and frame rendering under load.
  - Ensured recording sessions clean up resources and report final diagnostics correctly.

- **Tests**
  - Added coverage for hardware encoding, recording reliability, Windows diagnostics, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->