### PR TITLE
release: 0.9.70-alpha.1 (Windows)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.69",
+  "version": "0.9.70",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.70-alpha.1.md
+++ b/changelog/0.9.70-alpha.1.md
@@ -1,0 +1,26 @@
+---
+version: 0.9.70-alpha.1
+date: 2026-08-24
+channel: alpha
+platforms:
+  - windows
+title: Screen + camera recording holds its frame rate
+summary: A community-contributed fix makes screen + camera recordings on the direct D3D11 path hold steady cadence — deeper texture pools stop transient frame skips, and the encoder no longer silently loses frames when two arrive close together. New per-tick render diagnostics make any remaining loss visible.
+highlights:
+  - Screen + camera recordings hold their target frame rate on the direct D3D11 path — measured 29.5 fps at a 30 fps target on mid-range hardware, up from 27.5.
+  - Texture pools are sized for camera sessions, so a brief GPU fence delay no longer skips a frame silently.
+  - The encoder wakes the moment a new frame is published instead of one clock beat later, so back-to-back frames are no longer overwritten before being read.
+  - New render diagnostics (tick overruns, worst tick lag, compose-stage time) land in support bundles, making frame loss traceable to its stage.
+  - Contributed by @petercr with physical evidence on Windows 11 hardware — thank you!
+---
+
+This Alpha carries petercr's screen + camera cadence work for the direct
+Windows capture path: two loss mechanisms — texture-pool exhaustion under
+camera fence residency, and a latest-wins race between the frame pump and
+the encoder drain — were isolated with new per-tick diagnostics and fixed.
+The protected acceptance lane now includes screen + camera direct-record
+smokes at 1080p30 and 1080p60, and every recording's support bundle carries
+render tick overruns and compose-stage timings, so any remaining loss can
+be traced to the exact stage that caused it.
+
+macOS is unaffected by this change set and stays on 0.9.68.


### PR DESCRIPTION
Windows-only release for #267 (petercr's screen+camera D3D11 cadence fix). macOS stays 0.9.68.