### PR TITLE
docs: 0.9.70-alpha.1 addendum

### DIFF
--- a/docs/releases/0.9.68.md
+++ b/docs/releases/0.9.68.md
@@ -64,3 +64,20 @@ pipeline gets hygiene + per-recording frame accounting.
   Cloudflare-API upload fallback (needs an owner-created API token) and a
   Worker-fronted download/update path so Spanish users can update during
   blocks.
+
+## Addendum — Windows 0.9.70-alpha.1 (2026-08-24)
+
+Community PR #267 (petercr): screen+camera direct-D3D11 cadence — deeper
+texture pools for camera sessions, encoder drain wakes on publish (no more
+latest-wins frame loss), per-tick render diagnostics
+(`renderTickOverruns`, `renderTickLagMaxMs`, `renderComposeStageMaxMs`),
+ScreenCamera 1080p30/60 protected acceptance lanes, smoke evidence file.
+Physical evidence 1080p30: 29.01–29.6 fps vs the 28.5 floor.
+
+- Release: #268 (version 0.9.70; macOS unaffected, stays 0.9.68).
+- Candidate run 32728247299 — source
+  `21e931ec788d99962b3e39ac5bee416749f07ed2`, installer SHA-256
+  `4069213a87265a7c8758de8d780cb640b388ae0b3863799a5591f6cedf4c30a6`,
+  publisher `Uros Miric`. Pilot promotion PASS; pilot manifest verified.
+- Open review asks on #267: 1080p60 lane physical evidence;
+  `render_publish_stage_max_us` not yet surfaced.


### PR DESCRIPTION
Windows pilot record for #267/#268.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Windows 0.9.70-alpha.1.
  * Documented Direct3D 11 cadence improvements, rendering diagnostics, protected acceptance testing, 1080p30 evidence, candidate metadata, and remaining review items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->