### PR TITLE
feat(cohost): presence state — pendingMessages/nextTickAt/tickInFlight/messagesSeen/questionsTotal; off-shaped state everywhere

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -386,6 +386,7 @@ import type {
   VideorcAccountSnapshot,
   ViewerSample
 } from '../shared/backend'
+import { offCohostWindowState } from '../shared/backend'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -457,7 +458,9 @@ let commentsWindowAlwaysOnTop = false
 let commentsWindowClosing = false
 let commentsWindowContentProtected = false
 let latestCommentHighlightState: CommentHighlightState = { generation: 0, phase: 'idle' }
-let latestCohostWindowState: CohostWindowState | null = null
+// Off-shaped from the start (co-host presence W1): the Comments window's
+// mount-time `cohost-get` must always receive a concrete state, never null.
+let latestCohostWindowState: CohostWindowState = offCohostWindowState()
 let latestLiveCommentsSnapshot: LiveChatSnapshot | null = null
 const commentsHistoryCache = new CommentsHistoryCache()
 const commentsViewSelection = new CommentsViewSelection({ kind: 'live' })

--- a/apps/desktop/src/renderer/comments/main.tsx
+++ b/apps/desktop/src/renderer/comments/main.tsx
@@ -12,6 +12,7 @@ import type {
   LiveChatMessage,
   ViewerSample
 } from '@/lib/backend'
+import { offCohostWindowState } from '@/lib/backend'
 import { cohostHighlightMessageId } from '@/lib/cohost-view'
 import type { EntitlementUiGate } from '@/lib/entitlement-ui'
 import { chatSendFailures, pendingCommentsSendOperation, sendablePlatforms } from '@/lib/chat-send'
@@ -92,8 +93,9 @@ function CommentsWindowApp(): ReactElement {
   }, [])
   const [viewerSample, setViewerSample] = useState<ViewerSample | null>(null)
   // Co-host: the MAIN renderer resolves Premium, consent and the engine state,
-  // and relays ONE value. This window never re-derives gating.
-  const [cohost, setCohost] = useState<CohostWindowState | null>(null)
+  // and relays ONE value. This window never re-derives gating. Presence is
+  // unconditional: the window mounts on the off shape, never on null.
+  const [cohost, setCohost] = useState<CohostWindowState>(offCohostWindowState)
   const [cohostActionPending, setCohostActionPending] = useState(false)
   useEffect(() => {
     const applyView = (next: CommentsViewSnapshot): void => {
@@ -163,7 +165,7 @@ function CommentsWindowApp(): ReactElement {
     })
     void window.videorc
       ?.getCohostWindowState?.()
-      .then((state) => setCohost(state ?? null))
+      .then((state) => state && setCohost(state))
       .catch(() => {})
     const offCohost = window.videorc?.onCohostWindowState?.((state) => setCohost(state))
     return () => {
@@ -223,7 +225,7 @@ function CommentsWindowApp(): ReactElement {
           kind,
           targetId
         })
-        .then((state) => setCohost((current) => (current ? { ...current, state } : current)))
+        .then((state) => setCohost((current) => ({ ...current, state })))
         .catch((error) =>
           setSendFailures([
             {
@@ -244,17 +246,16 @@ function CommentsWindowApp(): ReactElement {
     requestHighlight(message)
   }
 
-  // Fail-closed: without a relayed value the segment stays hidden entirely.
-  const cohostGate: EntitlementUiGate | undefined = cohost
-    ? cohost.entitled
-      ? { allowed: true }
-      : {
-          allowed: false,
-          featureId: 'live-cohost',
-          reason: cohost.entitlementReason ?? 'Live Co-host requires Videorc Premium.',
-          ...(cohost.upgradeUrl ? { upgradeUrl: cohost.upgradeUrl } : {})
-        }
-    : undefined
+  // Fail-closed: the relay seed is off-shaped and un-entitled, so the gate is
+  // always derivable — presence never depends on a push having arrived.
+  const cohostGate: EntitlementUiGate = cohost.entitled
+    ? { allowed: true }
+    : {
+        allowed: false,
+        featureId: 'live-cohost',
+        reason: cohost.entitlementReason ?? 'Live Co-host requires Videorc Premium.',
+        ...(cohost.upgradeUrl ? { upgradeUrl: cohost.upgradeUrl } : {})
+      }
 
   return (
     <CommentsReader
@@ -270,10 +271,10 @@ function CommentsWindowApp(): ReactElement {
       sendPending={sendPending}
       sendTargets={sendTargets}
       cohostActionPending={cohostActionPending}
-      cohostConsented={cohost?.consented === true}
-      cohostEnabled={cohost?.enabled === true}
+      cohostConsented={cohost.consented}
+      cohostEnabled={cohost.enabled}
       cohostGate={cohostGate}
-      cohostState={cohost?.state ?? null}
+      cohostState={cohost.state}
       onCohostAnswered={(question) => sendCohostAction('answered')(question.id)}
       onCohostDismissFlag={(flag) => sendCohostAction('dismiss-flag')(flag.messageId)}
       onCohostDismissQuestion={(question) => sendCohostAction('dismiss-question')(question.id)}

--- a/apps/desktop/src/renderer/src/components/comments-reader.tsx
+++ b/apps/desktop/src/renderer/src/components/comments-reader.tsx
@@ -98,7 +98,12 @@ export function CommentsReader({
   sendOperation?: CommentsSendOperation | null
   sendFailures?: ChatSendFailure[]
   onSend?: (text: string, options?: { inReplyToQuestionId?: string }) => void
-  /** Latest `cohost.state`; null hides the Co-host segment entirely. */
+  /**
+   * Latest `cohost.state`. The relay always supplies a concrete state now —
+   * `offCohostState()` when the engine is off or has not reported yet — so
+   * presence is knowable from the first frame. Null is still tolerated for
+   * backward compat and hides the Co-host segment entirely.
+   */
   cohostState?: CohostState | null
   cohostGate?: EntitlementUiGate
   cohostConsented?: boolean

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -245,7 +245,7 @@ import type {
   YouTubeStreamStatusResult,
   ViewerSample
 } from '@/lib/backend'
-import { createEmptyLiveChatSnapshot } from '@/lib/backend'
+import { createEmptyLiveChatSnapshot, offCohostState } from '@/lib/backend'
 import { renderCaptionCueFramePng, renderCaptionOverlayPng } from '@/lib/caption-overlay'
 import { renderCommentHighlightPng } from '@/lib/caption-overlay'
 import {
@@ -2915,9 +2915,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   // One relayed value for the detached Comments window: the window never
   // re-derives Premium or consent, it renders what the main renderer resolved.
+  // Presence is unconditional: before the engine reports (or when it is off)
+  // the relay carries the off shape, never null.
   const cohostWindowState = useMemo<CohostWindowState>(
     () => ({
-      state: cohostState,
+      state: cohostState ?? offCohostState(),
       entitled: cohostGate.allowed,
       entitlementReason: cohostGate.allowed ? null : cohostGate.reason,
       upgradeUrl: (cohostGate.allowed ? undefined : cohostGate.upgradeUrl) ?? null,

--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -933,6 +933,38 @@ describe('backend RPC contract', () => {
     }
     expect(validateBackendEventPayload('cohost.state', state)).toEqual(state)
     expect(validateBackendRpcResult('cohost.status', state)).toEqual(state)
+
+    // Presence fields (W1): optional so a pre-presence backend still
+    // validates (`state` above omits them), typed when present.
+    const working = {
+      ...state,
+      tickInFlight: true,
+      pendingMessages: 4,
+      nextTickAt: '2026-08-22T10:00:28Z',
+      messagesSeen: 84,
+      questionsTotal: 5
+    }
+    expect(validateBackendEventPayload('cohost.state', working)).toEqual(working)
+    expect(validateBackendRpcResult('cohost.status', working)).toEqual(working)
+    expect(validateBackendEventPayload('cohost.state', { ...working, nextTickAt: null })).toEqual({
+      ...working,
+      nextTickAt: null
+    })
+    expect(() =>
+      validateBackendEventPayload('cohost.state', { ...working, pendingMessages: -1 })
+    ).toThrow('cohost.state')
+    expect(() =>
+      validateBackendEventPayload('cohost.state', { ...working, pendingMessages: 1.5 })
+    ).toThrow('cohost.state')
+    expect(() =>
+      validateBackendEventPayload('cohost.state', { ...working, tickInFlight: 'yes' })
+    ).toThrow('cohost.state')
+    expect(() =>
+      validateBackendEventPayload('cohost.state', { ...working, nextTickAt: 12 })
+    ).toThrow('cohost.state')
+    expect(() =>
+      validateBackendEventPayload('cohost.state', { ...working, messagesSeen: -4 })
+    ).toThrow('cohost.state')
     const off = {
       sessionId: null,
       status: 'off',

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -1405,7 +1405,14 @@ const cohostStateSchema = objectSchema(
     mood: nullableSchema(enumSchema(['hype', 'calm', 'tense', 'mixed'])),
     lastTickAt: nullableSchema(timestamp),
     tickSeq: nonNegativeInteger,
-    partial: booleanSchema
+    partial: booleanSchema,
+    // Presence fields (W1): optional on the wire so pre-presence backends
+    // still validate; the current backend always sends them.
+    tickInFlight: optionalSchema(booleanSchema),
+    pendingMessages: optionalSchema(nonNegativeInteger),
+    nextTickAt: optionalSchema(nullableSchema(timestamp)),
+    messagesSeen: optionalSchema(nonNegativeInteger),
+    questionsTotal: optionalSchema(nonNegativeInteger)
   },
   { allowUnknown: false }
 ) as RuntimeSchema<CohostState>

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -3182,7 +3182,8 @@ export interface VideorcApi {
   /** Co-host relay: the main renderer pushes state, the window seeds + follows
    * it, and window actions come back through the same correlated broker. */
   pushCohostWindowState: (state: CohostWindowState) => Promise<void>
-  getCohostWindowState: () => Promise<CohostWindowState | null>
+  /** Never null: main seeds the relay cache with `offCohostWindowState()`. */
+  getCohostWindowState: () => Promise<CohostWindowState>
   onCohostWindowState: (callback: (state: CohostWindowState) => void) => () => void
   sendCohostAction: (command: CohostActionCommand) => Promise<CohostState>
   onCohostActionRequest: (callback: (command: CohostActionCommand) => void) => () => void
@@ -3606,6 +3607,50 @@ export interface CohostState {
   tickSeq: number
   /** True when the last tick dropped messages under the 60-message delta cap. */
   partial: boolean
+  /**
+   * Presence fields (co-host presence W1). All optional on the wire so a
+   * backend from before them still validates; absent means the default
+   * (false / 0 / null).
+   */
+  /** A tick HTTP request is outstanding right now ("thinking"). */
+  tickInFlight?: boolean
+  /** Delta messages collected but not yet sent in a tick ("reading N new"). */
+  pendingMessages?: number
+  /**
+   * ISO-8601 instant of the scheduler's earliest next pass; present only while
+   * `pendingMessages > 0` (burst rule bounded by the 8 s min gap, trickle rule
+   * at anchor + 20 s, pushed back by a backoff/quota window).
+   */
+  nextTickAt?: string | null
+  /** Session total of chat messages the engine noted for ticks. */
+  messagesSeen?: number
+  /** Distinct question ids surfaced this session — lifetime, not open count. */
+  questionsTotal?: number
+}
+
+/**
+ * Off-shaped `cohost.state`: what the backend reports when no engine session
+ * exists. Presence is unconditional — surfaces render this instead of hiding
+ * (null never reaches the Comments window relay any more).
+ */
+export function offCohostState(): CohostState {
+  return {
+    sessionId: null,
+    status: 'off',
+    reason: null,
+    detail: null,
+    questions: [],
+    flags: [],
+    mood: null,
+    lastTickAt: null,
+    tickSeq: 0,
+    partial: false,
+    tickInFlight: false,
+    pendingMessages: 0,
+    nextTickAt: null,
+    messagesSeen: 0,
+    questionsTotal: 0
+  }
 }
 
 /**
@@ -3638,7 +3683,8 @@ export interface CohostFlagParams {
  * value; the window never re-derives gating.
  */
 export interface CohostWindowState {
-  state: CohostState | null
+  /** Always concrete: `offCohostState()` until the engine reports, never null. */
+  state: CohostState
   /** Premium gate result. Fail-closed: false until the main renderer says otherwise. */
   entitled: boolean
   entitlementReason: string | null
@@ -3647,6 +3693,21 @@ export interface CohostWindowState {
   consented: boolean
   /** Persisted `cohost.settings.enabled`. */
   enabled: boolean
+}
+
+/**
+ * Fail-closed seed for the Comments window relay: co-host presence must be
+ * knowable from the first frame, so the window mounts on this instead of null.
+ */
+export function offCohostWindowState(): CohostWindowState {
+  return {
+    state: offCohostState(),
+    entitled: false,
+    entitlementReason: null,
+    upgradeUrl: null,
+    consented: false,
+    enabled: false
+  }
 }
 
 export type CohostActionKind = 'answered' | 'dismiss-question' | 'dismiss-flag'

--- a/apps/desktop/src/shared/protocol-contract-fixtures.test.ts
+++ b/apps/desktop/src/shared/protocol-contract-fixtures.test.ts
@@ -193,6 +193,22 @@ describe('shared high-risk protocol fixture', () => {
       detail: null,
       mood: null
     })
+    // Presence fields (W1): the off shape is all defaults, the listening shape
+    // carries a pending delta with its announced next pass.
+    expect(fixtures.cohost.offState).toMatchObject({
+      tickInFlight: false,
+      pendingMessages: 0,
+      nextTickAt: null,
+      messagesSeen: 0,
+      questionsTotal: 0
+    })
+    expect(fixtures.cohost.state).toMatchObject({
+      tickInFlight: false,
+      pendingMessages: 4,
+      nextTickAt: '2026-08-22T10:00:28Z',
+      messagesSeen: 84,
+      questionsTotal: 5
+    })
     // `detail` carries the failed tick's envelope verbatim, or a desktop code
     // with no HTTP status; a pre-`detail` payload validates unchanged.
     for (const shape of ['errorState', 'timeoutState', 'legacyState'] as const) {
@@ -214,6 +230,17 @@ describe('shared high-risk protocol fixture', () => {
       status: null
     })
     expect('detail' in fixtures.cohost.legacyState).toBe(false)
+    // The legacy payload predates the presence fields; validating it proves
+    // the schema (and serde on the Rust side) defaults them.
+    for (const key of [
+      'tickInFlight',
+      'pendingMessages',
+      'nextTickAt',
+      'messagesSeen',
+      'questionsTotal'
+    ]) {
+      expect(key in fixtures.cohost.legacyState).toBe(false)
+    }
   })
 
   it('keeps comment pagination defaults and deletion DTOs identical', () => {

--- a/crates/videorc-backend/src/cohost.rs
+++ b/crates/videorc-backend/src/cohost.rs
@@ -241,8 +241,9 @@ impl CohostErrorDetail {
 
 /// The `cohost.state` event payload and the result of every `cohost.*` RPC.
 /// Nullable fields serialize as explicit `null` (the renderer reducer keys on
-/// them), never as absent keys. `detail` is additionally `default` on read so
-/// a payload from before it existed still parses.
+/// them), never as absent keys. `detail` and the presence fields are
+/// additionally `default` on read so a payload from before they existed still
+/// parses.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CohostState {
@@ -259,6 +260,26 @@ pub struct CohostState {
     pub last_tick_at: Option<String>,
     pub tick_seq: u64,
     pub partial: bool,
+    /// A tick HTTP request is outstanding right now ("thinking").
+    #[serde(default)]
+    pub tick_in_flight: bool,
+    /// Delta messages collected but not yet sent in a tick — "I've seen your
+    /// chat and I'm on it".
+    #[serde(default)]
+    pub pending_messages: u32,
+    /// ISO-8601 instant of the scheduler's earliest possible next pass, present
+    /// only while `pending_messages > 0`: the burst rule (>= 5 pending) fires as
+    /// soon as the 8 s min gap allows, the trickle rule at anchor + 20 s, and a
+    /// backoff/quota window pushes both back.
+    #[serde(default)]
+    pub next_tick_at: Option<String>,
+    /// Session total of chat messages noted to the engine (entered a delta).
+    #[serde(default)]
+    pub messages_seen: u64,
+    /// Distinct question ids this session ever surfaced — lifetime count, not
+    /// the open count.
+    #[serde(default)]
+    pub questions_total: u64,
 }
 
 impl CohostState {
@@ -274,6 +295,11 @@ impl CohostState {
             last_tick_at: None,
             tick_seq: 0,
             partial: false,
+            tick_in_flight: false,
+            pending_messages: 0,
+            next_tick_at: None,
+            messages_seen: 0,
+            questions_total: 0,
         }
     }
 }
@@ -356,6 +382,12 @@ struct CohostSession {
     backoff_index: usize,
     next_attempt_at: Option<Instant>,
     in_flight: bool,
+    /// Session total of messages that entered a delta (presence indicator).
+    messages_seen: u64,
+    /// Every question id this session ever surfaced, so `questions_total`
+    /// counts each grouped question exactly once across ticks.
+    counted_question_ids: HashSet<String>,
+    questions_total: u64,
 }
 
 impl CohostSession {
@@ -392,10 +424,25 @@ impl CohostSession {
             backoff_index: 0,
             next_attempt_at: None,
             in_flight: false,
+            messages_seen: 0,
+            counted_question_ids: HashSet::new(),
+            questions_total: 0,
         }
     }
 
     fn snapshot(&self) -> CohostState {
+        self.snapshot_at(Instant::now())
+    }
+
+    fn snapshot_at(&self, now: Instant) -> CohostState {
+        let next_tick_at = next_tick_due_at(
+            self.pending.len(),
+            self.last_tick_at.unwrap_or(self.started_at),
+            self.last_tick_at,
+            self.next_attempt_at,
+            now,
+        )
+        .map(|due| iso_after(now, due));
         CohostState {
             session_id: Some(self.session_id.clone()),
             status: self.status,
@@ -407,6 +454,11 @@ impl CohostSession {
             last_tick_at: self.last_tick_iso.clone(),
             tick_seq: self.tick_seq,
             partial: self.partial,
+            tick_in_flight: self.in_flight,
+            pending_messages: u32::try_from(self.pending.len()).unwrap_or(u32::MAX),
+            next_tick_at,
+            messages_seen: self.messages_seen,
+            questions_total: self.questions_total,
         }
     }
 
@@ -453,6 +505,7 @@ impl CohostSession {
             }
             noted += 1;
         }
+        self.messages_seen = self.messages_seen.saturating_add(noted as u64);
         noted
     }
 
@@ -539,6 +592,9 @@ impl CohostSession {
                 if self.known_set.contains(&id) && !message_ids.contains(&id) {
                     message_ids.push(id);
                 }
+            }
+            if self.counted_question_ids.insert(incoming.id.clone()) {
+                self.questions_total = self.questions_total.saturating_add(1);
             }
             next_questions.push(CohostQuestion {
                 id: incoming.id,
@@ -656,6 +712,51 @@ pub(crate) fn tick_due(
     now.duration_since(anchor) >= TICK_IDLE_INTERVAL
 }
 
+/// Earliest instant the scheduler could send the next tick, pure for the test
+/// matrix and `None` on an empty delta. The burst rule (>= 5 pending) fires as
+/// soon as the 8 s min gap allows; the trickle rule fires at anchor + 20 s; a
+/// backoff/quota `next_attempt_at` pushes both back. Never in the past.
+pub(crate) fn next_tick_due_at(
+    pending: usize,
+    anchor: Instant,
+    last_tick: Option<Instant>,
+    next_attempt_at: Option<Instant>,
+    now: Instant,
+) -> Option<Instant> {
+    if pending == 0 {
+        return None;
+    }
+    let mut due = if pending >= TICK_BURST_THRESHOLD {
+        now
+    } else {
+        anchor + TICK_IDLE_INTERVAL
+    };
+    if let Some(last) = last_tick {
+        due = due.max(last + TICK_MIN_GAP);
+    }
+    if let Some(attempt) = next_attempt_at {
+        due = due.max(attempt);
+    }
+    Some(due.max(now))
+}
+
+/// Wall-clock ISO-8601 for a monotonic instant `due` relative to `now`.
+fn iso_after(now: Instant, due: Instant) -> String {
+    let delta = chrono::Duration::from_std(due.saturating_duration_since(now))
+        .unwrap_or_else(|_| chrono::Duration::zero());
+    (chrono::Utc::now() + delta).to_rfc3339()
+}
+
+/// Emission bucket for `pending_messages`: `cohost.state` is pushed when the
+/// bucket changes (0 -> 1, then every +5), never per message.
+pub(crate) fn pending_bucket(pending: usize) -> usize {
+    if pending == 0 {
+        0
+    } else {
+        1 + (pending - 1) / 5
+    }
+}
+
 /// Map one chat row onto the tick wire shape. Non-`message` events (paid,
 /// membership, system, moderation), tombstones, and custom RTMP rows (no chat
 /// platform) are excluded.
@@ -765,6 +866,14 @@ impl CohostEngine {
         self.session
             .as_mut()
             .map(|session| session.note_messages(messages))
+            .unwrap_or(0)
+    }
+
+    /// Messages buffered for the next tick (0 without a session).
+    pub(crate) fn pending_len(&self) -> usize {
+        self.session
+            .as_ref()
+            .map(|session| session.pending.len())
             .unwrap_or(0)
     }
 
@@ -967,16 +1076,27 @@ pub(crate) async fn stop_cohost_for_session_end(state: &AppState) {
 }
 
 /// Delivery-path hook: remember eligible rows for the next tick. Rows from a
-/// different session are ignored by the engine's own guard.
+/// different session are ignored by the engine's own guard. The UI learns
+/// about queued chat when `pending_messages` crosses an emission bucket
+/// (0 -> 1, then every +5) — a reaction per wave, never a per-message storm.
 pub(crate) async fn note_messages(state: &AppState, messages: &[LiveChatMessage]) {
     if messages.is_empty() {
         return;
     }
-    let mut engine = state.cohost.lock().await;
-    if engine.session.is_none() {
-        return;
-    }
-    engine.note_messages(messages);
+    let snapshot = {
+        let mut engine = state.cohost.lock().await;
+        if engine.session.is_none() {
+            return;
+        }
+        let bucket_before = pending_bucket(engine.pending_len());
+        engine.note_messages(messages);
+        let bucket_after = pending_bucket(engine.pending_len());
+        if bucket_before == bucket_after {
+            return;
+        }
+        engine.snapshot()
+    };
+    emit_state(state, &snapshot);
 }
 
 pub async fn mark_question_answered(
@@ -1068,13 +1188,15 @@ async fn run_scheduler_pass(state: &AppState, generation: u64) -> bool {
         let mut engine = state.cohost.lock().await;
         let prepared = engine.prepare_tick(generation, token.is_some(), premium, Instant::now());
         match prepared {
-            Ok(prepared) => Ok(prepared),
+            // The snapshot taken here carries tick_in_flight=true and the
+            // drained delta; emitting it below is the "thinking..." signal.
+            Ok(prepared) => Ok((prepared, engine.snapshot())),
             Err(TickGate::Stopped) => return false,
             Err(TickGate::Idle) => return true,
             Err(TickGate::Paused(reason)) => Err((reason, engine.snapshot())),
         }
     };
-    let prepared = match prepared {
+    let (prepared, in_flight_snapshot) = match prepared {
         Ok(prepared) => prepared,
         Err((reason, snapshot)) => {
             state.emit_log(
@@ -1088,6 +1210,9 @@ async fn run_scheduler_pass(state: &AppState, generation: u64) -> bool {
             return true;
         }
     };
+    // tick_in_flight toggles true exactly here and false in apply_tick_result;
+    // both edges reach the renderer (this emit, and the post-tick emit below).
+    emit_state(state, &in_flight_snapshot);
     let Some(token) = token else {
         return true;
     };
@@ -2041,6 +2166,239 @@ mod tests {
         assert_eq!(json["partial"], false);
         assert_eq!(json["questions"], serde_json::json!([]));
         assert_eq!(json["flags"], serde_json::json!([]));
+        // Presence fields always ride the wire, defaults included.
+        assert_eq!(json["tickInFlight"], false);
+        assert_eq!(json["pendingMessages"], 0);
+        assert_eq!(json["nextTickAt"], serde_json::Value::Null);
+        assert_eq!(json["messagesSeen"], 0);
+        assert_eq!(json["questionsTotal"], 0);
+    }
+
+    #[test]
+    fn state_without_presence_fields_still_parses_to_defaults() {
+        // A payload from before the presence fields existed (<= 0.9.70).
+        let legacy: CohostState = serde_json::from_value(serde_json::json!({
+            "sessionId": "session-1",
+            "status": "listening",
+            "reason": null,
+            "detail": null,
+            "questions": [],
+            "flags": [],
+            "mood": null,
+            "lastTickAt": "2026-08-22T10:00:20Z",
+            "tickSeq": 2,
+            "partial": false
+        }))
+        .unwrap();
+        assert!(!legacy.tick_in_flight);
+        assert_eq!(legacy.pending_messages, 0);
+        assert_eq!(legacy.next_tick_at, None);
+        assert_eq!(legacy.messages_seen, 0);
+        assert_eq!(legacy.questions_total, 0);
+    }
+
+    #[test]
+    fn pending_bucket_emits_at_one_then_every_five() {
+        let cases = [
+            (0, 0),
+            (1, 1),
+            (2, 1),
+            (5, 1),
+            (6, 2),
+            (10, 2),
+            (11, 3),
+            (60, 12),
+        ];
+        for (pending, bucket) in cases {
+            assert_eq!(pending_bucket(pending), bucket, "pending={pending}");
+        }
+    }
+
+    #[test]
+    fn next_tick_due_at_matches_both_scheduler_rules() {
+        let start = Instant::now();
+        let now = start + secs(2);
+        // Empty delta: no next pass to announce.
+        assert_eq!(next_tick_due_at(0, start, None, None, now), None);
+        // Trickle rule: 1..4 pending fire at anchor + 20 s.
+        assert_eq!(
+            next_tick_due_at(1, start, None, None, now),
+            Some(start + secs(20))
+        );
+        assert_eq!(
+            next_tick_due_at(4, start, None, None, now),
+            Some(start + secs(20))
+        );
+        // Burst rule: >= 5 pending fire immediately without a previous tick...
+        assert_eq!(next_tick_due_at(5, start, None, None, now), Some(now));
+        // ...and as soon as the 8 s min gap allows after one.
+        let last = start + secs(1);
+        assert_eq!(
+            next_tick_due_at(9, last, Some(last), None, now),
+            Some(last + secs(8))
+        );
+        // Trickle after a tick: the 20 s rule dominates the 8 s floor.
+        assert_eq!(
+            next_tick_due_at(1, last, Some(last), None, now),
+            Some(last + secs(20))
+        );
+        // A backoff/quota window pushes both rules back.
+        let attempt = start + secs(40);
+        assert_eq!(
+            next_tick_due_at(5, last, Some(last), Some(attempt), now),
+            Some(attempt)
+        );
+        // The announced pass is never in the past.
+        let late = start + secs(90);
+        assert_eq!(
+            next_tick_due_at(1, last, Some(last), Some(attempt), late),
+            Some(late)
+        );
+    }
+
+    #[test]
+    fn tick_in_flight_toggles_around_the_request_on_success_and_failure() {
+        let start = Instant::now();
+        let (mut engine, generation) = running_engine(start);
+        assert!(!engine.snapshot().tick_in_flight);
+        engine.note_messages(&messages("session-1", 0..7));
+        let queued = engine
+            .session
+            .as_ref()
+            .unwrap()
+            .snapshot_at(start + secs(1));
+        assert_eq!(queued.pending_messages, 7);
+        assert!(!queued.tick_in_flight);
+        assert!(
+            queued.next_tick_at.is_some(),
+            "pending messages must announce the next pass"
+        );
+
+        // Sending drains the delta and raises tick_in_flight until the result.
+        engine
+            .prepare_tick(generation, true, true, start + secs(1))
+            .unwrap();
+        let in_flight = engine.snapshot();
+        assert!(in_flight.tick_in_flight);
+        assert_eq!(in_flight.pending_messages, 0);
+        assert_eq!(in_flight.next_tick_at, None);
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Ok(response(vec![question("q_1", &[])])),
+            start + secs(2),
+            "t1"
+        ));
+        let merged = engine.snapshot();
+        assert!(!merged.tick_in_flight);
+        assert_eq!(merged.pending_messages, 0);
+        assert_eq!(merged.messages_seen, 7);
+        assert_eq!(merged.questions_total, 1);
+
+        // Failure path clears the flag too.
+        engine.note_messages(&messages("session-1", 7..14));
+        engine
+            .prepare_tick(generation, true, true, start + secs(30))
+            .unwrap();
+        assert!(engine.snapshot().tick_in_flight);
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Err(CohostApiError::network("offline")),
+            start + secs(31),
+            "t2"
+        ));
+        let failed = engine.snapshot();
+        assert!(!failed.tick_in_flight);
+        assert_eq!(failed.pending_messages, 0);
+        assert_eq!(failed.messages_seen, 14);
+    }
+
+    #[test]
+    fn questions_total_counts_each_grouped_id_once_for_the_session() {
+        let start = Instant::now();
+        let (mut engine, generation) = running_engine(start);
+        let rows = messages("session-1", 0..5);
+        engine.note_messages(&rows);
+        engine
+            .prepare_tick(generation, true, true, start + secs(1))
+            .unwrap();
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Ok(response(vec![
+                question("q_1", &[rows[0].id.as_str()]),
+                question("q_2", &[rows[1].id.as_str()]),
+            ])),
+            start + secs(2),
+            "t1"
+        ));
+        assert_eq!(engine.snapshot().questions_total, 2);
+
+        // A kept id does not re-count; a dismissed id keeps its count; a new
+        // id adds one.
+        assert!(engine.mark_answered("session-1", "q_2").unwrap());
+        engine.note_messages(&messages("session-1", 5..10));
+        engine
+            .prepare_tick(generation, true, true, start + secs(30))
+            .unwrap();
+        assert!(engine.apply_tick_result(
+            generation,
+            0,
+            Ok(response(vec![
+                question("q_1", &[rows[2].id.as_str()]),
+                question("q_3", &[rows[3].id.as_str()]),
+            ])),
+            start + secs(31),
+            "t2"
+        ));
+        let snapshot = engine.snapshot();
+        assert_eq!(snapshot.questions_total, 3);
+        assert_eq!(snapshot.questions.len(), 2, "open count stays distinct");
+        assert_eq!(snapshot.messages_seen, 10);
+    }
+
+    #[tokio::test]
+    async fn note_messages_emits_only_on_bucket_crossings() {
+        let state = test_state();
+        {
+            let mut engine = state.cohost.lock().await;
+            engine.settings.enabled = true;
+            engine.start_session("session-1".to_string(), true, None, Instant::now());
+        }
+        let mut events = state.events.subscribe();
+        let drain_states = |events: &mut broadcast::Receiver<crate::protocol::ServerEvent>| {
+            let mut states = Vec::new();
+            while let Ok(event) = events.try_recv() {
+                if event.event == COHOST_STATE_EVENT {
+                    states.push(event.payload);
+                }
+            }
+            states
+        };
+
+        // 0 -> 1 crosses into the first bucket: one emit.
+        note_messages(&state, &messages("session-1", 0..1)).await;
+        let states = drain_states(&mut events);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0]["pendingMessages"], 1);
+        assert!(states[0]["nextTickAt"].is_string());
+        assert_eq!(states[0]["tickInFlight"], false);
+
+        // 1 -> 4 stays inside the bucket: silent.
+        note_messages(&state, &messages("session-1", 1..4)).await;
+        assert!(drain_states(&mut events).is_empty());
+
+        // 4 -> 7 crosses into the second bucket: one emit.
+        note_messages(&state, &messages("session-1", 4..7)).await;
+        let states = drain_states(&mut events);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0]["pendingMessages"], 7);
+
+        // No engine session: never an emit.
+        state.cohost.lock().await.stop_session();
+        note_messages(&state, &messages("session-1", 7..9)).await;
+        assert!(drain_states(&mut events).is_empty());
     }
 
     #[tokio::test]

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -4431,6 +4431,13 @@ mod tests {
 
         let state_wire = shared_high_risk_contract_fixture_value("/cohost/state");
         let state: crate::cohost::CohostState = serde_json::from_value(state_wire.clone()).unwrap();
+        // Presence fields (W1): pending delta, scheduled next pass, in-flight
+        // flag, and the session lifetime counters ride every state payload.
+        assert!(!state.tick_in_flight);
+        assert_eq!(state.pending_messages, 4);
+        assert_eq!(state.next_tick_at.as_deref(), Some("2026-08-22T10:00:28Z"));
+        assert_eq!(state.messages_seen, 84);
+        assert_eq!(state.questions_total, 5);
         assert_eq!(serde_json::to_value(state).unwrap(), state_wire);
 
         let off_wire = shared_high_risk_contract_fixture_value("/cohost/offState");
@@ -4465,9 +4472,15 @@ mod tests {
         );
         assert_eq!(serde_json::to_value(timed_out).unwrap(), timeout_wire);
 
-        // A payload from before `detail` existed still parses (serde default).
+        // A payload from before `detail` and the presence fields existed still
+        // parses (serde defaults).
         let legacy_wire = shared_high_risk_contract_fixture_value("/cohost/legacyState");
         assert!(legacy_wire.get("detail").is_none());
+        assert!(legacy_wire.get("tickInFlight").is_none());
+        assert!(legacy_wire.get("pendingMessages").is_none());
+        assert!(legacy_wire.get("nextTickAt").is_none());
+        assert!(legacy_wire.get("messagesSeen").is_none());
+        assert!(legacy_wire.get("questionsTotal").is_none());
         let legacy: crate::cohost::CohostState = serde_json::from_value(legacy_wire).unwrap();
         assert_eq!(legacy, crate::cohost::CohostState::off());
     }

--- a/protocol-fixtures/high-risk-contracts.json
+++ b/protocol-fixtures/high-risk-contracts.json
@@ -291,7 +291,12 @@
       "mood": "hype",
       "lastTickAt": "2026-08-22T10:00:20Z",
       "tickSeq": 2,
-      "partial": false
+      "partial": false,
+      "tickInFlight": false,
+      "pendingMessages": 4,
+      "nextTickAt": "2026-08-22T10:00:28Z",
+      "messagesSeen": 84,
+      "questionsTotal": 5
     },
     "offState": {
       "sessionId": null,
@@ -303,7 +308,12 @@
       "mood": null,
       "lastTickAt": null,
       "tickSeq": 0,
-      "partial": false
+      "partial": false,
+      "tickInFlight": false,
+      "pendingMessages": 0,
+      "nextTickAt": null,
+      "messagesSeen": 0,
+      "questionsTotal": 0
     },
     "errorState": {
       "sessionId": "session-fixture",
@@ -319,7 +329,12 @@
       "mood": null,
       "lastTickAt": "2026-08-22T10:00:20Z",
       "tickSeq": 3,
-      "partial": false
+      "partial": false,
+      "tickInFlight": false,
+      "pendingMessages": 2,
+      "nextTickAt": "2026-08-22T10:00:40Z",
+      "messagesSeen": 12,
+      "questionsTotal": 3
     },
     "timeoutState": {
       "sessionId": "session-fixture",
@@ -335,7 +350,12 @@
       "mood": null,
       "lastTickAt": "2026-08-22T10:00:20Z",
       "tickSeq": 3,
-      "partial": false
+      "partial": false,
+      "tickInFlight": false,
+      "pendingMessages": 0,
+      "nextTickAt": null,
+      "messagesSeen": 12,
+      "questionsTotal": 3
     },
     "legacyState": {
       "sessionId": null,

--- a/scripts/smoke-cohost-fake.mjs
+++ b/scripts/smoke-cohost-fake.mjs
@@ -18,7 +18,10 @@ import { connectBackend, request } from './smoke-recording-session.mjs'
 // drives the fake live-chat connector as scripted "lanes", and proves the
 // engine end to end without the cloud:
 //
-//   settings gate -> start requires the active chat session -> first tick has
+//   settings gate -> off-shaped status with default presence fields -> start
+//   requires the active chat session -> queued chat announces itself
+//   (pendingMessages bucket emit + nextTickAt) -> tickInFlight toggles around
+//   the request -> first tick has
 //   the exact wire shape -> repeated text groups into ONE question whose
 //   askers/messageIds grow across ticks -> marker message is flagged ->
 //   429 quota pauses and resumes after Retry-After -> 403 pauses
@@ -131,6 +134,16 @@ try {
     off.status === 'off' && off.sessionId === null,
     `Engine should be off before a chat session: ${JSON.stringify(off)}`
   )
+  // Presence W1: cohost.status is ALWAYS a concrete state; before any session
+  // it is the off shape with every presence field at its default.
+  expect(
+    off.tickInFlight === false &&
+      off.pendingMessages === 0 &&
+      off.nextTickAt === null &&
+      off.messagesSeen === 0 &&
+      off.questionsTotal === 0,
+    `Off state should carry default presence fields: ${JSON.stringify(off)}`
+  )
   await expectRejected(
     () => request(backend, timeoutMs, 'cohost.start', { sessionId, consentToProcessChat: true }),
     'cohost.start without an active Comments session'
@@ -157,6 +170,10 @@ try {
     started.status === 'listening' && started.sessionId === sessionId && started.tickSeq === 0,
     `cohost.start did not report listening: ${JSON.stringify(started)}`
   )
+  expect(
+    started.tickInFlight === false && started.pendingMessages === 0 && started.messagesSeen === 0,
+    `Fresh session should start with empty presence counters: ${JSON.stringify(started)}`
+  )
   const again = await request(backend, timeoutMs, 'cohost.start', {
     sessionId,
     consentToProcessChat: true
@@ -166,8 +183,35 @@ try {
     'Repeated cohost.start was not a no-op.'
   )
 
+  // --- Presence W1: queued chat is announced before the first tick -----------
+  phase('presence: pending bucket emit before tick 1')
+  const pendingState = await waitForState(
+    observed,
+    (state) => state.tickSeq === 0 && (state.pendingMessages ?? 0) >= 1,
+    'a pending-bucket cohost.state before the first tick'
+  )
+  expect(
+    pendingState.tickInFlight === false &&
+      typeof pendingState.nextTickAt === 'string' &&
+      !Number.isNaN(Date.parse(pendingState.nextTickAt)),
+    `Pending messages must announce the next pass: ${JSON.stringify({ pendingMessages: pendingState.pendingMessages, nextTickAt: pendingState.nextTickAt })}`
+  )
+  expect(
+    pendingState.messagesSeen >= pendingState.pendingMessages,
+    `messagesSeen should count every noted message: ${JSON.stringify({ messagesSeen: pendingState.messagesSeen, pendingMessages: pendingState.pendingMessages })}`
+  )
+
   // --- Tick 1: burst, exact wire shape, grouped question, flag ---------------
   phase('tick 1: burst (>= 5 new messages)')
+  const inFlight1 = await waitForState(
+    observed,
+    (state) => state.tickSeq === 1 && state.tickInFlight === true,
+    'the tick-in-flight cohost.state for tick 1'
+  )
+  expect(
+    inFlight1.pendingMessages === 0,
+    `Sending a tick drains the pending delta: ${JSON.stringify({ pendingMessages: inFlight1.pendingMessages })}`
+  )
   const s1 = await waitForTick(observed, 1)
   expect(
     s1.status === 'listening' && s1.reason === null,
@@ -176,6 +220,12 @@ try {
   expect(
     typeof s1.lastTickAt === 'string' && s1.partial === false && typeof s1.mood === 'string',
     `Tick 1 state lacks lastTickAt/partial/mood: ${JSON.stringify(s1)}`
+  )
+  // Presence W1: the merged tick clears the in-flight flag; pending stays at
+  // whatever arrived since the request went out (0 unless a message raced in).
+  expect(
+    s1.tickInFlight === false && s1.messagesSeen >= 5 && s1.questionsTotal >= 1,
+    `Merged tick 1 should reset in-flight and grow the session counters: ${JSON.stringify({ tickInFlight: s1.tickInFlight, messagesSeen: s1.messagesSeen, questionsTotal: s1.questionsTotal })}`
   )
   const r1 = requireRequest(1)
   assertRequestShape(r1.body)
@@ -441,6 +491,7 @@ try {
 
   console.log(
     `Live Co-host fake smoke PASS - ${fake.state.requests.length} ticks over ${totalMessages} messages: ` +
+      `off-shaped presence defaults, pending-bucket emit with nextTickAt, tickInFlight toggle, ` +
       `wire shape, 5-asker grouping across ${contributingTicks.size} ticks, flag, ` +
       `429/403/503 status+reason mapping with Retry-After and backoff honored, dismiss, ` +
       `20 s trickle rule, reply-answered, and ${IDLE_PROOF_MS / 1000} s idle without a tick.`
@@ -549,9 +600,11 @@ function collectCohostStates(ws) {
 }
 
 function waitForTick(observed, tickSeq) {
+  // tickSeq increments when the request is BUILT, so each tick emits twice:
+  // once in flight ("thinking") and once merged. Wait for the merged one.
   return waitForState(
     observed,
-    (state) => state.tickSeq === tickSeq,
+    (state) => state.tickSeq === tickSeq && state.tickInFlight !== true,
     `cohost.state for tick ${tickSeq}`
   )
 }


### PR DESCRIPTION
W1 of the co-host presence indicators plan (`2026-08-24 - Videorc Co-host Presence Indicators Plan`). Wire/state only — the W2 Comments-window indicators and W3 Studio session-panel line build on this.

## Problem

`comments-reader.tsx` hides the Co-host segment entirely when `cohost.state` is null — which it is whenever the engine is off/unstarted, consent was never given, or the detached Comments window opened before the first relay push. The feature is invisible exactly when the streamer wonders whether it exists, and there is no signal between chat arriving and a tick firing.

## What changed

### New `CohostState` presence fields (all `#[serde(default)]`, camelCase)

| Field | Meaning |
| --- | --- |
| `tickInFlight: boolean` | A tick HTTP request is outstanding ("thinking…") |
| `pendingMessages: number` | Delta messages collected but not yet sent in a tick |
| `nextTickAt: string \| null` | ISO-8601 earliest next scheduler pass, only while `pendingMessages > 0`: burst rule (≥5) fires as soon as the 8 s min gap allows, trickle rule at anchor + 20 s, both pushed back by a backoff/quota window; never in the past |
| `messagesSeen: number` | Session total of chat rows noted to the engine |
| `questionsTotal: number` | Distinct question ids this session (lifetime, not open count) |

TS mirrors are optional on the wire so a pre-presence backend still validates; the current backend always sends them.

### Emit rules

- `cohost.state` on `pendingMessages` **bucket crossings** (0→1, then every +5) — a reaction per wave, never a per-message event storm.
- `tickInFlight=true` emitted immediately before `post_cohost_tick`; false after success **and** failure via the existing post-merge emit (which also shows the drained delta, `pendingMessages: 0`).
- After every tick, as before.

### Off-shaped state everywhere

- `cohost.status` and every engine accessor return a concrete `CohostState` with `status: 'off'` (already true; `off()` now carries the presence defaults).
- Main process seeds the Comments-window relay cache with `offCohostWindowState()` so `comments-window:cohost-get` never returns null; the main renderer relays `cohostState ?? offCohostState()`; the Comments window mounts on the off shape (`CohostWindowState.state` is now non-nullable).
- `comments-reader.tsx` prop doc updated: null still tolerated for backward compat, but the relay never sends it now.

## Tests

- **Rust**: presence defaults + legacy (pre-presence) payload parse, wire keys explicit, `pending_bucket` matrix, `next_tick_due_at` matrix for both scheduler rules (+ backoff + never-in-the-past), `tickInFlight` toggling around the request on success and failure with pending reset, `questionsTotal` counts each grouped id once, `note_messages` emits only on bucket crossings; fixture round-trips.
- **TS**: contract-schema accept/reject cases for every new field; protocol fixtures extended (`legacyState` deliberately untouched to prove serde/schema defaults).
- **Smoke** (`pnpm smoke:cohost-fake`): asserts the off-shaped initial state before start, the pending-bucket emit with a parseable `nextTickAt`, the in-flight emit with the delta drained to 0, and the post-tick reset; `waitForTick` now waits for the merged (non-in-flight) emit of each tick.

## Gates (all green locally)

- `cargo fmt --check --all`, `cargo test -p videorc-backend cohost` (31 passed), `cargo test -p videorc-backend protocol`, `cargo clippy -p videorc-backend -- -D warnings`
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- `pnpm --filter @videorc/desktop test` (1458 passed), `pnpm test:scripts` (1058 passed)
- `pnpm smoke:cohost-fake` — full run PASS (9 ticks / 44 messages, presence assertions included)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Co-host status details, including pending messages, scheduled activity, in-progress processing, and session totals.
  * Co-host displays now provide clear inactive-state information when the service is unavailable or has not reported.
* **Bug Fixes**
  * Improved Co-host state consistency across windows and comments, preventing missing or ambiguous status during startup.
* **Tests**
  * Expanded coverage for status transitions, legacy compatibility, validation, scheduling, and session metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->