### PR TITLE
ui(cohost): permanent presence indicators — header status, heartbeat, reading/thinking states, session-panel line

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -343,6 +343,7 @@ import type {
   CaptionsUpdate,
   CaptionsWindowState,
   CohostActionCommand,
+  CohostEnableCommand,
   CohostState,
   CohostWindowState,
   CommentHighlightCommand,
@@ -12268,6 +12269,44 @@ app.whenReady().then(async () => {
   secureIpcHandle(
     'comments-window:cohost-action-result-push',
     (event, resolution: CommentsCommandResolution<CohostState>) => {
+      if (!mainWindow || event.sender.id !== mainWindow.webContents.id) return false
+      return commentsCommandBroker.resolve(resolution)
+    }
+  )
+  // Turning the co-host on from the window's presence popover / nudge. Unlike
+  // the row actions this is deliberately session-independent: a streamer who
+  // is not live yet is exactly who needs to find the switch.
+  secureIpcHandle(
+    'comments-window:cohost-enable',
+    (event, value: unknown): Promise<CohostWindowState> => {
+      if (!commentsWindow || event.sender.id !== commentsWindow.webContents.id) {
+        return Promise.reject(new Error('Only the Comments window can change co-host settings.'))
+      }
+      const requestId = commentsCommandRequestId(value)
+      if (!value || typeof value !== 'object' || !('enabled' in value)) {
+        return Promise.reject(new Error('Co-host enable requires an enabled flag.'))
+      }
+      const command = value as CohostEnableCommand
+      if (typeof command.enabled !== 'boolean') {
+        return Promise.reject(new Error('Co-host enable requires a boolean enabled flag.'))
+      }
+      if (command.grantConsent !== undefined && typeof command.grantConsent !== 'boolean') {
+        return Promise.reject(new Error('Co-host consent grant must be a boolean.'))
+      }
+      return commentsCommandBroker.request(requestId, () => {
+        if (!mainWindow || mainWindow.webContents.isDestroyed()) return false
+        sendElectronEvent(mainWindow.webContents, 'comments-window:cohost-enable-request', {
+          requestId,
+          enabled: command.enabled,
+          ...(command.grantConsent === true ? { grantConsent: true } : {})
+        })
+        return true
+      })
+    }
+  )
+  secureIpcHandle(
+    'comments-window:cohost-enable-result-push',
+    (event, resolution: CommentsCommandResolution<CohostWindowState>) => {
       if (!mainWindow || event.sender.id !== mainWindow.webContents.id) return false
       return commentsCommandBroker.resolve(resolution)
     }

--- a/apps/desktop/src/preload/api-policy.ts
+++ b/apps/desktop/src/preload/api-policy.ts
@@ -26,7 +26,14 @@ export const AUXILIARY_API_KEYS = {
     'onCommentsSnapshot',
     'onCommentsDelta',
     'getViewerSample',
-    'onViewerSample'
+    'onViewerSample',
+    // Co-host presence: the window renders the relayed state and can act on it
+    // (dismiss/answer, and — presence W2 — turn the engine on). Without these
+    // the Comments window silently had no co-host at all.
+    'getCohostWindowState',
+    'onCohostWindowState',
+    'sendCohostAction',
+    'sendCohostEnable'
   ],
   captions: [
     'getCaptionsWindowState',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -59,6 +59,10 @@ const api: VideorcApi = {
   onCohostActionRequest: (callback) => subscribe('comments-window:cohost-action-request', callback),
   pushCohostActionResult: (resolution) =>
     invoke('comments-window:cohost-action-result-push', resolution),
+  sendCohostEnable: (command) => invoke('comments-window:cohost-enable', command),
+  onCohostEnableRequest: (callback) => subscribe('comments-window:cohost-enable-request', callback),
+  pushCohostEnableResult: (resolution) =>
+    invoke('comments-window:cohost-enable-result-push', resolution),
   clearComments: (command) => invoke('comments-window:clear', command),
   onCommentsClearRequest: (callback) => subscribe('comments-window:clear-request', callback),
   pushCommentsClearResult: (resolution) => invoke('comments-window:clear-result-push', resolution),

--- a/apps/desktop/src/renderer/comments/main.tsx
+++ b/apps/desktop/src/renderer/comments/main.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
 import ReactDOM from 'react-dom/client'
+import { toast } from 'sonner'
 
 import { CommentsReader } from '@/components/comments-reader'
 import { AppErrorBoundary } from '@/components/error-boundary'
@@ -13,7 +14,12 @@ import type {
   ViewerSample
 } from '@/lib/backend'
 import { offCohostWindowState } from '@/lib/backend'
-import { cohostHighlightMessageId } from '@/lib/cohost-view'
+import {
+  cohostHighlightMessageId,
+  cohostNudgeDismissedFromStorage,
+  COHOST_NUDGE_STORAGE_KEY
+} from '@/lib/cohost-view'
+import { Toaster } from '@/components/ui/sonner'
 import type { EntitlementUiGate } from '@/lib/entitlement-ui'
 import { chatSendFailures, pendingCommentsSendOperation, sendablePlatforms } from '@/lib/chat-send'
 import type { ChatSendFailure } from '@/lib/chat-send'
@@ -97,6 +103,9 @@ function CommentsWindowApp(): ReactElement {
   // unconditional: the window mounts on the off shape, never on null.
   const [cohost, setCohost] = useState<CohostWindowState>(offCohostWindowState)
   const [cohostActionPending, setCohostActionPending] = useState(false)
+  const [cohostNudgeDismissed, setCohostNudgeDismissed] = useState(() =>
+    cohostNudgeDismissedFromStorage(localStorage.getItem(COHOST_NUDGE_STORAGE_KEY))
+  )
   useEffect(() => {
     const applyView = (next: CommentsViewSnapshot): void => {
       const previous = viewRef.current
@@ -238,6 +247,21 @@ function CommentsWindowApp(): ReactElement {
         .finally(() => setCohostActionPending(false))
     }
 
+  // Turning the co-host on (and, from the consent CTA, granting cloud-AI
+  // consent) is main-renderer owned; the relay reply carries the truth back so
+  // the switch reflects what actually happened, not what was clicked.
+  const setCohostEnabled = (enabled: boolean, grantConsent = false): void => {
+    void window.videorc
+      ?.sendCohostEnable?.({ requestId: crypto.randomUUID(), enabled, grantConsent })
+      .then((state) => state && setCohost(state))
+      .catch((error) =>
+        toast.error(
+          error instanceof Error ? error.message : 'Could not change the co-host setting.',
+          { id: 'cohost-enable' }
+        )
+      )
+  }
+
   const showQuestionOnStream = (question: CohostQuestion): void => {
     const messageId = cohostHighlightMessageId(question)
     if (!messageId) return
@@ -257,110 +281,130 @@ function CommentsWindowApp(): ReactElement {
         ...(cohost.upgradeUrl ? { upgradeUrl: cohost.upgradeUrl } : {})
       }
 
+  // The engine was asked to start but has not reported listening yet — the one
+  // state the wire cannot express (it still reads `off`).
+  const cohostStarting =
+    live && cohost.enabled && cohost.entitled && cohost.consented && cohost.state.status === 'off'
+
   return (
-    <CommentsReader
-      viewerSample={view.mode.kind === 'live' ? viewerSample : null}
-      snapshot={snapshot}
-      viewMode={view.mode}
-      alwaysOnTop={alwaysOnTop}
-      highlightApplyingId={highlightApplyingId}
-      highlightFailure={highlightFailure}
-      highlightState={highlightState}
-      sendFailures={sendFailures}
-      sendOperation={sendOperation}
-      sendPending={sendPending}
-      sendTargets={sendTargets}
-      cohostActionPending={cohostActionPending}
-      cohostConsented={cohost.consented}
-      cohostEnabled={cohost.enabled}
-      cohostGate={cohostGate}
-      cohostState={cohost.state}
-      onCohostAnswered={(question) => sendCohostAction('answered')(question.id)}
-      onCohostDismissFlag={(flag) => sendCohostAction('dismiss-flag')(flag.messageId)}
-      onCohostDismissQuestion={(question) => sendCohostAction('dismiss-question')(question.id)}
-      onCohostShowOnStream={live ? showQuestionOnStream : undefined}
-      onBackToLive={
-        view.mode.kind === 'history'
-          ? () => {
-              void window.videorc?.setCommentsViewMode?.({ kind: 'live' })
-            }
-          : undefined
-      }
-      onClear={
-        view.mode.kind === 'live' && snapshot.sessionId
-          ? () => {
-              setSendFailures([])
-              void window.videorc
-                ?.clearComments?.({
-                  requestId: crypto.randomUUID(),
-                  sessionId: snapshot.sessionId!
-                })
-                .catch((error) =>
-                  setSendFailures([
-                    {
-                      destinationId: 'comments-clear-command',
-                      platform: 'custom',
-                      reason: error instanceof Error ? error.message : 'Could not clear Comments.'
-                    }
-                  ])
-                )
-            }
-          : undefined
-      }
-      onHighlight={live ? requestHighlight : undefined}
-      onSend={(text, options) => {
-        if (!snapshot.sessionId) return
-        const operationId = crypto.randomUUID()
-        sendPendingOperationIdRef.current = operationId
-        setSendPending(true)
-        setSendFailures([])
-        applySendOperation(
-          pendingCommentsSendOperation({
-            id: operationId,
-            sessionId: snapshot.sessionId,
-            text,
-            providers: snapshot.providers
-          })
-        )
-        void window.videorc
-          ?.sendChatFromCommentsWindow?.({
-            requestId: crypto.randomUUID(),
-            operationId,
-            sessionId: snapshot.sessionId,
-            text,
-            ...(options?.inReplyToQuestionId
-              ? { inReplyToQuestionId: options.inReplyToQuestionId }
-              : {})
-          })
-          .then((operation) => {
-            if (sendPendingOperationIdRef.current !== operationId) return
-            applySendOperation(operation)
-            if (commentsSendOperationTerminal(operation)) {
-              sendPendingOperationIdRef.current = null
-              setSendPending(false)
-            }
-          })
-          .catch((error) => {
-            if (sendPendingOperationIdRef.current !== operationId) return
-            if (!commentsSendTransportFailureCanReplace(sendOperationRef.current, operationId)) {
-              sendPendingOperationIdRef.current = null
-              setSendPending(false)
-              return
-            }
-            sendPendingOperationIdRef.current = null
-            setSendPending(false)
-            applySendOperation(null)
-            setSendFailures([
-              {
-                destinationId: 'comments-command',
-                platform: 'custom',
-                reason: error instanceof Error ? error.message : 'Send failed.'
+    <>
+      <CommentsReader
+        viewerSample={view.mode.kind === 'live' ? viewerSample : null}
+        snapshot={snapshot}
+        viewMode={view.mode}
+        alwaysOnTop={alwaysOnTop}
+        highlightApplyingId={highlightApplyingId}
+        highlightFailure={highlightFailure}
+        highlightState={highlightState}
+        sendFailures={sendFailures}
+        sendOperation={sendOperation}
+        sendPending={sendPending}
+        sendTargets={sendTargets}
+        cohostActionPending={cohostActionPending}
+        cohostConsented={cohost.consented}
+        cohostEnabled={cohost.enabled}
+        cohostGate={cohostGate}
+        cohostNudgeDismissedForever={cohostNudgeDismissed}
+        cohostStarting={cohostStarting}
+        cohostState={cohost.state}
+        onCohostAnswered={(question) => sendCohostAction('answered')(question.id)}
+        onCohostEnable={(enabled) => setCohostEnabled(enabled)}
+        onCohostEnableConsent={() => setCohostEnabled(true, true)}
+        onCohostNudgeDismiss={() => {
+          setCohostNudgeDismissed(true)
+          localStorage.setItem(COHOST_NUDGE_STORAGE_KEY, '1')
+        }}
+        onCohostDismissFlag={(flag) => sendCohostAction('dismiss-flag')(flag.messageId)}
+        onCohostDismissQuestion={(question) => sendCohostAction('dismiss-question')(question.id)}
+        onCohostShowOnStream={live ? showQuestionOnStream : undefined}
+        onBackToLive={
+          view.mode.kind === 'history'
+            ? () => {
+                void window.videorc?.setCommentsViewMode?.({ kind: 'live' })
               }
-            ])
-          })
-      }}
-      onToggleAlwaysOnTop={() => void window.videorc?.setCommentsWindowAlwaysOnTop?.(!alwaysOnTop)}
-    />
+            : undefined
+        }
+        onClear={
+          view.mode.kind === 'live' && snapshot.sessionId
+            ? () => {
+                setSendFailures([])
+                void window.videorc
+                  ?.clearComments?.({
+                    requestId: crypto.randomUUID(),
+                    sessionId: snapshot.sessionId!
+                  })
+                  .catch((error) =>
+                    setSendFailures([
+                      {
+                        destinationId: 'comments-clear-command',
+                        platform: 'custom',
+                        reason: error instanceof Error ? error.message : 'Could not clear Comments.'
+                      }
+                    ])
+                  )
+              }
+            : undefined
+        }
+        onHighlight={live ? requestHighlight : undefined}
+        onSend={(text, options) => {
+          if (!snapshot.sessionId) return
+          const operationId = crypto.randomUUID()
+          sendPendingOperationIdRef.current = operationId
+          setSendPending(true)
+          setSendFailures([])
+          applySendOperation(
+            pendingCommentsSendOperation({
+              id: operationId,
+              sessionId: snapshot.sessionId,
+              text,
+              providers: snapshot.providers
+            })
+          )
+          void window.videorc
+            ?.sendChatFromCommentsWindow?.({
+              requestId: crypto.randomUUID(),
+              operationId,
+              sessionId: snapshot.sessionId,
+              text,
+              ...(options?.inReplyToQuestionId
+                ? { inReplyToQuestionId: options.inReplyToQuestionId }
+                : {})
+            })
+            .then((operation) => {
+              if (sendPendingOperationIdRef.current !== operationId) return
+              applySendOperation(operation)
+              if (commentsSendOperationTerminal(operation)) {
+                sendPendingOperationIdRef.current = null
+                setSendPending(false)
+              }
+            })
+            .catch((error) => {
+              if (sendPendingOperationIdRef.current !== operationId) return
+              if (!commentsSendTransportFailureCanReplace(sendOperationRef.current, operationId)) {
+                sendPendingOperationIdRef.current = null
+                setSendPending(false)
+                return
+              }
+              sendPendingOperationIdRef.current = null
+              setSendPending(false)
+              applySendOperation(null)
+              setSendFailures([
+                {
+                  destinationId: 'comments-command',
+                  platform: 'custom',
+                  reason: error instanceof Error ? error.message : 'Send failed.'
+                }
+              ])
+            })
+        }}
+        onToggleAlwaysOnTop={() =>
+          void window.videorc?.setCommentsWindowAlwaysOnTop?.(!alwaysOnTop)
+        }
+      />
+      {/* The Comments window frames video and is dark-always; sonner needs its
+          own host here because this is a separate React root. */}
+      <Toaster offset={{ bottom: 16, right: 16 }} position="bottom-right" theme="dark" />
+    </>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/cohost-nudge.tsx
+++ b/apps/desktop/src/renderer/src/components/cohost-nudge.tsx
@@ -1,0 +1,36 @@
+import { Robot } from '@phosphor-icons/react'
+import type { ReactElement } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+/**
+ * The off-but-useful row. It appears for exactly one audience — live right now,
+ * entitled, already consented, and simply has co-host off — and it says what
+ * the feature would do rather than that it exists. Dismissal is persisted, so
+ * "no thanks" is answered once and never asked again.
+ */
+export function CohostNudge({
+  onTurnOn,
+  onDismiss
+}: {
+  onTurnOn: () => void
+  onDismiss: () => void
+}): ReactElement {
+  return (
+    <div
+      className="mt-1.5 flex items-center gap-2 rounded-row border border-border/60 bg-card/30 px-2.5 py-1.5 text-[11px] text-muted-foreground"
+      data-slot="cohost-nudge"
+    >
+      <Robot aria-hidden className="size-4 shrink-0" weight="duotone" />
+      <span className="min-w-0 flex-1">
+        Co-host is off. It can group your chat&apos;s questions and draft replies.
+      </span>
+      <Button className="shrink-0" size="xs" type="button" variant="ghost" onClick={onTurnOn}>
+        Turn on
+      </Button>
+      <Button className="shrink-0" size="xs" type="button" variant="ghost" onClick={onDismiss}>
+        Dismiss
+      </Button>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/cohost-pane.test.ts
+++ b/apps/desktop/src/renderer/src/components/cohost-pane.test.ts
@@ -234,16 +234,48 @@ describe('CohostPane', () => {
         }
       })
     })
-    expect(markup).toContain('error · AI error')
+    expect(markup).toContain('data-slot="cohost-pane-status"')
+    expect(markup).toContain('>error<')
+    expect(markup).toContain('data-tone="destructive"')
     expect(markup).toContain(`title="${detail}"`)
     expect(markup).toContain('data-slot="cohost-error-detail"')
     expect(markup).toContain('once co-host is listening again')
     expect(markup).not.toContain('Listening — questions')
-    // Monochrome: the detail line is muted copy, never a destructive accent.
+    // Monochrome: only the presence DOT carries the error accent; the label and
+    // the detail line stay chrome.
     expect(markup).not.toContain('text-destructive')
 
     const healthy = renderPane({ state: state() })
     expect(healthy).not.toContain('data-slot="cohost-error-detail"')
     expect(healthy).toContain('Listening — questions from chat will appear here.')
+  })
+  it('mirrors the working shimmer in the segment header while chat is queued', () => {
+    const reading = renderPane({ state: state({ pendingMessages: 4 }) })
+    expect(reading).toContain('data-slot="cohost-typing-dots"')
+    expect(reading).toContain('>reading 4 new…<')
+    // The empty state stops claiming "Listening —" while there is real work.
+    expect(reading).toContain('Reading 4 new messages…')
+    expect(reading).not.toContain('Listening — questions')
+
+    const thinking = renderPane({ state: state({ tickInFlight: true, pendingMessages: 4 }) })
+    expect(thinking).toContain('typing-dot-fast')
+    expect(thinking).toContain('>thinking…<')
+    expect(thinking).toContain('Thinking about the last batch…')
+  })
+
+  it('shows the presence dot for every state, live-green only while listening', () => {
+    expect(renderPane({ state: state() })).toContain('data-tone="live"')
+    expect(renderPane({ state: state({ status: 'off', sessionId: null }) })).toContain(
+      'data-tone="muted"'
+    )
+  })
+
+  it('flashes the grouped delta in place of the count', () => {
+    const markup = renderPane({
+      flash: 'grouped 2 questions',
+      state: state({ questions: [question()] })
+    })
+    expect(markup).toContain('grouped 2 questions')
+    expect(markup).not.toContain('>1 q<')
   })
 })

--- a/apps/desktop/src/renderer/src/components/cohost-pane.tsx
+++ b/apps/desktop/src/renderer/src/components/cohost-pane.tsx
@@ -11,6 +11,7 @@ import {
 
 import { CohostFlagRow } from '@/components/cohost-flag-row'
 import { CohostQuestionRow } from '@/components/cohost-question-row'
+import { CohostPresenceDot, CohostTypingDots } from '@/components/cohost-status'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
@@ -18,8 +19,10 @@ import { Command, CommandList } from '@/components/ui/command'
 import { Kbd } from '@/components/ui/kbd'
 import { Separator } from '@/components/ui/separator'
 import type { CohostFlag, CohostQuestion, CohostState } from '@/lib/backend'
+import { cohostEmptyStateCopy, cohostPresenceView, cohostQuestionIds } from '@/lib/cohost-presence'
 import {
-  cohostChipView,
+  cohostErrorDetail,
+  cohostErrorDetailText,
   cohostFlagRowKey,
   cohostHighlightMessageId,
   cohostPaneMode,
@@ -27,13 +30,14 @@ import {
   cohostRowAt,
   cohostRows,
   moveCohostSelection,
+  reduceCohostUnread,
   resolveCohostSelection,
   sortedCohostFlags,
   sortedCohostQuestions,
-  COHOST_MOOD_LABELS
+  COHOST_MOOD_LABELS,
+  EMPTY_COHOST_UNREAD
 } from '@/lib/cohost-view'
 import type { EntitlementUiGate } from '@/lib/entitlement-ui'
-import { cn } from '@/lib/utils'
 
 /**
  * The Co-host segment above the live message list, in BOTH the in-app rail and
@@ -51,6 +55,9 @@ export function CohostPane({
   gate,
   consented,
   enabled,
+  starting = false,
+  flash = null,
+  expandSignal = 0,
   highlightedMessageId = null,
   actionPending = false,
   onReply,
@@ -60,12 +67,19 @@ export function CohostPane({
   onDismissFlag,
   onJumpToMessage,
   onEnableConsent,
+  onOpenChange,
   onUpgrade
 }: {
   state: CohostState | null
   gate: EntitlementUiGate
   consented: boolean
   enabled: boolean
+  /** The engine was asked to start but has not reported listening yet. */
+  starting?: boolean
+  /** One-shot "grouped 2 questions" delta from the owner surface. */
+  flash?: string | null
+  /** Bumped by the header status element to scroll to + expand this pane. */
+  expandSignal?: number
   highlightedMessageId?: string | null
   actionPending?: boolean
   onReply: (question: CohostQuestion) => void
@@ -75,6 +89,9 @@ export function CohostPane({
   onDismissFlag: (flag: CohostFlag) => void
   onJumpToMessage?: (messageId: string) => void
   onEnableConsent?: () => void
+  /** Reports the segment's open/closed state so the owner can throttle the
+   * collapsed-pane question toast against what is actually on screen. */
+  onOpenChange?: (open: boolean) => void
   onUpgrade?: (url: string) => void
 }): ReactElement | null {
   const mode = cohostPaneMode({ gate, consented, enabled })
@@ -82,12 +99,37 @@ export function CohostPane({
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [nowMs, setNowMs] = useState(() => Date.now())
   const rootRef = useRef<HTMLDivElement>(null)
+  const paneRef = useRef<HTMLDivElement>(null)
+
+  const [unread, setUnread] = useState(EMPTY_COHOST_UNREAD)
+  const autoExpandedSessionRef = useRef<string | null>(null)
 
   const questions = useMemo(() => sortedCohostQuestions(state?.questions ?? []), [state?.questions])
   const flags = useMemo(() => sortedCohostFlags(state?.flags ?? []), [state?.flags])
   const rows = useMemo(() => cohostRows(state), [state])
   const activeKey = resolveCohostSelection(rows, selectedKey)
   const activeRow = cohostRowAt(rows, selectedKey)
+  const questionIds = useMemo(() => cohostQuestionIds(state), [state])
+  const presence = cohostPresenceView(state, nowMs, {
+    starting,
+    unread: open ? 0 : unread.count
+  })
+
+  // Unread while collapsed: the badge is the collapsed pane's only way to say
+  // "something arrived". Expanding re-baselines it to what is on screen.
+  useEffect(() => {
+    setUnread((current) => reduceCohostUnread(current, { questionIds, open }))
+  }, [open, questionIds])
+
+  // The FIRST question of a session opens the pane once — after that the
+  // streamer's collapse decision is theirs to keep.
+  useEffect(() => {
+    const sessionId = state?.sessionId ?? null
+    if (!sessionId || questionIds.length === 0) return
+    if (autoExpandedSessionRef.current === sessionId) return
+    autoExpandedSessionRef.current = sessionId
+    setOpen(true)
+  }, [questionIds.length, state?.sessionId])
 
   // Ages are the only time-dependent copy in the pane; one slow tick keeps them
   // honest without re-rendering the message list underneath.
@@ -96,6 +138,20 @@ export function CohostPane({
     const timer = setInterval(() => setNowMs(Date.now()), 30_000)
     return () => clearInterval(timer)
   }, [rows.length])
+
+  useEffect(() => {
+    onOpenChange?.(open)
+  }, [onOpenChange, open])
+
+  // The header status element takes you here: expand, scroll into view, focus.
+  useEffect(() => {
+    if (expandSignal <= 0) return
+    setOpen(true)
+    paneRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    // Focus lands on the row list once the collapsible content is mounted.
+    const frame = requestAnimationFrame(() => rootRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [expandSignal])
 
   // ⌘J focuses the pane. In the main window plain ⌘J already toggles the
   // Comments window, so this only ever fires where the pane is mounted.
@@ -145,7 +201,12 @@ export function CohostPane({
     return null
   }
 
-  const chip = cohostChipView(state)
+  // The failed tick in the server's own words. The engine clears `detail` the
+  // moment it listens again, so a stale detail is never shown.
+  const errorDetail =
+    state?.status === 'error' || state?.status === 'paused'
+      ? cohostErrorDetailText(cohostErrorDetail(state))
+      : null
   const primaryAction = (): void => {
     if (!activeRow) return
     if (activeRow.kind === 'question') {
@@ -203,6 +264,7 @@ export function CohostPane({
 
   return (
     <Collapsible
+      ref={paneRef}
       className="shrink-0 rounded-row border border-border/60 bg-card/30"
       data-slot="cohost-pane"
       open={open}
@@ -218,18 +280,26 @@ export function CohostPane({
         <span className="shrink-0 text-[10px] font-medium tracking-wide text-muted-foreground">
           alpha
         </span>
-        {chip ? (
-          <span
-            className={cn(
-              'truncate text-[11px]',
-              chip.tone === 'live' ? 'text-success' : 'text-muted-foreground'
-            )}
-            title={chip.detail ?? undefined}
-          >
-            {chip.label.replace(/^Co-host: /, '')}
-          </span>
-        ) : null}
+        <CohostPresenceDot view={presence} />
+        <span
+          className="truncate text-[11px] text-muted-foreground"
+          data-slot="cohost-pane-status"
+          title={presence.tooltipLines.join('\n') || undefined}
+        >
+          {flash ?? presence.label.replace(/^Co-host\s*(·\s*)?/, '')}
+        </span>
+        {presence.dots ? <CohostTypingDots fast={presence.kind === 'thinking'} /> : null}
         <span className="flex-1" />
+        {presence.unreadBadge ? (
+          <Badge
+            aria-label={`${presence.unreadBadge} new questions`}
+            className="shrink-0 tabular-nums"
+            data-slot="cohost-unread-badge"
+            variant="secondary"
+          >
+            {presence.unreadBadge} new
+          </Badge>
+        ) : null}
         {state?.partial ? (
           <Badge title="Chat outran one AI pass; the newest messages were used." variant="outline">
             Partial
@@ -242,15 +312,15 @@ export function CohostPane({
 
       <CollapsibleContent>
         <Separator />
-        {chip?.detail ? (
+        {errorDetail ? (
           // The failed tick in the server's own words, so "AI error" is never
-          // the whole story. Monochrome; the chip already carries the state.
+          // the whole story. Monochrome; the dot already carries the state.
           <p
             className="truncate px-2.5 py-1 text-[11px] text-subtle"
             data-slot="cohost-error-detail"
-            title={chip.detail}
+            title={errorDetail}
           >
-            {chip.detail}
+            {errorDetail}
           </p>
         ) : null}
         <Command
@@ -265,10 +335,8 @@ export function CohostPane({
         >
           <CommandList className="max-h-48 px-1 py-1">
             {rows.length === 0 ? (
-              <p className="px-2 py-3 text-xs text-subtle">
-                {state?.status === 'listening'
-                  ? 'Listening — questions from chat will appear here.'
-                  : 'Questions from chat will appear here once co-host is listening again.'}
+              <p className="px-2 py-3 text-xs text-subtle" data-slot="cohost-empty-state">
+                {cohostEmptyStateCopy(presence, state)}
               </p>
             ) : (
               <>

--- a/apps/desktop/src/renderer/src/components/cohost-status.test.ts
+++ b/apps/desktop/src/renderer/src/components/cohost-status.test.ts
@@ -1,0 +1,142 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { CohostStatus } from '@/components/cohost-status'
+import type { CohostQuestion, CohostState } from '@/lib/backend'
+import { offCohostState } from '@/lib/backend'
+import type { EntitlementUiGate } from '@/lib/entitlement-ui'
+
+const NOW = Date.parse('2026-08-24T12:00:00.000Z')
+const ALLOWED: EntitlementUiGate = { allowed: true }
+
+function question(overrides: Partial<CohostQuestion> = {}): CohostQuestion {
+  return {
+    id: 'q-1',
+    text: 'What keyboard is that?',
+    messageIds: ['twitch:m-1'],
+    askers: ['Ada'],
+    platforms: ['twitch'],
+    priority: 'normal',
+    suggestedReply: 'Keychron Q1.',
+    fromNotes: false,
+    firstSeenAt: '2026-08-24T11:59:00.000Z',
+    updatedAt: '2026-08-24T11:59:00.000Z',
+    ...overrides
+  }
+}
+
+function listening(overrides: Partial<CohostState> = {}): CohostState {
+  return {
+    ...offCohostState(),
+    sessionId: 'sess-1',
+    status: 'listening',
+    lastTickAt: '2026-08-24T11:59:48.000Z',
+    tickSeq: 4,
+    messagesSeen: 84,
+    questionsTotal: 5,
+    ...overrides
+  }
+}
+
+function renderStatus(props: Partial<Parameters<typeof CohostStatus>[0]> = {}): string {
+  return renderToStaticMarkup(
+    createElement(CohostStatus, {
+      consented: true,
+      enabled: true,
+      gate: ALLOWED,
+      nowMs: NOW,
+      state: listening(),
+      ...props
+    })
+  )
+}
+
+describe('CohostStatus', () => {
+  it('always renders, including for an off engine', () => {
+    const markup = renderStatus({ state: offCohostState(), enabled: false })
+    expect(markup).toContain('data-slot="cohost-status"')
+    expect(markup).toContain('data-state-kind="off"')
+    expect(markup).toContain('Co-host off')
+    expect(markup).toContain('data-tone="muted"')
+  })
+
+  it('renders the same element for a null state — presence is unconditional', () => {
+    expect(renderStatus({ state: null, enabled: false })).toContain('Co-host off')
+  })
+
+  it('earns the live dot only while listening', () => {
+    const markup = renderStatus({ state: listening({ questions: [question()] }) })
+    expect(markup).toContain('data-state-kind="listening"')
+    expect(markup).toContain('data-tone="live"')
+    expect(markup).toContain('bg-success')
+    expect(markup).toContain('Co-host · 1 q')
+    expect(markup).not.toContain('cohost-typing-dots')
+  })
+
+  it('shows the typing shimmer while reading queued chat', () => {
+    const markup = renderStatus({ state: listening({ pendingMessages: 4 }) })
+    expect(markup).toContain('Co-host · reading 4 new…')
+    expect(markup).toContain('data-slot="cohost-typing-dots"')
+    expect(markup).toContain('typing-dot')
+    expect(markup).not.toContain('typing-dot-fast')
+  })
+
+  it('runs the shimmer faster and pulses the dot while a tick is in flight', () => {
+    const markup = renderStatus({ state: listening({ tickInFlight: true, pendingMessages: 4 }) })
+    expect(markup).toContain('Co-host · thinking…')
+    expect(markup).toContain('typing-dot-fast')
+    expect(markup).toContain('animate-pulse')
+  })
+
+  it('uses destructive red only for a real error', () => {
+    const markup = renderStatus({
+      state: listening({
+        status: 'error',
+        reason: 'gateway-error',
+        detail: { code: 'ai-gateway-error', message: 'Every model failed.', status: 502 }
+      })
+    })
+    expect(markup).toContain('data-state-kind="error"')
+    expect(markup).toContain('data-tone="destructive"')
+    expect(markup).toContain('Co-host error')
+    // The server's own words live in the tooltip, not in the label.
+    expect(markup).toContain('ai-gateway-error (HTTP 502)')
+  })
+
+  it('names the pause reason without colour', () => {
+    const markup = renderStatus({
+      state: listening({ status: 'paused', reason: 'quota-exhausted' })
+    })
+    expect(markup).toContain('Co-host paused · quota')
+    expect(markup).toContain('data-tone="muted"')
+    expect(markup).not.toContain('bg-destructive')
+  })
+
+  it('flashes the grouped delta in place of the label', () => {
+    const markup = renderStatus({
+      flash: 'grouped 2 questions',
+      state: listening({ questions: [question()] })
+    })
+    expect(markup).toContain('grouped 2 questions')
+    expect(markup).not.toContain('>Co-host · 1 q<')
+  })
+
+  it('carries the collapsed-pane unread count', () => {
+    const markup = renderStatus({ unread: 3 })
+    expect(markup).toContain('3 new questions')
+  })
+
+  it('renders the tooltip as one fact per line', () => {
+    const markup = renderStatus({
+      state: listening({ pendingMessages: 2, nextTickAt: '2026-08-24T12:00:07.000Z' })
+    })
+    expect(markup).toContain('last pass 12s ago')
+    expect(markup).toContain('84 messages read')
+    expect(markup).toContain('next pass in ~7s')
+  })
+
+  it('keeps the trigger draggable-safe in the frameless window header', () => {
+    expect(renderStatus()).toContain('[-webkit-app-region:no-drag]')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/cohost-status.tsx
+++ b/apps/desktop/src/renderer/src/components/cohost-status.tsx
@@ -1,0 +1,233 @@
+import { Robot } from '@phosphor-icons/react'
+import { useState, type ReactElement } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger
+} from '@/components/ui/popover'
+import { Switch } from '@/components/ui/switch'
+import type { CohostState } from '@/lib/backend'
+import { cohostPresenceView, type CohostPresenceView } from '@/lib/cohost-presence'
+import type { EntitlementUiGate } from '@/lib/entitlement-ui'
+import { cn } from '@/lib/utils'
+
+/**
+ * The PERMANENT co-host presence element in the Comments window toolbar. It is
+ * always rendered — the whole point of W2 is that "is the co-host even there?"
+ * is never a question a streamer has to ask mid-stream.
+ *
+ * Click behaviour splits on one axis: a co-host that exists takes you to it
+ * (scroll + expand the pane); a co-host that is OFF offers the one action that
+ * changes that, in a popover, gated exactly like the pane is.
+ */
+export function CohostStatus({
+  state,
+  gate,
+  consented,
+  enabled,
+  nowMs,
+  starting = false,
+  unread = 0,
+  flash = null,
+  onOpenPane,
+  onEnable,
+  onEnableConsent,
+  onUpgrade
+}: {
+  state: CohostState | null
+  gate: EntitlementUiGate
+  consented: boolean
+  enabled: boolean
+  /** Ticking clock for the relative tooltip lines. */
+  nowMs: number
+  starting?: boolean
+  unread?: number
+  /** One-shot "grouped 2 questions" delta, shown in place of the label. */
+  flash?: string | null
+  onOpenPane?: () => void
+  onEnable?: (enabled: boolean) => void
+  onEnableConsent?: () => void
+  onUpgrade?: (url: string) => void
+}): ReactElement {
+  const [open, setOpen] = useState(false)
+  const view = cohostPresenceView(state, nowMs, { starting, unread })
+  const tooltip = view.tooltipLines.join('\n')
+  const offPopover = view.kind === 'off'
+
+  const body = <CohostStatusBody flash={flash} label={view.label} view={view} />
+
+  if (!offPopover) {
+    return (
+      <button
+        aria-label={view.label}
+        className={STATUS_TRIGGER}
+        data-slot="cohost-status"
+        data-state-kind={view.kind}
+        title={tooltip || undefined}
+        type="button"
+        onClick={onOpenPane}
+      >
+        {body}
+      </button>
+    )
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        aria-label={view.label}
+        className={STATUS_TRIGGER}
+        data-slot="cohost-status"
+        data-state-kind={view.kind}
+        title={tooltip || undefined}
+      >
+        {body}
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72">
+        <PopoverHeader>
+          <PopoverTitle className="flex items-center gap-2 text-sm">
+            <Robot aria-hidden className="size-4 shrink-0" weight="duotone" />
+            Live Chat Co-host
+          </PopoverTitle>
+          <PopoverDescription>
+            Groups the questions your chat is repeating and drafts a reply for each. Nothing sends
+            without you.
+          </PopoverDescription>
+        </PopoverHeader>
+        {!gate.allowed ? (
+          <div className="flex flex-col gap-2">
+            <p className="text-xs text-muted-foreground">{gate.reason}</p>
+            {gate.upgradeUrl && onUpgrade ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setOpen(false)
+                  onUpgrade(gate.upgradeUrl as string)
+                }}
+              >
+                View Premium
+              </Button>
+            ) : null}
+          </div>
+        ) : !consented ? (
+          <div className="flex flex-col gap-2">
+            <p className="text-xs text-muted-foreground">
+              Co-host reads live chat with Videorc cloud AI. Turn on cloud AI to use it.
+            </p>
+            {onEnableConsent ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setOpen(false)
+                  onEnableConsent()
+                }}
+              >
+                Turn on cloud AI
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <div className="flex items-center gap-3">
+            <Label className="min-w-0 flex-1 text-xs font-normal" htmlFor="cohost-status-enable">
+              Read live chat during this stream
+            </Label>
+            <Switch
+              checked={enabled}
+              disabled={!onEnable}
+              id="cohost-status-enable"
+              onCheckedChange={(next) => onEnable?.(next)}
+            />
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+const STATUS_TRIGGER =
+  'flex shrink-0 items-center gap-1.5 rounded-chip px-1.5 py-0.5 text-xs transition-colors duration-100 hover:bg-accent/60 [-webkit-app-region:no-drag]'
+
+function CohostStatusBody({
+  view,
+  label,
+  flash
+}: {
+  view: CohostPresenceView
+  label: string
+  flash: string | null
+}): ReactElement {
+  return (
+    <>
+      <CohostPresenceDot view={view} />
+      {/* The DOT carries the error; the label stays chrome. The logo has two
+          red eyes, not a red face. */}
+      <span
+        className={cn('truncate', view.kind === 'off' ? 'text-subtle' : 'text-muted-foreground')}
+      >
+        {flash ?? label}
+      </span>
+      {view.dots ? <CohostTypingDots fast={view.kind === 'thinking'} /> : null}
+      {view.unreadBadge ? (
+        <span
+          aria-label={`${view.unreadBadge} new questions`}
+          className="shrink-0 rounded-chip bg-foreground/10 px-1 text-[10px] font-medium tabular-nums text-foreground"
+        >
+          {view.unreadBadge}
+        </span>
+      ) : null}
+    </>
+  )
+}
+
+/**
+ * The presence dot. Green ONLY while the engine is really listening, red ONLY
+ * on a real error; everything else is the muted chrome gray (videorc-design:
+ * color is information, never decoration).
+ */
+export function CohostPresenceDot({
+  view,
+  className
+}: {
+  view: CohostPresenceView
+  className?: string
+}): ReactElement {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'size-1.5 shrink-0 rounded-full',
+        view.dotTone === 'live'
+          ? 'bg-success'
+          : view.dotTone === 'destructive'
+            ? 'bg-destructive'
+            : 'bg-muted-foreground',
+        view.pulse && 'animate-pulse',
+        className
+      )}
+      data-slot="cohost-presence-dot"
+      data-tone={view.dotTone}
+    />
+  )
+}
+
+/** Three shimmering dots — "someone is typing", read instantly as "working". */
+export function CohostTypingDots({ fast = false }: { fast?: boolean }): ReactElement {
+  return (
+    <span aria-hidden className="flex shrink-0 items-center gap-0.5" data-slot="cohost-typing-dots">
+      {[0, 1, 2].map((index) => (
+        <span
+          className={cn('typing-dot size-1 rounded-full bg-current', fast && 'typing-dot-fast')}
+          key={index}
+        />
+      ))}
+    </span>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/comments-reader.tsx
+++ b/apps/desktop/src/renderer/src/components/comments-reader.tsx
@@ -1,7 +1,10 @@
 import { ChatCircle, Eye, PaperPlaneRight, PushPin } from '@phosphor-icons/react'
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import { toast } from 'sonner'
 
+import { CohostNudge } from '@/components/cohost-nudge'
 import { CohostPane } from '@/components/cohost-pane'
+import { CohostStatus } from '@/components/cohost-status'
 import { CommentRow, commentHighlightPresentationForMessage } from '@/components/comment-row'
 import { CommentsDestinationStatus } from '@/components/comments-destination-status'
 import { CHAT_PLATFORM_LABELS, ChatPlatformIcon } from '@/components/chat-platform-icon'
@@ -31,7 +34,13 @@ import type {
   ViewerSample
 } from '@/lib/backend'
 import { chatDraftMaxChars, validateChatDraft, type ChatSendFailure } from '@/lib/chat-send'
-import { draftForQuestion } from '@/lib/cohost-view'
+import { cohostGroupedDeltaFlash } from '@/lib/cohost-presence'
+import {
+  cohostNudgeVisible,
+  cohostQuestionToast,
+  draftForQuestion,
+  COHOST_QUESTION_TOAST_ID
+} from '@/lib/cohost-view'
 import type { EntitlementUiGate } from '@/lib/entitlement-ui'
 import { liveChatEmptyMessage, sortMessagesChronological } from '@/lib/live-chat-view'
 import { cn } from '@/lib/utils'
@@ -69,6 +78,10 @@ export function CommentsReader({
   cohostConsented = false,
   cohostEnabled = false,
   cohostActionPending = false,
+  cohostStarting = false,
+  cohostNudgeDismissedForever = false,
+  onCohostEnable,
+  onCohostNudgeDismiss,
   onCohostShowOnStream,
   onCohostAnswered,
   onCohostDismissQuestion,
@@ -109,6 +122,13 @@ export function CommentsReader({
   cohostConsented?: boolean
   cohostEnabled?: boolean
   cohostActionPending?: boolean
+  /** The engine was asked to start but has not reported listening yet. */
+  cohostStarting?: boolean
+  /** Persisted "never offer the nudge again". */
+  cohostNudgeDismissedForever?: boolean
+  /** Turn the engine on/off from the header popover or the nudge row. */
+  onCohostEnable?: (enabled: boolean) => void
+  onCohostNudgeDismiss?: () => void
   onCohostShowOnStream?: (question: CohostQuestion) => void
   onCohostAnswered?: (question: CohostQuestion) => void
   onCohostDismissQuestion?: (question: CohostQuestion) => void
@@ -145,12 +165,89 @@ export function CommentsReader({
     cohostGate !== undefined &&
     mode === 'Live' &&
     viewMode?.kind !== 'history'
+  // Presence is PERMANENT: the header element renders for every state the
+  // build can be in, including off. Only a surface without the co-host wiring
+  // at all (no gate) omits it.
+  const cohostPresent = cohostGate !== undefined
+  const [cohostNowMs, setCohostNowMs] = useState(() => Date.now())
+  const [cohostFlash, setCohostFlash] = useState<string | null>(null)
+  const [cohostExpand, setCohostExpand] = useState(0)
+  const [cohostPaneOpen, setCohostPaneOpen] = useState(true)
+  const cohostPaneOpenRef = useRef(true)
+  const previousCohostStateRef = useRef<CohostState | null>(null)
+  const cohostToastAtRef = useRef<number | null>(null)
+  const [cohostNudgeDismissedSessionId, setCohostNudgeDismissedSessionId] = useState<string | null>(
+    null
+  )
 
   useEffect(() => {
     if (!viewerSample) return
     const timer = setInterval(() => setNowMs(Date.now()), 15_000)
     return () => clearInterval(timer)
   }, [viewerSample])
+
+  // The presence tooltip counts in real time ("last pass 12s ago"), so it gets
+  // its own one-second clock — but only while the co-host element is mounted.
+  useEffect(() => {
+    if (!cohostPresent) return
+    const timer = setInterval(() => setCohostNowMs(Date.now()), 1_000)
+    return () => clearInterval(timer)
+  }, [cohostPresent])
+
+  useEffect(() => {
+    cohostPaneOpenRef.current = cohostPaneOpen
+  }, [cohostPaneOpen])
+
+  // One pass through every co-host state change: the ~2s "grouped N questions"
+  // flash, and the keyed, throttled question toast for a collapsed pane.
+  useEffect(() => {
+    const previous = previousCohostStateRef.current
+    if (!cohostState) return
+    previousCohostStateRef.current = cohostState
+    const nowMs = Date.now()
+
+    const questionToast = cohostQuestionToast({
+      previous,
+      next: cohostState,
+      paneOpen: cohostPaneOpenRef.current,
+      lastToastAtMs: cohostToastAtRef.current,
+      nowMs
+    })
+    if (questionToast) {
+      cohostToastAtRef.current = questionToast.atMs
+      toast(questionToast.message, { id: COHOST_QUESTION_TOAST_ID })
+    }
+
+    const delta = cohostGroupedDeltaFlash(previous, cohostState)
+    if (delta) setCohostFlash(delta)
+  }, [cohostState])
+
+  useEffect(() => {
+    if (!cohostFlash) return
+    const timer = setTimeout(() => setCohostFlash(null), 2_000)
+    return () => clearTimeout(timer)
+  }, [cohostFlash])
+
+  const cohostNudge =
+    cohostGate !== undefined &&
+    cohostNudgeVisible({
+      sessionId: mode === 'Live' ? (snapshot.sessionId ?? null) : null,
+      gateAllowed: cohostGate.allowed,
+      consented: cohostConsented,
+      enabled: cohostEnabled,
+      dismissedForever: cohostNudgeDismissedForever,
+      dismissedSessionId: cohostNudgeDismissedSessionId
+    })
+
+  // Dismiss = "don't offer this again" (persisted by the owner). Turning it on
+  // only needs to hide the row for this session; `enabled` does the rest.
+  const dismissCohostNudge = useCallback(
+    (persist: boolean) => {
+      setCohostNudgeDismissedSessionId(snapshot.sessionId ?? null)
+      if (persist) onCohostNudgeDismiss?.()
+    },
+    [onCohostNudgeDismiss, snapshot.sessionId]
+  )
 
   useEffect(() => {
     const viewport = scrollViewport(scrollRootRef.current)
@@ -227,6 +324,23 @@ export function CommentsReader({
             {viewerChipLabel(viewerSample)}
           </span>
         ) : null}
+        {/* Permanent presence: whatever the co-host is doing (including
+            nothing), the streamer can read it here without opening anything. */}
+        {cohostPresent ? (
+          <CohostStatus
+            consented={cohostConsented}
+            enabled={cohostEnabled}
+            flash={cohostFlash}
+            gate={cohostGate!}
+            nowMs={cohostNowMs}
+            starting={cohostStarting}
+            state={cohostState}
+            onEnable={onCohostEnable}
+            onEnableConsent={onCohostEnableConsent}
+            onOpenPane={() => setCohostExpand((value) => value + 1)}
+            onUpgrade={onCohostUpgrade}
+          />
+        ) : null}
         <div className="flex items-center gap-0.5 [-webkit-app-region:no-drag]">
           {viewMode?.kind === 'history' && onBackToLive ? (
             <Button size="sm" type="button" variant="ghost" onClick={onBackToLive}>
@@ -261,14 +375,18 @@ export function CommentsReader({
             actionPending={cohostActionPending}
             consented={cohostConsented}
             enabled={cohostEnabled}
+            expandSignal={cohostExpand}
+            flash={cohostFlash}
             gate={cohostGate!}
             highlightedMessageId={highlightedId}
+            starting={cohostStarting}
             state={cohostState}
             onAnswered={(question) => onCohostAnswered?.(question)}
             onDismissFlag={(flag) => onCohostDismissFlag?.(flag)}
             onDismissQuestion={(question) => onCohostDismissQuestion?.(question)}
             onEnableConsent={onCohostEnableConsent}
             onJumpToMessage={scrollToMessage}
+            onOpenChange={setCohostPaneOpen}
             onReply={(question) =>
               setReplyPrefill((current) => ({
                 seq: (current?.seq ?? 0) + 1,
@@ -325,6 +443,7 @@ export function CommentsReader({
 
       {onSend && mode === 'Live' && viewMode?.kind !== 'history' ? (
         <SendRow
+          cohostNudge={cohostNudge}
           cohostState={cohostState}
           failures={sendFailures}
           operation={sendOperation}
@@ -332,6 +451,11 @@ export function CommentsReader({
           prefill={replyPrefill}
           providers={snapshot.providers}
           targets={sendTargets}
+          onCohostNudgeDismiss={() => dismissCohostNudge(true)}
+          onCohostNudgeTurnOn={() => {
+            dismissCohostNudge(false)
+            onCohostEnable?.(true)
+          }}
           onSend={onSend}
         />
       ) : null}
@@ -347,6 +471,9 @@ function SendRow({
   operation,
   prefill,
   cohostState,
+  cohostNudge,
+  onCohostNudgeTurnOn,
+  onCohostNudgeDismiss,
   onSend
 }: {
   targets: StreamPlatform[]
@@ -356,6 +483,10 @@ function SendRow({
   operation: CommentsSendOperation | null
   prefill: { seq: number; text: string; questionId: string } | null
   cohostState: CohostState | null
+  /** Show the off-but-useful co-host row under the destination strip. */
+  cohostNudge: boolean
+  onCohostNudgeTurnOn: () => void
+  onCohostNudgeDismiss: () => void
   onSend: (text: string, options?: { inReplyToQuestionId?: string }) => void
 }): ReactElement {
   const [draft, setDraft] = useState('')
@@ -444,6 +575,9 @@ function SendRow({
           providers={providers}
           sendTargets={targets}
         />
+        {cohostNudge ? (
+          <CohostNudge onDismiss={onCohostNudgeDismiss} onTurnOn={onCohostNudgeTurnOn} />
+        ) : null}
         {operation ? (
           <div className="mt-1.5 flex flex-col gap-1" aria-label="Latest comment delivery">
             <Badge

--- a/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
@@ -5,17 +5,20 @@ import {
   ImageSquare,
   Info,
   Record,
+  Robot,
   StopCircle,
   WarningCircle,
   type Icon
 } from '@phosphor-icons/react'
-import type { ReactElement, ReactNode } from 'react'
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
 
+import { CohostPresenceDot } from '@/components/cohost-status'
 import { PanelSection } from '@/components/panel-section'
 import { Button } from '@/components/ui/button'
 import { Kbd } from '@/components/ui/kbd'
 import { useWorkspaceNav } from '@/components/workspace-nav'
-import { useStudioCore } from '@/hooks/use-studio'
+import { useStudioChat, useStudioCore, useStudioShell } from '@/hooks/use-studio'
+import { cohostPresenceView } from '@/lib/cohost-presence'
 import type { SessionStartFailure } from '@/lib/session-start-failure'
 import { outputSummary, streamingSummary } from '@/lib/studio-session-view'
 
@@ -89,6 +92,9 @@ export function SessionPanel({
           value={outputSummary(video)}
           onNavigate={() => openStudioPanel('recording')}
         />
+        {/* Presence W3: while a session runs, whether the co-host is reading
+            chat is a session fact — knowable without the Comments window. */}
+        {active ? <CohostSessionRow /> : null}
       </div>
 
       <div className="flex flex-col gap-2 border-t border-border pt-4">
@@ -191,6 +197,39 @@ export function SessionPanel({
   )
 }
 
+/**
+ * One co-host line, same derivation as the Comments window header so the two
+ * surfaces cannot disagree. Dot + label only: this panel is a fact list, not a
+ * working surface, so the typing shimmer stays where the work is read.
+ */
+function CohostSessionRow(): ReactElement {
+  const { cohostState } = useStudioChat()
+  const { openCommentsWindow } = useStudioShell()
+  const [nowMs, setNowMs] = useState(() => Date.now())
+
+  useEffect(() => {
+    const timer = setInterval(() => setNowMs(Date.now()), 5_000)
+    return () => clearInterval(timer)
+  }, [])
+
+  const view = cohostPresenceView(cohostState, nowMs)
+
+  return (
+    <SessionRow
+      icon={Robot}
+      label="Co-host"
+      title={view.tooltipLines.join('\n') || undefined}
+      value={
+        <span className="flex min-w-0 items-center gap-1.5">
+          <CohostPresenceDot view={view} />
+          <span className="truncate">{view.label.replace(/^Co-host\s*(·\s*)?/, '')}</span>
+        </span>
+      }
+      onNavigate={() => void openCommentsWindow()}
+    />
+  )
+}
+
 // The takeover on-air switch (its ONE home — the Assets grid manages images,
 // this flips them). Live-safe: activation only needs the backend socket, so it
 // works mid-session; a takeover replaces the output regardless of scene.
@@ -264,11 +303,14 @@ function SessionRow({
   icon: RowIcon,
   label,
   value,
+  title,
   onNavigate
 }: {
   icon: Icon
   label: string
   value: ReactNode
+  /** Native tooltip for rows whose value is a summary of more facts. */
+  title?: string
   onNavigate?: () => void
 }): ReactElement {
   const body = (
@@ -286,6 +328,7 @@ function SessionRow({
     return (
       <button
         className="flex items-center gap-3 rounded-row px-2.5 py-2 text-sm transition-colors hover:bg-accent"
+        title={title}
         type="button"
         onClick={onNavigate}
       >
@@ -293,5 +336,9 @@ function SessionRow({
       </button>
     )
   }
-  return <div className="flex items-center gap-3 rounded-row px-2.5 py-2 text-sm">{body}</div>
+  return (
+    <div className="flex items-center gap-3 rounded-row px-2.5 py-2 text-sm" title={title}>
+      {body}
+    </div>
+  )
 }

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -133,6 +133,7 @@ import type {
   AccountCallbackEnvelope,
   AiCapabilities,
   CohostActionCommand,
+  CohostEnableCommand,
   CohostFlagParams,
   CohostQuestion,
   CohostQuestionParams,
@@ -2929,9 +2930,46 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     [aiConsent, cohostEnabled, cohostGate, cohostState]
   )
 
+  const cohostWindowStateRef = useRef(cohostWindowState)
   useEffect(() => {
+    cohostWindowStateRef.current = cohostWindowState
     void window.videorc?.pushCohostWindowState?.(cohostWindowState)
   }, [cohostWindowState])
+
+  // "Turn on co-host" from the Comments window's presence popover or nudge.
+  // Both settings (engine enabled, cloud-AI consent) are main-renderer owned,
+  // so the window asks and gets the resolved window state back.
+  useEffect(() => {
+    const off = window.videorc?.onCohostEnableRequest?.((command: CohostEnableCommand) => {
+      void (async () => {
+        if (command.grantConsent === true) setAiConsent(true)
+        const settingsPatch: CohostSettingsPatch = { enabled: command.enabled }
+        if (!client) throw new Error('Backend socket is not connected.')
+        const next = await client.request<CohostSettings>('cohost.settings.set', settingsPatch)
+        setCohostSettings(next)
+        return {
+          ...cohostWindowStateRef.current,
+          consented: command.grantConsent === true || cohostWindowStateRef.current.consented,
+          enabled: next.enabled
+        } satisfies CohostWindowState
+      })()
+        .then(async (state) => {
+          await window.videorc?.pushCohostEnableResult?.({
+            requestId: command.requestId,
+            ok: true,
+            value: state
+          })
+        })
+        .catch(async (error) => {
+          await window.videorc?.pushCohostEnableResult?.({
+            requestId: command.requestId,
+            ok: false,
+            error: error instanceof Error ? error.message : 'Could not change the co-host setting.'
+          })
+        })
+    })
+    return off
+  }, [client, setAiConsent])
 
   useEffect(() => {
     const off = window.videorc?.onCohostActionRequest?.((command: CohostActionCommand) => {

--- a/apps/desktop/src/renderer/src/lib/cohost-presence.test.ts
+++ b/apps/desktop/src/renderer/src/lib/cohost-presence.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CohostQuestion, CohostState } from '@/lib/backend'
+import { offCohostState } from '@/lib/backend'
+import {
+  cohostAgoLabel,
+  cohostEmptyStateCopy,
+  cohostGroupedDeltaFlash,
+  cohostNextPassLabel,
+  cohostPresenceView,
+  cohostQuestionIds
+} from '@/lib/cohost-presence'
+
+const NOW = Date.parse('2026-08-24T12:00:00.000Z')
+
+function question(overrides: Partial<CohostQuestion> = {}): CohostQuestion {
+  return {
+    id: 'q-1',
+    text: 'What keyboard is that?',
+    messageIds: ['twitch:m-1'],
+    askers: ['Ada'],
+    platforms: ['twitch'],
+    priority: 'normal',
+    suggestedReply: 'Keychron Q1.',
+    fromNotes: false,
+    firstSeenAt: '2026-08-24T11:59:00.000Z',
+    updatedAt: '2026-08-24T11:59:00.000Z',
+    ...overrides
+  }
+}
+
+function listening(overrides: Partial<CohostState> = {}): CohostState {
+  return {
+    ...offCohostState(),
+    sessionId: 'sess-1',
+    status: 'listening',
+    lastTickAt: '2026-08-24T11:59:48.000Z',
+    tickSeq: 4,
+    messagesSeen: 84,
+    questionsTotal: 5,
+    ...overrides
+  }
+}
+
+describe('cohostPresenceView', () => {
+  it('renders the off shape as a state, never as nothing', () => {
+    const view = cohostPresenceView(offCohostState(), NOW)
+    expect(view.kind).toBe('off')
+    expect(view.label).toBe('Co-host off')
+    expect(view.dotTone).toBe('muted')
+    expect(view.dots).toBe(false)
+    expect(view.pulse).toBe(false)
+    expect(view.openCount).toBe(0)
+    expect(view.tooltipLines[0]).toContain('Co-host is off')
+  })
+
+  it('treats a null state exactly like the off shape', () => {
+    expect(cohostPresenceView(null, NOW).label).toBe(
+      cohostPresenceView(offCohostState(), NOW).label
+    )
+  })
+
+  it('reports starting when the caller asked the engine to come up', () => {
+    const view = cohostPresenceView(offCohostState(), NOW, { starting: true })
+    expect(view.kind).toBe('starting')
+    expect(view.label).toBe('Co-host starting')
+    expect(view.dotTone).toBe('muted')
+    expect(view.pulse).toBe(true)
+  })
+
+  it('earns the live accent only while listening, with the open count', () => {
+    const view = cohostPresenceView(
+      listening({ questions: [question(), question({ id: 'q-2' }), question({ id: 'q-3' })] }),
+      NOW
+    )
+    expect(view.kind).toBe('listening')
+    expect(view.label).toBe('Co-host · 3 q')
+    expect(view.dotTone).toBe('live')
+    expect(view.dots).toBe(false)
+    expect(view.openCount).toBe(3)
+  })
+
+  it('says listening (not "0 q") when the chat has asked nothing yet', () => {
+    expect(cohostPresenceView(listening(), NOW).label).toBe('Co-host listening')
+  })
+
+  it('counts the queued messages it has seen but not sent', () => {
+    const view = cohostPresenceView(listening({ pendingMessages: 4 }), NOW)
+    expect(view.kind).toBe('reading')
+    expect(view.label).toBe('Co-host · reading 4 new…')
+    expect(view.dots).toBe(true)
+    expect(view.pulse).toBe(false)
+    expect(view.dotTone).toBe('live')
+  })
+
+  it('lets thinking outrank reading — the tick already carries the backlog', () => {
+    const view = cohostPresenceView(listening({ pendingMessages: 4, tickInFlight: true }), NOW)
+    expect(view.kind).toBe('thinking')
+    expect(view.label).toBe('Co-host · thinking…')
+    expect(view.dots).toBe(true)
+    expect(view.pulse).toBe(true)
+  })
+
+  it('names the pause reason and stays monochrome', () => {
+    const view = cohostPresenceView(listening({ status: 'paused', reason: 'quota-exhausted' }), NOW)
+    expect(view.kind).toBe('paused')
+    expect(view.label).toBe('Co-host paused · quota')
+    expect(view.dotTone).toBe('muted')
+  })
+
+  it('uses destructive red for a real error only', () => {
+    const view = cohostPresenceView(
+      listening({
+        status: 'error',
+        reason: 'gateway-error',
+        detail: { code: 'ai-gateway-error', message: 'Every model failed.', status: 502 }
+      }),
+      NOW
+    )
+    expect(view.kind).toBe('error')
+    expect(view.label).toBe('Co-host error')
+    expect(view.dotTone).toBe('destructive')
+    expect(view.tooltipLines).toContain('ai-gateway-error (HTTP 502): Every model failed.')
+  })
+
+  it('builds the tooltip from lastTickAt, messagesSeen and questionsTotal', () => {
+    const view = cohostPresenceView(listening({ questions: [question()] }), NOW)
+    expect(view.tooltipLines).toEqual([
+      'last pass 12s ago',
+      '84 messages read',
+      '5 questions found (1 open)'
+    ])
+  })
+
+  it('adds the next-pass ETA whenever the scheduler published one', () => {
+    const view = cohostPresenceView(
+      listening({ pendingMessages: 2, nextTickAt: '2026-08-24T12:00:07.000Z' }),
+      NOW
+    )
+    expect(view.tooltipLines).toContain('next pass in ~7s')
+  })
+
+  it('carries the unread badge through from the collapse reducer', () => {
+    expect(cohostPresenceView(listening(), NOW, { unread: 2 }).unreadBadge).toBe(2)
+    expect(cohostPresenceView(listening(), NOW, { unread: 0 }).unreadBadge).toBeUndefined()
+  })
+})
+
+describe('relative formatters', () => {
+  it('formats ages compactly', () => {
+    expect(cohostAgoLabel('2026-08-24T12:00:00.000Z', NOW)).toBe('just now')
+    expect(cohostAgoLabel('2026-08-24T11:59:48.000Z', NOW)).toBe('12s ago')
+    expect(cohostAgoLabel('2026-08-24T11:56:00.000Z', NOW)).toBe('4m ago')
+    expect(cohostAgoLabel('2026-08-24T10:00:00.000Z', NOW)).toBe('2h ago')
+    expect(cohostAgoLabel(null, NOW)).toBeNull()
+    expect(cohostAgoLabel('not-a-date', NOW)).toBeNull()
+  })
+
+  it('never promises a pass that is already due', () => {
+    expect(cohostNextPassLabel('2026-08-24T12:00:07.000Z', NOW)).toBe('~7s')
+    expect(cohostNextPassLabel('2026-08-24T12:02:00.000Z', NOW)).toBe('~2m')
+    expect(cohostNextPassLabel('2026-08-24T11:59:00.000Z', NOW)).toBe('any moment')
+    expect(cohostNextPassLabel(null, NOW)).toBeNull()
+  })
+})
+
+describe('cohostEmptyStateCopy', () => {
+  it('upgrades from static listening copy to the real work', () => {
+    const reading = listening({ pendingMessages: 4 })
+    expect(cohostEmptyStateCopy(cohostPresenceView(reading, NOW), reading)).toBe(
+      'Reading 4 new messages…'
+    )
+    const one = listening({ pendingMessages: 1 })
+    expect(cohostEmptyStateCopy(cohostPresenceView(one, NOW), one)).toBe('Reading 1 new message…')
+    const idle = listening()
+    expect(cohostEmptyStateCopy(cohostPresenceView(idle, NOW), idle)).toBe(
+      'Listening — questions from chat will appear here.'
+    )
+    const off = offCohostState()
+    expect(cohostEmptyStateCopy(cohostPresenceView(off, NOW), off)).toBe(
+      'Questions from chat will appear here once co-host is listening again.'
+    )
+  })
+})
+
+describe('cohostGroupedDeltaFlash', () => {
+  it('flashes the questions a newer tick actually added', () => {
+    const previous = listening({ questions: [question()] })
+    const next = listening({
+      tickSeq: 5,
+      questions: [question(), question({ id: 'q-2' }), question({ id: 'q-3' })]
+    })
+    expect(cohostGroupedDeltaFlash(previous, next)).toBe('grouped 2 questions')
+  })
+
+  it('uses the singular for one question', () => {
+    const previous = listening({ questions: [] })
+    const next = listening({ tickSeq: 5, questions: [question()] })
+    expect(cohostGroupedDeltaFlash(previous, next)).toBe('grouped 1 question')
+  })
+
+  it('stays silent for action results, older ticks and a new session', () => {
+    const previous = listening({ questions: [question()] })
+    // Same tickSeq: an action result, not a pass.
+    expect(
+      cohostGroupedDeltaFlash(
+        previous,
+        listening({ questions: [question(), question({ id: 'q-2' })] })
+      )
+    ).toBeNull()
+    // A newer tick that removed a question is not a "grouped" event.
+    expect(cohostGroupedDeltaFlash(previous, listening({ tickSeq: 5, questions: [] }))).toBeNull()
+    expect(
+      cohostGroupedDeltaFlash(
+        previous,
+        listening({ sessionId: 'sess-2', tickSeq: 9, questions: [question({ id: 'q-9' })] })
+      )
+    ).toBeNull()
+    expect(cohostGroupedDeltaFlash(null, listening({ questions: [question()] }))).toBeNull()
+  })
+})
+
+describe('cohostQuestionIds', () => {
+  it('reads ids out of any state shape, including null', () => {
+    expect(
+      cohostQuestionIds(listening({ questions: [question(), question({ id: 'q-2' })] }))
+    ).toEqual(['q-1', 'q-2'])
+    expect(cohostQuestionIds(null)).toEqual([])
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/cohost-presence.ts
+++ b/apps/desktop/src/renderer/src/lib/cohost-presence.ts
@@ -1,0 +1,231 @@
+import type { CohostQuestion, CohostState } from './backend'
+import { cohostErrorDetail, cohostErrorDetailText, cohostReasonLabel } from './cohost-view'
+
+// Co-host presence (W2). One pure derivation of `cohost.state` that every
+// surface renders: the Comments window header, the pane's segment header and
+// the Studio session panel. Presence is UNCONDITIONAL — a null or off-shaped
+// state is a state ("Co-host off"), never an absence.
+//
+// Color discipline (videorc-design): the live accent is earned ONLY by an
+// engine that is actually listening; destructive red ONLY by a real error.
+// Everything else is monochrome chrome.
+
+export type CohostPresenceKind =
+  | 'off'
+  | 'starting'
+  | 'listening'
+  | 'reading'
+  | 'thinking'
+  | 'paused'
+  | 'error'
+
+export interface CohostPresenceView {
+  kind: CohostPresenceKind
+  /** The one-line label next to the dot. */
+  label: string
+  dotTone: 'muted' | 'live' | 'destructive'
+  /** Heartbeat: the engine is doing something the user cannot see yet. */
+  pulse: boolean
+  /** Three-dot "typing" shimmer — the chat-app affordance for "working on it". */
+  dots: boolean
+  /** Tooltip body, one fact per line; empty when there is nothing honest to say. */
+  tooltipLines: string[]
+  /** Open questions the streamer has not answered or dismissed. */
+  openCount: number
+  /** New questions since the pane was collapsed; absent when there are none. */
+  unreadBadge?: number
+}
+
+export interface CohostPresenceOptions {
+  /**
+   * The renderer asked the engine to start (entitled + consented + enabled with
+   * a live chat session) but no listening state has arrived yet. Only the
+   * caller knows this — the wire state still reads `off`.
+   */
+  starting?: boolean
+  /** Unread question count from the pane's collapse reducer. */
+  unread?: number
+}
+
+/** "12s ago", "4m ago", "2h ago" — compact enough for a dense tooltip line. */
+export function cohostAgoLabel(iso: string | null | undefined, nowMs: number): string | null {
+  if (!iso) return null
+  const at = Date.parse(iso)
+  if (!Number.isFinite(at)) return null
+  const seconds = Math.max(0, Math.round((nowMs - at) / 1000))
+  if (seconds < 1) return 'just now'
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  return `${Math.round(minutes / 60)}h ago`
+}
+
+/** "~7s" / "~2m" — the scheduler's earliest next pass, never a false promise. */
+export function cohostNextPassLabel(iso: string | null | undefined, nowMs: number): string | null {
+  if (!iso) return null
+  const at = Date.parse(iso)
+  if (!Number.isFinite(at)) return null
+  const seconds = Math.round((at - nowMs) / 1000)
+  if (seconds <= 0) return 'any moment'
+  if (seconds < 60) return `~${seconds}s`
+  return `~${Math.round(seconds / 60)}m`
+}
+
+function nonNegative(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
+function plural(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`
+}
+
+function presenceKind(
+  state: CohostState | null,
+  options: CohostPresenceOptions
+): CohostPresenceKind {
+  if (!state || state.status === 'off') return options.starting ? 'starting' : 'off'
+  if (state.status === 'error') return 'error'
+  if (state.status === 'paused') return 'paused'
+  // Listening. Thinking outranks reading: a tick is already carrying whatever
+  // was pending, so "thinking…" is the truthful newer fact.
+  if (state.tickInFlight === true) return 'thinking'
+  if (nonNegative(state.pendingMessages) > 0) return 'reading'
+  return 'listening'
+}
+
+function presenceLabel(
+  kind: CohostPresenceKind,
+  state: CohostState | null,
+  openCount: number
+): string {
+  switch (kind) {
+    case 'off':
+      return 'Co-host off'
+    case 'starting':
+      return 'Co-host starting'
+    case 'reading': {
+      const pending = nonNegative(state?.pendingMessages)
+      return `Co-host · reading ${pending} new…`
+    }
+    case 'thinking':
+      return 'Co-host · thinking…'
+    case 'listening':
+      return openCount > 0 ? `Co-host · ${openCount} q` : 'Co-host listening'
+    case 'paused': {
+      const reason = cohostReasonLabel(state?.reason ?? null)
+      return reason ? `Co-host paused · ${reason}` : 'Co-host paused'
+    }
+    case 'error':
+      return 'Co-host error'
+  }
+}
+
+function presenceTooltip(
+  kind: CohostPresenceKind,
+  state: CohostState | null,
+  openCount: number,
+  nowMs: number
+): string[] {
+  const lines: string[] = []
+  if (kind === 'off') {
+    lines.push('Co-host is off. It reads live chat, groups questions and drafts replies.')
+  }
+  if (kind === 'starting') {
+    lines.push('Co-host is starting — waiting for the first pass.')
+  }
+
+  const lastPass = cohostAgoLabel(state?.lastTickAt ?? null, nowMs)
+  if (lastPass) lines.push(`last pass ${lastPass}`)
+
+  const seen = nonNegative(state?.messagesSeen)
+  if (seen > 0) lines.push(`${seen} ${plural(seen, 'message')} read`)
+
+  const total = nonNegative(state?.questionsTotal)
+  if (total > 0) {
+    lines.push(`${total} ${plural(total, 'question')} found (${openCount} open)`)
+  } else if (openCount > 0) {
+    lines.push(`${openCount} ${plural(openCount, 'question')} open`)
+  }
+
+  const nextPass = cohostNextPassLabel(state?.nextTickAt ?? null, nowMs)
+  if (nextPass) lines.push(`next pass in ${nextPass}`)
+
+  if (state?.partial === true) lines.push('Chat outran one AI pass; the newest messages were used.')
+
+  // The failed tick in the server's own words — the one thing a streamer can
+  // paste into a bug report. Only ever shown on a state that actually failed.
+  if (kind === 'error' || kind === 'paused') {
+    const detail = cohostErrorDetailText(cohostErrorDetail(state))
+    if (detail) lines.push(detail)
+  }
+
+  return lines
+}
+
+/**
+ * The single presence derivation. `now` drives the relative tooltip copy, so a
+ * caller that ticks a clock every second gets honest "last pass"/"next pass"
+ * lines without the view layer owning any time logic.
+ */
+export function cohostPresenceView(
+  state: CohostState | null,
+  now: number,
+  options: CohostPresenceOptions = {}
+): CohostPresenceView {
+  const kind = presenceKind(state, options)
+  const openCount = state?.questions.length ?? 0
+  const unread = nonNegative(options.unread)
+  return {
+    kind,
+    label: presenceLabel(kind, state, openCount),
+    dotTone:
+      kind === 'error'
+        ? 'destructive'
+        : kind === 'listening' || kind === 'reading' || kind === 'thinking'
+          ? 'live'
+          : 'muted',
+    pulse: kind === 'starting' || kind === 'thinking',
+    dots: kind === 'reading' || kind === 'thinking',
+    tooltipLines: presenceTooltip(kind, state, openCount, now),
+    openCount,
+    ...(unread > 0 ? { unreadBadge: unread } : {})
+  }
+}
+
+/** The pane's empty-state copy: static "Listening —" upgrades to real work. */
+export function cohostEmptyStateCopy(view: CohostPresenceView, state: CohostState | null): string {
+  if (view.kind === 'reading') {
+    const pending = nonNegative(state?.pendingMessages)
+    return `Reading ${pending} new ${plural(pending, 'message')}…`
+  }
+  if (view.kind === 'thinking') return 'Thinking about the last batch…'
+  if (view.kind === 'listening') return 'Listening — questions from chat will appear here.'
+  if (view.kind === 'starting') return 'Starting — questions from chat will appear here.'
+  return 'Questions from chat will appear here once co-host is listening again.'
+}
+
+/**
+ * The one-shot delta flash after a tick landed: "grouped 2 questions". Shown
+ * for ~2s in place of the count so the streamer SEES the pass do something,
+ * even when the open count nets out unchanged.
+ *
+ * Requires a real newer tick — an action result (same `tickSeq`) or a state for
+ * a different session never flashes.
+ */
+export function cohostGroupedDeltaFlash(
+  previous: CohostState | null,
+  next: CohostState
+): string | null {
+  if (!previous) return null
+  if (previous.sessionId !== next.sessionId) return null
+  if (next.tickSeq <= previous.tickSeq) return null
+  const known = new Set(previous.questions.map((question) => question.id))
+  const added = next.questions.filter((question) => !known.has(question.id)).length
+  if (added <= 0) return null
+  return `grouped ${added} ${plural(added, 'question')}`
+}
+
+/** Question ids in a stable shape for the unread reducer and the toast. */
+export function cohostQuestionIds(state: CohostState | null): string[] {
+  return (state?.questions ?? []).map((question: CohostQuestion) => question.id)
+}

--- a/apps/desktop/src/renderer/src/lib/cohost-view.test.ts
+++ b/apps/desktop/src/renderer/src/lib/cohost-view.test.ts
@@ -18,17 +18,24 @@ import {
   cohostErrorToastMessage,
   cohostFlagRowKey,
   cohostHighlightMessageId,
+  cohostNudgeDismissedFromStorage,
+  cohostNudgeVisible,
   cohostPaneMode,
   cohostQuestionRowKey,
+  cohostQuestionToast,
+  cohostQuestionToastMessage,
   cohostRowAt,
   cohostRows,
   draftForQuestion,
   moveCohostSelection,
+  reduceCohostUnread,
   resolveCohostSelection,
   sortedCohostFlags,
   sortedCohostQuestions,
   trimDraftToCap,
-  EMPTY_COHOST_STATE
+  COHOST_QUESTION_TOAST_THROTTLE_MS,
+  EMPTY_COHOST_STATE,
+  EMPTY_COHOST_UNREAD
 } from '@/lib/cohost-view'
 import { CHAT_SEND_MAX_CHARS } from '@/lib/chat-send'
 
@@ -458,5 +465,176 @@ describe('cohostErrorToast', () => {
     expect(cohostErrorToast(recovered, { ...tick5, tickSeq: 11 })?.key).toBe(
       'gateway-error:ai-gateway-error'
     )
+  })
+})
+
+describe('reduceCohostUnread', () => {
+  it('counts nothing while the pane is open, and re-baselines what is on screen', () => {
+    const next = reduceCohostUnread(EMPTY_COHOST_UNREAD, {
+      questionIds: ['q-1', 'q-2'],
+      open: true
+    })
+    expect(next.count).toBe(0)
+    expect(next.seenIds).toEqual(['q-1', 'q-2'])
+  })
+
+  it('counts only the questions that arrived after the collapse', () => {
+    const seen = reduceCohostUnread(EMPTY_COHOST_UNREAD, { questionIds: ['q-1'], open: true })
+    const collapsed = reduceCohostUnread(seen, { questionIds: ['q-1', 'q-2', 'q-3'], open: false })
+    expect(collapsed.count).toBe(2)
+    // Expanding clears the badge and moves the baseline forward.
+    const reopened = reduceCohostUnread(collapsed, {
+      questionIds: ['q-1', 'q-2', 'q-3'],
+      open: true
+    })
+    expect(reopened.count).toBe(0)
+    expect(
+      reduceCohostUnread(reopened, { questionIds: ['q-1', 'q-2', 'q-3'], open: false }).count
+    ).toBe(0)
+  })
+
+  it('returns the same object when nothing changed', () => {
+    const seen = reduceCohostUnread(EMPTY_COHOST_UNREAD, { questionIds: ['q-1'], open: true })
+    expect(reduceCohostUnread(seen, { questionIds: ['q-1'], open: true })).toBe(seen)
+    const collapsed = reduceCohostUnread(seen, { questionIds: ['q-1', 'q-2'], open: false })
+    expect(reduceCohostUnread(collapsed, { questionIds: ['q-1', 'q-2'], open: false })).toBe(
+      collapsed
+    )
+  })
+})
+
+describe('cohostQuestionToast', () => {
+  const previous = state({ questions: [question({ id: 'q-1' })] })
+  const arrival = state({
+    tickSeq: 5,
+    questions: [question({ id: 'q-1' }), question({ id: 'q-hot', priority: 'high' })]
+  })
+
+  it('raises one keyed toast for a new high-priority question on a collapsed pane', () => {
+    const raised = cohostQuestionToast({
+      previous,
+      next: arrival,
+      paneOpen: false,
+      lastToastAtMs: null,
+      nowMs: 1_000
+    })
+    expect(raised?.message).toContain('Co-host:')
+    expect(raised?.message).toContain('⌘J')
+    expect(raised?.atMs).toBe(1_000)
+  })
+
+  it('stays silent while the pane is open — the row is already on screen', () => {
+    expect(
+      cohostQuestionToast({
+        previous,
+        next: arrival,
+        paneOpen: true,
+        lastToastAtMs: null,
+        nowMs: 1_000
+      })
+    ).toBeNull()
+  })
+
+  it('never toasts a normal-priority question or one it already knew', () => {
+    expect(
+      cohostQuestionToast({
+        previous,
+        next: state({ tickSeq: 5, questions: [question({ id: 'q-1' }), question({ id: 'q-2' })] }),
+        paneOpen: false,
+        lastToastAtMs: null,
+        nowMs: 1_000
+      })
+    ).toBeNull()
+    expect(
+      cohostQuestionToast({
+        previous: arrival,
+        next: arrival,
+        paneOpen: false,
+        lastToastAtMs: null,
+        nowMs: 1_000
+      })
+    ).toBeNull()
+  })
+
+  it('throttles to one toast a minute', () => {
+    const laterArrival = state({
+      tickSeq: 6,
+      questions: [question({ id: 'q-1' }), question({ id: 'q-hot2', priority: 'high' })]
+    })
+    expect(
+      cohostQuestionToast({
+        previous,
+        next: laterArrival,
+        paneOpen: false,
+        lastToastAtMs: 1_000,
+        nowMs: 1_000 + COHOST_QUESTION_TOAST_THROTTLE_MS - 1
+      })
+    ).toBeNull()
+    expect(
+      cohostQuestionToast({
+        previous,
+        next: laterArrival,
+        paneOpen: false,
+        lastToastAtMs: 1_000,
+        nowMs: 1_000 + COHOST_QUESTION_TOAST_THROTTLE_MS
+      })
+    ).not.toBeNull()
+  })
+
+  it('does not toast from a state that is not listening', () => {
+    expect(
+      cohostQuestionToast({
+        previous,
+        next: { ...arrival, status: 'paused', reason: 'quota-exhausted' },
+        paneOpen: false,
+        lastToastAtMs: null,
+        nowMs: 1_000
+      })
+    ).toBeNull()
+  })
+
+  it('names how many people are asking', () => {
+    expect(
+      cohostQuestionToastMessage(question({ askers: ['Ada', 'Bo', 'Cy', 'Dee', 'Eve'] }))
+    ).toBe('Co-host: 5 people asking — What keyboard is that? — ⌘J')
+    expect(cohostQuestionToastMessage(question({ askers: ['Ada'] }))).toBe(
+      'Co-host: Ada is asking — What keyboard is that? — ⌘J'
+    )
+  })
+})
+
+describe('cohostNudgeVisible', () => {
+  const base = {
+    sessionId: 'session-1',
+    gateAllowed: true,
+    consented: true,
+    enabled: false,
+    dismissedForever: false,
+    dismissedSessionId: null
+  }
+
+  it('shows for the one audience it helps', () => {
+    expect(cohostNudgeVisible(base)).toBe(true)
+  })
+
+  it('never nudges toward a locked, unconsented, already-on, or idle co-host', () => {
+    expect(cohostNudgeVisible({ ...base, sessionId: null })).toBe(false)
+    expect(cohostNudgeVisible({ ...base, gateAllowed: false })).toBe(false)
+    expect(cohostNudgeVisible({ ...base, consented: false })).toBe(false)
+    expect(cohostNudgeVisible({ ...base, enabled: true })).toBe(false)
+  })
+
+  it('answers "no thanks" once per session and once forever', () => {
+    expect(cohostNudgeVisible({ ...base, dismissedSessionId: 'session-1' })).toBe(false)
+    // A new session is a new chance — unless the answer was persisted.
+    expect(cohostNudgeVisible({ ...base, dismissedSessionId: 'session-0' })).toBe(true)
+    expect(cohostNudgeVisible({ ...base, dismissedForever: true })).toBe(false)
+  })
+
+  it('reads the persisted flag from storage', () => {
+    expect(cohostNudgeDismissedFromStorage('1')).toBe(true)
+    expect(cohostNudgeDismissedFromStorage('true')).toBe(true)
+    expect(cohostNudgeDismissedFromStorage('0')).toBe(false)
+    expect(cohostNudgeDismissedFromStorage(null)).toBe(false)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/cohost-view.ts
+++ b/apps/desktop/src/renderer/src/lib/cohost-view.ts
@@ -397,3 +397,141 @@ export function cohostErrorToast(
   if (previous?.status === 'error' && cohostErrorToastKey(previous) === key) return null
   return { reason: next.reason, key, message: cohostErrorToastMessage(next.reason, next.detail) }
 }
+
+// --- Collapsed-pane salience (presence W2) ---------------------------------
+
+/**
+ * Unread questions while the pane is collapsed. The seen set is re-baselined
+ * every time the pane is OPEN, so expanding always clears the badge and
+ * collapsing starts counting from what the streamer actually looked at.
+ */
+export interface CohostUnreadState {
+  /** Question ids the streamer has had on screen. */
+  seenIds: readonly string[]
+  count: number
+}
+
+export const EMPTY_COHOST_UNREAD: CohostUnreadState = { seenIds: [], count: 0 }
+
+function sameIds(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index])
+}
+
+/** Pure reducer. Returns the SAME object when nothing changed, so the segment
+ * header does not re-render on every unrelated tick. */
+export function reduceCohostUnread(
+  current: CohostUnreadState,
+  next: { questionIds: readonly string[]; open: boolean }
+): CohostUnreadState {
+  if (next.open) {
+    if (current.count === 0 && sameIds(current.seenIds, next.questionIds)) return current
+    return { seenIds: [...next.questionIds], count: 0 }
+  }
+  const seen = new Set(current.seenIds)
+  const count = next.questionIds.filter((id) => !seen.has(id)).length
+  return count === current.count ? current : { ...current, count }
+}
+
+// --- Quiet keyed question toast --------------------------------------------
+
+/** One keyed toast slot: a newer question REPLACES the older one in place. */
+export const COHOST_QUESTION_TOAST_ID = 'cohost-question'
+/** At most one question toast a minute — mid-stream, a popup is an interruption. */
+export const COHOST_QUESTION_TOAST_THROTTLE_MS = 60_000
+
+const COHOST_QUESTION_TOAST_TEXT_CAP = 64
+
+/** "Co-host: 5 people asking — What keyboard is that? — ⌘J" */
+export function cohostQuestionToastMessage(question: CohostQuestion): string {
+  const askers = question.askers.length
+  const who =
+    askers > 1
+      ? `${askers} people asking`
+      : askers === 1
+        ? `${question.askers[0]} is asking`
+        : 'a new question'
+  const text = trimDraftToCap(question.text, COHOST_QUESTION_TOAST_TEXT_CAP)
+  return text ? `Co-host: ${who} — ${text} — ⌘J` : `Co-host: ${who} — ⌘J`
+}
+
+export interface CohostQuestionToast {
+  message: string
+  /** When the toast was raised, for the caller's throttle bookkeeping. */
+  atMs: number
+}
+
+/**
+ * Toast discipline: the pane already shows every question, so a toast is only
+ * news when the pane is COLLAPSED and a genuinely new HIGH-priority question
+ * arrived — throttled to one a minute and keyed so it never stacks.
+ */
+export function cohostQuestionToast({
+  previous,
+  next,
+  paneOpen,
+  lastToastAtMs,
+  nowMs
+}: {
+  previous: CohostState | null
+  next: CohostState
+  paneOpen: boolean
+  lastToastAtMs: number | null
+  nowMs: number
+}): CohostQuestionToast | null {
+  if (paneOpen) return null
+  if (next.status !== 'listening') return null
+  if (lastToastAtMs !== null && nowMs - lastToastAtMs < COHOST_QUESTION_TOAST_THROTTLE_MS) {
+    return null
+  }
+  const known = new Set(
+    previous && previous.sessionId === next.sessionId
+      ? previous.questions.map((question) => question.id)
+      : []
+  )
+  const candidate = sortedCohostQuestions(next.questions).find(
+    (question) => question.priority === 'high' && !known.has(question.id)
+  )
+  if (!candidate) return null
+  return { message: cohostQuestionToastMessage(candidate), atMs: nowMs }
+}
+
+// --- Off-but-useful nudge ---------------------------------------------------
+
+/** Persisted "don't offer this again" flag — one renderer-local boolean, the
+ * same mechanism as the audio mixer's monitor-when-idle preference. */
+export const COHOST_NUDGE_STORAGE_KEY = 'videorc.cohostNudgeDismissed'
+
+export function cohostNudgeDismissedFromStorage(raw: string | null | undefined): boolean {
+  return raw === '1' || raw === 'true'
+}
+
+export interface CohostNudgeInput {
+  /** The live chat session id, or null when no session is running. */
+  sessionId: string | null
+  /** Premium gate result — never nudge someone toward a locked feature. */
+  gateAllowed: boolean
+  consented: boolean
+  enabled: boolean
+  /** Persisted across launches. */
+  dismissedForever: boolean
+  /** Session the row was dismissed for in this run (max once per session). */
+  dismissedSessionId: string | null
+}
+
+/**
+ * The row only appears for the ONE audience it helps: live right now, allowed
+ * to run co-host, already consented to cloud AI — and simply has it off.
+ */
+export function cohostNudgeVisible({
+  sessionId,
+  gateAllowed,
+  consented,
+  enabled,
+  dismissedForever,
+  dismissedSessionId
+}: CohostNudgeInput): boolean {
+  if (!sessionId) return false
+  if (enabled || !gateAllowed || !consented) return false
+  if (dismissedForever) return false
+  return dismissedSessionId !== sessionId
+}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -286,6 +286,34 @@
     background: var(--glass-shine-sweep);
     box-shadow: var(--glass-shine-rim);
   }
+
+  /* Co-host "working on it" shimmer — the chat-app typing affordance. Opacity
+     only: nothing bounces, nothing moves, nothing reflows the toolbar row. The
+     dots inherit currentColor so they stay monochrome chrome. */
+  .typing-dot {
+    animation: typing-dot-shimmer 1.2s ease-in-out infinite;
+  }
+  .typing-dot:nth-child(2) {
+    animation-delay: 0.15s;
+  }
+  .typing-dot:nth-child(3) {
+    animation-delay: 0.3s;
+  }
+  /* Tick in flight is the faster, more urgent version of the same idea. */
+  .typing-dot-fast {
+    animation-duration: 0.75s;
+  }
+}
+
+@keyframes typing-dot-shimmer {
+  0%,
+  70%,
+  100% {
+    opacity: 0.25;
+  }
+  35% {
+    opacity: 1;
+  }
 }
 
 @layer base {

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -3188,6 +3188,14 @@ export interface VideorcApi {
   sendCohostAction: (command: CohostActionCommand) => Promise<CohostState>
   onCohostActionRequest: (callback: (command: CohostActionCommand) => void) => () => void
   pushCohostActionResult: (resolution: CommentsCommandResolution<CohostState>) => Promise<boolean>
+  /** Turning co-host on (and granting cloud-AI consent) from the Comments
+   * window: the MAIN renderer owns both settings, so the window asks. The
+   * result is the relayed window state, so the switch never lies. */
+  sendCohostEnable: (command: CohostEnableCommand) => Promise<CohostWindowState>
+  onCohostEnableRequest: (callback: (command: CohostEnableCommand) => void) => () => void
+  pushCohostEnableResult: (
+    resolution: CommentsCommandResolution<CohostWindowState>
+  ) => Promise<boolean>
   getBundledBackgroundAssets: () => Promise<BackgroundImportResult[]>
   beginAccountSignIn: (authorizeUrl: string) => Promise<void>
   signOutAccount: () => Promise<VideorcAccountSnapshot>
@@ -3720,6 +3728,18 @@ export interface CohostActionCommand {
   kind: CohostActionKind
   /** Question id for question actions; the flagged message id for flags. */
   targetId: string
+}
+
+/**
+ * Correlated "turn the co-host on/off" from the Comments window (presence W2).
+ * Session-independent by design: the header popover is reachable while idle,
+ * which is exactly when a streamer discovers the feature.
+ */
+export interface CohostEnableCommand {
+  requestId: string
+  enabled: boolean
+  /** Grant renderer-local cloud-AI consent in the same click. */
+  grantConsent?: boolean
 }
 
 // Live captions (captions.* RPCs + events; premium cloud-AI feature).

--- a/apps/desktop/src/shared/electron-ipc-contract.test.ts
+++ b/apps/desktop/src/shared/electron-ipc-contract.test.ts
@@ -26,8 +26,8 @@ import {
 describe('Electron IPC contract', () => {
   it('maps every renderer-facing invoke channel to a real async API method', () => {
     expectTypeOf<ElectronInvokeMappingInvariant>().toEqualTypeOf<true>()
-    expect(Object.keys(electronInvokeApiMethods)).toHaveLength(99)
-    expect(new Set(Object.values(electronInvokeApiMethods)).size).toBe(99)
+    expect(Object.keys(electronInvokeApiMethods)).toHaveLength(101)
+    expect(new Set(Object.values(electronInvokeApiMethods)).size).toBe(101)
     expectTypeOf<ElectronInvokeArgs<'resource:trash-session-deletion'>>().toEqualTypeOf<
       Parameters<VideorcApi['trashSessionDeletion']>
     >()

--- a/apps/desktop/src/shared/electron-ipc-contract.ts
+++ b/apps/desktop/src/shared/electron-ipc-contract.ts
@@ -7,6 +7,7 @@ import type {
   CaptionsUpdate,
   CaptionsWindowState,
   CohostActionCommand,
+  CohostEnableCommand,
   CohostWindowState,
   CommentHighlightCommand,
   CommentHighlightState,
@@ -121,6 +122,8 @@ export const electronInvokeApiMethods = {
   'comments-window:cohost-get': 'getCohostWindowState',
   'comments-window:cohost-action': 'sendCohostAction',
   'comments-window:cohost-action-result-push': 'pushCohostActionResult',
+  'comments-window:cohost-enable': 'sendCohostEnable',
+  'comments-window:cohost-enable-result-push': 'pushCohostEnableResult',
   'captions-window:open': 'openCaptionsWindow',
   'captions-window:close': 'closeCaptionsWindow',
   'captions-window:toggle': 'toggleCaptionsWindow',
@@ -187,6 +190,7 @@ export interface ElectronIpcEventMap {
   'comments-window:viewers': ViewerSample | null
   'comments-window:cohost': CohostWindowState
   'comments-window:cohost-action-request': CohostActionCommand
+  'comments-window:cohost-enable-request': CohostEnableCommand
   'captions-window:state': CaptionsWindowState
   'captions-window:snapshot': CaptionWindowSnapshot
   'captions-window:lines': CaptionsUpdate[]
@@ -221,6 +225,7 @@ export const electronEventChannels = [
   'comments-window:viewers',
   'comments-window:cohost',
   'comments-window:cohost-action-request',
+  'comments-window:cohost-enable-request',
   'captions-window:state',
   'captions-window:snapshot',
   'captions-window:lines',
@@ -958,6 +963,8 @@ export const boundedPassthroughElectronInvokeChannels = [
   'comments-window:cohost-get',
   'comments-window:cohost-action',
   'comments-window:cohost-action-result-push',
+  'comments-window:cohost-enable',
+  'comments-window:cohost-enable-result-push',
   'captions-window:open',
   'captions-window:close',
   'captions-window:toggle',
@@ -1072,6 +1079,7 @@ export const boundedPassthroughElectronEventChannels = [
   'comments-window:viewers',
   'comments-window:cohost',
   'comments-window:cohost-action-request',
+  'comments-window:cohost-enable-request',
   'captions-window:state',
   'captions-window:snapshot',
   'glass:wallpaper',

--- a/apps/desktop/src/shared/renderer-security-policy.ts
+++ b/apps/desktop/src/shared/renderer-security-policy.ts
@@ -99,6 +99,8 @@ export const IPC_INVOKE_ROLES = {
   'comments-window:cohost-get': MAIN_AND_COMMENTS,
   'comments-window:cohost-action': MAIN_AND_COMMENTS,
   'comments-window:cohost-action-result-push': MAIN_ONLY,
+  'comments-window:cohost-enable': MAIN_AND_COMMENTS,
+  'comments-window:cohost-enable-result-push': MAIN_ONLY,
   'comments-window:send': MAIN_AND_COMMENTS,
   'comments-window:send-result-push': MAIN_ONLY,
   'comments-window:clear': MAIN_AND_COMMENTS,


### PR DESCRIPTION
Slices **W2 + W3** of *2026-08-24 — Videorc Co-host Presence Indicators Plan*, on top of W1 (#270).

Owner complaint this answers: *"when I livestream I have no clue if cohost exists or not."* Presence is now **unconditional** — a null or off-shaped state renders as a state ("Co-host off"), never as nothing.

## What a streamer sees

| State | Header element | Dot |
|---|---|---|
| Off | `Co-host off` — click opens a popover: Premium-gated enable switch, cloud-AI consent CTA, one line of copy | muted |
| Starting | `Co-host starting` (pulsing) | muted |
| Listening, idle | `Co-host · 3 q` (open questions), or `Co-host listening` at zero | **live green** |
| Reading queued chat | `Co-host · reading 4 new…` + three-dot typing shimmer | live green |
| Tick in flight | `Co-host · thinking…` + faster shimmer, dot pulses | live green |
| Just grouped | flashes `grouped 2 questions` for ~2s, then back to the count | live green |
| Paused | `Co-host paused · quota` (reason word) | muted |
| Error | `Co-host error`, server's code/message in the tooltip | **destructive red** |

Tooltip on every state, ticking every second: `last pass 12s ago` · `84 messages read` · `5 questions found (3 open)` · `next pass in ~7s`.

## Changes

- **`lib/cohost-presence.ts` (new, pure)** — `cohostPresenceView(state, now, options)` is the single derivation every surface renders, plus `cohostGroupedDeltaFlash`, `cohostEmptyStateCopy`, and the relative formatters. The Comments header, the pane header and the Studio session panel cannot disagree.
- **`components/cohost-status.tsx` (new)** — the permanent toolbar element, mounted next to the viewer chip in `comments-reader.tsx`, always rendered. Click scrolls to + expands the pane; when off it opens a shadcn `Popover` (enable `Switch` via `liveCohostGate`, consent CTA, upsell).
- **Pane (`cohost-pane.tsx`)** — segment header mirrors the dot/shimmer, collapsed **unread-question badge**, first question of a session auto-expands once, empty state upgrades from `Listening —` to `Reading 4 new messages…`, one-shot grouped-delta flash.
- **Quiet keyed toast** — a new HIGH-priority question with the pane collapsed raises `toast(…, { id: 'cohost-question' })`, throttled to once per 60s. Sonner's `Toaster` now has a host in the Comments window (it is a separate React root).
- **Off-but-useful nudge** — for the one audience it helps (live + entitled + consented + co-host off): one dismissible row under the destination strip, dismissal persisted in `videorc.cohostNudgeDismissed`, at most once per session.
- **W3 — `studio/session-panel.tsx`** — one co-host line during an active session (dot + label only), click opens/focuses the Comments window.
- **CSS** — `typing-dot` shimmer in `styles.css`: opacity only, no bounce, and it collapses under `prefers-reduced-motion`.

## Bug found and fixed along the way

`preload/api-policy.ts` never granted the **comments** renderer role `getCohostWindowState` / `onCohostWindowState` / `sendCohostAction`. Every call site uses optional chaining, so in a packaged build the detached Comments window silently had *no co-host at all* — the same symptom W1 set out to fix, one layer lower. Added those keys, plus the new `sendCohostEnable` relay (window asks → main → main renderer owns settings + consent) with its IPC contract entries, runtime channel classification and role policy.

## Design discipline

shadcn only (`Popover`, `Switch`, `Label`, `Button`, `Badge`, `Collapsible`, sonner). Live-green **only** for listening; destructive red **only** for a real error, and only on the dot — the label stays chrome ("the logo has two red eyes, not a red face"). Shimmer is opacity-only; transitions are 100ms.

## Gates

`pnpm typecheck` · `pnpm lint` · `pnpm format:check` · `pnpm --filter @videorc/desktop test` (159 files, 1504 passed) · `pnpm build` — all green. Renderer-only + IPC relay; no capture/preview/recording path touched.

## Not in this PR

Backend `smoke:cohost-fake` extension and the owner's by-eye pass on a live stream (plan's remaining acceptance items).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added co-host controls for enabling, disabling, and granting consent directly from the Comments window.
  * Added clear co-host presence states, including listening, reading, thinking, paused, starting, and error indicators.
  * Added unread question counts, grouped-question updates, animated typing indicators, tooltips, and question notifications.
  * Added contextual nudges to turn on co-host, with session and permanent dismissal options.
  * Added live co-host status to active studio sessions with navigation to Comments.

* **Bug Fixes**
  * Improved error messaging, status clarity, and pane expansion behavior when new questions arrive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->