### PR TITLE
release: 0.9.71-beta.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.71-beta.1.md
+++ b/changelog/0.9.71-beta.1.md
@@ -1,0 +1,27 @@
+---
+version: 0.9.71-beta.1
+date: 2026-08-24
+channel: beta
+platforms:
+  - macos
+title: You always know what the co-host is doing
+summary: The Comments window now shows the co-host's state at all times — off, reading your chat, thinking, paused, or stuck — with a live heartbeat, a "reading N new messages…" indicator the moment chat comes in, and a receipt when it groups questions. The Studio session panel carries the same status.
+highlights:
+  - A permanent co-host status lives in the Comments window header — even when the co-host is off, you see "Co-host off" with a one-click way to turn it on, instead of nothing at all.
+  - When chat messages arrive you see "reading 4 new…" with typing dots, then "thinking…" while the AI pass runs, then a brief "grouped 2 questions" receipt — the co-host is visibly alive with your chat.
+  - The tooltip answers everything at a glance — last pass 12s ago, 84 messages read, 5 questions found, 3 open.
+  - A collapsed Co-host pane shows an unread-question badge, and the first question of a session opens the pane once by itself.
+  - The Studio session panel shows the same co-host status during a session, so you know its state without the Comments window open.
+  - If you go live with the co-host off but available, one dismissible line offers to turn it on.
+---
+
+The co-host's biggest flaw wasn't the AI — it was that you couldn't tell
+whether it existed. The Comments window hid the entire co-host section
+whenever the engine was off or hadn't reported yet, which is precisely
+when you'd wonder about it. That's gone: the header now carries a
+permanent status element with five honest states, a green heartbeat that
+pulses with every AI pass, typing dots while your chat is being read, and
+a one-line receipt when questions get grouped. The same status appears in
+the Studio session panel during a session. Green means listening, red
+means stuck (with the reason a hover away), and quiet gray means off —
+never absence.


### PR DESCRIPTION
Version bump + macOS changelog for the co-host presence indicators (#270, #271). Windows follows after the macOS release per owner instruction.