### PR TITLE
fix(diagnostics): mf p95 null blocked macOS session start

### DIFF
--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -1011,7 +1011,9 @@ const diagnosticStatsSchema = boundedSemanticValue(
       encoderBridgeFreshFrames: optionalSchema(nonNegativeInteger),
       encoderBridgeMfSubmittedFrames: optionalSchema(nonNegativeInteger),
       encoderBridgeMfInputCreditTimeouts: optionalSchema(nonNegativeInteger),
-      encoderBridgeMfInputCreditWaitP95Ms: optionalSchema(numberSchema({ min: 0 })),
+      // Nullable for defense in depth: serde emits null if the backend ever
+      // regresses the skip_serializing_if on this Windows-only field.
+      encoderBridgeMfInputCreditWaitP95Ms: optionalSchema(nullableSchema(numberSchema({ min: 0 }))),
       windowsD3d11Media: optionalSchema(windowsD3d11MediaDiagnosticsSchema),
       previewImagePollCounts: optionalSchema(previewImagePollCountsSchema),
       updatedAt: optionalSchema(timestamp)

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -2158,7 +2158,7 @@ export interface DiagnosticStats {
   /** Writer-thread Media Foundation input-credit waits that hit the two-frame cap and skipped a frame. */
   encoderBridgeMfInputCreditTimeouts: number
   /** P95 wall time the writer thread spent waiting for a Media Foundation input credit (Windows only). */
-  encoderBridgeMfInputCreditWaitP95Ms?: number
+  encoderBridgeMfInputCreditWaitP95Ms?: number | null
   /** Scalar-only state for the Windows D3D11 media authority. */
   windowsD3d11Media?: WindowsD3d11MediaDiagnostics
   websocketTransport: WebSocketTransportDiagnosticStats

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1828,8 +1828,10 @@ pub struct DiagnosticStats {
     #[serde(default)]
     pub encoder_bridge_mf_input_credit_timeouts: u64,
     /// P95 wall time the writer thread spent waiting for a Media Foundation
-    /// input credit (Windows only).
-    #[serde(default)]
+    /// input credit (Windows only). MUST skip when None: the renderer contract
+    /// validates this key with a finite-number schema, and serde would emit
+    /// `null` — which blocked every macOS session start in 0.9.68–0.9.70.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encoder_bridge_mf_input_credit_wait_p95_ms: Option<f64>,
     /// Scalar-only state for the Windows D3D11 capture/compositor/presenter/MF
     /// authority. This remains present (with `unavailable`) on other platforms
@@ -3833,6 +3835,19 @@ impl ServerEvent {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn mf_input_credit_wait_p95_is_absent_when_none() {
+        // 0.9.68 regression: serde emitted `"encoderBridgeMfInputCreditWaitP95Ms": null`
+        // and the renderer contract (optional finite number) rejected every
+        // diagnostics.stats payload on macOS, blocking session start.
+        let stats = crate::diagnostics::idle_diagnostics();
+        let json = serde_json::to_value(&stats).expect("stats serialize");
+        assert!(
+            json.get("encoderBridgeMfInputCreditWaitP95Ms").is_none(),
+            "None must serialize as an absent key, not null"
+        );
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Owner-reported: 'backend.diagnostics.stats.result.encoderBridgeMfInputCreditWaitP95Ms must be a finite number' → cannot record. Root cause: #262's Option<f64> lacked skip_serializing_if while the contract's optionalSchema rejects null; macOS always None → null → every diagnostics.stats invalid → start blocked. Fix on both sides + regression test. Gates: protocol 32/32, clippy clean, typecheck, contract tests 1504.