### PR TITLE
docs: fix 0.9.71-alpha.1 changelog channel

### DIFF
--- a/changelog/0.9.71-alpha.1.md
+++ b/changelog/0.9.71-alpha.1.md
@@ -1,7 +1,7 @@
 ---
 version: 0.9.71-alpha.1
 date: 2026-08-24
-channel: beta
+channel: alpha
 platforms:
   - windows
 title: Co-host status you can actually see


### PR DESCRIPTION
channel said beta; the alpha version id requires channel alpha (scripts/lib/changelog.mjs rule). Pilot promotion preflight loads all entries and would fail. Docs-only; candidate build does not consume the changelog, so no version bump per runbook.