### PR TITLE
docs: 0.9.71/0.9.72 release record

### DIFF
--- a/docs/releases/0.9.71.md
+++ b/docs/releases/0.9.71.md
@@ -1,0 +1,60 @@
+# Videorc 0.9.71 Beta 1 (macOS) / 0.9.72 Alpha 1 (Windows)
+
+P0 hotfix release: macOS 0.9.68–0.9.70 could not start any recording, because
+one Windows-only diagnostics field serialized as `null` on macOS and the
+renderer contract rejected the whole stats payload inside the session-start
+settle loop. Ships together with the co-host presence indicators.
+
+## Scope (PRs #270–#276)
+
+- **P0 fix (#273):** `encoderBridgeMfInputCreditWaitP95Ms` (added by #262)
+  was `Option<f64>` with `#[serde(default)]` but no `skip_serializing_if`.
+  macOS never runs the Media Foundation sampler, so every `diagnostics.stats`
+  carried `null`; the renderer contract's `optionalSchema` accepts only
+  `undefined` (never null), so validation failed with "must be a finite
+  number" and session start was blocked on every macOS install of
+  0.9.68–0.9.70. Fix on both sides: serde now skips the absent value, the
+  contract entry is nullable-wrapped for defense in depth, the TS type is
+  `number | null`, and a regression test pins that idle stats serialize
+  without the key.
+- **Co-host presence indicators (#270, #271):** the Comments window shows the
+  co-host's state at all times (off / reading / thinking / paused / stuck)
+  with a live heartbeat, a "reading N new messages…" indicator, and a
+  grouping receipt; the Studio session panel carries the same status. #271
+  also fixed the packaged Comments window preload never exposing co-host APIs
+  to the `comments` role.
+- **Version/changelog mechanics (#272, #274, #275, #276):** 0.9.71 bump;
+  Windows changelog; the first Windows changelog draft said `channel: beta`
+  and was rejected by `changelog:check` inside the 0.9.71-alpha.1 candidate
+  build (run 32748846434, failed before signing) — per the runbook every
+  correction bumps the numeric version, so Windows shipped as
+  **0.9.72-alpha.1** (#276) and 0.9.71-alpha.1 is abandoned with nothing
+  stored under its id.
+
+## Ship record
+
+- macOS 0.9.71-beta.1: built, signed, notarized, uploaded 2026-08-24
+  (~18:00 UTC); feed verified (`latest-mac.yml` → 0.9.71, updater zip 206);
+  Discord announced. Urgent replacement for 0.9.68.
+- Windows 0.9.72-alpha.1 (pilot): candidate run 32751503480 (source
+  `c2bb4263`, installer SHA-256 `1082bd61…64cca`), sign gate approved per
+  standing owner directive; pilot promotion run 32755251073 uploaded and
+  SHA-verified every object under `updates/windows/pilot/` +
+  `releases/windows/pilot/`; Discord announced. Public promotion still
+  requires the physical acceptance record.
+
+## Known issues / follow-ups
+
+- **Second-session recording lag (open P0):** on the owner's box, recordings
+  after the first 1–2 per backend generation are majority-frozen (compositor
+  re-serves held frames at steady cadence; preview lags identically; app
+  restart resets it). Measured on a 34s 4K30 file: 51 freeze spans, 18.6s
+  frozen, 73% duplicated frames. Under investigation via
+  `pnpm smoke:session-decay` (new multi-session freshness harness);
+  synthetic and real-screen-only runs do not reproduce — real-camera runs
+  are pending a local TCC grant. Fix planned as 0.9.73.
+- The post-recording quality check passed the frozen file — it does not
+  measure frame freshness yet (planned with the fix).
+- Camera start on devices whose selected format advertises a higher max fps
+  than its rate ranges accept (Cam Link 4K: format says 61, ranges cap at
+  60) logs a harmless "kept its native frame cadence" warning per start.


### PR DESCRIPTION
Release record for macOS 0.9.71-beta.1 (P0 recording-start hotfix #273 + presence indicators) and Windows 0.9.72-alpha.1 pilot (runbook bump after the 0.9.71-alpha.1 changelog-channel candidate failure). Records the open second-session lag P0 and follow-ups.