### PR TITLE
fix(recording): deterministic encoder teardown + leak fence + logger hardening (0.9.74)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.74-beta.1.md
+++ b/changelog/0.9.74-beta.1.md
@@ -1,0 +1,34 @@
+---
+version: 0.9.74-beta.1
+date: 2026-08-25
+channel: beta
+platforms:
+  - macos
+title: Recordings stop tripping over the previous one
+summary: Each recording's encoder is now torn down deterministically the moment its session ends. Previously the encoder loop of a finished session could keep running — still compressing 4K video with no session attached — competing with the next recording's screen and camera capture, which is the strongest lead in the "later recordings freeze" investigation. Recording starts now also wait for (and loudly report) any leftover encoder from a previous session, and a backend logging failure can no longer crash a recording in progress.
+highlights:
+  - When a recording ends, its encoder is shut down and reaped within a bounded deadline — it can no longer keep encoding in the background and steal capture bandwidth from your next clip.
+  - Starting a recording now checks for leftover encoders from previous sessions, waits briefly for them to clear, and warns you honestly if one is still running.
+  - A failure to write a log line (for example when the app is shutting down) can no longer crash the recording backend mid-session.
+---
+
+## Fixed
+
+- macOS session teardown now stops and joins both encoder-bridge writers with
+  a 3s deadline immediately after the muxer exits — the deterministic twin of
+  the Windows-side join that already existed. A writer that fails to exit is
+  detached and reported (`encoder-bridge-writer-leaked`) instead of silently
+  living on.
+- Session start fences on leftover writers (`encoder-bridge-writer-lingering`
+  warning after a 2s grace) so a leaked encoder can never silently sabotage
+  the next recording.
+- The backend's log writer swallows stderr failures instead of panicking —
+  a broken log pipe could previously abort the whole backend mid-recording.
+
+## Investigation
+
+- The frozen-frames collapse reproduces only with real capture devices under
+  a live session and correlates with leftover encoder activity; these fixes
+  remove that interference and instrument any residual leak loudly. If a
+  recording still degrades, the session log and support bundle now name the
+  leak explicitly.

--- a/crates/videorc-backend/src/diagnostics.rs
+++ b/crates/videorc-backend/src/diagnostics.rs
@@ -2584,6 +2584,7 @@ mod tests {
             "Frame accounting: duration 6.7s @ target 60.0 fps (~402 frames); \
              captured: screen 59.0 fps (~395), camera n/a fps (~n/a); \
              compositor: 214 ticks, 188 intervals skipped, render 32.0 fps, 0 dropped, 214 cpu, 0 cpu-fallback; \
+             source serves: screen 0 fresh / 0 held (oldest 0ms), camera 0 fresh / 0 held (oldest 0ms); \
              bridge input: 119 (116 fresh, 3 repeat, 0 synthetic) at 17.7 fps; \
              submitted: 119 (mf 119), coalesced-dropped 0, encoder-dropped 0; \
              encoded output: 119 frames (4096 bytes, 0 errors); \

--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{self, Write as StdWrite};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Condvar, Mutex as StdMutex, OnceLock};
 use std::thread;
@@ -725,6 +725,39 @@ impl EncoderBridgeRecordingSession {
         self.stop.store(true, Ordering::Relaxed);
     }
 
+    /// Deterministic teardown: signal stop, then reap the writer thread within
+    /// `deadline`. Returns false when the writer failed to exit in time — the
+    /// thread is then deliberately detached (a hung writer must never block
+    /// session finalization) and the caller must report the leak loudly.
+    ///
+    /// Why this exists (2026-08-24 second-session-lag incident): the handles
+    /// used to die implicitly at the end of the session monitor, AFTER awaits
+    /// that can stall (idle-preview restart, export). Any stall left the
+    /// writer thread alive and still encoding 4K through VideoToolbox with no
+    /// session attached, competing with the next session's capture pipeline.
+    pub fn stop_and_reap(mut self, deadline: Duration) -> bool {
+        self.stop();
+        let mut reaped = true;
+        if let Some(writer) = self.writer.take() {
+            let deadline_at = std::time::Instant::now() + deadline;
+            while !writer.is_finished() && std::time::Instant::now() < deadline_at {
+                thread::sleep(Duration::from_millis(25));
+            }
+            if writer.is_finished() {
+                let _ = writer.join();
+            } else {
+                // Dropping the JoinHandle detaches the thread; Drop below
+                // must not retry the join (writer is already taken).
+                drop(writer);
+                reaped = false;
+            }
+        }
+        if let Some(task) = self.diagnostics_task.take() {
+            task.abort();
+        }
+        reaped
+    }
+
     #[cfg(target_os = "windows")]
     pub(crate) fn stop_and_join_writer(&mut self) {
         self.stop();
@@ -1274,7 +1307,33 @@ struct EncoderBridgeWriterEvent {
     error: Option<String>,
 }
 
+/// Live synthetic writer threads in this process. A session start observing a
+/// nonzero count from a PREVIOUS session means that session's writer never
+/// exited — the leaked-encoder condition behind the 2026-08-24 frozen-frames
+/// incident — and must be reported loudly before recording proceeds.
+static LIVE_SYNTHETIC_WRITERS: AtomicUsize = AtomicUsize::new(0);
+
+pub fn live_synthetic_writers() -> usize {
+    LIVE_SYNTHETIC_WRITERS.load(Ordering::Relaxed)
+}
+
+struct SyntheticWriterLiveGuard;
+
+impl SyntheticWriterLiveGuard {
+    fn enter() -> Self {
+        LIVE_SYNTHETIC_WRITERS.fetch_add(1, Ordering::Relaxed);
+        Self
+    }
+}
+
+impl Drop for SyntheticWriterLiveGuard {
+    fn drop(&mut self) {
+        LIVE_SYNTHETIC_WRITERS.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
+    let _live_guard = SyntheticWriterLiveGuard::enter();
     let SyntheticRecordingWriterParams {
         session_id,
         target_fps,
@@ -5325,6 +5384,74 @@ fn frame_count(duration_ms: u64, fps: u32) -> u64 {
 mod tests {
     use super::*;
     use crate::diagnostics::idle_diagnostics;
+
+    fn test_session_with_writer(
+        stop: Arc<AtomicBool>,
+        writer: thread::JoinHandle<()>,
+    ) -> EncoderBridgeRecordingSession {
+        EncoderBridgeRecordingSession {
+            stop,
+            terminal_failure: Arc::new(StdMutex::new(None)),
+            startup_ready: None,
+            fifo_path: PathBuf::from("/nonexistent-test-fifo"),
+            writer: Some(writer),
+            diagnostics_task: None,
+            #[cfg(target_os = "windows")]
+            d3d11_input: None,
+        }
+    }
+
+    /// Serializes the two live-writer-counter tests: the counter is process
+    /// global, so parallel test threads would race each other's deltas.
+    static LIVE_WRITER_TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    #[test]
+    fn stop_and_reap_joins_a_cooperative_writer_and_reports_success() {
+        let _serial = LIVE_WRITER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let base = live_synthetic_writers();
+        let stop = Arc::new(AtomicBool::new(false));
+        let writer_stop = stop.clone();
+        let writer = thread::spawn(move || {
+            let _live = SyntheticWriterLiveGuard::enter();
+            while !writer_stop.load(Ordering::Relaxed) {
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+        let session = test_session_with_writer(stop, writer);
+        assert!(session.stop_and_reap(Duration::from_secs(2)));
+        assert!(live_synthetic_writers() <= base);
+    }
+
+    #[test]
+    fn stop_and_reap_detaches_a_hung_writer_and_reports_the_leak() {
+        let _serial = LIVE_WRITER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let stop = Arc::new(AtomicBool::new(false));
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let writer = thread::spawn(move || {
+            let _live = SyntheticWriterLiveGuard::enter();
+            // Deliberately ignores the stop flag until released, like the
+            // leaked writers in the 2026-08-24 incident.
+            let _ = release_rx.recv();
+        });
+        let session = test_session_with_writer(stop.clone(), writer);
+        assert!(!session.stop_and_reap(Duration::from_millis(120)));
+        assert!(stop.load(Ordering::Relaxed), "stop flag must still be set");
+        assert_eq!(
+            live_synthetic_writers(),
+            1,
+            "leak stays visible in the counter"
+        );
+        release_tx.send(()).expect("release the fake writer");
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while live_synthetic_writers() != 0 && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(live_synthetic_writers(), 0);
+    }
 
     #[test]
     fn media_foundation_writer_input_credit_cap_is_two_frame_intervals() {

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -196,6 +196,24 @@ use crate::youtube::{
     YouTubeStreamStatusResult,
 };
 
+/// Stderr writer that reports every write as successful even when the real
+/// write fails (e.g. the parent process died and the pipe broke). See the
+/// tracing init below for why log writes must never be able to kill the
+/// backend.
+struct FailSilentStderr;
+
+impl std::io::Write for FailSilentStderr {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let _ = std::io::stderr().write(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let _ = std::io::stderr().flush();
+        Ok(())
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // One JSON line on stderr per panic so the supervisor's crash record
@@ -205,7 +223,12 @@ async fn main() -> Result<()> {
         .with_env_filter(
             EnvFilter::from_default_env().add_directive("videorc_backend=info".parse()?),
         )
-        .with_writer(std::io::stderr)
+        // NOT plain std::io::stderr: the fmt layer's writer panics on write
+        // failure, and a panic aborts the whole backend (panic hook → abort).
+        // If the supervisor/parent dies first, stderr becomes a broken pipe
+        // and the next log line would kill an otherwise healthy backend
+        // mid-recording. Logging must never be load-bearing.
+        .with_writer(|| FailSilentStderr)
         .init();
     // F-021 root cause: SkyLight ASSERTS (SIGABRT, "CGS_REQUIRE_INIT
     // did_initialize") if a window-server call runs before this process's

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -2691,6 +2691,34 @@ pub async fn start_session(
             encoder_bridge_video_output,
             encoder_bridge_stream_profile.is_some(),
         );
+        // Start fence: a writer thread from a PREVIOUS session still running
+        // here means that session leaked its encoder (still encoding with no
+        // session attached). It competes with this session's capture pipeline
+        // and produces the frozen-frames failure, so wait briefly for it to
+        // die and otherwise say so loudly before recording anyway.
+        {
+            let fence_deadline = Instant::now() + Duration::from_secs(2);
+            while crate::encoder_bridge::live_synthetic_writers() > 0
+                && Instant::now() < fence_deadline
+            {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            let lingering = crate::encoder_bridge::live_synthetic_writers();
+            if lingering > 0 {
+                let message = format!(
+                    "{lingering} encoder writer(s) from a previous session are still running; \
+                     this recording may drop or freeze frames until they exit."
+                );
+                state.emit_log("warn", message.clone());
+                let _ = emit_health_event(
+                    &state,
+                    Some(&session_id),
+                    HealthLevel::Warn,
+                    "encoder-bridge-writer-lingering",
+                    &message,
+                );
+            }
+        }
         let mut recording_bridge = start_synthetic_recording_bridge(
             state.clone(),
             session_id.clone(),
@@ -5429,7 +5457,45 @@ async fn monitor_session(
         drop(active);
     }
     #[cfg(not(target_os = "windows"))]
-    drop(retired_active);
+    if let Some(mut active) = retired_active {
+        // Deterministic, bounded bridge teardown — the macOS twin of the
+        // Windows stop_and_join_writer arm above. The muxer process is gone,
+        // so both writers must die before finalize/export/idle-preview work:
+        // relying on Drop's unbounded join (or on this function even reaching
+        // its end) left stopped sessions' writers alive and still encoding 4K
+        // through VideoToolbox, starving the next session's capture pipeline
+        // (2026-08-24 frozen-frames incident).
+        let bridges: Vec<EncoderBridgeRecordingSession> = active
+            .encoder_bridge
+            .take()
+            .into_iter()
+            .chain(active.encoder_bridge_stream.take())
+            .collect();
+        drop(active);
+        if !bridges.is_empty() {
+            let reap_result = tokio::task::spawn_blocking(move || {
+                let reaps: Vec<bool> = bridges
+                    .into_iter()
+                    .map(|bridge| bridge.stop_and_reap(Duration::from_secs(3)))
+                    .collect();
+                reaps.into_iter().all(|reaped| reaped)
+            })
+            .await;
+            if !matches!(reap_result, Ok(true)) {
+                let message = "Encoder bridge writer did not exit within 3s of session end; \
+                     thread detached and may keep encoder resources busy until it exits."
+                    .to_string();
+                state.emit_log("warn", message.clone());
+                let _ = emit_health_event(
+                    &state,
+                    Some(&session_id),
+                    HealthLevel::Warn,
+                    "encoder-bridge-writer-leaked",
+                    &message,
+                );
+            }
+        }
+    }
 
     // Dropping ActiveRecording stops the native post-controls audio producer.
     // Close the caption bus now, drain the provider's final utterance within a

--- a/scripts/smoke-recording-session-decay.mjs
+++ b/scripts/smoke-recording-session-decay.mjs
@@ -29,6 +29,7 @@
 // (content-independent: a repeat means the compositor delivered no new frame
 // in time) become the hard freshness gate.
 
+import { randomBytes } from 'node:crypto'
 import { existsSync, mkdtempSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -36,6 +37,10 @@ import { join, resolve } from 'node:path'
 import { launchDevApp } from './lib/app-launcher.mjs'
 import { analyzeRecording, writeReports } from './lib/recording-analyzer.mjs'
 import { siblingFfprobePath } from './lib/ffmpeg-sibling-paths.mjs'
+import {
+  launchScreenMotionStimulus,
+  stopScreenMotionStimulus
+} from './lib/screen-motion-stimulus.mjs'
 import { requestSmokeCommand } from './lib/smoke-command-client.mjs'
 import { pickDevice } from './lib/source-selection.mjs'
 import { connectBackend, request } from './smoke-recording-session.mjs'
@@ -53,6 +58,17 @@ const idleMs = Number(process.env.VIDEORC_DECAY_IDLE_MS ?? 8000)
 
 const realScreen = process.env.VIDEORC_DECAY_REAL_SCREEN === '1'
 const realCamera = process.env.VIDEORC_DECAY_REAL_CAMERA === '1'
+// VIDEORC_DECAY_PACKAGED_APP: drive the INSTALLED app instead of the dev app.
+// The packaged bundle carries the user's real TCC camera/screen grants, which
+// the ad-hoc dev Electron cannot obtain on this box (macOS refuses to prompt).
+const packagedAppExecutable =
+  process.env.VIDEORC_DECAY_PACKAGED_APP === '1'
+    ? (process.env.VIDEORC_PACKAGED_APP_EXECUTABLE ??
+      '/Applications/Videorc.app/Contents/MacOS/Videorc')
+    : null
+const packagedSmokeCapability = packagedAppExecutable
+  ? randomBytes(32).toString('base64url')
+  : undefined
 
 // One fixed shipping-shaped profile. 1080p30 holds full cadence under hard
 // content on every supported box (matrix smoke proves 1080p60 does), so any
@@ -199,15 +215,47 @@ async function recordSession({ ws, smoke, index, sources }) {
   const encoded = bridge.encoderBridgeEncodedOutputFrames
   const repeated = bridge.encoderBridgeRepeatedFrames
   let repeatRatio = null
-  if (typeof encoded === 'number' && encoded > 0 && typeof repeated === 'number') {
+  if (typeof encoded === 'number' && typeof repeated === 'number' && encoded + repeated >= 60) {
     repeatRatio = repeated / (encoded + repeated)
     // The bridge legitimately repeats a handful of frames around start/stop;
-    // a session that is >10% repeats recorded a slideshow.
+    // a session that is >10% repeats recorded a slideshow. Under 60 frames
+    // observed (a stats read racing the bridge ramp-up) there is no verdict.
     if (repeatRatio > 0.1) {
       failures.push(
         `bridge served ${(repeatRatio * 100).toFixed(1)}% repeated frames ` +
           `(${repeated} repeated vs ${encoded} encoded)`
       )
+    }
+  }
+  // The owner's 0.9.71–0.9.73 decay lives UPSTREAM of the bridge: capture
+  // producers (ScreenCaptureKit / camera) slow to 6–16 fps while the
+  // compositor faithfully re-serves held frames at full cadence — bridge
+  // repeats stay near zero, so only the source-serve counters can see it.
+  // With the motion stimulus on the real screen, fresh serves must track the
+  // session fps; held-serve dominance is the producer-stall signature.
+  if (realScreen) {
+    const fresh = bridge.compositorScreenSourceFreshServes
+    const held = bridge.compositorScreenSourceHeldServes
+    if (typeof fresh === 'number' && typeof held === 'number' && fresh + held >= 60) {
+      const freshRate = fresh / ((fresh + held) / PROFILE.fps)
+      if (held > fresh) {
+        failures.push(
+          `screen producer stalled: ${fresh} fresh vs ${held} held serves ` +
+            `(~${freshRate.toFixed(1)} fresh fps against ${PROFILE.fps} target)`
+        )
+      }
+    }
+  }
+  if (realCamera) {
+    const fresh = bridge.compositorCameraSourceFreshServes
+    const held = bridge.compositorCameraSourceHeldServes
+    if (
+      typeof fresh === 'number' &&
+      typeof held === 'number' &&
+      fresh + held >= 60 &&
+      held > fresh
+    ) {
+      failures.push(`camera producer stalled: ${fresh} fresh vs ${held} held serves`)
     }
   }
   return {
@@ -226,13 +274,23 @@ async function recordSession({ ws, smoke, index, sources }) {
 
 const results = []
 let stopApp = async () => {}
+let motionStimulus = null
 let launchedOk = false
 try {
   const launch = await launchDevApp({
+    spawnSpec: packagedAppExecutable ? { command: packagedAppExecutable, args: [] } : undefined,
+    packagedSmokeCommandCapability: packagedSmokeCapability,
     env: {
       VIDEORC_SMOKE_COMMAND_SERVER: '1',
       VIDEORC_SMOKE_STATE_DIR: outputDirectory,
       VIDEORC_USER_DATA_DIR: userDataDir,
+      ...(packagedAppExecutable
+        ? {
+            VIDEORC_PACKAGED_SMOKE_TEST: '1',
+            VIDEORC_SMOKE_COMMAND_CAPABILITY: packagedSmokeCapability,
+            VIDEORC_SMOKE_PRINT_BACKEND_READY: '1'
+          }
+        : {}),
       // Per-frame noise: every compositor-fresh frame is unique, so a held
       // frame is an exact duplicate and freezedetect sees it immediately.
       VIDEORC_SYNTHETIC_HARD_CONTENT: '1'
@@ -248,6 +306,13 @@ try {
   const ws = await connectBackend(launch.connections['backend-ready'], timeoutMs)
   const smoke = launch.connections['preview-motion-ready']
   const sources = await resolveRealSources(ws)
+  if (realScreen) {
+    motionStimulus = await launchScreenMotionStimulus({
+      outputDirectory,
+      ffmpegPath
+    })
+    console.log('[session-decay] screen motion stimulus running')
+  }
 
   for (let index = 0; index < sessionCount; index += 1) {
     try {
@@ -288,6 +353,7 @@ try {
 } catch (error) {
   console.error(`Session decay smoke failed to launch: ${String(error?.message ?? error)}`)
 } finally {
+  if (motionStimulus) await stopScreenMotionStimulus(motionStimulus)
   await stopApp()
 }
 


### PR DESCRIPTION
Live-sampled the owner's backend: stopped sessions' encoder writers kept encoding 4K via VideoToolbox with no session attached (macOS lacked the Windows-side deterministic join), competing with the next session's capture. Bounded stop+reap at session end, live-writer counter + start fence with honest warnings, stderr-panic hardening (crash reports proved a broken log pipe aborts the backend). Gates: encoder_bridge 69, recording 299, diagnostics 40, clippy, fmt, typecheck, lint, desktop 1504, matrix smoke PASS, decay smoke 6/6 after flake guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording session shutdown to prevent lingering encoder activity and reduce frozen frames.
  * Added startup checks and health warnings when previous recording processes do not exit cleanly.
  * Prevented backend failures when log output is interrupted.
* **Testing**
  * Expanded recording diagnostics and smoke checks for stalled or outdated frame sources.
  * Added support for validating packaged app recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->