### PR TITLE
fix(electron): exclude main, preview, and proof surfaces from capture — the app must not record itself

### DIFF
--- a/apps/desktop/src/main/window-capture-protection.test.ts
+++ b/apps/desktop/src/main/window-capture-protection.test.ts
@@ -17,12 +17,17 @@ describe('window capture protection policy', () => {
     'proof-surface'
   ]
 
-  it('protects ONLY the notes teleprompter, on every platform', () => {
+  it('protects operator surfaces and notes, keeps the show visible', () => {
     // Owner call, 2026-08-19: comments and captions are part of the show and
-    // must stay visible in recordings; notes is the one private window.
+    // must stay visible in recordings. Owner call, 2026-08-24: main, preview,
+    // and proof surfaces are private control surfaces — they must not appear
+    // in Videorc's own preview or recordings.
+    const protectedRoles = new Set<VideorcWindowRole>(['main', 'preview', 'notes', 'proof-surface'])
     for (const platform of ['darwin', 'win32', 'linux'] as const) {
       for (const role of everyRole) {
-        expect(videorcWindowRequiresCaptureProtection(role, platform)).toBe(role === 'notes')
+        expect(videorcWindowRequiresCaptureProtection(role, platform)).toBe(
+          protectedRoles.has(role)
+        )
       }
     }
   })

--- a/apps/desktop/src/main/window-capture-protection.ts
+++ b/apps/desktop/src/main/window-capture-protection.ts
@@ -34,16 +34,27 @@ export const WINDOW_CAPTURE_PROTECTION_SMOKE_MARKERS: Readonly<Record<VideorcWin
   })
 
 /**
- * Only Notes is a private teleprompter that must never enter a captured
- * display; Comments and Captions are part of the show and stay VISIBLE in
- * recordings (owner call, 2026-08-19 — "only notes should be invisible").
- * The rule is deliberately identical on every platform.
+ * Notes is a private teleprompter and must never enter a captured display.
+ * Main and preview are the operator's own control surfaces — they must not
+ * leak into Videorc's own preview or recordings either (owner call,
+ * 2026-08-24 — "the main app shows up in the preview view and in the
+ * recordings and it is not supposed to"), nor into other apps' captures.
+ * Comments and Captions are part of the show and stay VISIBLE in recordings
+ * (owner call, 2026-08-19). The rule is deliberately identical on every
+ * platform.
  */
+const CAPTURE_PROTECTED_ROLES: ReadonlySet<VideorcWindowRole> = new Set([
+  'main',
+  'preview',
+  'notes',
+  'proof-surface'
+])
+
 export function videorcWindowRequiresCaptureProtection(
   role: VideorcWindowRole,
   _platform: NodeJS.Platform
 ): boolean {
-  return role === 'notes'
+  return CAPTURE_PROTECTED_ROLES.has(role)
 }
 
 /**


### PR DESCRIPTION
## Summary
Today the app records itself: with a whole-monitor screen session, the main window and detached preview appear both in the live preview and in the finished recording. `videorcWindowRequiresCaptureProtection` protected only Notes (owner call 2026-08-19, when Comments/Captions were ruled part of the show), leaving every operator control surface capturable by our own recorder.

This treats self-exclusion as product correctness rather than a per-window preference: **main**, **preview**, and **proof-surface** now get `setContentProtection(true)` (WDA_EXCLUDEFROMCAPTURE on Windows); Comments/Captions stay visible per the 2026-08-19 call.

## Verification (Windows 11 x64, GTX 1650 SUPER)
- Whole-monitor screen+camera recording: main window and detached preview no longer appear in the live preview or the recorded artifact; desktop background renders in their place
- Desktop unit tests: 1503 passed (updated policy test documents both owner calls)
- `pnpm typecheck`: clean

## Testing
- `pnpm --filter @videorc/desktop exec vitest run src/main/window-capture-protection.test.ts`: 5/5
- Manual record on packaged build confirms no self-mirror

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded screen-capture protection to main, preview, notes, and proof-surface windows across all supported platforms.
  * Comments and captions remain visible during screen capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->