### PR TITLE
release: 0.9.75-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.75-beta.1.md
+++ b/changelog/0.9.75-beta.1.md
@@ -1,0 +1,43 @@
+---
+version: 0.9.75-beta.1
+date: 2026-08-25
+channel: beta
+platforms:
+  - macos
+title: Shortcuts on demand, and capture that owns its own frames
+summary: Sidebar shortcut hints now appear only while you hold Command, so the shortcut layer shows up exactly when you ask for it instead of sitting on screen permanently. Underneath, macOS capture was reworked to track ownership per session rather than process-wide — a finished recording can no longer leave frames, encoders or preview state behind for the next one — with far deeper diagnostics behind it, including honest per-source frame freshness and drop reasons in every support bundle.
+highlights:
+  - Hold Command to see the sidebar's keyboard shortcuts; release it and they fade away, so the list is there when you want it and quiet when you don't.
+  - macOS capture now owns its frames per session, so stopping a recording releases its encoder, textures and preview state instead of leaving them for the next session to fight over.
+  - Recordings are checked more strictly after capture, including frame freshness and whether the screen actually moved, so a frozen or empty recording is reported rather than passing quietly.
+  - Support bundles now say exactly why a frame was dropped and how fresh each source was, which is what turns a "it looked laggy" report into a specific answer.
+  - Icons across the app are now managed as one reviewed set, which removes several near-duplicate glyphs that meant the same thing.
+---
+
+## Fixed
+
+- Capture ownership on macOS is tracked per session and role instead of
+  process-wide, with bounded teardown deadlines and a pre-start admission
+  check: a session cannot begin while a previous session's capture is still
+  holding the pipeline.
+- Metal texture ownership is retained through GPU completion and held frames
+  are reused by storage identity, so the texture cache is only flushed once
+  the work using it has finished.
+- Preview fallback startup is generation-safe, so a restarted preview cannot
+  be adopted by a stale generation.
+
+## Diagnostics
+
+- AVFoundation drop reasons and ScreenCaptureKit status are attributed per
+  frame; retained-frame identities are process-monotonic; zero-copy backing is
+  reported truthfully rather than assumed.
+- Recording analysis gates fail closed on unique-frame ratio, source freshness
+  and coverage, bridge input coverage, and terminal lifecycle accounting.
+
+## Known issue
+
+The 4K screen-and-camera source decay first reported on 2026-08-24 is **not
+yet confirmed fixed**. This release hardens ownership and makes the failure
+visible and measurable; owner-device acceptance on real 4K screen + camera
+sessions is still outstanding, and is tracked in
+`docs/acceptance/2026-08-24-macos-recording-source-decay.md`.


### PR DESCRIPTION
Version bump + changelog for 0.9.75-beta.1. Ships #283 (per-session capture ownership, diagnostics, fail-closed analysis gates) and #282 (icon registry, licence-aware icon build, ⌘-held shortcut chips).

Changelog is explicit that the 4K source-decay incident is **not** confirmed fixed — owner acceptance on real screen+camera sessions is still outstanding. Combined-tree gates before this bump: typecheck, lint, format, desktop 1514 tests, test:scripts 1094, renderer build, cargo build/clippy/fmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added on-demand sidebar shortcuts activated while holding Command.
  - Improved per-session capture ownership and recording validation.
  - Added more detailed frame diagnostics.
  - Consolidated available icon sets.

- **Bug Fixes**
  - Improved Metal rendering and preview lifecycle stability.
  - Known issue remains where 4K screen-and-camera sources may gradually degrade during capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->