### PR TITLE
docs: 0.9.75 release record

### DIFF
--- a/docs/releases/0.9.75.md
+++ b/docs/releases/0.9.75.md
@@ -1,0 +1,71 @@
+# Videorc 0.9.75 Beta 1 (macOS)
+
+Per-session macOS capture ownership, a reviewed icon set, and sidebar
+shortcut chips that appear only while ⌘ is held.
+
+## Scope (PRs #282, #283, #284)
+
+- **#283 — capture ownership is per session, not per process.** Global writer
+  counting replaced by session/role ownership with bounded shared teardown
+  deadlines and a pre-start admission refusal, so a session cannot begin while
+  a previous session's capture still holds the pipeline. `CVMetalTexture`
+  ownership is retained through GPU completion, held frames are reused by
+  storage identity, and the texture cache flushes only after completed work.
+  Adds AVFoundation drop-reason and ScreenCaptureKit status attribution,
+  process-monotonic retained-frame identities, truthful zero-copy backing
+  diagnostics, and fail-closed recording-analysis gates (unique-frame ratio,
+  source freshness/age coverage, bridge input coverage, terminal lifecycle
+  accounting).
+- **#282 — icon registry + ⌘-held shortcut chips.** The renderer had 100
+  distinct icon imports across 52 files with duplicate meanings (three warning
+  variants, two pins, two locks, two spinners); icons are now named by meaning
+  in one registry — 90 slots over 85 glyphs — with `no-restricted-imports`
+  banning direct icon-package imports. Adds a dependency-free, licence-aware
+  icon build (`pnpm icons:build`, refuses to exceed the 100-icon ceiling) and
+  `docs/icon-set.md`. Sidebar shortcut chips now reveal only while ⌘ (Ctrl off
+  macOS) is held.
+- **#284 —** version bump + changelog.
+
+## Ship record
+
+Built from a clean worktree checkout of `main` @ `520ae1a5` (the primary
+checkout was on another agent's branch with uncommitted work; the runbook
+forbids a modified checkout as a release identity). Signed with Developer ID
+Application: Uros Miric (C2PA37RB58), notarized and stapled, uploaded and
+verified 2026-08-25; feed serves 0.9.75 and the updater zip returns 206.
+Discord announced.
+
+Combined-tree gates run BEFORE merging #282 on top of #283 — the check whose
+absence let 0.9.68 ship a dead record button: typecheck, lint, format:check,
+desktop suite 1514 tests / 160 files, `test:scripts` 1094, renderer build,
+`cargo build`/`clippy -D warnings`/`fmt --check`.
+
+## Known issue — the 4K source decay is NOT confirmed fixed
+
+#283 explicitly does not claim the 2026-08-24 incident is resolved. Its
+permissioned ScreenCaptureKit gate repeatedly reported a live source while
+capturing only the desktop wallpaper and cursor — no motion-stimulus window
+ever appeared in Videorc's own captured frame — so the fail-closed colour
+signature stopped before encoding and plan 041 hit its mandatory STOP.
+
+Outstanding: untouched-baseline and candidate 3× >60-second 4K30 screen +
+camera batches on the owner's device, plus `smoke:recording-matrix` and the
+remaining device suite. No thresholds were weakened and no synthetic evidence
+substitutes for device acceptance. Evidence and locations:
+`docs/acceptance/2026-08-24-macos-recording-source-decay.md`.
+
+What this release does give that 0.9.74 did not: when the decay happens, the
+per-source freshness, drop reasons and lifecycle accounting in the support
+bundle name the stage that stalled.
+
+## Follow-ups
+
+- Owner acceptance recordings (>60s, screen + camera) on 0.9.75.
+- The Nucleo icon export itself — the registry, build pipeline and semantic
+  audit are ready; the glyphs need the licensed account, and the open
+  question of where the SVGs may live in a public AGPL repo needs an owner
+  decision (`docs/icon-set.md`).
+- Removing the ~113 now-dead `weight` props once a single-weight icon set
+  lands.
+- Windows has not shipped these changes; the pilot lane is still on
+  0.9.72-alpha.1.


### PR DESCRIPTION
Release record for 0.9.75-beta.1 (macOS): #283 per-session capture ownership, #282 icon registry + ⌘-held chips. Records the combined-tree gate run, the clean-worktree build identity, and the still-unconfirmed 4K source-decay status.