### PR TITLE
fix(sidebar): unstick shortcut chips after ⌘+digit, animate the reveal, tighten the rail

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1609,12 +1609,31 @@ function createWindow(): void {
     mainWindow.loadFile(rendererPath)
   }
 
+  // Deduped so a held key's repeat storm does not flood the renderer.
+  let lastPublishedShortcutModifier = false
+  const publishShortcutModifier = (held: boolean): void => {
+    if (held === lastPublishedShortcutModifier) {
+      return
+    }
+    lastPublishedShortcutModifier = held
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      sendElectronEvent(mainWindow.webContents, 'shortcut:modifier', held)
+    }
+  }
+
   // Page-navigation shortcuts must be caught here, not in the renderer:
   // Chromium reserves ⌘1–⌘9 (tab switching) and ⌘0 (zoom) and never delivers
   // them to the page's keydown, so a document listener silently misses them.
   // before-input-event runs ahead of that handling; we preventDefault and
   // forward the raw key to the renderer, which owns the key→tab mapping.
   mainWindow.webContents.on('before-input-event', (event, input) => {
+    // Modifier state is published from HERE because here is the only place it
+    // can be observed. The renderer never sees a ⌘+digit chord (we swallow it
+    // below), and in practice it never sees the keyup that ends one either —
+    // which left the sidebar's shortcut chips stuck on after every ⌘1–⌘9.
+    // before-input-event still receives every keyUp, so main stays truthful.
+    publishShortcutModifier(input.meta || input.control)
+
     if (input.type !== 'keyDown' || input.alt || input.shift) {
       return
     }
@@ -1629,6 +1648,10 @@ function createWindow(): void {
       }
     }
   })
+
+  // Focus leaving the window means the modifier can be released without any
+  // event ever reaching us (⌘Tab is exactly that).
+  mainWindow.on('blur', () => publishShortcutModifier(false))
 
   mainWindow.on('closed', () => {
     commentsCommandBroker.rejectAll()

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -169,6 +169,7 @@ const api: VideorcApi = {
   checkDirectory: (capabilityId) => invoke('system:check-directory', capabilityId),
   onOAuthCallbackUrl: (callback) => subscribe('oauth:callback-url', callback),
   onShortcutNavigate: (callback) => subscribe('shortcut:navigate', callback),
+  onShortcutModifier: (callback) => subscribe('shortcut:modifier', callback),
   onBackendConnection: (callback) => subscribe('backend:connection', callback),
   onBackendLifecycle: (callback) => subscribe('backend:lifecycle', callback),
   onBackendLog: (callback) => subscribe('backend:log', callback),

--- a/apps/desktop/src/renderer/src/components/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar.tsx
@@ -5,8 +5,10 @@ import logoUrl from '@/assets/videorc-logo.png'
 import { AccountMenu } from '@/components/account-menu'
 import { type StatusDotTone } from '@/components/status-dot'
 import { ThemeToggle } from '@/components/theme-toggle'
+import { Badge } from '@/components/ui/badge'
 import { Kbd, KbdGroup } from '@/components/ui/kbd'
 import { useModifierHeld } from '@/hooks/use-modifier-held'
+import { usePrefersReducedMotion } from '@/hooks/use-reduced-motion'
 import { displayKeyGlyph } from '@/lib/platform'
 import { shortcutChipProps } from '@/lib/shortcut-overlay'
 import { useUpdater } from '@/hooks/use-updater'
@@ -15,6 +17,7 @@ import {
   STUDIO_PANELS,
   WORKSPACE_TABS,
   shortcutDigitFor,
+  shortcutOrderFor,
   type StudioPanel,
   type WorkspaceTab
 } from '@/components/workspace-nav'
@@ -29,6 +32,7 @@ function NavRow({
   shortcutDigit,
   modKey,
   shortcutVisible,
+  shortcutIndex,
   onClick
 }: {
   icon: AppIcon
@@ -38,6 +42,7 @@ function NavRow({
   shortcutDigit?: string
   modKey: string
   shortcutVisible: boolean
+  shortcutIndex: number
   onClick: () => void
 }): ReactElement {
   return (
@@ -64,7 +69,7 @@ function NavRow({
         // row from reflowing the instant ⌘ goes down. `aria-keyshortcuts` on
         // the button already tells assistive tech about the shortcut, so the
         // hidden chip is decoration and stays out of the accessibility tree.
-        <Kbd {...shortcutChipProps(shortcutVisible)}>
+        <Kbd {...shortcutChipProps(shortcutVisible, shortcutIndex)}>
           {modKey}
           {shortcutDigit}
         </Kbd>
@@ -162,25 +167,29 @@ export function Sidebar({
   // surfaces exactly when the user reaches for it (videorc-design keeps the
   // app keyboard-first; this keeps it quiet too).
   const shortcutVisible = useModifierHeld(platform)
+  // The cascade is an inline delay, so no CSS variant can drop it for us.
+  const reducedMotion = usePrefersReducedMotion()
 
   return (
-    <aside className="-mt-9 flex w-56 shrink-0 flex-col border-r bg-sidebar pt-9 text-sidebar-foreground backdrop-blur-2xl">
-      <div className="flex select-none items-center gap-3 px-4 py-4">
+    <aside className="-mt-9 flex w-48 shrink-0 flex-col border-r bg-sidebar pt-9 text-sidebar-foreground backdrop-blur-2xl">
+      <div className="flex select-none items-center gap-3 px-4 py-3">
         {/* The PNG bakes a ~4% transparent margin around the tile; the scaled
             overflow-hidden wrapper crops it so the hairline ring hugs the art. */}
         <div className="size-9 shrink-0 overflow-hidden rounded-[9px] shadow-[0_2px_8px_rgba(0,0,0,0.35)] ring-1 ring-border dark:shadow-[0_3px_10px_rgba(0,0,0,0.55)]">
           <img alt="Videorc" className="size-full scale-[1.09]" src={logoUrl} />
         </div>
-        <div className="flex min-w-0 flex-col gap-1">
-          <span className="flex min-w-0 items-baseline gap-1.5 text-sm leading-none font-semibold tracking-tight">
-            <span className="truncate">Videorc</span>
-            <span className="shrink-0 text-[10px] font-medium tracking-wide text-muted-foreground">
-              beta
-            </span>
+        <div className="flex min-w-0 flex-col items-start gap-1.5">
+          <span className="truncate text-sm leading-none font-semibold tracking-tight">
+            Videorc
           </span>
-          <span className="truncate text-[11px] leading-none tracking-wide text-muted-foreground">
-            Recording studio
-          </span>
+          {/* Monochrome: the channel is not a status, and colour in this app
+              means live or broken. */}
+          <Badge
+            variant="outline"
+            className="h-4 rounded-chip px-1.5 py-0 text-[10px] leading-none font-medium tracking-wide text-muted-foreground"
+          >
+            beta
+          </Badge>
         </div>
       </div>
       <div
@@ -213,6 +222,7 @@ export function Sidebar({
               isActive={active === tab.id}
               triggerId={tab.id}
               shortcutDigit={shortcutDigitFor(tab.id)}
+              shortcutIndex={reducedMotion ? 0 : shortcutOrderFor(tab.id)}
               modKey={modKey}
               shortcutVisible={shortcutVisible}
               onClick={() => onSelect(tab.id)}
@@ -230,6 +240,7 @@ export function Sidebar({
               isActive={activeStudioPanel === panel.id}
               triggerId={panel.legacyTabId}
               shortcutDigit={shortcutDigitFor(panel.id)}
+              shortcutIndex={reducedMotion ? 0 : shortcutOrderFor(panel.id)}
               modKey={modKey}
               shortcutVisible={shortcutVisible}
               onClick={() => onSelectStudioPanel(panel.id)}
@@ -247,6 +258,7 @@ export function Sidebar({
               isActive={active === tab.id}
               triggerId={tab.id}
               shortcutDigit={shortcutDigitFor(tab.id)}
+              shortcutIndex={reducedMotion ? 0 : shortcutOrderFor(tab.id)}
               modKey={modKey}
               shortcutVisible={shortcutVisible}
               onClick={() => onSelect(tab.id)}
@@ -269,6 +281,7 @@ export function Sidebar({
                 isActive={active === tab.id}
                 triggerId={tab.id}
                 shortcutDigit={shortcutDigitFor(tab.id)}
+                shortcutIndex={reducedMotion ? 0 : shortcutOrderFor(tab.id)}
                 modKey={modKey}
                 shortcutVisible={shortcutVisible}
                 onClick={() => onSelect(tab.id)}

--- a/apps/desktop/src/renderer/src/components/workspace-nav.tsx
+++ b/apps/desktop/src/renderer/src/components/workspace-nav.tsx
@@ -86,6 +86,16 @@ export function shortcutDigitFor(tab: WorkspaceTab): string | undefined {
   return WORKSPACE_SHORTCUTS.find((entry) => entry.tab === tab)?.digit
 }
 
+/**
+ * A page's position in the shortcut order, which is also its position down the
+ * sidebar. The reveal cascade uses it so the chips arrive top-to-bottom
+ * regardless of which sidebar group a row sits in.
+ */
+export function shortcutOrderFor(tab: WorkspaceTab): number {
+  const index = WORKSPACE_SHORTCUTS.findIndex((entry) => entry.tab === tab)
+  return index === -1 ? 0 : index
+}
+
 export function workspaceTabLabel(tab: WorkspaceTab): string {
   return (
     WORKSPACE_TABS.find((entry) => entry.id === tab)?.label ??

--- a/apps/desktop/src/renderer/src/hooks/use-modifier-held.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-modifier-held.ts
@@ -5,46 +5,64 @@ import { commandModifierKey, nextModifierHeldState } from '@/lib/shortcut-overla
 /**
  * True while the command modifier (⌘ / Ctrl) is physically down.
  *
- * A thin DOM adapter over the state machine in `lib/shortcut-overlay` — the
- * rules, and the reasons for them, live there.
+ * Reads from two sources, because one of them is lossy:
+ *
+ * - **The main process**, which intercepts ⌘1–⌘9 in `before-input-event` and
+ *   therefore sees every modifier transition. This is the authority.
+ * - **Window key events**, which never see those chords — nor, in practice,
+ *   the keyup that ends one — but still work in contexts without the Electron
+ *   bridge.
+ *
+ * Plus two repairs that cost nothing: a fired page shortcut closes the layer
+ * (the reminder did its job), and pointer movement without the modifier
+ * clears any state that somehow survived both signals.
+ *
+ * The rules live in `lib/shortcut-overlay`; this is the DOM/IPC adapter.
  */
 export function useModifierHeld(platform: string | undefined): boolean {
   const [held, setHeld] = useState(false)
 
   useEffect(() => {
     const modifier = commandModifierKey(platform)
+    const apply = (probe: Parameters<typeof nextModifierHeldState>[1]): void => {
+      setHeld((current) => nextModifierHeldState(current, probe))
+    }
 
-    // keydown fires repeatedly while a key is held; reducing from the real
-    // modifier state makes repeats idempotent instead of thrash.
-    const onKey = (event: KeyboardEvent): void => {
-      setHeld((current) =>
-        nextModifierHeldState(current, {
-          kind: 'key',
-          modifierDown: event.getModifierState(modifier)
-        })
-      )
-    }
-    const onBlur = (): void => {
-      setHeld((current) => nextModifierHeldState(current, { kind: 'blur' }))
-    }
-    const onVisibilityChange = (): void => {
-      setHeld((current) =>
-        nextModifierHeldState(current, {
-          kind: 'visibility',
-          hidden: document.visibilityState === 'hidden'
-        })
-      )
+    // keydown repeats while a key is held; reducing from the real modifier
+    // state makes repeats idempotent instead of thrash.
+    const onKey = (event: KeyboardEvent): void =>
+      apply({ kind: 'key', modifierDown: event.getModifierState(modifier) })
+    const onBlur = (): void => apply({ kind: 'blur' })
+    const onVisibilityChange = (): void =>
+      apply({ kind: 'visibility', hidden: document.visibilityState === 'hidden' })
+    const onPointerMove = (event: MouseEvent): void => {
+      // Only ever a repair, never the thing that opens the layer: moving the
+      // mouse with ⌘ already down must not make chips appear out of nowhere.
+      if (!event.metaKey && !event.ctrlKey) {
+        apply({ kind: 'pointer', modifierDown: false })
+      }
     }
 
     window.addEventListener('keydown', onKey)
     window.addEventListener('keyup', onKey)
     window.addEventListener('blur', onBlur)
+    window.addEventListener('mousemove', onPointerMove)
     document.addEventListener('visibilitychange', onVisibilityChange)
+    const offModifier = window.videorc?.onShortcutModifier?.((modifierDown) =>
+      apply({ kind: 'main', modifierDown })
+    )
+    const offNavigate = window.videorc?.onShortcutNavigate?.(() =>
+      apply({ kind: 'shortcut-fired' })
+    )
+
     return () => {
       window.removeEventListener('keydown', onKey)
       window.removeEventListener('keyup', onKey)
       window.removeEventListener('blur', onBlur)
+      window.removeEventListener('mousemove', onPointerMove)
       document.removeEventListener('visibilitychange', onVisibilityChange)
+      offModifier?.()
+      offNavigate?.()
     }
   }, [platform])
 

--- a/apps/desktop/src/renderer/src/hooks/use-reduced-motion.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+/**
+ * Whether the user asked the OS for reduced motion.
+ *
+ * Tailwind's `motion-reduce:` variant covers anything expressible as a class,
+ * but not values computed at runtime — a per-row stagger delay has to be an
+ * inline style, and inline styles are invisible to CSS variants. Components
+ * that compute motion read this and drop it themselves.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia?.(QUERY).matches === true
+  )
+
+  useEffect(() => {
+    const media = window.matchMedia?.(QUERY)
+    if (!media) {
+      return
+    }
+    const update = (): void => setReduced(media.matches)
+    update()
+    media.addEventListener('change', update)
+    return () => media.removeEventListener('change', update)
+  }, [])
+
+  return reduced
+}

--- a/apps/desktop/src/renderer/src/lib/shortcut-overlay.test.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-overlay.test.ts
@@ -64,6 +64,30 @@ describe('nextModifierHeldState', () => {
   })
 })
 
+describe('nextModifierHeldState — sources beyond this window', () => {
+  it('closes when a page shortcut fires', () => {
+    // ⌘1–⌘9 are intercepted by the main process, so this window never sees the
+    // chord and, in practice, never sees the keyup that ends it. Without this
+    // the chips stayed on screen after every ⌘+digit.
+    assert.equal(nextModifierHeldState(true, { kind: 'shortcut-fired' }), false)
+  })
+
+  it('takes the main process as the authority in both directions', () => {
+    assert.equal(nextModifierHeldState(false, { kind: 'main', modifierDown: true }), true)
+    // Stale local state must lose to a fresher reading from main.
+    assert.equal(nextModifierHeldState(true, { kind: 'main', modifierDown: false }), false)
+  })
+
+  it('repairs a stuck layer on pointer movement without the modifier', () => {
+    assert.equal(nextModifierHeldState(true, { kind: 'pointer', modifierDown: false }), false)
+  })
+
+  it('keeps the layer up while the mouse moves WITH the modifier held', () => {
+    // Reaching for the mouse mid-⌘ must not hide the shortcuts you are reading.
+    assert.equal(nextModifierHeldState(true, { kind: 'pointer', modifierDown: true }), true)
+  })
+})
+
 describe('shortcutChipProps', () => {
   it('keeps chips mounted and out of the accessibility tree in both states', () => {
     for (const visible of [true, false]) {
@@ -77,9 +101,34 @@ describe('shortcutChipProps', () => {
     }
   })
 
-  it('fades in fast and respects reduced motion', () => {
-    const props = shortcutChipProps(true)
-    assert.match(props.className, /duration-100/)
-    assert.match(props.className, /motion-reduce:transition-none/)
+  it('reveals with a fade, a slide and a scale — and hides instantly', () => {
+    const shown = shortcutChipProps(true)
+    assert.match(shown.className, /duration-\[120ms\]/)
+    assert.match(shown.className, /translate-x-0/)
+    assert.match(shown.className, /scale-100/)
+    // Hiding has no transition: a keyboard layer that lingers after the key is
+    // released reads as lag, not polish.
+    const hidden = shortcutChipProps(false)
+    assert.match(hidden.className, /duration-0/)
+    assert.match(hidden.className, /translate-x-1/)
+    assert.match(hidden.className, /scale-\[0\.98\]/)
+  })
+
+  it('cascades down the list on reveal and never on hide', () => {
+    assert.equal(shortcutChipProps(true, 0).style.transitionDelay, undefined)
+    assert.equal(shortcutChipProps(true, 3).style.transitionDelay, '36ms')
+    // Capped, so the last row is still fast — the cascade is a texture, not a wait.
+    assert.equal(shortcutChipProps(true, 50).style.transitionDelay, '96ms')
+    assert.equal(shortcutChipProps(false, 5).style.transitionDelay, undefined)
+  })
+
+  it('drops the transform under reduced motion, and can drop the cascade too', () => {
+    const props = shortcutChipProps(true, 4)
+    assert.match(props.className, /motion-reduce:transition-opacity/)
+    assert.match(props.className, /motion-reduce:transform-none/)
+    // The cascade is an inline delay, which no CSS variant can reach — the
+    // caller opts out by passing index 0 (see the sidebar's reduced-motion
+    // read). Proving the opt-out works is the most this pure function can do.
+    assert.equal(shortcutChipProps(true, 0).style.transitionDelay, undefined)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/shortcut-overlay.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-overlay.ts
@@ -27,21 +27,46 @@ export function commandModifierKey(platform: string | undefined): ModifierKey {
  * missed event self-correct on the next one.
  */
 export type ModifierProbe =
+  /** A keydown/keyup the window actually received. */
   | { kind: 'key'; modifierDown: boolean }
+  /**
+   * The authoritative reading from the main process. Main intercepts ⌘1–⌘9 in
+   * `before-input-event`, so those chords — and in practice the keyup that
+   * ends them — never reach this window at all. Main still sees every one, so
+   * its reading wins over anything derived from DOM events.
+   */
+  | { kind: 'main'; modifierDown: boolean }
+  /** A page shortcut fired: the reminder has served its purpose. */
+  | { kind: 'shortcut-fired' }
+  /**
+   * Pointer movement, carrying the modifier state the event was born with.
+   * A last-resort repair: if the layer is somehow stuck, it clears the moment
+   * the user moves the mouse — while moving the mouse WITH ⌘ held keeps it up.
+   */
+  | { kind: 'pointer'; modifierDown: boolean }
   | { kind: 'blur' }
   | { kind: 'visibility'; hidden: boolean }
 
 /**
  * Next visibility state for the shortcut layer.
  *
- * `blur` and a hidden document both force it closed: when ⌘Tab, ⌘Q or a
- * native menu takes focus mid-press, the window never receives the `keyup`,
- * so without this the chips would stay stuck on until the next key press.
+ * `blur` and a hidden document force it closed: when ⌘Tab, ⌘Q or a native
+ * menu takes focus mid-press, the window never receives the `keyup`, so
+ * without this the chips would stay stuck on until the next key press.
+ *
+ * Every source that carries a modifier reading is treated the same way —
+ * whoever spoke last saw the key most recently. That is deliberate: the DOM
+ * signal is lossy for ⌘+digit chords, and main's is not, so the layer must
+ * never prefer stale local state over a fresher reading from anywhere.
  */
 export function nextModifierHeldState(current: boolean, probe: ModifierProbe): boolean {
   switch (probe.kind) {
     case 'key':
+    case 'main':
+    case 'pointer':
       return probe.modifierDown
+    case 'shortcut-fired':
+      return false
     case 'blur':
       return false
     case 'visibility':
@@ -49,26 +74,54 @@ export function nextModifierHeldState(current: boolean, probe: ModifierProbe): b
   }
 }
 
+/** Reveal cascades down the list at this step, so it reads as one motion. */
+const CHIP_STAGGER_MS = 12
+/** …but the last row still arrives fast; the cascade is a texture, not a wait. */
+const CHIP_STAGGER_MAX_MS = 96
+
 /**
- * Presentation for one key chip in the sidebar. The chip is always MOUNTED —
- * hiding it with opacity keeps its width reserved, so rows do not reflow the
- * instant ⌘ goes down — and always `aria-hidden`, because the row's own
- * `aria-keyshortcuts` is what assistive tech reads. Reveal is a 100ms fade
- * (videorc-design motion: fast, subtle, no bounce) and is skipped entirely
- * under `prefers-reduced-motion`.
+ * Presentation for one key chip in the sidebar.
+ *
+ * The chip is always MOUNTED — hiding it with opacity keeps its width
+ * reserved, so rows do not reflow the instant ⌘ goes down — and always
+ * `aria-hidden`, because the row's own `aria-keyshortcuts` is what assistive
+ * tech reads.
+ *
+ * Reveal is a 120ms fade with a 1px slide and a scale from 0.98 (the design
+ * language's panel motion, borrowed at chip scale), staggered by row so the
+ * layer cascades instead of flashing on as a block. Hiding is instant and
+ * unstaggered: a keyboard layer that lingers after the key is released reads
+ * as lag, not polish.
+ *
+ * Reduced motion is handled in two halves, because it has to be: the
+ * transform is dropped by Tailwind's `motion-reduce:` variant, but the
+ * cascade is an inline delay computed at runtime, which no CSS variant can
+ * see — so callers pass `index: 0` when the user asked for less motion.
+ *
+ * @param index Row position, for the cascade. Pass 0 to opt out.
  */
-export function shortcutChipProps(visible: boolean): {
+export function shortcutChipProps(
+  visible: boolean,
+  index = 0
+): {
   'aria-hidden': true
   'data-videorc-nav-shortcut': string
   'data-visible': 'true' | 'false'
   className: string
+  style: { transitionDelay?: string }
 } {
+  const delayMs = visible ? Math.min(index * CHIP_STAGGER_MS, CHIP_STAGGER_MAX_MS) : 0
   return {
     'aria-hidden': true,
     'data-videorc-nav-shortcut': '',
     'data-visible': visible ? 'true' : 'false',
-    className: `transition-opacity duration-100 ease-out motion-reduce:transition-none ${
-      visible ? 'opacity-100' : 'opacity-0'
-    }`
+    className: [
+      'transition-[opacity,transform] ease-out motion-reduce:transition-opacity',
+      'motion-reduce:transform-none',
+      visible
+        ? 'opacity-100 translate-x-0 scale-100 duration-[120ms]'
+        : 'opacity-0 translate-x-1 scale-[0.98] duration-0'
+    ].join(' '),
+    style: delayMs > 0 ? { transitionDelay: `${delayMs}ms` } : {}
   }
 }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -3389,6 +3389,8 @@ export interface VideorcApi {
    * the raw key here ("1".."9" or ",").
    */
   onShortcutNavigate: (callback: (key: string) => void) => () => void
+  /** Whether the command modifier is physically down; see main's before-input-event. */
+  onShortcutModifier: (callback: (held: boolean) => void) => () => void
   onBackendConnection: (callback: (connection: BackendConnection) => void) => () => void
   onBackendLifecycle: (callback: (event: BackendLifecycleEvent) => void) => () => void
   onBackendLog: (callback: (log: BackendLogEvent) => void) => () => void

--- a/apps/desktop/src/shared/electron-ipc-contract.ts
+++ b/apps/desktop/src/shared/electron-ipc-contract.ts
@@ -196,6 +196,7 @@ export interface ElectronIpcEventMap {
   'captions-window:lines': CaptionsUpdate[]
   'oauth:callback-url': OAuthCallbackEnvelope
   'shortcut:navigate': string
+  'shortcut:modifier': boolean
   'global-shortcuts:triggered': GlobalShortcutAction
   'preview-surface:pump-mode': boolean
   'preview-surface:resync-scene': undefined
@@ -231,6 +232,7 @@ export const electronEventChannels = [
   'captions-window:lines',
   'oauth:callback-url',
   'shortcut:navigate',
+  'shortcut:modifier',
   'global-shortcuts:triggered',
   'preview-surface:pump-mode',
   'preview-surface:resync-scene',
@@ -1051,6 +1053,10 @@ const specificRuntimeEventSchemas = {
   'notes-window:flush-request': undefinedSchema,
   'oauth:callback-url': oauthCallbackEnvelopeSchema,
   'shortcut:navigate': enumSchema(['1', '2', '3', '4', '5', '6', '7', '8', '9', ',']),
+  // Whether the command modifier is physically down. Main is the only place
+  // that can know: it intercepts ⌘1–⌘9 in before-input-event, so the renderer
+  // never receives those chords — nor, in practice, the keyup that ends them.
+  'shortcut:modifier': booleanSchema,
   'global-shortcuts:triggered': enumSchema(['record-toggle', 'stream-toggle', 'mic-toggle']),
   'preview-surface:pump-mode': booleanSchema,
   'preview-surface:resync-scene': undefinedSchema,


### PR DESCRIPTION
Fixes the stuck-chips bug and finishes the sidebar pass.

## The bug: chips stayed on screen after ⌘+digit

**Root cause, from the code rather than a guess.** `main/index.ts` intercepts
⌘1–⌘9 and ⌘, in `before-input-event` and calls `preventDefault()`, because
Chromium reserves those chords for tab switching and never delivers them to the
page. The renderer sees the opening ⌘ keydown (chips appear) but never the
chord — and in practice never the keyup that ends it. So the layer never learned
the key was released.

The shortcut layer was reading modifier state purely from window key events,
which are structurally blind here. **Modifier state is now published from main**,
the only place that can see it: `before-input-event` still receives every
`keyUp`, including the ones it suppresses. The renderer prefers that signal and
keeps its DOM listeners as the fallback for contexts without the bridge; main
also publishes `false` on window blur, where the release can happen with no
event at all (⌘Tab).

Two repairs ride along, each costing nothing: a fired page shortcut closes the
layer, and pointer movement without the modifier clears anything that survived
both signals — while moving the mouse **with** ⌘ held keeps the chips up, so
reaching for the mouse mid-⌘ doesn't hide the shortcuts you're reading.

## The reveal animates

120ms fade + 1px slide + scale from 0.98, staggered 12ms per row (capped at
96ms) so the layer cascades top-to-bottom instead of flashing on as a block.
The cascade follows the shortcut order, so it runs down the sidebar regardless
of which group a row sits in. Hiding stays instant — a keyboard layer that
lingers after release reads as lag.

Reduced motion needed handling in two halves: Tailwind's `motion-reduce:`
variant drops the transform, but the cascade is an inline delay computed at
runtime, which no CSS variant can see — so the sidebar reads the media query
and passes index 0. (My first pass shipped a test claiming the cascade was
dropped when it wasn't; that's now true rather than merely asserted.)

## The rail loses 32px, the header loses a line

`w-56 → w-48`. With chips hidden by default, the reserved chip column read as a
dead channel down the whole list — the gap in the report. The longest row
("Livestream" + ⌘5) needs ~70px of the 101px still available, so nothing
truncates. The chip stays mounted with its width reserved: that's what stops
eleven rows reflowing every time ⌘ goes down.

The header drops "Recording studio" and moves `beta` under the name as a
monochrome outline badge — colour in this app means live or broken, and a
release channel is neither.

## Verification

typecheck · lint · format:check · desktop 1520 tests / 160 files · test:scripts
1094 · renderer build.

`probe:preview-lifecycle` was run because sidebar width has unglued the docked
preview before. It **fails — and fails identically on clean main** ("Main window
is not ready for preview motion smoke", memory sample count below threshold),
so it is the known pre-existing breakage on this box, not a geometry regression.
The docked preview measures its slot from the DOM rather than a fixed width, so
it follows the narrower rail.

**Not verified by me:** the visual result. I tried to screenshot the running app
and kept capturing the wrong region, so the width is verified by measurement,
not by eye — worth a glance in both themes.

One commit, not four: the reducer's new probes are shared by the fix and the
animation, so a split wouldn't have produced a tree that builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sidebar shortcut indicators to accurately reflect modifier-key state.
  * Added staggered shortcut-chip animations for clearer navigation feedback.
  * Added a compact beta badge and refreshed sidebar spacing.

* **Accessibility**
  * Shortcut animations now respect reduced-motion preferences.

* **Bug Fixes**
  * Fixed shortcut indicators remaining active after focus changes or intercepted keyboard shortcuts.
  * Improved shortcut overlay behavior when navigating with keyboard commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->