### PR TITLE
release: 0.9.76-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.75",
+  "version": "0.9.76",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.76-beta.1.md
+++ b/changelog/0.9.76-beta.1.md
@@ -1,0 +1,30 @@
+---
+version: 0.9.76-beta.1
+date: 2026-08-25
+channel: beta
+platforms:
+  - macos
+title: The shortcut layer behaves itself
+summary: Holding Command now reveals the sidebar's keyboard shortcuts with a quick cascade, and — the actual bug — they disappear again after you use one. Pressing ⌘2 used to leave every hint stuck on screen until the next keypress. The sidebar is also 32px narrower now that those hints are hidden by default, and the header reads as just "Videorc" with a beta badge underneath.
+highlights:
+  - Using a shortcut no longer leaves the hints stuck on screen — press ⌘2, let go, and they're gone.
+  - The hints now cascade in over the sidebar instead of appearing all at once, and vanish the instant you release Command.
+  - Moving the mouse while still holding Command keeps the hints up, so reaching for the trackpad doesn't hide what you're reading.
+  - The sidebar is narrower, closing the empty gap that opened up when the shortcut hints became hidden by default.
+  - The header is just "Videorc" with a beta badge below it — the "Recording studio" line is gone.
+---
+
+## Fixed
+
+- Sidebar shortcut hints stayed visible after any ⌘+digit navigation. Those
+  chords are intercepted before the app window ever sees them, so the window
+  also never saw the key being released; the app now takes the modifier state
+  from the process that does see it, and clears the hints on window focus loss,
+  after a shortcut fires, and on mouse movement without the key held.
+
+## Changed
+
+- Shortcut hints reveal with a short staggered fade and hide instantly.
+  Motion is reduced automatically when the system asks for it.
+- The sidebar is 32px narrower; the header drops its subtitle and shows the
+  release channel as a badge under the app name.


### PR DESCRIPTION
Version bump + changelog for 0.9.76-beta.1: sidebar shortcut-layer fix, staggered reveal, narrower rail, header cleanup (#286).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sidebar shortcut hints remaining visible after ⌘+digit navigation.
  - Hints now clear when the window loses focus, a shortcut completes, or the mouse moves without a modifier key held.

- **UI Improvements**
  - Added staggered fade-in animations for shortcut hints, with reduced-motion support.
  - Sidebar width reduced by 32px.
  - Updated the header branding to “Videorc” with a beta badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->