### PR TITLE
docs: 0.9.76 release record

### DIFF
--- a/docs/releases/0.9.76.md
+++ b/docs/releases/0.9.76.md
@@ -1,0 +1,62 @@
+# Videorc 0.9.76 Beta 1 (macOS)
+
+Sidebar shortcut layer: the stuck-chips bug, an animated reveal, a narrower
+rail and a cleaner header.
+
+## Scope (PRs #286, #287)
+
+- **The bug.** Sidebar shortcut chips stayed visible after any ⌘+digit
+  navigation. `main/index.ts` intercepts ⌘1–⌘9 and ⌘, in `before-input-event`
+  (Chromium reserves those chords for tab switching and never delivers them to
+  the page), so the renderer saw the opening ⌘ keydown but neither the chord
+  nor the keyup that ended it. The shortcut layer read modifier state purely
+  from window key events, which are structurally blind to exactly this case.
+  Modifier state is now published from main — the only place that receives
+  every `keyUp`, including the ones it suppresses — with the DOM listeners kept
+  as the fallback for contexts without the bridge, plus `false` on window blur
+  (⌘Tab releases with no event at all). Two further repairs: a fired page
+  shortcut closes the layer, and pointer movement without the modifier clears
+  residual state, while movement WITH the modifier held keeps it up.
+- **Reveal.** 120ms fade + 1px slide + scale from 0.98, staggered 12ms per row
+  (capped 96ms) in shortcut order, so the layer cascades down the sidebar
+  rather than flashing on. Hiding is instant. Reduced motion is handled in two
+  halves: Tailwind's variant drops the transform, and the sidebar passes index
+  0 to drop the cascade, because an inline delay computed at runtime is
+  invisible to CSS variants.
+- **Rail + header.** `w-56 → w-48` (the reserved chip column read as a dead
+  channel once chips were hidden by default; the longest row needs ~70px of
+  the 101px still available). Header drops "Recording studio" and shows `beta`
+  as a monochrome outline badge under the name.
+
+## Ship record
+
+Built from the clean worktree checkout of `main` @ `44dda998`. Signed with
+Developer ID Application: Uros Miric (C2PA37RB58), notarized and stapled,
+uploaded and verified 2026-08-25; feed serves 0.9.76 and the updater zip
+returns 206. R2 TLS issuer verified genuine (Google Trust Services) before
+upload. Discord announced.
+
+Gates: typecheck, lint, format:check, desktop 1520 tests / 160 files,
+`test:scripts` 1094, renderer build.
+
+`probe:preview-lifecycle` was run because sidebar width has unglued the docked
+preview before. It fails — **and fails identically on clean `main`** ("Main
+window is not ready for preview motion smoke", memory sample count below
+threshold) — so it is the known pre-existing breakage on this box, not a
+geometry regression. The docked preview measures its slot from the DOM rather
+than a fixed width, so it follows the narrower rail.
+
+## Not verified
+
+The visual result was checked by measurement, not by eye: attempts to
+screenshot the running app kept capturing the wrong region. Worth a glance in
+both themes — sidebar width, header badge, and the reveal cascade.
+
+## Still open
+
+- The 4K screen+camera source decay remains unconfirmed (see
+  `docs/releases/0.9.75.md`); owner acceptance recordings are still outstanding.
+- The Nucleo glyph swap is blocked on the licensed export and the open licence
+  question in `docs/icon-set.md`.
+- Windows has not shipped any of this; the pilot lane is still on
+  0.9.72-alpha.1.


### PR DESCRIPTION
Release record for 0.9.76-beta.1 (macOS): sidebar shortcut-layer fix, reveal animation, narrower rail, header cleanup. Records the pre-existing probe failure comparison and what was not verified by eye.