### PR TITLE
fix: settings gap, glass scrollbars, record-only co-host, Cam Link 4K capture, idle mic meter

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2133,6 +2133,15 @@ function notesWindowHtml(document: NotesDocument): string {
       font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       overflow: hidden; user-select: none; -webkit-user-select: none; }
     body { display: flex; flex-direction: column; }
+    /* Same scrollbar recipe as the app (styles.css): no track, a barely-there
+       thumb inset inside its hit area. This window is a data-URL document, so
+       it cannot inherit the app stylesheet — keep the two in step by hand. */
+    ::-webkit-scrollbar { width: 10px; height: 10px; background: transparent; }
+    ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner { background: transparent; }
+    ::-webkit-scrollbar-button { display: none; }
+    ::-webkit-scrollbar-thumb { background-color: rgba(255,255,255,0.12); border: 3px solid transparent;
+      background-clip: content-box; border-radius: 999px; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08); }
+    ::-webkit-scrollbar-thumb:hover { background-color: rgba(255,255,255,0.22); }
     .drag-bar { height: 34px; display: flex; align-items: center; gap: 10px;
       padding: 0 12px 0 78px; box-sizing: border-box; background: ${DARK_WINDOW_PALETTE.panel};
       border-bottom: 1px solid ${DARK_WINDOW_PALETTE.hairline}; -webkit-app-region: drag; }

--- a/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/audio-mixer.tsx
@@ -5,9 +5,6 @@ import { PanelSection } from '@/components/panel-section'
 import { StatusBadge } from '@/components/status-badge'
 import { BarVisualizer, paintBarVisualizer } from '@/components/ui/bar-visualizer'
 import { Button } from '@/components/ui/button'
-import { Kbd } from '@/components/ui/kbd'
-import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
 import { useWorkspaceNav } from '@/components/workspace-nav'
 import { useStudioAudio, useStudioCore, useStudioDiagnostics } from '@/hooks/use-studio'
 import {
@@ -18,11 +15,7 @@ import {
 import type { AudioMeterStatus } from '@/lib/backend'
 import { formatDb } from '@/lib/format'
 import { resampleMicVisualLevelsInto } from '@/lib/mic-visual-frame'
-import {
-  audioMixerMonitorLabel,
-  audioMixerMonitorWhenIdle,
-  withAudioMixerMonitorWhenIdle
-} from '@/lib/mic-visual-gate'
+import { audioMixerMonitorLabel } from '@/lib/mic-visual-gate'
 import { advanceClipHoldDeadline, fallbackBandLevels } from '@/lib/mic-meter'
 import { systemAccessAction, systemAccessRows, type SystemAccessAction } from '@/lib/system-access'
 import { cn } from '@/lib/utils'
@@ -56,11 +49,12 @@ export function audioMixerSignalLive(
  * hold. The backend stays the capture/health authority: its 1 Hz
  * `micLiveLevel` and the on-demand 700 ms "Check level" sample drive a
  * deterministic coarse-band fallback (same dBFS scale) whenever the analyser
- * cannot open the selected device. The analyser is armed by a running
- * session or by the persisted "Monitor input" toggle (M); an idle Studio with
- * monitoring off never opens the microphone, so the bars sit at floor and
- * the OS shows no mic indicator. The stream also releases while the document
- * is hidden (idle-CPU discipline). System audio shows its honest
+ * cannot open the selected device. The analyser runs whenever the mixer is
+ * on screen — including with no session — because "is my microphone working?"
+ * is a question people ask BEFORE recording, and a meter pinned at the floor
+ * cannot answer it. The OS microphone indicator is therefore lit while the
+ * mixer is visible; the stream releases as soon as the page or the window is
+ * hidden (idle-CPU discipline). System audio shows its honest
  * "unavailable — pending native adapter" state; real capture is Phase-2 (F3).
  */
 export function AudioMixer(): ReactElement {
@@ -73,9 +67,7 @@ export function AudioMixer(): ReactElement {
     handleSystemPermission,
     mediaAccess,
     runtimeInfo,
-    isSessionActive,
-    settings,
-    setSettings
+    isSessionActive
   } = useStudioCore()
   const { audioMeter, audioMeterLoading } = useStudioAudio()
   const { diagnosticStats } = useStudioDiagnostics()
@@ -124,12 +116,7 @@ export function AudioMixer(): ReactElement {
   )
   const analyserDriven = micVisual.active && !muted
   const signalLive = audioMixerSignalLive(muted, micVisual.active, liveLevel)
-  const monitorWhenIdle = audioMixerMonitorWhenIdle(settings)
   const monitorLabel = audioMixerMonitorLabel({ sessionActive: isSessionActive, signalLive })
-  // The M shortcut lives in StudioMicVisualProvider (one home for Studio and
-  // Sources); this switch is the pointer surface for the same setting.
-  const setMonitorWhenIdle = (next: boolean): void =>
-    setSettings((current) => withAudioMixerMonitorWhenIdle(current, next))
   const fallbackLevels = fallbackBandLevels(
     muted || !selectedMicrophone ? 0 : level,
     MIXER_BAR_COUNT
@@ -202,25 +189,11 @@ export function AudioMixer(): ReactElement {
             {monitorLabel}
           </span>
         </div>
-        {/* Idle only: a session arms the meter by itself, so the toggle has
-            nothing to say while one runs. "Check level" stays as the
-            backend's one-shot reading for people who keep monitoring off. */}
+        {/* The meter runs whenever the mixer is visible, so there is nothing
+            to arm. "Check level" stays: it is the BACKEND's own reading, the
+            answer when the browser analyser cannot open the device at all. */}
         {!isSessionActive ? (
           <div className="flex items-center justify-between gap-2">
-            <Label
-              className="gap-2 text-xs font-normal text-muted-foreground"
-              htmlFor="audio-mixer-monitor-input"
-            >
-              <Switch
-                checked={monitorWhenIdle}
-                disabled={!selectedMicrophone}
-                id="audio-mixer-monitor-input"
-                size="sm"
-                onCheckedChange={setMonitorWhenIdle}
-              />
-              Monitor input
-              <Kbd>M</Kbd>
-            </Label>
             {!signalLive ? (
               <Button
                 className="shrink-0"

--- a/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/mic-picker-preview.tsx
@@ -1,14 +1,11 @@
 import { useRef, type ReactElement, type RefObject } from 'react'
 
-import { Button } from '@/components/ui/button'
-import { Kbd } from '@/components/ui/kbd'
 import { LiveWaveform, type LiveWaveformHandle } from '@/components/ui/live-waveform'
 import { useStudioCore } from '@/hooks/use-studio'
 import {
   useStudioMicVisualLifecycle,
   useStudioMicVisualPainter
 } from '@/hooks/use-studio-mic-visual'
-import { audioMixerMonitorWhenIdle, withAudioMixerMonitorWhenIdle } from '@/lib/mic-visual-gate'
 
 /**
  * See-before-you-pick mic preview (Studio audio rework S4): a scrolling live
@@ -27,15 +24,11 @@ export function MicPickerPreview({
   deviceName: string | undefined
 }): ReactElement {
   const lifecycle = useStudioMicVisualLifecycle()
-  const { captureConfig, isSessionActive, settings, setSettings } = useStudioCore()
+  const { captureConfig } = useStudioCore()
   const waveformRef = useRef<LiveWaveformHandle>(null)
   useMicPickerFramePainter(waveformRef)
   const enabled = Boolean(deviceName)
-  const monitoringOff =
-    enabled &&
-    !isSessionActive &&
-    !captureConfig.audio.microphoneMuted &&
-    !audioMixerMonitorWhenIdle(settings)
+  const muted = enabled && captureConfig.audio.microphoneMuted
 
   return (
     <div className="flex flex-col gap-1" data-videorc-mic-preview>
@@ -55,18 +48,11 @@ export function MicPickerPreview({
           Live preview unavailable — the mic may be in use or needs permission. Recording is
           unaffected.
         </span>
-      ) : monitoringOff ? (
-        <span className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-          <span>Input monitoring is off while idle.</span>
-          <Button
-            className="shrink-0"
-            size="xs"
-            variant="ghost"
-            onClick={() => setSettings((current) => withAudioMixerMonitorWhenIdle(current, true))}
-          >
-            Monitor input
-            <Kbd>M</Kbd>
-          </Button>
+      ) : muted ? (
+        // The one honest reason the waveform is flat while the picker is open:
+        // idle no longer silences it, so a mute is worth naming.
+        <span className="text-xs text-muted-foreground">
+          Microphone is muted — unmute to see its level.
         </span>
       ) : null}
     </div>

--- a/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
@@ -93,8 +93,11 @@ export function SessionPanel({
           onNavigate={() => openStudioPanel('recording')}
         />
         {/* Presence W3: while a session runs, whether the co-host is reading
-            chat is a session fact — knowable without the Comments window. */}
-        {active ? <CohostSessionRow /> : null}
+            chat is a session fact — knowable without the Comments window.
+            Streaming only: the co-host reads LIVE chat, so a record-only
+            session has no chat for it to read and the row would be an idle
+            status for a feature that is not part of what the user started. */}
+        {active && captureConfig.streamEnabled ? <CohostSessionRow /> : null}
       </div>
 
       <div className="flex flex-col gap-2 border-t border-border pt-4">

--- a/apps/desktop/src/renderer/src/components/tabs/settings-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-layout.test.ts
@@ -13,8 +13,8 @@ const settingsTabBody = settingsSource.slice(
   settingsSource.indexOf('function AboutAndUpdates')
 )
 
-/** Section titles per column of the upper (ConfigGrid) region, in render order. */
-function upperRegionColumns(): string[][] {
+/** Section titles per column of the single ConfigGrid, in render order. */
+function settingsColumns(): string[][] {
   const region = settingsTabBody.slice(
     settingsTabBody.indexOf('<ConfigGrid>'),
     settingsTabBody.indexOf('</ConfigGrid>')
@@ -39,10 +39,20 @@ describe('Settings layout', () => {
     expect(configGrid).toContain("cn('grid items-start gap-5 lg:grid-cols-2', className)")
   })
 
-  it('splits the upper region into two stacked, content-height columns', () => {
-    expect(upperRegionColumns()).toEqual([
-      ['Recording & storage', 'System access'],
-      ['Co-host', 'Global shortcuts', 'Remote control']
+  it('lays every card out in ONE grid, so no column can wait on another', () => {
+    // Two stacked grids left a void: a grid row is as tall as its tallest
+    // column, and the second grid could not start until the first ended, so
+    // whenever the (tall) co-host column outgrew the left one, the left column
+    // stopped early and the gap stretched to the next grid. One grid with two
+    // independent stacks cannot reproduce that.
+    const grids = settingsTabBody.match(/<ConfigGrid>/g) ?? []
+    expect(grids).toHaveLength(1)
+  })
+
+  it('splits the cards into two stacked, content-height columns', () => {
+    expect(settingsColumns()).toEqual([
+      ['Recording & storage', 'System access', 'Appearance & behavior', 'Import', 'Support'],
+      ['Co-host', 'Global shortcuts', 'Remote control', 'Shortcuts']
     ])
   })
 

--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -152,13 +152,13 @@ export function SettingsTab({
 
   return (
     <div className="flex flex-col gap-5">
-      {/* B4 (live feedback batch 3): two content-height columns, NOT a stretch
-        grid — Remote control (header-only when off) used to inflate to the tall
-        Co-host card's row height. Left carries the two long-form cards, right
-        stacks the three shorter ones, so the columns land within a card of each
-        other and every card is exactly as tall as its own content. Below `lg`
-        the columns collapse and the sections read in priority order: storage,
-        permissions, co-host, shortcuts, remote. */}
+      {/* ONE grid, two continuous columns (was two stacked grids). A grid row is
+        as tall as its tallest column and the second grid could not start until the
+        first ended, so whenever the right column outgrew the left — the co-host
+        card is tall — the left column stopped early and a void stretched down to
+        the next grid. Two independent stacks cannot do that: each card sits at its
+        own content height with a uniform gap, and neither column waits for the
+        other. Below `lg` they collapse and read in priority order. */}
       <ConfigGrid>
         <div className="flex flex-col gap-5">
           <PanelSection
@@ -411,6 +411,94 @@ export function SettingsTab({
               </p>
             </div>
           </PanelSection>
+          <PanelSection
+            description="How Videorc looks and behaves on this device."
+            icon={ThemeIcon}
+            title="Appearance & behavior"
+          >
+            <FieldGroup>
+              <Field>
+                <FieldLabel>Theme</FieldLabel>
+                <ToggleGroup
+                  type="single"
+                  value={theme ?? 'system'}
+                  variant="outline"
+                  onValueChange={(value) => value && setTheme(value)}
+                >
+                  <ToggleGroupItem value="light">Light</ToggleGroupItem>
+                  <ToggleGroupItem value="dark">Dark</ToggleGroupItem>
+                  <ToggleGroupItem value="system">System</ToggleGroupItem>
+                </ToggleGroup>
+              </Field>
+              {runtimeInfo?.platform === 'win32' ? (
+                <Field>
+                  <div className="flex items-center justify-between gap-3">
+                    <FieldLabel>Graphics acceleration</FieldLabel>
+                    <StatusBadge
+                      tone={runtimeInfo.hardwareAccelerationDisabled ? 'warn' : 'good'}
+                      value={gpuRenderingLabel(runtimeInfo)}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {graphicsAccelerationDescription(runtimeInfo)}
+                  </p>
+                  {runtimeInfo.hardwareAccelerationDisabled &&
+                  runtimeInfo.gpuFallback.source !== 'env' ? (
+                    <Button
+                      className="w-fit"
+                      disabled={runtimeInfo.gpuFallback.retryScheduled}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void scheduleHardwareAccelerationRetry()}
+                    >
+                      <RefreshIcon data-icon="inline-start" />
+                      {runtimeInfo.gpuFallback.retryScheduled
+                        ? 'Retry scheduled'
+                        : 'Retry on next launch'}
+                    </Button>
+                  ) : null}
+                </Field>
+              ) : null}
+            </FieldGroup>
+          </PanelSection>
+
+          <PanelSection
+            description="Coming from OBS Studio? Bring your scenes and settings across."
+            icon={DownloadIcon}
+            title="Import"
+          >
+            {/* O4 (OBS import plan): the wizard previews the truthful
+                imported/approximated/skipped report BEFORE anything applies. */}
+            <div>
+              <Button size="sm" variant="outline" onClick={() => setObsImportOpen(true)}>
+                <DownloadIcon data-icon="inline-start" />
+                Import from OBS…
+              </Button>
+            </div>
+            <ObsImportDialog open={obsImportOpen} onOpenChange={setObsImportOpen} />
+          </PanelSection>
+
+          <PanelSection description="Get help or report a problem." icon={BugIcon} title="Support">
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  disabled={supportBundleExportPending}
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void exportSupportBundle()}
+                >
+                  <BugIcon data-icon="inline-start" />
+                  {supportBundleExportPending ? 'Exporting\u2026' : 'Export support bundle'}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Reporting a problem? Export a support bundle (redacted logs + diagnostics) to share
+                with us.
+              </p>
+            </div>
+          </PanelSection>
+
+          <AboutAndUpdates onShowWhatsNew={onShowWhatsNew} />
         </div>
 
         <div className="flex flex-col gap-5">
@@ -517,129 +605,35 @@ export function SettingsTab({
               <p className="text-xs text-muted-foreground">{REMOTE_CONTROL_OFF_HINT}</p>
             )}
           </PanelSection>
-        </div>
-      </ConfigGrid>
-
-      {/* Lower region: the four short cards stack in one column beside the tall
-        Shortcuts card, so the columns read as balanced. */}
-      <ConfigGrid>
-        <div className="flex flex-col gap-5">
           <PanelSection
-            description="How Videorc looks and behaves on this device."
-            icon={ThemeIcon}
-            title="Appearance & behavior"
+            description="Every keyboard shortcut in Videorc."
+            icon={KeyboardIcon}
+            title="Shortcuts"
           >
-            <FieldGroup>
-              <Field>
-                <FieldLabel>Theme</FieldLabel>
-                <ToggleGroup
-                  type="single"
-                  value={theme ?? 'system'}
-                  variant="outline"
-                  onValueChange={(value) => value && setTheme(value)}
-                >
-                  <ToggleGroupItem value="light">Light</ToggleGroupItem>
-                  <ToggleGroupItem value="dark">Dark</ToggleGroupItem>
-                  <ToggleGroupItem value="system">System</ToggleGroupItem>
-                </ToggleGroup>
-              </Field>
-              {runtimeInfo?.platform === 'win32' ? (
-                <Field>
-                  <div className="flex items-center justify-between gap-3">
-                    <FieldLabel>Graphics acceleration</FieldLabel>
-                    <StatusBadge
-                      tone={runtimeInfo.hardwareAccelerationDisabled ? 'warn' : 'good'}
-                      value={gpuRenderingLabel(runtimeInfo)}
-                    />
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {graphicsAccelerationDescription(runtimeInfo)}
-                  </p>
-                  {runtimeInfo.hardwareAccelerationDisabled &&
-                  runtimeInfo.gpuFallback.source !== 'env' ? (
-                    <Button
-                      className="w-fit"
-                      disabled={runtimeInfo.gpuFallback.retryScheduled}
-                      size="sm"
-                      variant="outline"
-                      onClick={() => void scheduleHardwareAccelerationRetry()}
+            <div className="flex flex-col gap-3">
+              {[...shortcutsByGroup().entries()].map(([group, entries]) => (
+                <div key={group} className="flex flex-col gap-1">
+                  <span className="text-[12.5px] leading-none font-medium text-subtle">
+                    {group}
+                  </span>
+                  {entries.map((entry) => (
+                    <div
+                      key={entry.id}
+                      className="flex items-center gap-3 rounded-row px-2.5 py-1.5 text-sm"
                     >
-                      <RefreshIcon data-icon="inline-start" />
-                      {runtimeInfo.gpuFallback.retryScheduled
-                        ? 'Retry scheduled'
-                        : 'Retry on next launch'}
-                    </Button>
-                  ) : null}
-                </Field>
-              ) : null}
-            </FieldGroup>
-          </PanelSection>
-
-          <PanelSection
-            description="Coming from OBS Studio? Bring your scenes and settings across."
-            icon={DownloadIcon}
-            title="Import"
-          >
-            {/* O4 (OBS import plan): the wizard previews the truthful
-                imported/approximated/skipped report BEFORE anything applies. */}
-            <div>
-              <Button size="sm" variant="outline" onClick={() => setObsImportOpen(true)}>
-                <DownloadIcon data-icon="inline-start" />
-                Import from OBS…
-              </Button>
-            </div>
-            <ObsImportDialog open={obsImportOpen} onOpenChange={setObsImportOpen} />
-          </PanelSection>
-
-          <PanelSection description="Get help or report a problem." icon={BugIcon} title="Support">
-            <div className="flex flex-col gap-2">
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  disabled={supportBundleExportPending}
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void exportSupportBundle()}
-                >
-                  <BugIcon data-icon="inline-start" />
-                  {supportBundleExportPending ? 'Exporting\u2026' : 'Export support bundle'}
-                </Button>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Reporting a problem? Export a support bundle (redacted logs + diagnostics) to share
-                with us.
-              </p>
+                      <span className="flex-1 truncate text-muted-foreground">{entry.label}</span>
+                      <KbdGroup>
+                        {displayKeyGlyphs(entry.keys, runtimeInfo?.platform).map((key, index) => (
+                          <Kbd key={`${entry.id}-${index}`}>{key}</Kbd>
+                        ))}
+                      </KbdGroup>
+                    </div>
+                  ))}
+                </div>
+              ))}
             </div>
           </PanelSection>
-
-          <AboutAndUpdates onShowWhatsNew={onShowWhatsNew} />
         </div>
-
-        <PanelSection
-          description="Every keyboard shortcut in Videorc."
-          icon={KeyboardIcon}
-          title="Shortcuts"
-        >
-          <div className="flex flex-col gap-3">
-            {[...shortcutsByGroup().entries()].map(([group, entries]) => (
-              <div key={group} className="flex flex-col gap-1">
-                <span className="text-[12.5px] leading-none font-medium text-subtle">{group}</span>
-                {entries.map((entry) => (
-                  <div
-                    key={entry.id}
-                    className="flex items-center gap-3 rounded-row px-2.5 py-1.5 text-sm"
-                  >
-                    <span className="flex-1 truncate text-muted-foreground">{entry.label}</span>
-                    <KbdGroup>
-                      {displayKeyGlyphs(entry.keys, runtimeInfo?.platform).map((key, index) => (
-                        <Kbd key={`${entry.id}-${index}`}>{key}</Kbd>
-                      ))}
-                    </KbdGroup>
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
-        </PanelSection>
       </ConfigGrid>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/ui/scroll-area.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/scroll-area.tsx
@@ -37,14 +37,17 @@ function ScrollBar({
       data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        'flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent',
+        // No track and no edge hairline: the gutter is invisible and only the
+        // thumb reads. Matches the native scrollbar rules in styles.css so the
+        // two populations cannot drift apart.
+        'flex touch-none select-none bg-transparent p-[3px] transition-colors data-horizontal:h-2.5 data-horizontal:flex-col data-vertical:h-full data-vertical:w-2.5',
         className
       )}
       {...props}
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="relative flex-1 rounded-full bg-border"
+        className="relative flex-1 rounded-full bg-[var(--scrollbar-thumb)] shadow-[inset_0_0_0_1px_var(--scrollbar-thumb-ring)] transition-colors hover:bg-[var(--scrollbar-thumb-hover)]"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )

--- a/apps/desktop/src/renderer/src/hooks/studio-mic-visual-provider.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-mic-visual-provider.test.ts
@@ -2,13 +2,9 @@ import { StrictMode, act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// Existing lifecycle cases run with idle monitoring ON so the gate is not
-// what they exercise; the gate cases below flip these explicitly.
 const providerState = vi.hoisted(() => ({
   microphoneMuted: false,
-  sessionActive: false,
-  monitorWhenIdle: true,
-  setSettingsCalls: 0
+  sessionActive: false
 }))
 
 vi.mock('@/hooks/use-document-visible', () => ({ useDocumentVisible: () => true }))
@@ -17,20 +13,7 @@ vi.mock('@/hooks/use-studio', () => ({
     captureConfig: { audio: { microphoneMuted: providerState.microphoneMuted } },
     mediaAccess: { microphone: 'granted' },
     selectedMicrophone: { id: 'backend-mic-1', name: 'Studio microphone' },
-    isSessionActive: providerState.sessionActive,
-    settings: { audioMixer: { monitorWhenIdle: providerState.monitorWhenIdle } },
-    setSettings: (
-      update:
-        | { audioMixer?: { monitorWhenIdle?: boolean } }
-        | ((current: { audioMixer?: { monitorWhenIdle?: boolean } }) => {
-            audioMixer?: { monitorWhenIdle?: boolean }
-          })
-    ) => {
-      providerState.setSettingsCalls += 1
-      const current = { audioMixer: { monitorWhenIdle: providerState.monitorWhenIdle } }
-      const next = typeof update === 'function' ? update(current) : update
-      providerState.monitorWhenIdle = next.audioMixer?.monitorWhenIdle === true
-    }
+    isSessionActive: providerState.sessionActive
   })
 }))
 
@@ -64,23 +47,20 @@ describe('StudioMicVisualProvider', () => {
     restoreEnvironment = undefined
     providerState.microphoneMuted = false
     providerState.sessionActive = false
-    providerState.monitorWhenIdle = true
-    providerState.setSettingsCalls = 0
   })
 
-  it('keeps the microphone closed while idle and arms it for a session automatically', async () => {
+  it('meters an idle mixer and releases the microphone when the mixer leaves', async () => {
     const environment = installBrowserAudioEnvironment()
     restoreEnvironment = environment.restore
     const lifecycleStates: boolean[] = []
-    providerState.monitorWhenIdle = false
-    const renderProvider = async (): Promise<void> => {
+    const renderProvider = async (enabled: boolean): Promise<void> => {
       await act(async () => {
         root?.render(
           createElement(
             StrictMode,
             null,
             createElement(StudioMicVisualProvider, {
-              enabled: true,
+              enabled,
               children: createElement(VisualConsumer, {
                 onLifecycle: (active) => lifecycleStates.push(active)
               })
@@ -92,89 +72,23 @@ describe('StudioMicVisualProvider', () => {
       })
     }
 
-    // Idle Studio, monitoring off: no getUserMedia, no AudioContext, no clock —
-    // the OS shows no mic indicator and the bars sit at floor.
+    // No session, nothing armed, no toggle: the meter runs because the mixer
+    // is on screen. "Is my microphone working?" is asked BEFORE recording, and
+    // bars pinned at the floor cannot answer it.
     root = createRoot(environment.container)
-    await renderProvider()
-    await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-    })
-    expect(environment.getUserMedia).not.toHaveBeenCalled()
-    expect(environment.contexts).toHaveLength(0)
-    expect(environment.scheduledFrames.size).toBe(0)
-    expect(lifecycleStates.at(-1)).toBe(false)
-
-    // A session starts (recording or streaming): the meter arms itself.
-    providerState.sessionActive = true
-    await renderProvider()
+    await renderProvider(true)
     await vi.waitFor(() => expect(environment.contexts).toHaveLength(1))
     expect(environment.getUserMedia).toHaveBeenCalledTimes(1)
     expect(environment.scheduledFrames.size).toBe(1)
     expect(lifecycleStates.at(-1)).toBe(true)
 
-    // Session ends with monitoring still off: the microphone is released.
-    providerState.sessionActive = false
-    await renderProvider()
+    // The workspace moves elsewhere: the microphone is released immediately —
+    // it is genuinely open while metering, so leaving must close it.
+    await renderProvider(false)
     await vi.waitFor(() => expect(environment.contexts[0].close).toHaveBeenCalledTimes(1))
     expect(environment.stopTrack).toHaveBeenCalledTimes(1)
     expect(environment.scheduledFrames.size).toBe(0)
     expect(lifecycleStates.at(-1)).toBe(false)
-
-    // Monitor input on (the M shortcut flips the persisted setting): idle
-    // monitoring opens the analyser again.
-    environment.pressKey('m')
-    expect(providerState.setSettingsCalls).toBe(1)
-    expect(providerState.monitorWhenIdle).toBe(true)
-    await renderProvider()
-    await vi.waitFor(() => expect(environment.contexts).toHaveLength(2))
-    expect(environment.getUserMedia).toHaveBeenCalledTimes(2)
-    expect(lifecycleStates.at(-1)).toBe(true)
-  })
-
-  it('ignores the M shortcut while a session runs and inside editable fields', async () => {
-    const environment = installBrowserAudioEnvironment()
-    restoreEnvironment = environment.restore
-    providerState.monitorWhenIdle = false
-    providerState.sessionActive = true
-    root = createRoot(environment.container)
-    await act(async () => {
-      root?.render(
-        createElement(
-          StrictMode,
-          null,
-          createElement(StudioMicVisualProvider, {
-            enabled: true,
-            children: createElement(LifecycleObserver)
-          })
-        )
-      )
-      await Promise.resolve()
-    })
-    environment.pressKey('m')
-    expect(providerState.setSettingsCalls).toBe(0)
-
-    providerState.sessionActive = false
-    await act(async () => {
-      root?.render(
-        createElement(
-          StrictMode,
-          null,
-          createElement(StudioMicVisualProvider, {
-            enabled: true,
-            children: createElement(LifecycleObserver)
-          })
-        )
-      )
-      await Promise.resolve()
-    })
-    environment.pressKey('m', { editable: true })
-    environment.pressKey('m', { metaKey: true })
-    environment.pressKey('m', { repeat: true })
-    expect(providerState.setSettingsCalls).toBe(0)
-    environment.pressKey('M')
-    expect(providerState.setSettingsCalls).toBe(1)
-    expect(providerState.monitorWhenIdle).toBe(true)
   })
 
   it('tears down visual microphone resources and stops reporting live when muted', async () => {

--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -4260,11 +4260,11 @@ describe('real StudioProvider lifecycle', () => {
     expect(await api.getPendingOAuthCallbacks()).toEqual(pendingProviderCallbacks)
   })
 
-  it('arms the visual mic meter for a session and never opens the mic while idle', async () => {
-    // Live feedback batch 3, B2: the owner saw the mixer react while not
-    // recording. With Monitor input at its default (off), an idle Studio must
-    // not touch getUserMedia; starting a session arms the analyser by itself;
-    // stopping releases it again.
+  it('meters the mic on a real idle Studio and keeps it open across a session', async () => {
+    // The meter is armed by the mixer being on screen, not by a session: the
+    // question it answers ("is my microphone working?") is asked before
+    // recording starts. B2 previously kept it closed while idle; that made an
+    // idle meter indistinguishable from a dead microphone.
     const backend = new StudioBackend()
     TestWebSocket.backend = backend
     vi.stubGlobal('WebSocket', TestWebSocket)
@@ -4326,16 +4326,17 @@ describe('real StudioProvider lifecycle', () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
     })
     expect(latest()?.core.isSessionActive).toBe(false)
-    expect(latest()?.core.settings.audioMixer?.monitorWhenIdle).toBe(false)
-    expect(audio.getUserMedia).not.toHaveBeenCalled()
-    expect(audio.contexts).toHaveLength(0)
-    expect(micLifecycle.at(-1)).toBe(false)
+    // Idle, with no toggle flipped: the analyser is already running.
+    await waitForObservation(() => micLifecycle.at(-1) === true)
+    expect(audio.getUserMedia).toHaveBeenCalledTimes(1)
+    expect(audio.contexts).toHaveLength(1)
 
     await act(async () => {
       await latest()?.core.startSession()
     })
     await waitForObservation(() => latest()?.recording.recording.state === 'recording')
-    await waitForObservation(() => micLifecycle.at(-1) === true)
+    expect(micLifecycle.at(-1)).toBe(true)
+    // Starting a session must REUSE the open stream, not open a second one.
     expect(audio.getUserMedia).toHaveBeenCalledTimes(1)
     expect(audio.getUserMedia.mock.calls[0]?.[0]).toMatchObject({
       audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
@@ -4347,9 +4348,10 @@ describe('real StudioProvider lifecycle', () => {
       await latest()?.core.stopSession()
     })
     await waitForObservation(() => latest()?.recording.recording.state === 'idle')
-    await waitForObservation(() => micLifecycle.at(-1) === false)
-    expect(audio.contexts[0]?.close).toHaveBeenCalledTimes(1)
-    expect(audio.stopTrack).toHaveBeenCalledTimes(1)
+    // Stopping the session leaves the meter running: the mixer is still on
+    // screen, and the user is still entitled to see their level.
+    expect(micLifecycle.at(-1)).toBe(true)
+    expect(audio.contexts[0]?.close).not.toHaveBeenCalled()
     expect(audio.getUserMedia).toHaveBeenCalledTimes(1)
   }, 15_000)
 })

--- a/apps/desktop/src/renderer/src/hooks/use-studio-mic-visual.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio-mic-visual.tsx
@@ -11,12 +11,7 @@ import {
 
 import { useDocumentVisible } from '@/hooks/use-document-visible'
 import { useStudioCore } from '@/hooks/use-studio'
-import { isEditableTarget } from '@/lib/format'
-import {
-  audioMixerMonitorWhenIdle,
-  micVisualAnalyserEnabled,
-  withAudioMixerMonitorWhenIdle
-} from '@/lib/mic-visual-gate'
+import { micVisualAnalyserEnabled } from '@/lib/mic-visual-gate'
 import { createMicVisualFrameBuffer, type MicVisualFrameBuffer } from '@/lib/mic-visual-frame'
 import type {
   MicVisualLifecycleSnapshot,
@@ -26,8 +21,6 @@ import type {
 
 const StudioMicVisualContext = createContext<MicVisualPipeline | undefined>(undefined)
 const PEAK_LABEL_INTERVAL_MS = 250
-/** Single-key toggle for "Monitor input" (SHORTCUTS id `mic-monitor`). */
-const MONITOR_INPUT_KEY = 'm'
 const IDLE_LIFECYCLE: MicVisualLifecycleSnapshot = Object.freeze({
   status: 'idle',
   active: false
@@ -60,10 +53,9 @@ const IDLE_PIPELINE: MicVisualPipeline = Object.freeze({
 /**
  * Workspace-scoped owner for renderer microphone visuals. The backend remains
  * the recording/health authority; this provider opens one visual-only browser
- * stream only while Studio/Sources is visible, OS access is already granted,
- * and the meter is armed — by a running session, or by the persisted
- * "Monitor input" setting while idle (micVisualAnalyserEnabled). An idle
- * Studio with monitoring off never opens the microphone.
+ * stream whenever Studio/Sources is visible with OS access granted and an
+ * unmuted microphone selected — session or not, so the meter can answer "is
+ * my microphone working?" before anything is recorded.
  */
 export function StudioMicVisualProvider({
   enabled,
@@ -72,8 +64,7 @@ export function StudioMicVisualProvider({
   enabled: boolean
   children: ReactNode
 }): ReactElement {
-  const { captureConfig, selectedMicrophone, mediaAccess, isSessionActive, settings, setSettings } =
-    useStudioCore()
+  const { captureConfig, selectedMicrophone, mediaAccess, isSessionActive } = useStudioCore()
   const documentVisible = useDocumentVisible()
   const [pipeline, setPipeline] = useState<MicVisualPipeline | null>(null)
   const selectionKey = selectedMicrophone?.id
@@ -88,12 +79,9 @@ export function StudioMicVisualProvider({
       documentVisible,
       microphoneSelected: Boolean(selectionKey),
       muted: captureConfig.audio.microphoneMuted,
-      sessionActive: isSessionActive,
-      monitorWhenIdle: audioMixerMonitorWhenIdle(settings)
+      sessionActive: isSessionActive
     })
   }
-  useMonitorInputShortcut(enabled && Boolean(selectionKey) && !isSessionActive, setSettings)
-
   useEffect(() => {
     if (pipeline || !source.enabled) {
       return
@@ -119,37 +107,6 @@ export function StudioMicVisualProvider({
       {children}
     </MicVisualPipelineProvider>
   )
-}
-
-/**
- * M toggles "Monitor input" while Studio/Sources is on screen and no session
- * runs (plain key, outside editable targets — same discipline as the D theme
- * toggle and the Space session toggle). One home for both tabs; the mixer's
- * switch and the picker's hint are the pointer surfaces of the same setting.
- */
-function useMonitorInputShortcut(
-  armed: boolean,
-  setSettings: ReturnType<typeof useStudioCore>['setSettings']
-): void {
-  useEffect(() => {
-    if (!armed) {
-      return
-    }
-    const onKeyDown = (event: KeyboardEvent): void => {
-      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
-        return
-      }
-      if (event.key.toLowerCase() !== MONITOR_INPUT_KEY || isEditableTarget(event.target)) {
-        return
-      }
-      event.preventDefault()
-      setSettings((current) =>
-        withAudioMixerMonitorWhenIdle(current, !audioMixerMonitorWhenIdle(current))
-      )
-    }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [armed, setSettings])
 }
 
 /** Public provider boundary used by the workspace and lifecycle integration tests. */

--- a/apps/desktop/src/renderer/src/lib/camera-format-shortfall.ts
+++ b/apps/desktop/src/renderer/src/lib/camera-format-shortfall.ts
@@ -100,5 +100,9 @@ export function cameraFormatShortfallMessage(shortfall: CameraFormatShortfall): 
   if (shortfall.fpsUnmet) {
     return `This camera's closest format is ${selected} — below the requested ${shortfall.requestedFps} fps. Recording will run at ${Math.round(shortfall.selectedMaxFps)} fps.`
   }
-  return `This camera's closest format is ${selected}, below the requested ${shortfall.requestedWidth}×${shortfall.requestedHeight}.`
+  // Name the consequence, not just the mismatch: a resolution shortfall means
+  // every frame is enlarged to fill the canvas, which is what the user
+  // actually sees. Saying only "below the requested 3840×2160" left people
+  // believing they were recording 4K because the OUTPUT is 4K.
+  return `This camera's closest format is ${selected}, so the image is upscaled to fill the ${shortfall.requestedWidth}×${shortfall.requestedHeight} canvas.`
 }

--- a/apps/desktop/src/renderer/src/lib/mic-visual-gate.test.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-visual-gate.test.ts
@@ -1,11 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-import { STORAGE_KEYS, defaultSettings, loadJson } from './capture'
 import {
   audioMixerMonitorLabel,
-  audioMixerMonitorWhenIdle,
   micVisualAnalyserEnabled,
-  withAudioMixerMonitorWhenIdle,
   type MicVisualGateInput
 } from './mic-visual-gate'
 
@@ -14,22 +11,18 @@ const ON_SCREEN: MicVisualGateInput = {
   documentVisible: true,
   microphoneSelected: true,
   muted: false,
-  sessionActive: false,
-  monitorWhenIdle: false
+  sessionActive: false
 }
 
 describe('micVisualAnalyserEnabled', () => {
-  it('keeps the microphone closed in an idle Studio with monitoring off', () => {
-    // The owner's complaint: bars reacting while not recording. Default OFF.
-    expect(micVisualAnalyserEnabled(ON_SCREEN)).toBe(false)
+  it('meters an idle mixer, because that is when people check the microphone', () => {
+    // This used to be false until a session started or a toggle was flipped,
+    // so the bars sat at the floor and looked identical to a dead microphone.
+    expect(micVisualAnalyserEnabled(ON_SCREEN)).toBe(true)
   })
 
-  it('arms the analyser for the whole session without touching the toggle', () => {
+  it('meters a running session too', () => {
     expect(micVisualAnalyserEnabled({ ...ON_SCREEN, sessionActive: true })).toBe(true)
-  })
-
-  it('opens the analyser while idle only when the user asked to monitor input', () => {
-    expect(micVisualAnalyserEnabled({ ...ON_SCREEN, monitorWhenIdle: true })).toBe(true)
   })
 
   it.each<[string, Partial<MicVisualGateInput>]>([
@@ -37,9 +30,12 @@ describe('micVisualAnalyserEnabled', () => {
     ['the document is hidden', { documentVisible: false }],
     ['no microphone is selected', { microphoneSelected: false }],
     ['the microphone is muted', { muted: true }]
-  ])('stays closed when %s even if armed', (_label, overrides) => {
-    const armed = { ...ON_SCREEN, sessionActive: true, monitorWhenIdle: true }
-    expect(micVisualAnalyserEnabled({ ...armed, ...overrides })).toBe(false)
+  ])('stays closed when %s, session or not', (_label, overrides) => {
+    // The microphone is genuinely open while the meter runs, so every one of
+    // these must still close it — this is what keeps the OS indicator honest.
+    for (const sessionActive of [false, true]) {
+      expect(micVisualAnalyserEnabled({ ...ON_SCREEN, sessionActive, ...overrides })).toBe(false)
+    }
   })
 })
 
@@ -48,7 +44,7 @@ describe('audioMixerMonitorLabel', () => {
     expect(audioMixerMonitorLabel({ sessionActive: true, signalLive: true })).toBe('Live')
   })
 
-  it('says Monitoring for idle input monitoring that is actually delivering', () => {
+  it('says Monitoring for an idle meter that is actually delivering', () => {
     expect(audioMixerMonitorLabel({ sessionActive: false, signalLive: true })).toBe('Monitoring')
   })
 
@@ -56,39 +52,5 @@ describe('audioMixerMonitorLabel', () => {
     expect(audioMixerMonitorLabel({ sessionActive: false, signalLive: false })).toBe('Idle')
     // Muted mid-session: the path is not live, and the label must not claim it.
     expect(audioMixerMonitorLabel({ sessionActive: true, signalLive: false })).toBe('Idle')
-  })
-})
-
-describe('audioMixer.monitorWhenIdle persistence', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  it('defaults to off, including for settings persisted before the key existed', () => {
-    expect(audioMixerMonitorWhenIdle(defaultSettings)).toBe(false)
-    expect(audioMixerMonitorWhenIdle(undefined)).toBe(false)
-    expect(audioMixerMonitorWhenIdle({ audioMixer: {} })).toBe(false)
-    vi.stubGlobal('localStorage', {
-      getItem: () => JSON.stringify({ outputDirectory: '/tmp/out', keepOriginalRecording: true }),
-      setItem: vi.fn(),
-      removeItem: vi.fn()
-    })
-    expect(audioMixerMonitorWhenIdle(loadJson(STORAGE_KEYS.settings, defaultSettings))).toBe(false)
-  })
-
-  it('round-trips the toggle through the settings storage path', () => {
-    const updated = withAudioMixerMonitorWhenIdle(defaultSettings, true)
-    expect(updated).not.toBe(defaultSettings)
-    expect(defaultSettings.audioMixer?.monitorWhenIdle).toBe(false)
-
-    const stored = new Map<string, string>([[STORAGE_KEYS.settings, JSON.stringify(updated)]])
-    vi.stubGlobal('localStorage', {
-      getItem: (key: string) => stored.get(key) ?? null,
-      setItem: (key: string, value: string) => stored.set(key, value),
-      removeItem: (key: string) => stored.delete(key)
-    })
-    const reloaded = loadJson(STORAGE_KEYS.settings, defaultSettings)
-    expect(audioMixerMonitorWhenIdle(reloaded)).toBe(true)
-    expect(audioMixerMonitorWhenIdle(withAudioMixerMonitorWhenIdle(reloaded, false))).toBe(false)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/mic-visual-gate.ts
+++ b/apps/desktop/src/renderer/src/lib/mic-visual-gate.ts
@@ -4,8 +4,6 @@
 // whenever Studio/Sources was on screen. Now: a running session always arms
 // it; an idle Studio only with the explicit "Monitor input" setting.
 
-import type { SettingsState } from './capture'
-
 export type MicVisualGateInput = Readonly<{
   /** Studio or Sources tab is the active workspace tab. */
   workspaceVisible: boolean
@@ -17,30 +15,20 @@ export type MicVisualGateInput = Readonly<{
   muted: boolean
   /** Recording/streaming active OR a start/stop request in flight. */
   sessionActive: boolean
-  /** Persisted settings.audioMixer.monitorWhenIdle. */
-  monitorWhenIdle: boolean
 }>
 
-/** Persisted preference with its default (OFF) applied. */
-export function audioMixerMonitorWhenIdle(
-  settings: Pick<SettingsState, 'audioMixer'> | undefined
-): boolean {
-  return settings?.audioMixer?.monitorWhenIdle === true
-}
-
-/** Settings updater for the Monitor input toggle (keeps sibling mixer prefs). */
-export function withAudioMixerMonitorWhenIdle<T extends Pick<SettingsState, 'audioMixer'>>(
-  settings: T,
-  monitorWhenIdle: boolean
-): T {
-  return { ...settings, audioMixer: { ...settings.audioMixer, monitorWhenIdle } }
-}
-
 /**
- * Analyser demand: (session active OR monitor-when-idle) AND the visual is
- * actually on screen for an unmuted, selected microphone. Starting a session
- * arms the meter without touching the toggle; stopping it disarms unless the
- * user opted into idle monitoring.
+ * Analyser demand: the mixer is on screen, the document is visible, and a
+ * microphone is selected and unmuted. Session or not.
+ *
+ * This used to require a running session or the "Monitor input" toggle, so an
+ * idle Studio showed bars pinned at the floor — indistinguishable from a dead
+ * microphone, which is exactly what people check before they hit record. The
+ * meter is now live whenever it is being looked at.
+ *
+ * The cost is deliberate and visible: macOS shows its microphone indicator
+ * while the mixer is open, because the microphone genuinely is. Leaving the
+ * page or hiding the window releases it (the visibility inputs above).
  */
 export function micVisualAnalyserEnabled(input: MicVisualGateInput): boolean {
   if (!input.workspaceVisible || !input.documentVisible) {
@@ -49,7 +37,7 @@ export function micVisualAnalyserEnabled(input: MicVisualGateInput): boolean {
   if (!input.microphoneSelected || input.muted) {
     return false
   }
-  return input.sessionActive || input.monitorWhenIdle
+  return true
 }
 
 export type AudioMixerMonitorLabel = 'Live' | 'Monitoring' | 'Idle'

--- a/apps/desktop/src/renderer/src/lib/shortcuts.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcuts.ts
@@ -26,10 +26,6 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
   { id: 'search', keys: ['⌘', 'K'], label: 'Search & commands', group: 'Navigation' },
 
   { id: 'record-toggle', keys: ['␣'], label: 'Start / stop the session', group: 'Session' },
-  // Audio mixer (Studio): arms the visual-only mic analyser while no session
-  // runs. A running session always arms it.
-  { id: 'mic-monitor', keys: ['M'], label: 'Monitor mic input while idle', group: 'Session' },
-
   { id: 'preview-window', keys: ['⌘', 'P'], label: 'Open preview window', group: 'Windows' },
   { id: 'notes-window', keys: ['⌘', '⇧', 'N'], label: 'Open notes window', group: 'Windows' },
   { id: 'comments-window', keys: ['⌘', '⇧', 'J'], label: 'Open comments window', group: 'Windows' },

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -39,6 +39,15 @@
 :root {
   --radius: 0.625rem;
 
+  /* Scrollbars carry no track at all — only a thumb, and barely that. Glass
+     here means what it means everywhere else in this app: translucency plus a
+     hairline, never a real backdrop blur (unreachable in this Electron setup;
+     see the design language's wallpaper-underlay note). Light mode needs a
+     darker thumb to register on porcelain. */
+  --scrollbar-thumb: oklch(0 0 0 / 15%);
+  --scrollbar-thumb-hover: oklch(0 0 0 / 28%);
+  --scrollbar-thumb-ring: oklch(0 0 0 / 6%);
+
   /* White glass — the porcelain twin of the black-glass column below.
      White-over-bright reads solid at higher alphas — light mode needs a
      thinner coat than dark to show at all. */
@@ -125,6 +134,9 @@
 }
 
 .dark {
+  --scrollbar-thumb: oklch(1 0 0 / 12%);
+  --scrollbar-thumb-hover: oklch(1 0 0 / 22%);
+  --scrollbar-thumb-ring: oklch(1 0 0 / 8%);
   /* Black glass — the reference column, tuned to the logo's glossy black orb:
      a true-black base (L 0.13 — not #000, which kills the glass depth), chrome
      text, polished-edge hairlines one step brighter than the classic 8%.
@@ -330,6 +342,35 @@
   :focus-visible {
     @apply outline-2 outline-offset-2 outline-ring/70;
   }
+  /* No track, no arrows, no corner — just a thumb floating over the content.
+     The transparent border plus background-clip insets the painted thumb to
+     ~4px inside a 10px hit area: barely visible to look at, still easy to
+     grab. Applies to native overflow scrollers everywhere; the Radix
+     ScrollArea mirrors the same tokens in its own component. */
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+    background: transparent;
+  }
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-track-piece,
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-button {
+    display: none;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb);
+    border: 3px solid transparent;
+    background-clip: content-box;
+    border-radius: 999px;
+    box-shadow: inset 0 0 0 1px var(--scrollbar-thumb-ring);
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scrollbar-thumb-hover);
+  }
+
   /* Honour reduced-motion: collapse transitions/animations, keep behaviour. */
   @media (prefers-reduced-motion: reduce) {
     *,

--- a/crates/videorc-backend/src/camera_capture.rs
+++ b/crates/videorc-backend/src/camera_capture.rs
@@ -151,6 +151,10 @@ pub fn choose_camera_format(
         .iter()
         .filter(|format| format_supports_fps(format, target_fps))
         .collect::<Vec<_>>();
+    // Resolution first among the fps-capable formats: a format that covers the
+    // requested pixels keeps the image native, while a smaller one is upscaled
+    // for the rest of the session. The nearest covering format wins so a 4K ask
+    // does not grab an 8K sensor mode it does not need.
     let selected = fps_capable
         .iter()
         .copied()
@@ -207,8 +211,18 @@ pub fn normalize_camera_formats(mut formats: Vec<CameraFormatSummary>) -> Vec<Ca
     formats
 }
 
+/// Capture devices advertise the fractional NTSC rates (29.97, 59.94) that
+/// broadcast video actually uses, while sessions are configured in whole
+/// numbers. Without a tolerance an Elgato Cam Link 4K — whose 2160p format
+/// tops out at 29.97 — fails a 30 fps request by 0.03, is dropped from the
+/// fps-capable set, and loses to 1080p60: the camera then captures 1080p and
+/// the 4K session upscales it, with only a "closest format" warning to show
+/// for it. One frame of slack costs nothing and matches the renderer's own
+/// FPS_TOLERANCE in camera-format-shortfall.ts.
+const FPS_TOLERANCE: f64 = 1.0;
+
 fn format_supports_fps(format: &CameraFormatSummary, target_fps: f64) -> bool {
-    format.min_fps <= target_fps && format.max_fps >= target_fps
+    format.min_fps <= target_fps + FPS_TOLERANCE && format.max_fps >= target_fps - FPS_TOLERANCE
 }
 
 fn camera_format_pixels(format: &CameraFormatSummary) -> u64 {
@@ -860,6 +874,100 @@ mod tests {
         assert_eq!(choice.format.width, 3840);
         assert_eq!(choice.format.height, 2160);
         assert!(choice.fallback_reason.unwrap().contains("1-30 fps"));
+    }
+
+    /// The owner's Elgato Cam Link 4K, as macOS enumerates it: the 2160p mode
+    /// runs at the fractional NTSC rate, the 1080p modes go faster.
+    fn cam_link_4k_formats() -> Vec<CameraFormatSummary> {
+        vec![
+            CameraFormatSummary {
+                width: 3840,
+                height: 2160,
+                min_fps: 29.97,
+                max_fps: 29.97,
+            },
+            CameraFormatSummary {
+                width: 1920,
+                height: 1080,
+                min_fps: 59.94,
+                max_fps: 59.94,
+            },
+            CameraFormatSummary {
+                width: 1920,
+                height: 1080,
+                min_fps: 29.97,
+                max_fps: 29.97,
+            },
+            CameraFormatSummary {
+                width: 1280,
+                height: 720,
+                min_fps: 59.94,
+                max_fps: 59.94,
+            },
+        ]
+    }
+
+    #[test]
+    fn captures_4k_natively_when_the_camera_runs_at_the_fractional_ntsc_rate() {
+        // 29.97 is not 30, and demanding an exact match made a 4K30 session
+        // capture 1080p60 and upscale it — the camera's own 4K mode was
+        // discarded for being 0.03 fps short.
+        let choice = choose_camera_format(&cam_link_4k_formats(), 3840, 2160, 30).unwrap();
+
+        assert_eq!((choice.format.width, choice.format.height), (3840, 2160));
+        assert!(
+            choice.fallback_reason.is_none(),
+            "a native-resolution capture at the device's own rate is not a fallback: {:?}",
+            choice.fallback_reason
+        );
+    }
+
+    #[test]
+    fn still_reports_a_shortfall_when_the_camera_truly_cannot_reach_the_request() {
+        // 60 fps at 4K is genuinely beyond this device, so the warning the
+        // owner sees in that case is honest and must survive.
+        let choice = choose_camera_format(&cam_link_4k_formats(), 3840, 2160, 60).unwrap();
+
+        assert_eq!((choice.format.width, choice.format.height), (1920, 1080));
+        assert!(choice.fallback_reason.is_some());
+    }
+
+    #[test]
+    fn prefers_covering_resolution_over_a_faster_smaller_format() {
+        // Both satisfy 30 fps; only one keeps the image native for a 4K canvas.
+        let formats = vec![
+            CameraFormatSummary {
+                width: 1920,
+                height: 1080,
+                min_fps: 1.0,
+                max_fps: 120.0,
+            },
+            CameraFormatSummary {
+                width: 3840,
+                height: 2160,
+                min_fps: 1.0,
+                max_fps: 30.0,
+            },
+        ];
+
+        let choice = choose_camera_format(&formats, 3840, 2160, 30).unwrap();
+
+        assert_eq!((choice.format.width, choice.format.height), (3840, 2160));
+    }
+
+    #[test]
+    fn fps_tolerance_does_not_accept_a_format_that_is_a_whole_tier_short() {
+        // Tolerance is one frame, not a licence to call 30 fps "close to 60".
+        let formats = vec![CameraFormatSummary {
+            width: 1920,
+            height: 1080,
+            min_fps: 1.0,
+            max_fps: 30.0,
+        }];
+
+        let choice = choose_camera_format(&formats, 1920, 1080, 60).unwrap();
+
+        assert!(choice.fallback_reason.is_some());
     }
 
     #[test]


### PR DESCRIPTION
Five reported items. Each was traced to its mechanism before being changed —
and one of them turned out to be a recording-quality bug, not a cosmetic nit.

## 1. The circled dead space in Settings

The tab rendered **two stacked `ConfigGrid`s**. A grid row is as tall as its
tallest column, and the second grid cannot start until the first ends — so
whenever the right column (co-host + shortcuts + remote) outgrew the left
(storage + System access), the left column stopped early and a void stretched
down to "Appearance & behavior". Now **one grid with two independent stacks**,
which cannot reproduce it. A test pins the single grid so it cannot come back.

## 2. Scrollbars: no track, one faint glass thumb

There were two populations: 7 files on shadcn `ScrollArea` (the Publish look)
and **10 on native `overflow-y-auto`**, which painted Chromium's default track
— the background you wanted gone. Both now draw no track and one barely-there
thumb, inset inside its hit area (transparent border + `background-clip`) so it
reads as a sliver but stays easy to grab. Both populations read the same CSS
variables, so they cannot drift apart. Glass here means what it means
everywhere else in this app — translucency plus a hairline — since real
backdrop blur is unreachable in this Electron setup. The Notes window is a
data-URL document and can't inherit the stylesheet, so it carries the recipe
inline; the Comments window loads the renderer bundle and inherits it.

## 3. Co-host during a recording

The session panel showed the row for *any* active session. The co-host reads
**live chat**, which a recording doesn't have, so the row now requires
streaming. Checked the neighbours rather than assuming: the nudge already lives
in the Comments window (inherently live) and the engine is driven by
`LiveChatMessage`, so a record-only session can't tick it. Neither needed a gate.

## 4. The camera warning — it was true, and that's the problem

**Your Cam Link was being captured at 1920×1080 and upscaled into the 4K
canvas.** `choose_camera_format` demanded an exact fps match, and capture
devices advertise the fractional NTSC rates broadcast video actually uses: the
Cam Link 4K's 2160p mode runs at **29.97**, missed a 30 fps request by 0.03,
was dropped from the fps-capable set, and lost to 1080p60. So 4K sessions
captured 1080p and enlarged every frame — the warning was the only symptom.

Fixed with one frame of tolerance (matching the renderer's own `FPS_TOLERANCE`)
plus preferring formats that cover the requested resolution. Tested against the
device's real format matrix, including the case where the shortfall is genuine
(4K60) and the warning must survive. The message now names the consequence —
that the image is upscaled — instead of only the mismatch.

## 5. Idle mic meter

The analyser required a running session or the "Monitor input" toggle, so an
idle mixer showed bars at the floor — indistinguishable from a dead microphone,
which is exactly what people check *before* recording. It now runs whenever the
mixer is on screen and releases when the page or window is hidden. The toggle
and its `M` shortcut are removed rather than left inert.

**One deliberate trade you should know about:** batch-3 made idle metering
opt-in specifically so macOS wouldn't light its microphone indicator while you
weren't recording. With this change the indicator is lit whenever the mixer is
visible, because the microphone genuinely is open. That's the honest cost of
live idle meters, and it belongs in the changelog.

## Verification

typecheck · lint · format:check · desktop 1517 tests / 160 files · test:scripts
1094 · renderer build · `cargo test -p videorc-backend camera` (133) · clippy
`-D warnings` · `cargo fmt --check`.

**Not verified by me:** the visual result — settings spacing, scrollbar
appearance in both themes, and the Cam Link now reporting 3840×2160 with no
warning. The camera fix is proven by unit test against the real format matrix,
but only your device can confirm the image is actually sharper.
