### PR TITLE
fix: release the idle mic on minimise, Settings priority order, co-host teardown on every terminal path

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1653,6 +1653,31 @@ function createWindow(): void {
   // event ever reaching us (⌘Tab is exactly that).
   mainWindow.on('blur', () => publishShortcutModifier(false))
 
+  // The renderer cannot detect minimise/hide on its own: this window disables
+  // backgroundThrottling (and macOS occlusion backgrounding), which also
+  // freezes the Page Visibility API — document.visibilityState stays
+  // 'visible' and no visibilitychange fires. Anything that must release
+  // hardware when the window goes away (the microphone meter) depends on
+  // this signal, so publish it from the side that knows.
+  let lastPublishedWindowVisible: boolean | null = null
+  const publishWindowVisible = (visible: boolean): void => {
+    if (visible === lastPublishedWindowVisible) {
+      return
+    }
+    lastPublishedWindowVisible = visible
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      sendElectronEvent(mainWindow.webContents, 'window:visible', visible)
+    }
+  }
+  mainWindow.on('show', () => publishWindowVisible(true))
+  mainWindow.on('restore', () => publishWindowVisible(true))
+  mainWindow.on('maximize', () => publishWindowVisible(true))
+  mainWindow.on('hide', () => publishWindowVisible(false))
+  mainWindow.on('minimize', () => publishWindowVisible(false))
+  mainWindow.webContents.on('did-finish-load', () => {
+    publishWindowVisible(Boolean(mainWindow?.isVisible() && !mainWindow.isMinimized()))
+  })
+
   mainWindow.on('closed', () => {
     commentsCommandBroker.rejectAll()
     destroyNativePreviewSurface()

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -170,6 +170,7 @@ const api: VideorcApi = {
   onOAuthCallbackUrl: (callback) => subscribe('oauth:callback-url', callback),
   onShortcutNavigate: (callback) => subscribe('shortcut:navigate', callback),
   onShortcutModifier: (callback) => subscribe('shortcut:modifier', callback),
+  onWindowVisible: (callback) => subscribe('window:visible', callback),
   onBackendConnection: (callback) => subscribe('backend:connection', callback),
   onBackendLifecycle: (callback) => subscribe('backend:lifecycle', callback),
   onBackendLog: (callback) => subscribe('backend:log', callback),

--- a/apps/desktop/src/renderer/src/components/tabs/settings-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-layout.test.ts
@@ -21,12 +21,16 @@ function settingsColumns(): string[][] {
   )
   const columns: string[][] = []
   for (const chunk of region.split('<div className="flex flex-col gap-5">').slice(1)) {
+    // Component-rendered sections carry no title prop, so match them by tag —
+    // and in the order they actually appear, since the collapsed reading order
+    // is exactly this sequence.
     const titles: string[] = []
-    for (const match of chunk.matchAll(/title="([^"]+)"/g)) {
-      titles.push(match[1] as string)
-    }
-    if (chunk.includes('<CohostSettingsSection />')) {
-      titles.unshift('Co-host')
+    for (const match of chunk.matchAll(
+      /title="([^"]+)"|<(CohostSettingsSection|AboutAndUpdates)\b/g
+    )) {
+      if (match[1]) titles.push(match[1])
+      else if (match[2] === 'CohostSettingsSection') titles.push('Co-host')
+      else titles.push('About & updates')
     }
     columns.push(titles)
   }
@@ -51,9 +55,27 @@ describe('Settings layout', () => {
 
   it('splits the cards into two stacked, content-height columns', () => {
     expect(settingsColumns()).toEqual([
-      ['Recording & storage', 'System access', 'Appearance & behavior', 'Import', 'Support'],
-      ['Co-host', 'Global shortcuts', 'Remote control', 'Shortcuts']
+      ['Recording & storage', 'System access', 'Co-host', 'Global shortcuts', 'Remote control'],
+      ['Appearance & behavior', 'Import', 'Support', 'About & updates', 'Shortcuts']
     ])
+  })
+
+  it('collapses in priority order on a narrow window', () => {
+    // Below `lg` the grid is one column and the left stack is read before the
+    // right, so column order IS the reading order. The window can be resized
+    // to 960px (main/index.ts minWidth) — under Tailwind's 1024px lg — so this
+    // ships. The cards people open Settings for must come before preferences
+    // and the version card.
+    const [first, second] = settingsColumns()
+    const reading = [...(first ?? []), ...(second ?? [])]
+    expect(reading.slice(0, 5)).toEqual([
+      'Recording & storage',
+      'System access',
+      'Co-host',
+      'Global shortcuts',
+      'Remote control'
+    ])
+    expect(reading.indexOf('About & updates')).toBeGreaterThan(reading.indexOf('Remote control'))
   })
 
   it('never pins a Settings card to a fixed height', () => {

--- a/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/settings-tab.tsx
@@ -152,13 +152,17 @@ export function SettingsTab({
 
   return (
     <div className="flex flex-col gap-5">
-      {/* ONE grid, two continuous columns (was two stacked grids). A grid row is
-        as tall as its tallest column and the second grid could not start until the
-        first ended, so whenever the right column outgrew the left — the co-host
-        card is tall — the left column stopped early and a void stretched down to
-        the next grid. Two independent stacks cannot do that: each card sits at its
-        own content height with a uniform gap, and neither column waits for the
-        other. Below `lg` they collapse and read in priority order. */}
+      {/* ONE grid, two continuous columns. A grid row is as tall as its tallest
+        column and a second grid could not start until the first ended, so when
+        the taller column outgrew the other, the short one stopped early and a
+        void stretched down the page. Two independent stacks cannot do that.
+
+        Column order is the NARROW-WINDOW reading order: below `lg` the grid
+        collapses and the left stack is read before the right, so the left
+        carries the cards people come to Settings for (storage, permissions,
+        co-host, shortcuts, remote) and the right carries preferences and
+        reference. The window can be resized to 960px, under the `lg`
+        breakpoint, so this order ships. */}
       <ConfigGrid>
         <div className="flex flex-col gap-5">
           <PanelSection
@@ -411,97 +415,7 @@ export function SettingsTab({
               </p>
             </div>
           </PanelSection>
-          <PanelSection
-            description="How Videorc looks and behaves on this device."
-            icon={ThemeIcon}
-            title="Appearance & behavior"
-          >
-            <FieldGroup>
-              <Field>
-                <FieldLabel>Theme</FieldLabel>
-                <ToggleGroup
-                  type="single"
-                  value={theme ?? 'system'}
-                  variant="outline"
-                  onValueChange={(value) => value && setTheme(value)}
-                >
-                  <ToggleGroupItem value="light">Light</ToggleGroupItem>
-                  <ToggleGroupItem value="dark">Dark</ToggleGroupItem>
-                  <ToggleGroupItem value="system">System</ToggleGroupItem>
-                </ToggleGroup>
-              </Field>
-              {runtimeInfo?.platform === 'win32' ? (
-                <Field>
-                  <div className="flex items-center justify-between gap-3">
-                    <FieldLabel>Graphics acceleration</FieldLabel>
-                    <StatusBadge
-                      tone={runtimeInfo.hardwareAccelerationDisabled ? 'warn' : 'good'}
-                      value={gpuRenderingLabel(runtimeInfo)}
-                    />
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {graphicsAccelerationDescription(runtimeInfo)}
-                  </p>
-                  {runtimeInfo.hardwareAccelerationDisabled &&
-                  runtimeInfo.gpuFallback.source !== 'env' ? (
-                    <Button
-                      className="w-fit"
-                      disabled={runtimeInfo.gpuFallback.retryScheduled}
-                      size="sm"
-                      variant="outline"
-                      onClick={() => void scheduleHardwareAccelerationRetry()}
-                    >
-                      <RefreshIcon data-icon="inline-start" />
-                      {runtimeInfo.gpuFallback.retryScheduled
-                        ? 'Retry scheduled'
-                        : 'Retry on next launch'}
-                    </Button>
-                  ) : null}
-                </Field>
-              ) : null}
-            </FieldGroup>
-          </PanelSection>
 
-          <PanelSection
-            description="Coming from OBS Studio? Bring your scenes and settings across."
-            icon={DownloadIcon}
-            title="Import"
-          >
-            {/* O4 (OBS import plan): the wizard previews the truthful
-                imported/approximated/skipped report BEFORE anything applies. */}
-            <div>
-              <Button size="sm" variant="outline" onClick={() => setObsImportOpen(true)}>
-                <DownloadIcon data-icon="inline-start" />
-                Import from OBS…
-              </Button>
-            </div>
-            <ObsImportDialog open={obsImportOpen} onOpenChange={setObsImportOpen} />
-          </PanelSection>
-
-          <PanelSection description="Get help or report a problem." icon={BugIcon} title="Support">
-            <div className="flex flex-col gap-2">
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  disabled={supportBundleExportPending}
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void exportSupportBundle()}
-                >
-                  <BugIcon data-icon="inline-start" />
-                  {supportBundleExportPending ? 'Exporting\u2026' : 'Export support bundle'}
-                </Button>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Reporting a problem? Export a support bundle (redacted logs + diagnostics) to share
-                with us.
-              </p>
-            </div>
-          </PanelSection>
-
-          <AboutAndUpdates onShowWhatsNew={onShowWhatsNew} />
-        </div>
-
-        <div className="flex flex-col gap-5">
           <CohostSettingsSection />
 
           <PanelSection
@@ -605,6 +519,97 @@ export function SettingsTab({
               <p className="text-xs text-muted-foreground">{REMOTE_CONTROL_OFF_HINT}</p>
             )}
           </PanelSection>
+        </div>
+
+        <div className="flex flex-col gap-5">
+          <PanelSection
+            description="How Videorc looks and behaves on this device."
+            icon={ThemeIcon}
+            title="Appearance & behavior"
+          >
+            <FieldGroup>
+              <Field>
+                <FieldLabel>Theme</FieldLabel>
+                <ToggleGroup
+                  type="single"
+                  value={theme ?? 'system'}
+                  variant="outline"
+                  onValueChange={(value) => value && setTheme(value)}
+                >
+                  <ToggleGroupItem value="light">Light</ToggleGroupItem>
+                  <ToggleGroupItem value="dark">Dark</ToggleGroupItem>
+                  <ToggleGroupItem value="system">System</ToggleGroupItem>
+                </ToggleGroup>
+              </Field>
+              {runtimeInfo?.platform === 'win32' ? (
+                <Field>
+                  <div className="flex items-center justify-between gap-3">
+                    <FieldLabel>Graphics acceleration</FieldLabel>
+                    <StatusBadge
+                      tone={runtimeInfo.hardwareAccelerationDisabled ? 'warn' : 'good'}
+                      value={gpuRenderingLabel(runtimeInfo)}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {graphicsAccelerationDescription(runtimeInfo)}
+                  </p>
+                  {runtimeInfo.hardwareAccelerationDisabled &&
+                  runtimeInfo.gpuFallback.source !== 'env' ? (
+                    <Button
+                      className="w-fit"
+                      disabled={runtimeInfo.gpuFallback.retryScheduled}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void scheduleHardwareAccelerationRetry()}
+                    >
+                      <RefreshIcon data-icon="inline-start" />
+                      {runtimeInfo.gpuFallback.retryScheduled
+                        ? 'Retry scheduled'
+                        : 'Retry on next launch'}
+                    </Button>
+                  ) : null}
+                </Field>
+              ) : null}
+            </FieldGroup>
+          </PanelSection>
+
+          <PanelSection
+            description="Coming from OBS Studio? Bring your scenes and settings across."
+            icon={DownloadIcon}
+            title="Import"
+          >
+            {/* O4 (OBS import plan): the wizard previews the truthful
+                imported/approximated/skipped report BEFORE anything applies. */}
+            <div>
+              <Button size="sm" variant="outline" onClick={() => setObsImportOpen(true)}>
+                <DownloadIcon data-icon="inline-start" />
+                Import from OBS…
+              </Button>
+            </div>
+            <ObsImportDialog open={obsImportOpen} onOpenChange={setObsImportOpen} />
+          </PanelSection>
+
+          <PanelSection description="Get help or report a problem." icon={BugIcon} title="Support">
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  disabled={supportBundleExportPending}
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void exportSupportBundle()}
+                >
+                  <BugIcon data-icon="inline-start" />
+                  {supportBundleExportPending ? 'Exporting\u2026' : 'Export support bundle'}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Reporting a problem? Export a support bundle (redacted logs + diagnostics) to share
+                with us.
+              </p>
+            </div>
+          </PanelSection>
+
+          <AboutAndUpdates onShowWhatsNew={onShowWhatsNew} />
           <PanelSection
             description="Every keyboard shortcut in Videorc."
             icon={KeyboardIcon}

--- a/apps/desktop/src/renderer/src/hooks/document-visible.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/document-visible.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The main window disables Electron's `backgroundThrottling`, which also
+ * freezes the Page Visibility API: `document.visibilityState` stays 'visible'
+ * while the window is minimised or hidden and no `visibilitychange` fires.
+ * Anything that releases hardware when the window goes away therefore CANNOT
+ * be driven by the DOM alone — it needs main's `window:visible`.
+ *
+ * These pin the wiring that makes that true, because the failure mode is
+ * silent: the hook keeps returning `true` forever and the microphone simply
+ * never closes.
+ */
+describe('window visibility wiring', () => {
+  it('reads main’s window:visible signal, not just the DOM', async () => {
+    const source = await import('node:fs').then(({ readFileSync }) =>
+      readFileSync(new URL('./use-document-visible.ts', import.meta.url), 'utf8')
+    )
+    expect(source).toContain('onWindowVisible')
+    // Either source reporting hidden must hide: main knows about minimise,
+    // the DOM knows about aux windows and tests.
+    expect(source).toMatch(/documentVisible && windowVisible/)
+  })
+
+  it('has a main-process publisher for every way the window leaves the screen', async () => {
+    const main = await import('node:fs').then(({ readFileSync }) =>
+      readFileSync(new URL('../../../main/index.ts', import.meta.url), 'utf8')
+    )
+    for (const event of ['hide', 'minimize']) {
+      expect(main).toContain(`mainWindow.on('${event}', () => publishWindowVisible(false))`)
+    }
+    for (const event of ['show', 'restore']) {
+      expect(main).toContain(`mainWindow.on('${event}', () => publishWindowVisible(true))`)
+    }
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-document-visible.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-document-visible.ts
@@ -1,21 +1,38 @@
 import { useEffect, useState } from 'react'
 
 /**
- * Tracks document visibility so always-on visuals (mic meters, visualizers)
- * can release their streams and rAF loops while the window is hidden or
- * minimized — the idle-CPU discipline the native preview's frame-polling
- * suppression follows.
+ * Whether this window is actually on screen.
+ *
+ * NOT just `document.visibilityState`. The main window runs with Electron's
+ * `backgroundThrottling` disabled (and, on macOS, occlusion backgrounding
+ * switched off), and that option also freezes the Page Visibility API: the
+ * document reports `visible` while the window is minimised or hidden, and no
+ * `visibilitychange` ever fires. A hook that trusted the DOM alone was
+ * therefore a constant `true` in production — fine while it only throttled
+ * animation, dangerous once the microphone meter depended on it to release
+ * the device.
+ *
+ * Main publishes the truth on `window:visible`; the DOM signal stays as the
+ * fallback for contexts without the bridge (aux windows, tests), and either
+ * source reporting hidden hides.
  */
 export function useDocumentVisible(): boolean {
-  const [visible, setVisible] = useState(() => document.visibilityState !== 'hidden')
+  const [documentVisible, setDocumentVisible] = useState(
+    () => typeof document === 'undefined' || document.visibilityState !== 'hidden'
+  )
+  const [windowVisible, setWindowVisible] = useState(true)
 
   useEffect(() => {
     const update = (): void => {
-      setVisible(document.visibilityState !== 'hidden')
+      setDocumentVisible(document.visibilityState !== 'hidden')
     }
     document.addEventListener('visibilitychange', update)
-    return () => document.removeEventListener('visibilitychange', update)
+    const off = window.videorc?.onWindowVisible?.((visible) => setWindowVisible(visible))
+    return () => {
+      document.removeEventListener('visibilitychange', update)
+      off?.()
+    }
   }, [])
 
-  return visible
+  return documentVisible && windowVisible
 }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -3391,6 +3391,8 @@ export interface VideorcApi {
   onShortcutNavigate: (callback: (key: string) => void) => () => void
   /** Whether the command modifier is physically down; see main's before-input-event. */
   onShortcutModifier: (callback: (held: boolean) => void) => () => void
+  /** Whether the main window is on screen (minimise/hide aware, unlike the Page Visibility API here). */
+  onWindowVisible: (callback: (visible: boolean) => void) => () => void
   onBackendConnection: (callback: (connection: BackendConnection) => void) => () => void
   onBackendLifecycle: (callback: (event: BackendLifecycleEvent) => void) => () => void
   onBackendLog: (callback: (log: BackendLogEvent) => void) => () => void

--- a/apps/desktop/src/shared/electron-ipc-contract.ts
+++ b/apps/desktop/src/shared/electron-ipc-contract.ts
@@ -197,6 +197,7 @@ export interface ElectronIpcEventMap {
   'oauth:callback-url': OAuthCallbackEnvelope
   'shortcut:navigate': string
   'shortcut:modifier': boolean
+  'window:visible': boolean
   'global-shortcuts:triggered': GlobalShortcutAction
   'preview-surface:pump-mode': boolean
   'preview-surface:resync-scene': undefined
@@ -233,6 +234,7 @@ export const electronEventChannels = [
   'oauth:callback-url',
   'shortcut:navigate',
   'shortcut:modifier',
+  'window:visible',
   'global-shortcuts:triggered',
   'preview-surface:pump-mode',
   'preview-surface:resync-scene',
@@ -1057,6 +1059,11 @@ const specificRuntimeEventSchemas = {
   // that can know: it intercepts ⌘1–⌘9 in before-input-event, so the renderer
   // never receives those chords — nor, in practice, the keyup that ends them.
   'shortcut:modifier': booleanSchema,
+  // Whether the main window is actually on screen. The renderer cannot tell:
+  // the window runs with backgroundThrottling disabled, which also freezes the
+  // Page Visibility API, so document.visibilityState reads 'visible' even when
+  // the window is minimised or hidden.
+  'window:visible': booleanSchema,
   'global-shortcuts:triggered': enumSchema(['record-toggle', 'stream-toggle', 'mic-toggle']),
   'preview-surface:pump-mode': booleanSchema,
   'preview-surface:resync-scene': undefinedSchema,

--- a/crates/videorc-backend/src/live_chat.rs
+++ b/crates/videorc-backend/src/live_chat.rs
@@ -3129,6 +3129,35 @@ mod tests {
     }
 
     #[test]
+    fn stop_session_is_idempotent_so_both_terminal_paths_can_call_it() {
+        // Teardown now runs from BOTH the session.stop RPC and the monitor's
+        // terminal path (a capture that ends on its own must not leave the
+        // chat connector and co-host running). Whichever fires second must be
+        // a harmless no-op rather than corrupting state or bumping the
+        // generation into a live session.
+        let mut coordinator = LiveChatCoordinator::new(10);
+        coordinator.start_session(
+            "s1".to_string(),
+            vec![provider_row(StreamPlatform::Youtube)],
+        );
+
+        coordinator.stop_session();
+        let generation_after_first = coordinator.generation;
+        let session_after_first = coordinator.session_id.clone();
+
+        coordinator.stop_session();
+
+        assert_eq!(coordinator.session_id, session_after_first);
+        assert!(coordinator.session_id.is_none());
+        assert!(coordinator.senders.is_empty());
+        assert_eq!(
+            coordinator.generation,
+            generation_after_first.wrapping_add(1),
+            "a second stop only advances the guard generation; it must not resurrect a session"
+        );
+    }
+
+    #[test]
     fn stop_session_marks_providers_ended_and_keeps_transcript() {
         let mut coordinator = LiveChatCoordinator::new(10);
         coordinator.start_session(

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -6326,6 +6326,16 @@ async fn monitor_session(
         }
     };
     drop(finalizing_permit);
+    // Live chat and the co-host belong to the SESSION, not to the stop RPC.
+    // They used to be torn down only by `session.stop`, so a capture that
+    // ended on its own — an RTMP timeout, an encoder-bridge failure, FFmpeg
+    // exiting early: all shipped incidents in this repo — left the chat
+    // connector delivering messages and the co-host scheduler ticking against
+    // a session that no longer existed. It kept reading the user's chat and
+    // spending cloud-AI quota, and would carry straight through into the next
+    // record-only session. Terminal is terminal, whoever declared it.
+    crate::live_chat::stop_live_chat(&state).await;
+
     // The terminal event is the desktop updater/restart gate. Publish it only
     // after MP4 export, caption ownership, duration probing, metadata commit,
     // and post-recording maintenance scheduling are complete and the backend's


### PR DESCRIPTION
Three confirmed findings from an adversarial pre-release review of #289, each verified against running code.

**1. The idle microphone could never be released (privacy, high).** `useDocumentVisible` is a constant `true` in the main window: `backgroundThrottling` is disabled there, and that also freezes the Page Visibility API — the document reports 'visible' while minimised/hidden and no event fires. #289 made that inert gate the ONLY thing closing an always-on microphone, so minimising left the mic open with the macOS indicator lit. Main now publishes real visibility on `window:visible`; the hook takes the lower of that and the DOM signal. Two tests pin it because the failure is silent.

**2. Settings collapsed in the wrong order (medium).** The grid merge pushed Appearance/Import/Support/About ahead of Co-host/Global shortcuts/Remote control below `lg` (reachable — minWidth is 960), while the comment still claimed priority order. Columns re-ordered; the test now asserts the collapsed reading order, not just column contents.

**3. Co-host survived an abnormal session end (high, pre-existing — and #289 would have hidden it).** `stop_live_chat` ran only from the `session.stop` RPC, so a capture that ended on its own (RTMP timeout, encoder-bridge failure, early FFmpeg exit) left chat delivering and the co-host ticking — spending AI quota and carrying into the next record-only session. The monitor's terminal path now tears both down; `stop_session` is idempotent and a test pins that both paths may fire.

Gates: typecheck, lint, format, desktop 1520 tests / 161 files, renderer build, cargo tests, clippy -D warnings, cargo fmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window visibility is now tracked more accurately across minimize, hide, restore, maximize, and show actions.
  * Visibility-aware behavior now activates only when both the app window and document are visible.
  * Settings sections now follow a clearer layout and reading order on narrow windows.

* **Bug Fixes**
  * Live chat and co-host scheduling now stop reliably when recording ends unexpectedly.
  * Repeated live chat shutdowns are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->