### PR TITLE
release: 0.9.77-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.76",
+  "version": "0.9.77",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.77-beta.1.md
+++ b/changelog/0.9.77-beta.1.md
@@ -1,0 +1,44 @@
+---
+version: 0.9.77-beta.1
+date: 2026-08-25
+channel: beta
+platforms:
+  - macos
+title: Capture cards record at their real resolution again
+summary: If you record through a capture card like the Cam Link 4K, Videorc was quietly capturing 1080p and enlarging it to fill a 4K canvas — because the card runs at 29.97 frames per second and a 30 fps request rejected it by three hundredths of a frame. It now captures at the card's native resolution. Also in this release: the mic meter works before you hit record, the co-host stays out of recording-only sessions, scrollbars lost their heavy background, and the empty space in Settings is gone.
+highlights:
+  - Capture cards now record at their native resolution instead of a 1080p image stretched to fit — if you use a Cam Link or similar, your 4K recordings were soft and now are not.
+  - The microphone meter moves whenever the mixer is on screen, so you can check your mic is working before recording rather than guessing.
+  - The co-host no longer appears during a recording-only session — it reads live chat, which a recording does not have.
+  - Scrollbars are now just a faint rounded thumb with no track behind it, everywhere in the app.
+  - Settings no longer has a large blank gap in the middle of the page.
+---
+
+## Fixed
+
+- **Capture-card resolution.** The camera format chooser demanded an exact
+  frame-rate match, and capture devices advertise the fractional rates
+  broadcast video actually uses (29.97, 59.94). A Cam Link 4K's 2160p mode
+  missed a 30 fps request by 0.03, was discarded, and lost to 1080p60 — so 4K
+  sessions captured 1080p and upscaled every frame. The chooser now allows one
+  frame of tolerance and prefers formats that cover the requested resolution.
+  Where a shortfall is genuine, the warning now says the image is upscaled
+  rather than only naming the mismatch.
+- **Co-host in recordings.** The Studio session panel showed co-host status for
+  any active session; it now requires streaming.
+- **Co-host after an interrupted stream.** Live chat and the co-host were torn
+  down only when you pressed Stop. A stream that ended by itself left the chat
+  connector delivering and the co-host running — including through a later
+  recording. Every terminal path now tears them down.
+- **Settings layout.** The page was built from two stacked grids, so a short
+  column left a void that stretched to the next grid.
+
+## Changed
+
+- The microphone meter runs whenever the audio mixer is visible, not only
+  during a session, and the "Monitor input" toggle (and its M shortcut) is
+  gone — there is nothing left to arm. **Note:** macOS shows its microphone
+  indicator while the mixer is on screen, because the microphone genuinely is
+  open. It is released when you leave the page, or minimise or hide the window.
+- Scrollbars draw no track and a faint inset thumb, consistently across the
+  app and the Notes window.


### PR DESCRIPTION
Version bump + changelog for 0.9.77-beta.1: capture-card native resolution (#289), plus the mic-release, Settings order and co-host teardown fixes from the pre-release review (#290).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capture-card resolution selection with fractional frame-rate tolerance.
  * Prioritized native capture resolutions and added warnings when upscaling is required.
  * Made co-host visibility available in streaming-only mode.

* **Bug Fixes**
  * Improved co-host cleanup, microphone-meter availability, scrollbar styling, and Settings layout.
  * Removed the monitor-input toggle and shortcut.

* **Documentation**
  * Added the macOS beta changelog for version 0.9.77-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->