### PR TITLE
docs: 0.9.77 release record

### DIFF
--- a/docs/releases/0.9.77.md
+++ b/docs/releases/0.9.77.md
@@ -1,0 +1,97 @@
+# Videorc 0.9.77 Beta 1 (macOS)
+
+Capture cards record at their native resolution again, the mic meter works
+before you record, and three defects an adversarial pre-release review caught
+in the batch that shipped it.
+
+## Scope (PRs #289, #290, #291)
+
+### #289 — the five-point batch
+
+- **Capture-card resolution (the headline; not cosmetic).**
+  `choose_camera_format` required an exact fps match, and capture devices
+  advertise the fractional NTSC rates broadcast video actually uses. An Elgato
+  Cam Link 4K's 2160p mode runs at 29.97, missed a 30 fps request by 0.03, was
+  dropped from the fps-capable set, and lost to 1920x1080@60 — so 4K sessions
+  captured 1080p and upscaled every frame, with only a "closest format"
+  warning as the symptom. Now: ±1 fps tolerance (matching the renderer's own
+  `FPS_TOLERANCE`) and a preference for formats covering the requested
+  resolution. Tested against the device's real format matrix, including the
+  4K60 case where the shortfall is genuine and the warning must survive.
+- **Settings dead space.** Two stacked `ConfigGrid`s: a grid row is as tall as
+  its tallest column and the second could not start until the first ended, so
+  a short column left a void. Now one grid, two independent stacks.
+- **Scrollbars.** Two populations (7 shadcn `ScrollArea`, 10 native
+  `overflow-y-auto`) unified on one recipe from shared CSS variables: no
+  track, a faint inset thumb. The Notes window is a data-URL document and
+  carries the recipe inline.
+- **Co-host gating.** The session panel showed co-host status for any active
+  session; it now requires streaming.
+- **Idle mic meter.** The analyser runs whenever the mixer is visible; the
+  "Monitor input" toggle and its `M` shortcut are retired.
+
+### #290 — what the pre-release review found
+
+An adversarial review (five dimension reviewers, each finding attacked by a
+separate refuter) ran against merged `main` before the build. Three findings
+survived refutation, all verified against running code:
+
+1. **The idle microphone could never be released (privacy).** Making the meter
+   always-on left the visibility gate as the only thing closing the device —
+   and that gate cannot fire in this window. The main window disables
+   `backgroundThrottling` (and macOS occlusion backgrounding), which also
+   freezes the Page Visibility API: `document.visibilityState` reads `visible`
+   while minimised or hidden and no event arrives, so `useDocumentVisible` was
+   a constant `true` in production. Minimising left the mic open with the
+   macOS indicator lit. Main now publishes real visibility on
+   `window:visible`; the hook takes the lower of that and the DOM signal. Two
+   tests pin the wiring — the failure mode is silent.
+2. **Settings collapsed in the wrong order.** The merge pushed Appearance,
+   Import, Support and About ahead of Co-host, Global shortcuts and Remote
+   control below `lg` — reachable, since `minWidth` is 960 — while the code's
+   own comment still claimed priority order. Columns re-ordered; the test now
+   asserts the collapsed reading order, not just column contents.
+3. **Co-host survived an abnormal session end (pre-existing; #289 would have
+   hidden it).** `stop_live_chat` ran only from the `session.stop` RPC, so a
+   capture that ended by itself (RTMP timeout, encoder-bridge failure, early
+   FFmpeg exit) left the chat connector delivering and the co-host scheduler
+   ticking against a dead session — spending cloud-AI quota and carrying into
+   the next record-only session. Gating the row on `streamEnabled` would have
+   removed the only visible symptom, so this was fixed at the source: the
+   monitor's terminal path tears both down. `stop_session` is idempotent and a
+   test pins that both paths may now fire.
+
+## Ship record
+
+Built from the clean worktree checkout of `main` @ `0.9.77` bump. Signed with
+Developer ID Application: Uros Miric (C2PA37RB58), notarized and stapled,
+uploaded and verified 2026-08-25; feed serves 0.9.77 and the updater zip
+returns 206. R2 TLS issuer verified genuine (Google Trust Services) before
+upload. Discord announced.
+
+Gates on merged main before AND after the review fixes: typecheck, lint,
+format:check, desktop suite 1520 tests / 161 files, `test:scripts` 1094,
+renderer build, `cargo test -p videorc-backend` (camera 133, live_chat 53),
+`clippy -D warnings`, `cargo fmt --check`.
+
+## Known trade
+
+The macOS microphone indicator is lit whenever the audio mixer is on screen,
+because the microphone genuinely is open — that is the cost of a meter that
+answers "is my mic working?" before recording. It is released on leaving the
+page, minimising, or hiding the window (which is what finding 1 above
+restored). Batch-3 originally chose the opposite trade; this reverses it
+deliberately at the owner's request.
+
+## Still open
+
+- The 4K screen+camera source decay remains unconfirmed (see
+  `docs/releases/0.9.75.md`); owner acceptance recordings still outstanding.
+  Note this release fixes a DIFFERENT 4K defect — camera capture resolution —
+  which may or may not relate to how those recordings looked.
+- Visual verification of this release (settings spacing, scrollbars in both
+  themes, Cam Link reporting 3840x2160 with no warning) is owner-side.
+- The Nucleo glyph swap is blocked on the licensed export and the licence
+  question in `docs/icon-set.md`.
+- Windows is still on 0.9.72-alpha.1; the camera chooser fix is shared code
+  and will ship with the next Windows pilot.


### PR DESCRIPTION
Release record for 0.9.77-beta.1 (macOS): capture-card native resolution, the five-point batch, and the three pre-release review findings with their mechanisms.