### PR TITLE
fix(recording): survive FIFO pressure and microphone loss

### DIFF
--- a/apps/desktop/src/main/smoke-command-security.test.ts
+++ b/apps/desktop/src/main/smoke-command-security.test.ts
@@ -176,6 +176,7 @@ describe('smoke command security', () => {
   it('keeps the protected backend bridge on a small debug-only RPC allowlist', () => {
     expect(SMOKE_BACKEND_RPC_METHOD_NAMES).toEqual(
       new Set([
+        'audio.test.disconnect',
         'audio.test.inject-pcm',
         'captions.test.inject-audio',
         'captions.test.snapshot',
@@ -184,6 +185,17 @@ describe('smoke command security', () => {
         'recording.start_test'
       ])
     )
+    expect(
+      validateSmokeBackendRpcRequest({
+        method: 'audio.test.disconnect',
+        params: { sessionId: 'session-1' },
+        timeoutMs: 30_000
+      })
+    ).toEqual({
+      method: 'audio.test.disconnect',
+      params: { sessionId: 'session-1' },
+      timeoutMs: 30_000
+    })
     expect(
       validateSmokeBackendRpcRequest({
         method: 'captions.test.snapshot',

--- a/apps/desktop/src/main/smoke-command-security.ts
+++ b/apps/desktop/src/main/smoke-command-security.ts
@@ -113,6 +113,7 @@ export const SMOKE_COMMAND_NAMES = new Set([
  * from becoming a generic admin proxy.
  */
 export const SMOKE_BACKEND_RPC_METHOD_NAMES = new Set([
+  'audio.test.disconnect',
   'audio.test.inject-pcm',
   'captions.test.inject-audio',
   'captions.test.snapshot',

--- a/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-panel.tsx
@@ -14,11 +14,14 @@ import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
 
 import { CohostPresenceDot } from '@/components/cohost-status'
 import { PanelSection } from '@/components/panel-section'
+import { SessionRuntimeAlert } from '@/components/studio/session-runtime-alert'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Kbd } from '@/components/ui/kbd'
 import { useWorkspaceNav } from '@/components/workspace-nav'
 import { useStudioChat, useStudioCore, useStudioShell } from '@/hooks/use-studio'
 import { cohostPresenceView } from '@/lib/cohost-presence'
+import type { SessionRuntimeNotice } from '@/lib/session-runtime-notice'
 import type { SessionStartFailure } from '@/lib/session-start-failure'
 import { outputSummary, streamingSummary } from '@/lib/studio-session-view'
 
@@ -42,13 +45,15 @@ export function SessionPanel({
   blockedReason = null,
   blockedJump = null,
   startFailure = null,
+  runtimeNotice = null,
   canStop,
   stopLabel,
   onRecord,
   onLiveStream,
   onStop,
   onRetryStart,
-  onDismissStartFailure
+  onDismissStartFailure,
+  onDismissRuntimeNotice
 }: {
   active: boolean
   startRequestPending: boolean
@@ -65,6 +70,9 @@ export function SessionPanel({
   /** The last refused Record / Go Live (B0): stays under the controls until
    * the user starts again or dismisses it — a 4s toast was the only signal. */
   startFailure?: SessionStartFailure | null
+  /** Mid-session recording failure/degradation: persists until dismissed or
+   * the next session begins. */
+  runtimeNotice?: SessionRuntimeNotice | null
   canStop: boolean
   stopLabel: string
   onRecord: () => void
@@ -72,6 +80,7 @@ export function SessionPanel({
   onStop: () => void
   onRetryStart?: () => void
   onDismissStartFailure?: () => void
+  onDismissRuntimeNotice?: () => void
 }): ReactElement {
   const { captureConfig } = useStudioCore()
   const { openStudioPanel, setActive } = useWorkspaceNav()
@@ -157,41 +166,47 @@ export function SessionPanel({
             it is status, it persists, and it carries the backend's reason
             verbatim (the toast can be missed mid-stream; this line cannot). */}
         {!active && startFailure ? (
-          <div
-            className="flex items-start gap-1.5 text-xs"
-            data-testid="session-start-failure"
-            key={startFailure.at}
-            role="alert"
-          >
-            <AlertIcon className="mt-px size-3.5 shrink-0 text-destructive" weight="fill" />
-            <p
-              className="line-clamp-3 min-w-0 flex-1 text-destructive"
-              title={startFailure.message}
-            >
-              <span className="font-medium">Could not start.</span> {startFailure.message}
-            </p>
-            <span className="flex shrink-0 items-center gap-2">
-              {onRetryStart ? (
-                <button
-                  className="font-medium text-foreground underline-offset-2 hover:underline"
-                  disabled={startRequestPending}
-                  type="button"
-                  onClick={onRetryStart}
-                >
-                  Retry
-                </button>
-              ) : null}
-              {onDismissStartFailure ? (
-                <button
-                  className="text-muted-foreground underline-offset-2 hover:underline"
-                  type="button"
-                  onClick={onDismissStartFailure}
-                >
-                  Dismiss
-                </button>
-              ) : null}
-            </span>
-          </div>
+          <Alert data-testid="session-start-failure" key={startFailure.at} variant="destructive">
+            <AlertIcon weight="fill" />
+            <AlertTitle>Could not start.</AlertTitle>
+            <AlertDescription className="min-w-0">
+              <p className="line-clamp-3" title={startFailure.message}>
+                {startFailure.message}
+              </p>
+              <div className="flex flex-wrap gap-1 pt-2">
+                {onRetryStart ? (
+                  <Button
+                    disabled={startRequestPending}
+                    size="xs"
+                    type="button"
+                    variant="ghost"
+                    onClick={onRetryStart}
+                  >
+                    Retry
+                  </Button>
+                ) : null}
+                {onDismissStartFailure ? (
+                  <Button size="xs" type="button" variant="ghost" onClick={onDismissStartFailure}>
+                    Dismiss
+                  </Button>
+                ) : null}
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+        {runtimeNotice && onDismissRuntimeNotice ? (
+          <SessionRuntimeAlert
+            notice={runtimeNotice}
+            onDismiss={onDismissRuntimeNotice}
+            onOpenLibrary={() => setActive('library')}
+            onRevealOutput={
+              runtimeNotice.kind === 'recording-failed' &&
+              runtimeNotice.activity === 'recording' &&
+              runtimeNotice.sessionId
+                ? () => void window.videorc?.revealSession?.(runtimeNotice.sessionId!)
+                : undefined
+            }
+          />
         ) : null}
       </div>
 

--- a/apps/desktop/src/renderer/src/components/studio/session-runtime-alert.test.ts
+++ b/apps/desktop/src/renderer/src/components/studio/session-runtime-alert.test.ts
@@ -1,0 +1,125 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SessionRuntimeAlert } from './session-runtime-alert'
+
+describe('SessionRuntimeAlert', () => {
+  it('renders an unexpected recording failure with recovery and dismiss actions', () => {
+    const markup = renderToStaticMarkup(
+      createElement(SessionRuntimeAlert, {
+        notice: {
+          kind: 'recording-failed',
+          sessionId: 'session-failed',
+          outputPath: '/recordings/session-failed.mkv',
+          activity: 'recording',
+          message: 'Encoder FIFO write exceeded the delivery budget.',
+          at: 1
+        },
+        onDismiss: vi.fn(),
+        onOpenLibrary: vi.fn(),
+        onRevealOutput: vi.fn()
+      })
+    )
+
+    expect(markup).toContain('role="alert"')
+    expect(markup).toContain('data-testid="session-runtime-notice"')
+    expect(markup).toContain('Recording stopped unexpectedly')
+    expect(markup).toContain('Encoder FIFO write exceeded the delivery budget.')
+    expect(markup).toContain('Open Library')
+    expect(markup).toContain('Show in Finder')
+    expect(markup).toContain('Dismiss')
+  })
+
+  it('renders microphone loss as degraded without recovery-file actions', () => {
+    const markup = renderToStaticMarkup(
+      createElement(SessionRuntimeAlert, {
+        notice: {
+          kind: 'microphone-input-lost',
+          sessionId: 'session-with-silence',
+          activity: 'recording',
+          phase: 'active',
+          message: 'The selected microphone stopped providing audio.',
+          at: 2
+        },
+        onDismiss: vi.fn(),
+        onOpenLibrary: vi.fn(),
+        onRevealOutput: vi.fn()
+      })
+    )
+
+    expect(markup).toContain('Microphone stopped — recording continues with silence')
+    expect(markup).toContain('The selected microphone stopped providing audio.')
+    expect(markup).toContain('Dismiss')
+    expect(markup).not.toContain('Open Library')
+    expect(markup).not.toContain('Show in Finder')
+  })
+
+  it('uses live-session copy when stream-only output is active', () => {
+    const failureMarkup = renderToStaticMarkup(
+      createElement(SessionRuntimeAlert, {
+        notice: {
+          kind: 'recording-failed',
+          activity: 'live-stream',
+          message: 'The streaming encoder stopped.',
+          at: 3
+        },
+        onDismiss: vi.fn()
+      })
+    )
+    const microphoneMarkup = renderToStaticMarkup(
+      createElement(SessionRuntimeAlert, {
+        notice: {
+          kind: 'microphone-input-lost',
+          activity: 'live-stream',
+          phase: 'active',
+          message: 'The selected microphone stopped providing audio.',
+          at: 4
+        },
+        onDismiss: vi.fn()
+      })
+    )
+
+    expect(failureMarkup).toContain('Live session stopped unexpectedly')
+    expect(failureMarkup).not.toContain('Recording stopped unexpectedly')
+    expect(microphoneMarkup).toContain('Microphone stopped — live session continues with silence')
+    expect(microphoneMarkup).not.toContain('recording continues')
+    expect(failureMarkup).not.toContain('Open Library')
+  })
+
+  it('switches a persistent microphone warning to past tense after a take is saved', () => {
+    const markup = renderToStaticMarkup(
+      createElement(SessionRuntimeAlert, {
+        notice: {
+          kind: 'microphone-input-lost',
+          activity: 'recording',
+          phase: 'ended',
+          message: 'The selected microphone stopped providing audio.',
+          at: 5
+        },
+        onDismiss: vi.fn()
+      })
+    )
+
+    expect(markup).toContain('Microphone stopped — saved recording contains silence')
+    expect(markup).not.toContain('recording continues')
+  })
+
+  it('does not claim a stopping session is still actively recording', () => {
+    const markup = renderToStaticMarkup(
+      createElement(SessionRuntimeAlert, {
+        notice: {
+          kind: 'microphone-input-lost',
+          activity: 'recording',
+          phase: 'ending',
+          message: 'The selected microphone stopped providing audio.',
+          at: 6
+        },
+        onDismiss: vi.fn()
+      })
+    )
+
+    expect(markup).toContain('Microphone stopped — finishing recording with silence')
+    expect(markup).not.toContain('recording continues')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/studio/session-runtime-alert.tsx
+++ b/apps/desktop/src/renderer/src/components/studio/session-runtime-alert.tsx
@@ -1,0 +1,53 @@
+import { AlertIcon } from '@/components/icons'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { sessionRuntimeNoticeTitle, type SessionRuntimeNotice } from '@/lib/session-runtime-notice'
+import type { ReactElement } from 'react'
+
+export function SessionRuntimeAlert({
+  notice,
+  onDismiss,
+  onOpenLibrary,
+  onRevealOutput
+}: {
+  notice: SessionRuntimeNotice
+  onDismiss: () => void
+  onOpenLibrary?: () => void
+  onRevealOutput?: () => void
+}): ReactElement {
+  const recordingFailed = notice.kind === 'recording-failed'
+
+  return (
+    <Alert
+      data-testid="session-runtime-notice"
+      key={notice.at}
+      variant={recordingFailed ? 'destructive' : 'warning'}
+    >
+      <AlertIcon weight="fill" />
+      <AlertTitle>{sessionRuntimeNoticeTitle(notice)}</AlertTitle>
+      <AlertDescription className="min-w-0">
+        <p className="line-clamp-3" title={notice.message}>
+          {notice.message}
+        </p>
+        <div className="flex flex-wrap gap-1 pt-2">
+          {recordingFailed && notice.activity === 'recording' && onOpenLibrary ? (
+            <Button size="xs" type="button" variant="ghost" onClick={onOpenLibrary}>
+              Open Library
+            </Button>
+          ) : null}
+          {recordingFailed &&
+          notice.activity === 'recording' &&
+          notice.outputPath &&
+          onRevealOutput ? (
+            <Button size="xs" type="button" variant="ghost" onClick={onRevealOutput}>
+              Show in Finder
+            </Button>
+          ) : null}
+          <Button size="xs" type="button" variant="ghost" onClick={onDismiss}>
+            Dismiss
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/studio-tab.tsx
@@ -62,6 +62,8 @@ export function StudioTab(): ReactElement {
     resolveGoLiveBlocker,
     sessionStartFailure,
     dismissSessionStartFailure,
+    sessionRuntimeNotice,
+    dismissSessionRuntimeNotice,
     retrySessionStart
   } = studio
 
@@ -173,9 +175,11 @@ export function StudioTab(): ReactElement {
               liveStreamBlockedReason={liveStreamBlockedReason}
               recordBlockedReason={recordBlockedReason}
               startFailure={sessionStartFailure}
+              runtimeNotice={sessionRuntimeNotice}
               startRequestPending={startRequestPending}
               stopLabel={stopLabel}
               onDismissStartFailure={dismissSessionStartFailure}
+              onDismissRuntimeNotice={dismissSessionRuntimeNotice}
               onLiveStream={handleLiveStream}
               onRecord={handleRecord}
               onRetryStart={retrySessionStart}

--- a/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/studio-provider.integration.test.ts
@@ -28,6 +28,7 @@ import type {
   PreviewSurfaceBounds,
   PreviewSurfaceStatus,
   PreviewWindowState,
+  RecordingStatus,
   Scene,
   SessionLogEntry,
   SessionSummary,
@@ -271,7 +272,9 @@ class StudioBackend {
   currentLayout = defaultCaptureConfig.layout
   currentScene = sceneForLayout(this.currentLayout)
   revision = 1
-  recordingState: 'idle' | 'recording' = 'idle'
+  recordingState: RecordingStatus['state'] = 'idle'
+  recordingSessionId: string | undefined
+  recordingStatusOverride: RecordingStatus | undefined
   accountTransportFailuresRemaining = 0
   accountSignInSuperseded = false
   oauthTransportFailuresRemaining = 1
@@ -462,7 +465,14 @@ class StudioBackend {
         }
         return this.audioMeterResult
       case 'recording.status':
-        return { state: this.recordingState, message: 'Ready.' }
+        if (this.recordingStatusOverride) {
+          return this.recordingStatusOverride
+        }
+        return {
+          state: this.recordingState,
+          ...(this.recordingSessionId ? { sessionId: this.recordingSessionId } : {}),
+          message: 'Ready.'
+        }
       case 'stream.output.topology.probe':
         return {
           capabilityKey: `stream-output-topology-v1:${'0'.repeat(64)}`,
@@ -926,6 +936,837 @@ describe('real StudioProvider lifecycle', () => {
     vi.unstubAllGlobals()
     vi.clearAllMocks()
     vi.useRealTimers()
+  })
+
+  it('shows one persistent recovery error when an active recording fails', async () => {
+    const backend = new StudioBackend()
+    backend.recordingState = 'recording'
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    const revealSession = vi.fn(async () => {})
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      revealSession
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+    const libraryNavigations: unknown[] = []
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.recording.recording.state === 'recording'
+    )
+    window.addEventListener('videorc:navigate-workspace', (event) => {
+      libraryNavigations.push((event as CustomEvent).detail)
+    })
+    vi.clearAllMocks()
+
+    const encoderFailure: HealthEvent = {
+      id: 'health-encoder-failure',
+      sessionId: 'session-failed',
+      level: 'error',
+      code: 'encoder-bridge-failed',
+      message: 'The encoder bridge stopped before capture finalization.',
+      permissionPane: null,
+      createdAt: '2026-08-25T09:55:26.585Z'
+    }
+    const failedStatus = {
+      state: 'failed' as const,
+      sessionId: 'session-failed',
+      outputPath: 'C:\\recordings\\session-failed.mkv',
+      message: 'Encoder FIFO write exceeded the complete-frame delivery budget.'
+    }
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({ event: 'health.event', payload: encoderFailure })
+      })
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({ event: 'recording.status', payload: failedStatus })
+      })
+      // The backend can repeat both the terminal status and its correlated
+      // health event. They still represent one user-visible failure.
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({ event: 'health.event', payload: encoderFailure })
+      })
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({ event: 'recording.status', payload: failedStatus })
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'failed')
+
+    expect(toastSpies.error).toHaveBeenCalledTimes(1)
+    expect(toastSpies.error).toHaveBeenCalledWith(
+      'Recording stopped unexpectedly',
+      expect.objectContaining({
+        id: 'recording-stopped-unexpectedly',
+        description: failedStatus.message,
+        duration: Infinity,
+        action: expect.objectContaining({ label: 'Open Library' }),
+        cancel: expect.objectContaining({ label: 'Show in Finder' })
+      })
+    )
+    expect(toastSpies.success).not.toHaveBeenCalled()
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'recording-failed',
+      activity: 'recording',
+      sessionId: 'session-failed',
+      outputPath: failedStatus.outputPath,
+      message: failedStatus.message
+    })
+
+    const toastOptions = toastSpies.error.mock.calls[0]?.[1] as {
+      action: { onClick: () => void }
+      cancel: { onClick: () => void }
+    }
+    toastOptions.action.onClick()
+    toastOptions.cancel.onClick()
+    expect(libraryNavigations).toEqual([{ tab: 'library', sessionId: 'session-failed' }])
+    expect(revealSession).toHaveBeenCalledWith('session-failed')
+
+    await act(async () => latest()!.core.dismissSessionRuntimeNotice())
+    expect(latest()?.core.sessionRuntimeNotice).toBeNull()
+    expect(toastSpies.dismiss).toHaveBeenCalledWith('recording-stopped-unexpectedly')
+  })
+
+  it('recovers a recording failure missed during reconnect from durable session history', async () => {
+    const initialBackend = new StudioBackend()
+    initialBackend.recordingState = 'recording'
+    TestWebSocket.backend = initialBackend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let emit: ((name: string, value: unknown) => void) | undefined
+    const revealSession = vi.fn(async () => {})
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      revealSession,
+      registerEmitter: (nextEmit) => {
+        emit = nextEmit
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+    const libraryNavigations: unknown[] = []
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.recording.recording.state === 'recording'
+    )
+    await act(async () => {
+      initialBackend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'recording',
+            sessionId: 'session-failed-in-gap',
+            startedAt: now,
+            message: 'Recording.'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(
+      () => latest()?.recording.recording.sessionId === 'session-failed-in-gap'
+    )
+    window.addEventListener('videorc:navigate-workspace', (event) => {
+      libraryNavigations.push((event as CustomEvent).detail)
+    })
+    vi.clearAllMocks()
+
+    const failureEvent: HealthEvent = {
+      id: 'health-failure-in-gap',
+      sessionId: 'session-failed-in-gap',
+      level: 'error',
+      code: 'encoder-bridge-failed',
+      message: 'Encoder FIFO write exceeded the complete-frame delivery budget.',
+      permissionPane: null,
+      createdAt: '2026-08-25T11:00:00.000Z'
+    }
+    const reconnectedBackend = new StudioBackend()
+    reconnectedBackend.sessionSummaries = [
+      sessionSummary({
+        id: 'session-failed-in-gap',
+        status: 'failed',
+        mode: 'record',
+        outputPath: 'C:\\recordings\\session-failed-in-gap.mkv',
+        healthEventCount: 1
+      })
+    ]
+    reconnectedBackend.sessionHealthEvents = [failureEvent]
+    TestWebSocket.backend = reconnectedBackend
+
+    await act(async () => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9992,
+        token: 'failure-gap-reconnect-token'
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(() => latest()?.core.sessionRuntimeNotice?.kind === 'recording-failed')
+
+    expect(latest()?.recording.recording.state).toBe('idle')
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'recording-failed',
+      activity: 'recording',
+      sessionId: 'session-failed-in-gap',
+      outputPath: 'C:\\recordings\\session-failed-in-gap.mkv',
+      message: failureEvent.message
+    })
+    expect(toastSpies.error).toHaveBeenCalledWith(
+      'Recording stopped unexpectedly',
+      expect.objectContaining({
+        id: 'recording-stopped-unexpectedly',
+        description: failureEvent.message,
+        duration: Infinity,
+        action: expect.objectContaining({ label: 'Open Library' }),
+        cancel: expect.objectContaining({ label: 'Show in Finder' })
+      })
+    )
+    expect(reconnectedBackend.commands).toContainEqual(
+      expect.objectContaining({
+        method: 'sessions.healthEvents.list',
+        params: expect.objectContaining({ sessionId: 'session-failed-in-gap' })
+      })
+    )
+
+    const toastOptions = toastSpies.error.mock.calls.at(-1)?.[1] as {
+      action: { onClick: () => void }
+      cancel: { onClick: () => void }
+    }
+    toastOptions.action.onClick()
+    toastOptions.cancel.onClick()
+    expect(libraryNavigations).toEqual([{ tab: 'library', sessionId: 'session-failed-in-gap' }])
+    expect(revealSession).toHaveBeenCalledWith('session-failed-in-gap')
+
+    vi.clearAllMocks()
+    const failedSnapshotEvent: HealthEvent = {
+      ...failureEvent,
+      id: 'health-failed-snapshot',
+      sessionId: 'session-failed-snapshot',
+      message: 'FFmpeg exited before the recording could be finalized.'
+    }
+    const failedSnapshotBackend = new StudioBackend()
+    failedSnapshotBackend.recordingStatusOverride = {
+      state: 'failed',
+      sessionId: 'session-failed-snapshot'
+    }
+    failedSnapshotBackend.sessionSummaries = [
+      sessionSummary({
+        id: 'session-failed-snapshot',
+        status: 'failed',
+        mode: 'record+stream',
+        outputPath: 'C:\\recordings\\session-failed-snapshot.mkv',
+        healthEventCount: 1
+      })
+    ]
+    failedSnapshotBackend.sessionHealthEvents = [failedSnapshotEvent]
+    TestWebSocket.backend = failedSnapshotBackend
+
+    await act(async () => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9995,
+        token: 'failed-snapshot-reconnect-token'
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(
+      () => latest()?.core.sessionRuntimeNotice?.sessionId === 'session-failed-snapshot'
+    )
+
+    expect(latest()?.recording.recording.state).toBe('failed')
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'recording-failed',
+      activity: 'recording',
+      sessionId: 'session-failed-snapshot',
+      outputPath: 'C:\\recordings\\session-failed-snapshot.mkv',
+      message: failedSnapshotEvent.message
+    })
+    expect(toastSpies.error).toHaveBeenCalledWith(
+      'Recording stopped unexpectedly',
+      expect.objectContaining({
+        description: failedSnapshotEvent.message,
+        cancel: expect.objectContaining({ label: 'Show in Finder' })
+      })
+    )
+  })
+
+  it('recovers a microphone loss missed during reconnect for the still-active session', async () => {
+    const initialBackend = new StudioBackend()
+    initialBackend.recordingState = 'recording'
+    initialBackend.recordingSessionId = 'session-mic-lost-in-gap'
+    TestWebSocket.backend = initialBackend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    let emit: ((name: string, value: unknown) => void) | undefined
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => [],
+      registerEmitter: (nextEmit) => {
+        emit = nextEmit
+      }
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        latest()?.recording.recording.sessionId === 'session-mic-lost-in-gap'
+    )
+    vi.clearAllMocks()
+
+    const microphoneLost: HealthEvent = {
+      id: 'health-mic-lost-in-gap',
+      sessionId: 'session-mic-lost-in-gap',
+      level: 'warn',
+      code: 'microphone-input-lost',
+      message:
+        'Microphone "Desk Mic" stopped after 92.3 seconds. Videorc replaced the missing input with silence.',
+      permissionPane: null,
+      createdAt: '2026-08-25T11:10:00.000Z'
+    }
+    const reconnectedBackend = new StudioBackend()
+    reconnectedBackend.recordingState = 'recording'
+    reconnectedBackend.recordingSessionId = 'session-mic-lost-in-gap'
+    reconnectedBackend.sessionSummaries = [
+      sessionSummary({
+        id: 'session-mic-lost-in-gap',
+        status: 'running',
+        mode: 'record',
+        healthEventCount: 1
+      })
+    ]
+    reconnectedBackend.sessionHealthEvents = [microphoneLost]
+    TestWebSocket.backend = reconnectedBackend
+
+    await act(async () => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9993,
+        token: 'microphone-gap-reconnect-token'
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(
+      () => latest()?.core.sessionRuntimeNotice?.kind === 'microphone-input-lost'
+    )
+
+    expect(latest()?.recording.recording.state).toBe('recording')
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'microphone-input-lost',
+      activity: 'recording',
+      phase: 'active',
+      sessionId: 'session-mic-lost-in-gap',
+      message: microphoneLost.message
+    })
+    expect(toastSpies.warning).toHaveBeenCalledTimes(1)
+    expect(toastSpies.warning).toHaveBeenCalledWith(
+      'Microphone stopped — recording continues with silence',
+      {
+        id: 'microphone-input-lost',
+        description: microphoneLost.message,
+        duration: Infinity
+      }
+    )
+    expect(reconnectedBackend.commands).toContainEqual(
+      expect.objectContaining({
+        method: 'sessions.healthEvents.list',
+        params: expect.objectContaining({ sessionId: 'session-mic-lost-in-gap' })
+      })
+    )
+
+    const secondReconnectBackend = new StudioBackend()
+    secondReconnectBackend.recordingState = 'recording'
+    secondReconnectBackend.recordingSessionId = 'session-mic-lost-in-gap'
+    secondReconnectBackend.sessionSummaries = reconnectedBackend.sessionSummaries
+    secondReconnectBackend.sessionHealthEvents = [microphoneLost]
+    TestWebSocket.backend = secondReconnectBackend
+    await act(async () => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9994,
+        token: 'microphone-gap-second-reconnect-token'
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(
+      () =>
+        latest()?.core.wsStatus === 'connected' &&
+        secondReconnectBackend.commands.some(
+          (command) => command.method === 'sessions.healthEvents.list'
+        )
+    )
+
+    expect(toastSpies.warning).toHaveBeenCalledTimes(1)
+
+    vi.clearAllMocks()
+    const replacementSessionBackend = new StudioBackend()
+    replacementSessionBackend.recordingState = 'stopping'
+    replacementSessionBackend.recordingSessionId = 'replacement-session'
+    replacementSessionBackend.sessionSummaries = [
+      sessionSummary({
+        id: 'session-mic-lost-in-gap',
+        status: 'failed',
+        mode: 'record',
+        healthEventCount: 1
+      }),
+      sessionSummary({
+        id: 'replacement-session',
+        status: 'running',
+        mode: 'record',
+        healthEventCount: 0
+      })
+    ]
+    replacementSessionBackend.sessionHealthEvents = [
+      {
+        ...microphoneLost,
+        id: 'old-session-terminal-failure',
+        level: 'error',
+        code: 'encoder-bridge-failed',
+        message: 'The prior session failed while the renderer was disconnected.'
+      }
+    ]
+    TestWebSocket.backend = replacementSessionBackend
+    await act(async () => {
+      emit?.('backend:connection', {
+        host: '127.0.0.1',
+        port: 9996,
+        token: 'replacement-session-reconnect-token'
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(
+      () => latest()?.recording.recording.sessionId === 'replacement-session'
+    )
+
+    expect(latest()?.core.sessionRuntimeNotice).toBeNull()
+    expect(toastSpies.error).not.toHaveBeenCalled()
+    expect(toastSpies.warning).not.toHaveBeenCalled()
+    expect(
+      replacementSessionBackend.commands.some(
+        (command) => command.method === 'sessions.healthEvents.list'
+      )
+    ).toBe(false)
+  })
+
+  it('does not resurrect historical runtime failures during a fresh bootstrap', async () => {
+    const backend = new StudioBackend()
+    backend.sessionSummaries = [
+      sessionSummary({
+        id: 'historical-failed-session',
+        status: 'failed',
+        mode: 'record',
+        healthEventCount: 2
+      })
+    ]
+    backend.sessionHealthEvents = [
+      {
+        id: 'historical-mic-loss',
+        sessionId: 'historical-failed-session',
+        level: 'warn',
+        code: 'microphone-input-lost',
+        message: 'Historical microphone loss.',
+        permissionPane: null,
+        createdAt: '2026-08-24T10:00:00.000Z'
+      },
+      {
+        id: 'historical-recording-failure',
+        sessionId: 'historical-failed-session',
+        level: 'error',
+        code: 'ffmpeg-exit',
+        message: 'Historical recording failure.',
+        permissionPane: null,
+        createdAt: '2026-08-24T10:01:00.000Z'
+      }
+    ]
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => []
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(
+      () => latest()?.core.wsStatus === 'connected' && latest()?.core.sessions.length === 1
+    )
+
+    expect(latest()?.core.sessionRuntimeNotice).toBeNull()
+    expect(
+      backend.commands.some((command) => command.method === 'sessions.healthEvents.list')
+    ).toBe(false)
+    expect(toastSpies.error).not.toHaveBeenCalled()
+    expect(toastSpies.warning).not.toHaveBeenCalled()
+  })
+
+  it('warns once when the microphone is lost while recording and still reports a saved take', async () => {
+    const backend = new StudioBackend()
+    TestWebSocket.backend = backend
+    vi.stubGlobal('WebSocket', TestWebSocket)
+
+    const api = createVideorcApi({
+      acknowledge: async () => true,
+      pending: async () => [],
+      acknowledgeProvider: async () => true,
+      pendingProvider: async () => []
+    })
+    const testDom = installProviderTestEnvironment(api)
+    restoreEnvironment = testDom.restore
+    const observations: StudioObservation[] = []
+    const latest = (): StudioObservation | undefined => observations.at(-1)
+
+    await act(async () => {
+      root = createRoot(testDom.container)
+      root.render(
+        createElement(
+          BackgroundAssetsProvider,
+          null,
+          createElement(
+            StudioProvider,
+            null,
+            createElement(Probe, {
+              observe: (value) => {
+                observations.push(value)
+              }
+            })
+          )
+        )
+      )
+    })
+    await waitForObservation(() => latest()?.core.wsStatus === 'connected')
+    vi.clearAllMocks()
+
+    const microphoneLost: HealthEvent = {
+      id: 'health-microphone-lost',
+      sessionId: 'session-with-silence',
+      level: 'warn',
+      code: 'microphone-input-lost',
+      message: 'The selected microphone stopped providing audio.',
+      permissionPane: null,
+      createdAt: '2026-08-25T10:01:00.000Z'
+    }
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'recording',
+            sessionId: 'session-with-silence',
+            startedAt: now,
+            message: 'Recording.'
+          }
+        })
+      })
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({ event: 'health.event', payload: microphoneLost })
+      })
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'health.event',
+          payload: { ...microphoneLost, id: 'health-microphone-lost-repeat' }
+        })
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'recording')
+
+    expect(toastSpies.warning).toHaveBeenCalledTimes(1)
+    expect(toastSpies.warning).toHaveBeenCalledWith(
+      'Microphone stopped — recording continues with silence',
+      {
+        id: 'microphone-input-lost',
+        description: microphoneLost.message,
+        duration: Infinity
+      }
+    )
+    expect(latest()?.recording.recording.state).toBe('recording')
+
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'idle',
+            sessionId: 'session-with-silence',
+            outputPath: 'C:\\recordings\\session-with-silence.mp4',
+            durationMs: 5_000,
+            message: 'Saved.'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'idle')
+
+    expect(toastSpies.success).toHaveBeenCalledTimes(1)
+    expect(toastSpies.success).toHaveBeenCalledWith(
+      'Recording saved',
+      expect.objectContaining({ duration: 12000 })
+    )
+    expect(toastSpies.error).not.toHaveBeenCalled()
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'microphone-input-lost',
+      activity: 'recording',
+      phase: 'ended',
+      sessionId: 'session-with-silence',
+      message: microphoneLost.message
+    })
+    expect(toastSpies.warning).toHaveBeenCalledTimes(2)
+    expect(toastSpies.warning).toHaveBeenLastCalledWith(
+      'Microphone stopped — saved recording contains silence',
+      {
+        id: 'microphone-input-lost',
+        description: microphoneLost.message,
+        duration: Infinity
+      }
+    )
+
+    vi.clearAllMocks()
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'streaming',
+            sessionId: 'next-session',
+            startedAt: '2026-08-25T10:05:00.000Z',
+            message: 'Live.'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(() => latest()?.recording.recording.sessionId === 'next-session')
+    expect(latest()?.core.sessionRuntimeNotice).toBeNull()
+    expect(toastSpies.dismiss).toHaveBeenCalledWith('microphone-input-lost')
+
+    vi.clearAllMocks()
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'health.event',
+          payload: {
+            ...microphoneLost,
+            id: 'health-stale-microphone-lost',
+            sessionId: 'session-with-silence'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+
+    expect(toastSpies.warning).not.toHaveBeenCalled()
+    expect(latest()?.core.sessionRuntimeNotice).toBeNull()
+
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'health.event',
+          payload: {
+            ...microphoneLost,
+            id: 'health-live-microphone-lost',
+            sessionId: 'next-session'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+
+    expect(toastSpies.warning).toHaveBeenCalledWith(
+      'Microphone stopped — live session continues with silence',
+      expect.objectContaining({ id: 'microphone-input-lost' })
+    )
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'microphone-input-lost',
+      activity: 'live-stream',
+      phase: 'active',
+      sessionId: 'next-session'
+    })
+
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'idle',
+            sessionId: 'next-session',
+            message: 'Live session ended.'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'idle')
+
+    expect(toastSpies.success).not.toHaveBeenCalled()
+    expect(toastSpies.warning).toHaveBeenLastCalledWith(
+      'Microphone stopped during the live session',
+      expect.objectContaining({ id: 'microphone-input-lost' })
+    )
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'microphone-input-lost',
+      activity: 'live-stream',
+      phase: 'ended'
+    })
+
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'streaming',
+            sessionId: 'late-live-loss',
+            message: 'Live.'
+          }
+        })
+      })
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'stopping',
+            sessionId: 'late-live-loss',
+            message: 'Ending live session.'
+          }
+        })
+      })
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'recording.status',
+          payload: {
+            state: 'idle',
+            sessionId: 'late-live-loss',
+            message: 'Live session ended.'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+    await waitForObservation(() => latest()?.recording.recording.state === 'idle')
+
+    vi.clearAllMocks()
+    await act(async () => {
+      backend.sockets[0]?.onmessage?.({
+        data: JSON.stringify({
+          event: 'health.event',
+          payload: {
+            ...microphoneLost,
+            id: 'health-late-live-microphone-lost',
+            sessionId: 'late-live-loss'
+          }
+        })
+      })
+      await Promise.resolve()
+    })
+
+    expect(toastSpies.warning).toHaveBeenCalledWith(
+      'Microphone stopped during the live session',
+      expect.objectContaining({ id: 'microphone-input-lost' })
+    )
+    expect(latest()?.core.sessionRuntimeNotice).toMatchObject({
+      kind: 'microphone-input-lost',
+      activity: 'live-stream',
+      phase: 'ended',
+      sessionId: 'late-live-loss'
+    })
   })
 
   it('keeps a committed live source selection when output proof catches up late', async () => {

--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -154,6 +154,7 @@ import type {
   AudioProcessingUpdateResult,
   BackendConnection,
   BackendHealth,
+  BackendLifecycleEvent,
   BackendLogEvent,
   CommentsWindowState,
   CompositorFrameReady,
@@ -212,6 +213,7 @@ import type {
   SessionCommentsPage,
   SessionDeletionOperation,
   SessionDetails,
+  SessionHealthEventsPage,
   SessionListPage,
   SessionLogEntry,
   SessionSummary,
@@ -314,12 +316,7 @@ import {
   pendingCompositorStatusSupersedes,
   type NativePreviewRendererTimingFields
 } from '@/lib/native-preview-present-policy'
-import { isTransientBackendError, shouldToastBackendError } from '@/lib/backend-transport'
-import {
-  isPremiumUpgradeMessage,
-  premiumRequiredIssueMessage,
-  VIDEORC_PREMIUM_URL
-} from '@/lib/premium-upgrade'
+import { isPremiumUpgradeMessage, premiumRequiredIssueMessage } from '@/lib/premium-upgrade'
 import {
   reduceSessionStartFailure,
   SESSION_START_FAILED_TOAST_ID,
@@ -328,7 +325,7 @@ import {
   sessionStartFailureToastOptions,
   type SessionStartFailure
 } from '@/lib/session-start-failure'
-import { recordingStartupHealthToast } from '@/lib/studio-health'
+import type { SessionRuntimeActivity, SessionRuntimeNotice } from '@/lib/session-runtime-notice'
 import { assertYouTubeTransitionConfirmed } from '@/lib/youtube-transition'
 import { effectiveSceneBackground } from '@/lib/background-assets'
 import { useBackgroundAssets } from '@/hooks/use-background-assets'
@@ -373,48 +370,14 @@ type CaptionOverlayWork = {
   position: 'top' | 'bottom'
 }
 
-function openPremiumUpgradePage(): void {
-  const opener = window.videorc?.openOAuthUrl
-  if (opener) {
-    void opener(VIDEORC_PREMIUM_URL)
-    return
-  }
-
-  window.open(VIDEORC_PREMIUM_URL, '_blank', 'noopener,noreferrer')
-}
-
-function premiumUpgradeToastOptions(description?: string) {
-  return {
-    description,
-    duration: 15000,
-    action: {
-      label: 'View Premium',
-      onClick: openPremiumUpgradePage
-    }
-  }
-}
-
-function sourceFallbackActiveSessionMessage(state: RecordingStatus['state']): string {
-  if (state === 'streaming') {
-    return 'Source changed while streaming. Check the output before continuing.'
-  }
-  return 'Source changed while recording. Check the output before continuing.'
-}
-
 const NATIVE_PREVIEW_SURFACE_PRESENT_REPORT_INTERVAL_MS = 250
 const WORKSPACE_NAVIGATE_EVENT = 'videorc:navigate-workspace'
 const AI_CONSENT_STORAGE_KEY = 'videorc.aiConsent'
+const RECORDING_STOPPED_UNEXPECTEDLY_TOAST_ID = 'recording-stopped-unexpectedly'
+const MICROPHONE_INPUT_LOST_TOAST_ID = 'microphone-input-lost'
 
-function isRecordingQualityEvent(code: string): boolean {
-  return code.startsWith('recording-quality-')
-}
-
-function openLibraryFromQualityToast(sessionId?: string): void {
-  window.dispatchEvent(
-    new CustomEvent(WORKSPACE_NAVIGATE_EVENT, {
-      detail: { tab: 'library', sessionId: sessionId ?? null }
-    })
-  )
+function loadSessionRuntimeRecovery() {
+  return import('@/lib/session-runtime-recovery')
 }
 
 // Steady-state telemetry (surface counters, diagnostics stats) commits to
@@ -1000,6 +963,10 @@ export type StudioContextValue = {
    * again or dismisses it. Rendered next to the Record control (B0). */
   sessionStartFailure: SessionStartFailure | null
   dismissSessionStartFailure: () => void
+  /** A mid-session failure or degraded recording condition. It stays beside
+   * the transport controls until dismissed or the next session starts. */
+  sessionRuntimeNotice: SessionRuntimeNotice | null
+  dismissSessionRuntimeNotice: () => void
   /** Re-run the exact start that failed (same streaming override). */
   retrySessionStart: () => void
   refreshScreens: () => Promise<void>
@@ -2493,7 +2460,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   settingsRef.current = settings
   // Stable handle for callbacks that only need to READ the config (labels,
   // lookups) without re-creating themselves on every config change.
-  const lastRecordingStateRef = useRef<string | null>(null)
+  const lastRecordingStateRef = useRef<RecordingStatus['state'] | null>(null)
+  const lastSessionActivityRef = useRef<SessionRuntimeActivity>('recording')
   // The idle status tick that ends a session does not reliably carry the
   // finished session's id; remember the last one seen so the saved-toast
   // actions can target the right recording.
@@ -2501,6 +2469,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   // Quality-gate toast dedupe: the gate can re-emit an updated not-100 verdict for
   // the same session (fast assessment, then post-repair); one toast is enough.
   const qualityToastSessionsRef = useRef<Set<string>>(new Set())
+  const recordingFailureSessionRef = useRef<string | null>(null)
+  const microphoneInputLostSessionRef = useRef<string | null>(null)
+  const sessionRuntimeEpochRef = useRef(0)
   const captureConfigRef = useRef(captureConfig)
   const liveAudioProcessingSyncRef = useRef<{
     token: object
@@ -2697,23 +2668,11 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     // Always keep the diagnostic record, even for suppressed transients.
     setLastError(message)
     if (isPremiumUpgradeMessage(message)) {
-      toast.error(message, premiumUpgradeToastOptions())
+      void loadSessionRuntimeRecovery().then((runtime) => runtime.showPremiumUpgrade(message))
       return
     }
-    // S1 (plan 024): a permission grant restarts the backend; the requests that
-    // fan out into the ~1s reconnect window reject with the transient transport
-    // strings. The Session badge already narrates "Connecting…"/"Backend
-    // offline", so suppress those toasts entirely while not connected instead of
-    // stacking a wall of red. A transport blip WHILE connected still surfaces —
-    // once, via a keyed id so it can never stack.
-    if (!shouldToastBackendError(message, wsStatusRef.current)) {
-      return
-    }
-    if (isTransientBackendError(message)) {
-      toast.error(message, { id: 'backend-transport' })
-      return
-    }
-    toast.error(message)
+    const status = wsStatusRef.current
+    void loadSessionRuntimeRecovery().then((runtime) => runtime.showBackendError(message, status))
   }, [])
 
   // --- Session-start failures are unmissable (B0) ----------------------------
@@ -2723,12 +2682,31 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   // user starts again or dismisses it. The retry closure is held in a ref so the
   // toast action (created once) always re-runs the LATEST failed start.
   const [sessionStartFailure, setSessionStartFailure] = useState<SessionStartFailure | null>(null)
+  const [sessionRuntimeNotice, setSessionRuntimeNotice] = useState<SessionRuntimeNotice | null>(
+    null
+  )
+  const sessionRuntimeNoticeRef = useRef<SessionRuntimeNotice | null>(null)
+  const replaceSessionRuntimeNotice = useCallback((notice: SessionRuntimeNotice | null) => {
+    sessionRuntimeNoticeRef.current = notice
+    setSessionRuntimeNotice(notice)
+  }, [])
   const sessionStartRetryRef = useRef<(() => void) | null>(null)
   const dismissSessionStartFailure = useCallback(() => {
     sessionStartRetryRef.current = null
     setSessionStartFailure((current) => reduceSessionStartFailure(current, { type: 'dismissed' }))
     toast.dismiss(SESSION_START_FAILED_TOAST_ID)
   }, [])
+  const dismissSessionRuntimeNotice = useCallback(() => {
+    sessionRuntimeEpochRef.current += 1
+    replaceSessionRuntimeNotice(null)
+    toast.dismiss(RECORDING_STOPPED_UNEXPECTEDLY_TOAST_ID)
+    toast.dismiss(MICROPHONE_INPUT_LOST_TOAST_ID)
+  }, [replaceSessionRuntimeNotice])
+  const clearSessionRuntimeState = useCallback(() => {
+    recordingFailureSessionRef.current = null
+    microphoneInputLostSessionRef.current = null
+    dismissSessionRuntimeNotice()
+  }, [dismissSessionRuntimeNotice])
   const retrySessionStart = useCallback(() => {
     const retry = sessionStartRetryRef.current
     if (!retry) {
@@ -2740,8 +2718,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     setSessionStartFailure((current) =>
       reduceSessionStartFailure(current, { type: 'start-attempted' })
     )
+    clearSessionRuntimeState()
     toast.dismiss(SESSION_START_FAILED_TOAST_ID)
-  }, [])
+  }, [clearSessionRuntimeState])
   const reportSessionStartFailure = useCallback(
     (error: unknown, retry: () => void) => {
       const message = sessionStartFailureMessage(error)
@@ -2753,7 +2732,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       if (isPremiumUpgradeMessage(message)) {
         // Premium gate: the upgrade link is the only useful action, and the
         // Session-panel line still carries the reason persistently.
-        toast.error(message, premiumUpgradeToastOptions())
+        void loadSessionRuntimeRecovery().then((runtime) => runtime.showPremiumUpgrade(message))
         return
       }
       toast.error(
@@ -2768,6 +2747,73 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       )
     },
     [retrySessionStart]
+  )
+
+  const publishRecordingFailure = useCallback(
+    async (status: RecordingStatus, activityOverride?: SessionRuntimeActivity): Promise<void> => {
+      const activity = activityOverride ?? lastSessionActivityRef.current
+      const continuationEpoch = sessionRuntimeEpochRef.current
+      const expectedSessionId = status.sessionId ?? lastRecordingSessionIdRef.current ?? undefined
+      const runtime = await loadSessionRuntimeRecovery()
+      if (
+        !runtime.sessionRuntimeContinuationIsCurrent(
+          continuationEpoch,
+          sessionRuntimeEpochRef.current,
+          expectedSessionId,
+          recordingRef.current.sessionId ?? lastRecordingSessionIdRef.current ?? undefined
+        )
+      ) {
+        return
+      }
+      const presentation = runtime.recordingFailurePresentation({
+        status,
+        activity,
+        ...(lastRecordingSessionIdRef.current
+          ? { fallbackSessionId: lastRecordingSessionIdRef.current }
+          : {}),
+        currentDedupeKey: recordingFailureSessionRef.current
+      })
+      if (!presentation) return
+      recordingFailureSessionRef.current = presentation.dedupeKey
+      replaceSessionRuntimeNotice(presentation.notice)
+      runtime.showRecordingFailure(presentation)
+    },
+    [replaceSessionRuntimeNotice]
+  )
+
+  const publishMicrophoneInputLost = useCallback(
+    async (event: HealthEvent): Promise<void> => {
+      const continuationEpoch = sessionRuntimeEpochRef.current
+      const expectedSessionId = event.sessionId ?? lastRecordingSessionIdRef.current ?? undefined
+      const runtime = await loadSessionRuntimeRecovery()
+      if (
+        !runtime.sessionRuntimeContinuationIsCurrent(
+          continuationEpoch,
+          sessionRuntimeEpochRef.current,
+          expectedSessionId,
+          recordingRef.current.sessionId ?? lastRecordingSessionIdRef.current ?? undefined
+        )
+      ) {
+        return
+      }
+      const presentation = runtime.microphoneLossPresentation({
+        event,
+        recording: recordingRef.current,
+        ...(lastRecordingSessionIdRef.current
+          ? { lastSessionId: lastRecordingSessionIdRef.current }
+          : {}),
+        lastActivity: lastSessionActivityRef.current,
+        currentDedupeKey: microphoneInputLostSessionRef.current
+      })
+      if (!presentation) return
+      microphoneInputLostSessionRef.current = presentation.dedupeKey
+      lastSessionActivityRef.current = presentation.activity
+      if (sessionRuntimeNoticeRef.current?.kind !== 'recording-failed') {
+        replaceSessionRuntimeNotice(presentation.notice)
+      }
+      runtime.showMicrophoneLoss(presentation)
+    },
+    [replaceSessionRuntimeNotice]
   )
 
   // --- Live Chat Co-host (Premium cloud AI) --------------------------------
@@ -3196,6 +3242,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
   )
 
   const applyRecordingStatus = useCallback((status: RecordingStatus) => {
+    if (status.state === 'recording' || status.state === 'streaming') {
+      lastSessionActivityRef.current = status.state === 'streaming' ? 'live-stream' : 'recording'
+    }
     recordingRef.current = status
     setRecording(status)
     syncFramePollingSuppressionRef.current?.()
@@ -4244,6 +4293,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
   useEffect(() => {
     let disposed = false
+    let latestLifecycleEvent: BackendLifecycleEvent | null = null
 
     if (typeof window === 'undefined' || !window.videorc) {
       // The preload bridge is unavailable (e.g. rendered outside Electron).
@@ -4270,6 +4320,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     const offLog = window.videorc.onBackendLog(appendLog)
     // F-014: surface backend crashes instead of zombie-ing with a Ready badge.
     const offLifecycle = window.videorc.onBackendLifecycle?.((event) => {
+      latestLifecycleEvent = event
       // Crash evidence (runtimeInfo.backendCrashes) is written by main at the
       // moment of the exit; re-read it so Diagnostics and the next bundle
       // export carry the record without a relaunch.
@@ -4280,25 +4331,12 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           }
         })
       }
-      if (event.state === 'restarting') {
-        toast.warning('Backend crashed', {
-          id: 'backend-lifecycle',
-          description: `Restarting automatically (attempt ${event.attempt ?? 1})…`
-        })
-      } else if (event.state === 'failed') {
-        toast.error('Backend crashed repeatedly', {
-          id: 'backend-lifecycle',
-          description: 'Automatic restarts stopped. Restart Videorc to recover.',
-          duration: Infinity
-        })
-      } else if (event.state === 'lost') {
-        toast.error('Backend shutdown could not be confirmed', {
-          id: 'backend-lifecycle',
-          description: 'A replacement was not started. Quit and reopen Videorc to recover safely.',
-          duration: Infinity
-        })
-      } else if (event.state === 'running') {
+      if (event.state === 'running') {
         toast.dismiss('backend-lifecycle')
+      } else {
+        void loadSessionRuntimeRecovery().then((runtime) => {
+          if (!disposed && latestLifecycleEvent === event) runtime.showBackendLifecycle(event)
+        })
       }
     })
 
@@ -4329,10 +4367,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       ].slice(-50)
 
       if (isActiveRecordingState(sessionState)) {
-        toast.warning(sourceFallbackActiveSessionMessage(sessionState), {
-          duration: 10_000,
-          id: 'source-reconciliation:active-session'
-        })
+        void loadSessionRuntimeRecovery().then((runtime) =>
+          runtime.showSourceFallbackActiveSession(sessionState)
+        )
       }
     },
     []
@@ -4359,6 +4396,10 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     let disposed = false
     const generation = bootstrapGenerationRef.current + 1
     bootstrapGenerationRef.current = generation
+    sessionRuntimeEpochRef.current += 1
+    const priorSessionState = lastRecordingStateRef.current ?? recordingRef.current.state
+    const priorSessionId = lastRecordingSessionIdRef.current ?? recordingRef.current.sessionId
+    const priorSessionWasActive = ['recording', 'streaming', 'stopping'].includes(priorSessionState)
     const focusRefreshCoordinator = focusRefreshCoordinatorRef.current
     const sessionListRefreshRequests = sessionListRefreshRequestRef.current
     const sessionListMoreSingleFlight = sessionListMoreSingleFlightRef.current
@@ -4669,25 +4710,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           const outputSessionId = job.outputSessionId
           if (outputSessionId && !announcedNoiseCleanupCompletionsRef.current.has(job.id)) {
             announcedNoiseCleanupCompletionsRef.current.add(job.id)
-            toast.success('Noise cleanup complete', {
-              id: `noise-cleanup-completed-${job.id}`,
-              description: 'A separate cleaned copy is ready. The original was not changed.',
-              duration: 15_000,
-              action: {
-                label: 'Play',
-                onClick: () => {
-                  const openSession = window.videorc?.openSession
-                  if (!openSession) return
-                  void openSession(outputSessionId).then((problem) => {
-                    if (problem) toast.error(problem)
-                  })
-                }
-              },
-              cancel: {
-                label: 'Show in Finder',
-                onClick: () => void window.videorc?.revealSession?.(outputSessionId)
-              }
-            })
+            void loadSessionRuntimeRecovery().then((runtime) =>
+              runtime.showNoiseCleanupCompleted(job.id, outputSessionId)
+            )
           }
         }
       }),
@@ -4695,7 +4720,9 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         bootstrapGuard.mark('recording')
         bootstrapGuard.mark('sessions')
         const status = payload as RecordingStatus
-        const previousState = lastRecordingStateRef.current
+        const previousState = lastRecordingStateRef.current ?? recordingRef.current.state
+        const previousSessionId =
+          lastRecordingSessionIdRef.current ?? recordingRef.current.sessionId
         lastRecordingStateRef.current = status.state
         if (status.sessionId) {
           lastRecordingSessionIdRef.current = status.sessionId
@@ -4712,44 +4739,53 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         // only refresh on the transition).
         if (
           ['recording', 'streaming'].includes(status.state) &&
-          !['recording', 'streaming'].includes(previousState ?? '')
+          (!['recording', 'streaming'].includes(previousState ?? '') ||
+            (status.sessionId && status.sessionId !== previousSessionId))
         ) {
+          clearSessionRuntimeState()
+          void loadSessionRuntimeRecovery()
           void refreshSessions(nextClient)
         }
-        // A finished recording gets its two natural next steps: watch it, or
-        // find it in the Library. (The publish pitch lives in the Publish tab,
-        // not in this toast — owner call, 2026-08-16.)
+        // A terminal session moves a persistent degradation notice to past
+        // tense. A saved recording also gets its two natural next steps: watch
+        // it, or find it in the Library. Stream-only sessions have no local
+        // artifact, so they must not claim that a recording was saved.
         if (
           status.state === 'idle' &&
           ['recording', 'streaming', 'stopping'].includes(previousState ?? '')
         ) {
-          const finishedSessionId = status.sessionId ?? lastRecordingSessionIdRef.current
-          const openInLibrary = (): void =>
-            openLibraryFromQualityToast(finishedSessionId ?? undefined)
-          toast.success('Recording saved', {
-            action: {
-              label: 'Play',
-              onClick: () => {
-                if (!finishedSessionId || !window.videorc?.openSession) {
-                  openInLibrary()
-                  return
-                }
-                void window.videorc.openSession(finishedSessionId).then((problem) => {
-                  // The export can still be finalizing right after the toast
-                  // fires; the Library row shows the honest state, so land
-                  // there instead of erroring on an eager click.
-                  if (problem) {
-                    openInLibrary()
-                  }
-                })
-              }
-            },
-            cancel: {
-              label: 'Open in Library',
-              onClick: openInLibrary
-            },
-            duration: 12000
+          const finishedActivity = lastSessionActivityRef.current
+          const finishedSessionId =
+            status.sessionId ?? lastRecordingSessionIdRef.current ?? undefined
+          const continuationEpoch = sessionRuntimeEpochRef.current
+          void loadSessionRuntimeRecovery().then((runtime) => {
+            if (
+              recordingRef.current.state !== 'idle' ||
+              !runtime.sessionRuntimeContinuationIsCurrent(
+                continuationEpoch,
+                sessionRuntimeEpochRef.current,
+                finishedSessionId,
+                recordingRef.current.sessionId ?? lastRecordingSessionIdRef.current ?? undefined
+              )
+            ) {
+              return
+            }
+            runtime.showSessionFinished({
+              status,
+              ...(lastRecordingSessionIdRef.current
+                ? { lastSessionId: lastRecordingSessionIdRef.current }
+                : {}),
+              activity: finishedActivity,
+              currentNotice: sessionRuntimeNoticeRef.current,
+              replaceNotice: replaceSessionRuntimeNotice
+            })
           })
+        }
+        if (
+          status.state === 'failed' &&
+          ['recording', 'streaming', 'stopping'].includes(previousState ?? '')
+        ) {
+          void publishRecordingFailure(status)
         }
       }),
       // Viewer rider V2: relay the latest concurrent-viewer sample to the
@@ -4790,58 +4826,31 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
               : current
           })
         }
-        if (isRecordingQualityEvent(event.code)) {
+        if (event.code.startsWith('recording-quality-')) {
           void refreshSessions(nextClient)
         }
-        // Recording startup barrier (B0): an unsteady start is a keyed warning
-        // (the session DID start); a refusal shares the start-failure toast key
-        // so the RPC rejection that follows updates it in place with Retry.
-        const startupToast = recordingStartupHealthToast(event)
-        if (startupToast) {
-          const show = startupToast.variant === 'warning' ? toast.warning : toast.error
-          show(startupToast.title, {
-            id: startupToast.id,
-            description: startupToast.description,
-            duration: startupToast.duration
+        if (event.code === 'microphone-input-lost') {
+          void publishMicrophoneInputLost(event)
+        } else {
+          const qualityDedupeKey = event.sessionId ?? event.message
+          const continuationEpoch = sessionRuntimeEpochRef.current
+          void loadSessionRuntimeRecovery().then((runtime) => {
+            if (
+              !runtime.sessionRuntimeContinuationIsCurrent(
+                continuationEpoch,
+                sessionRuntimeEpochRef.current,
+                event.sessionId ?? undefined,
+                recordingRef.current.sessionId ?? lastRecordingSessionIdRef.current ?? undefined
+              )
+            ) {
+              return
+            }
+            const shownKey = runtime.showSessionHealthEvent(
+              event,
+              qualityToastSessionsRef.current.has(qualityDedupeKey)
+            )
+            if (shownKey) qualityToastSessionsRef.current.add(shownKey)
           })
-        }
-        // Quality-gate toast policy: only interrupt for verdicts the user would
-        // notice and can act on — the backend marks those warn-level (e.g. a
-        // missing stream). Analyzer residuals and internal check/repair failures
-        // arrive info-level and live in the Library row + Diagnostics instead.
-        if (event.code === 'recording-quality-not-100' && event.level === 'warn') {
-          const dedupeKey = event.sessionId ?? event.message
-          if (!qualityToastSessionsRef.current.has(dedupeKey)) {
-            qualityToastSessionsRef.current.add(dedupeKey)
-            toast.warning('Recording is not 100%', {
-              description: event.message,
-              duration: 15000,
-              action: {
-                label: 'Open Library',
-                onClick: () => openLibraryFromQualityToast(event.sessionId ?? undefined)
-              }
-            })
-          }
-        } else if (event.code === 'camera-cadence-mismatch') {
-          // The camera is healthy but delivering a different rate than the session
-          // (e.g. a 24p HDMI feed into a 30fps session). The health event stays in
-          // the session record and diagnostics; a toast on every record start was
-          // noise for setups that live with a fixed-rate HDMI source.
-        } else if (event.code === 'mic-silent') {
-          // Plan 021 F3: the user must hear about a silent mic from the app,
-          // not from playing the file back. Warn = mid-session (stopping and
-          // fixing still saves the take); error = finalize verdict.
-          if (event.level === 'error') {
-            toast.error('Recording has no sound', {
-              description: event.message,
-              duration: 15000
-            })
-          } else {
-            toast.warning('Microphone is silent', {
-              description: event.message,
-              duration: 15000
-            })
-          }
         }
       }),
       nextClient.on('session.log', (payload) => {
@@ -5277,6 +5286,35 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           return
         }
 
+        let runtimeRecovery:
+          | {
+              kind: 'recording-failed'
+              status: RecordingStatus
+              activity: SessionRuntimeActivity
+            }
+          | { kind: 'microphone-input-lost'; event: HealthEvent }
+          | null = null
+        if (
+          priorSessionWasActive ||
+          ['recording', 'streaming', 'failed'].includes(nextRecording.state)
+        ) {
+          const recovery = await loadSessionRuntimeRecovery()
+          runtimeRecovery = await recovery.recoverSessionRuntime({
+            recording: nextRecording,
+            sessions: nextSessions.items,
+            ...(priorSessionId ? { priorSessionId } : {}),
+            priorSessionState,
+            loadHealthEvents: (sessionId) =>
+              bootstrapRequest<SessionHealthEventsPage>('sessions.healthEvents.list', {
+                sessionId,
+                limit: SESSION_DETAIL_BUFFER_LIMIT
+              }).then((page) => page.events)
+          })
+          if (!generationIsCurrent()) {
+            return
+          }
+        }
+
         let resolvedPreviewSurface = nextPreviewSurface
         if (
           previewSurfaceStatusRequiresMainAuthority(nextPreviewSurface) &&
@@ -5308,7 +5346,22 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           setDeviceList(nextDevices)
         }
         if (bootstrapGuard.isCurrent(bootstrapSnapshot, 'recording')) {
+          if (
+            ['recording', 'streaming', 'stopping'].includes(nextRecording.state) &&
+            nextRecording.sessionId !== priorSessionId
+          ) {
+            clearSessionRuntimeState()
+          }
           applyRecordingStatus(nextRecording)
+          if (nextRecording.sessionId) {
+            lastRecordingSessionIdRef.current = nextRecording.sessionId
+          }
+          if (runtimeRecovery?.kind === 'recording-failed') {
+            await publishRecordingFailure(runtimeRecovery.status, runtimeRecovery.activity)
+          } else if (runtimeRecovery?.kind === 'microphone-input-lost') {
+            await publishMicrophoneInputLost(runtimeRecovery.event)
+          }
+          lastRecordingStateRef.current = nextRecording.state
         }
         if (bootstrapGuard.isCurrent(bootstrapSnapshot, 'diagnostics')) {
           setDiagnosticStats(nextDiagnostics)
@@ -5481,6 +5534,7 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
 
     return () => {
       disposed = true
+      sessionRuntimeEpochRef.current += 1
       focusRefreshCoordinator.invalidate()
       sessionListRefreshRequests.clear()
       sessionListMoreSingleFlight.clear()
@@ -5556,12 +5610,16 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
     applyRecordingStatus,
     commitCohostState,
     commitDiagnosticStatsThrottled,
+    clearSessionRuntimeState,
     connection,
     nativePreviewSurfaceEnabled,
+    publishMicrophoneInputLost,
+    publishRecordingFailure,
     queueNativePreviewCompositorPresent,
     resetNativePreviewCompositorTiming,
     publishCommentHighlightState,
     refreshPlatformAccountsForClient,
+    replaceSessionRuntimeNotice,
     replaceLiveChatSnapshotState,
     updateLiveChatSnapshot,
     validatePlatformAccountsForClient,
@@ -9642,9 +9700,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       if (preflightDecision.kind === 'blocked') {
         const premiumIssue = premiumRequiredIssueMessage(preflight)
         if (premiumIssue) {
-          toast.error(
-            'Premium required for this Go Live setup.',
-            premiumUpgradeToastOptions(premiumIssue)
+          void loadSessionRuntimeRecovery().then((runtime) =>
+            runtime.showPremiumUpgrade('Premium required for this Go Live setup.', premiumIssue)
           )
         } else {
           toast.error('Resolve Go Live issues before starting.')
@@ -10195,9 +10252,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
         video
       })
       if (!gate.allowed) {
-        toast.error(
-          'Premium required for this media profile.',
-          premiumUpgradeToastOptions(gate.reason)
+        void loadSessionRuntimeRecovery().then((runtime) =>
+          runtime.showPremiumUpgrade('Premium required for this media profile.', gate.reason)
         )
         return
       }
@@ -10931,6 +10987,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       continueGoLiveWithReadyDestinations,
       sessionStartFailure,
       dismissSessionStartFailure,
+      sessionRuntimeNotice,
+      dismissSessionRuntimeNotice,
       retrySessionStart,
       refreshScreens,
       importScreenImage,
@@ -11125,6 +11183,8 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
       continueGoLiveWithReadyDestinations,
       sessionStartFailure,
       dismissSessionStartFailure,
+      sessionRuntimeNotice,
+      dismissSessionRuntimeNotice,
       retrySessionStart,
       refreshScreens,
       importScreenImage,

--- a/apps/desktop/src/renderer/src/lib/session-runtime-notice.ts
+++ b/apps/desktop/src/renderer/src/lib/session-runtime-notice.ts
@@ -1,0 +1,43 @@
+export type SessionRuntimeActivity = 'recording' | 'live-stream'
+
+export type SessionRuntimeNotice =
+  | {
+      kind: 'recording-failed'
+      activity: SessionRuntimeActivity
+      message: string
+      sessionId?: string
+      outputPath?: string
+      at: number
+    }
+  | {
+      kind: 'microphone-input-lost'
+      activity: SessionRuntimeActivity
+      phase: 'active' | 'ending' | 'ended'
+      message: string
+      sessionId?: string
+      at: number
+    }
+
+export function sessionRuntimeNoticeTitle(notice: SessionRuntimeNotice): string {
+  if (notice.kind === 'recording-failed') {
+    return notice.activity === 'live-stream'
+      ? 'Live session stopped unexpectedly'
+      : 'Recording stopped unexpectedly'
+  }
+
+  if (notice.phase === 'ended') {
+    return notice.activity === 'live-stream'
+      ? 'Microphone stopped during the live session'
+      : 'Microphone stopped — saved recording contains silence'
+  }
+
+  if (notice.phase === 'ending') {
+    return notice.activity === 'live-stream'
+      ? 'Microphone stopped as the live session ends'
+      : 'Microphone stopped — finishing recording with silence'
+  }
+
+  return notice.activity === 'live-stream'
+    ? 'Microphone stopped — live session continues with silence'
+    : 'Microphone stopped — recording continues with silence'
+}

--- a/apps/desktop/src/renderer/src/lib/session-runtime-recovery.test.ts
+++ b/apps/desktop/src/renderer/src/lib/session-runtime-recovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionSummary } from '@/lib/backend'
+import {
+  completeSessionRuntimeRecovery,
+  sessionRuntimeContinuationIsCurrent,
+  sessionRuntimeRecoveryPlan
+} from '@/lib/session-runtime-recovery'
+
+function failedSession(mode: string): SessionSummary {
+  return {
+    id: 'failed-session',
+    title: 'Failed session',
+    startedAt: '2026-08-25T10:00:00.000Z',
+    status: 'failed',
+    mode,
+    outputPath: '/recordings/failed-session.mkv',
+    healthEventCount: 1,
+    sessionLogCount: 1,
+    aiArtifactCount: 0,
+    commentCount: 0
+  }
+}
+
+describe('session runtime recovery', () => {
+  it('keeps combined record-and-stream failures attached to the local recording', () => {
+    const summary = failedSession('record+stream')
+    const recording = { state: 'failed' as const, sessionId: summary.id }
+    const plan = sessionRuntimeRecoveryPlan({
+      recording,
+      sessions: [summary],
+      priorSessionId: summary.id,
+      priorSessionState: 'recording'
+    })
+
+    expect(
+      completeSessionRuntimeRecovery({
+        plan,
+        recording,
+        events: [],
+        priorSessionState: 'recording'
+      })
+    ).toMatchObject({ kind: 'recording-failed', activity: 'recording' })
+  })
+
+  it('rejects lazy continuations from an old epoch or a different session', () => {
+    expect(sessionRuntimeContinuationIsCurrent(4, 4, 'session-a', 'session-a')).toBe(true)
+    expect(sessionRuntimeContinuationIsCurrent(4, 5, 'session-a', 'session-a')).toBe(false)
+    expect(sessionRuntimeContinuationIsCurrent(4, 4, 'session-a', 'session-b')).toBe(false)
+  })
+
+  it('does not recover a prior failure over a different session that is stopping', () => {
+    const prior = failedSession('record')
+    const replacement = {
+      ...failedSession('record'),
+      id: 'replacement-session',
+      title: 'Replacement session',
+      status: 'running' as const,
+      outputPath: '/recordings/replacement-session.mkv',
+      healthEventCount: 0
+    }
+    const recording = { state: 'stopping' as const, sessionId: replacement.id }
+    const plan = sessionRuntimeRecoveryPlan({
+      recording,
+      sessions: [prior, replacement],
+      priorSessionId: prior.id,
+      priorSessionState: 'recording'
+    })
+
+    expect(plan.failureSessionId).toBeUndefined()
+    expect(
+      completeSessionRuntimeRecovery({
+        plan,
+        recording,
+        events: [],
+        priorSessionState: 'recording'
+      })
+    ).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/session-runtime-recovery.ts
+++ b/apps/desktop/src/renderer/src/lib/session-runtime-recovery.ts
@@ -1,0 +1,448 @@
+import type {
+  BackendLifecycleEvent,
+  HealthEvent,
+  RecordingStatus,
+  SessionSummary
+} from '@/lib/backend'
+import {
+  sessionRuntimeNoticeTitle,
+  type SessionRuntimeActivity,
+  type SessionRuntimeNotice
+} from '@/lib/session-runtime-notice'
+import { VIDEORC_PREMIUM_URL } from '@/lib/premium-upgrade'
+import { recordingStartupHealthToast } from '@/lib/studio-health'
+import { isTransientBackendError, shouldToastBackendError } from '@/lib/backend-transport'
+import type { WsStatus } from '@/lib/capture'
+import { toast } from 'sonner'
+
+const WORKSPACE_NAVIGATE_EVENT = 'videorc:navigate-workspace'
+const RECORDING_STOPPED_UNEXPECTEDLY_TOAST_ID = 'recording-stopped-unexpectedly'
+const MICROPHONE_INPUT_LOST_TOAST_ID = 'microphone-input-lost'
+
+type SessionRuntimeRecoveryPlan = {
+  failureSessionId?: string
+  failureSummary?: SessionSummary
+  healthSessionId?: string
+}
+
+export type SessionRuntimeRecovery =
+  | {
+      kind: 'recording-failed'
+      status: RecordingStatus
+      activity: SessionRuntimeActivity
+    }
+  | { kind: 'microphone-input-lost'; event: HealthEvent }
+  | null
+
+export type RecordingFailurePresentation = {
+  dedupeKey: string
+  notice: Extract<SessionRuntimeNotice, { kind: 'recording-failed' }>
+}
+
+export type MicrophoneLossPresentation = {
+  dedupeKey: string
+  activity: SessionRuntimeActivity
+  notice: Extract<SessionRuntimeNotice, { kind: 'microphone-input-lost' }>
+}
+
+export function sessionRuntimeContinuationIsCurrent(
+  expectedEpoch: number,
+  currentEpoch: number,
+  expectedSessionId?: string,
+  currentSessionId?: string
+): boolean {
+  return (
+    expectedEpoch === currentEpoch && (!expectedSessionId || expectedSessionId === currentSessionId)
+  )
+}
+
+function openLibrary(sessionId?: string): void {
+  window.dispatchEvent(
+    new CustomEvent(WORKSPACE_NAVIGATE_EVENT, {
+      detail: { tab: 'library', sessionId: sessionId ?? null }
+    })
+  )
+}
+
+export function recordingFailurePresentation({
+  status,
+  activity,
+  fallbackSessionId,
+  currentDedupeKey
+}: {
+  status: RecordingStatus
+  activity: SessionRuntimeActivity
+  fallbackSessionId?: string
+  currentDedupeKey: string | null
+}): RecordingFailurePresentation | null {
+  const sessionId = status.sessionId ?? fallbackSessionId
+  const dedupeKey = sessionId ?? 'active-session'
+  if (currentDedupeKey === dedupeKey) return null
+  const message =
+    status.message ??
+    (activity === 'live-stream'
+      ? 'Videorc could not finish this live session.'
+      : 'Videorc could not finish this recording.')
+  return {
+    dedupeKey,
+    notice: {
+      kind: 'recording-failed',
+      activity,
+      message,
+      ...(sessionId ? { sessionId } : {}),
+      ...(status.outputPath ? { outputPath: status.outputPath } : {}),
+      at: Date.now()
+    }
+  }
+}
+
+export function showRecordingFailure({ notice }: RecordingFailurePresentation): void {
+  const sessionId = notice.sessionId
+  const revealSession = window.videorc?.revealSession
+  toast.dismiss(MICROPHONE_INPUT_LOST_TOAST_ID)
+  toast.error(sessionRuntimeNoticeTitle(notice), {
+    id: RECORDING_STOPPED_UNEXPECTEDLY_TOAST_ID,
+    description: notice.message,
+    duration: Infinity,
+    ...(notice.activity === 'recording'
+      ? {
+          action: {
+            label: 'Open Library',
+            onClick: () => openLibrary(sessionId)
+          }
+        }
+      : {}),
+    ...(notice.activity === 'recording' && sessionId && notice.outputPath && revealSession
+      ? {
+          cancel: {
+            label: 'Show in Finder',
+            onClick: () => void revealSession(sessionId)
+          }
+        }
+      : {})
+  })
+}
+
+export function microphoneLossPresentation({
+  event,
+  recording,
+  lastSessionId,
+  lastActivity,
+  currentDedupeKey
+}: {
+  event: HealthEvent
+  recording: RecordingStatus
+  lastSessionId?: string
+  lastActivity: SessionRuntimeActivity
+  currentDedupeKey: string | null
+}): MicrophoneLossPresentation | null {
+  const active = ['recording', 'streaming'].includes(recording.state)
+  const correlatedActive = active && (!event.sessionId || event.sessionId === recording.sessionId)
+  const correlatedTerminal =
+    Boolean(event.sessionId) &&
+    event.sessionId === lastSessionId &&
+    ['stopping', 'idle'].includes(recording.state)
+  if (!correlatedActive && !correlatedTerminal) return null
+
+  const dedupeKey = event.sessionId ?? lastSessionId ?? 'active-session'
+  if (currentDedupeKey === dedupeKey) return null
+  const activity: SessionRuntimeActivity =
+    recording.state === 'streaming'
+      ? 'live-stream'
+      : recording.state === 'recording'
+        ? 'recording'
+        : lastActivity
+  return {
+    dedupeKey,
+    activity,
+    notice: {
+      kind: 'microphone-input-lost',
+      activity,
+      phase: active ? 'active' : recording.state === 'stopping' ? 'ending' : 'ended',
+      message: event.message,
+      ...(event.sessionId ? { sessionId: event.sessionId } : {}),
+      at: Date.now()
+    }
+  }
+}
+
+export function showMicrophoneLoss({ notice }: MicrophoneLossPresentation): void {
+  toast.warning(sessionRuntimeNoticeTitle(notice), {
+    id: MICROPHONE_INPUT_LOST_TOAST_ID,
+    description: notice.message,
+    duration: Infinity
+  })
+}
+
+export function showBackendLifecycle(event: BackendLifecycleEvent): void {
+  if (event.state === 'restarting') {
+    toast.warning('Backend crashed', {
+      id: 'backend-lifecycle',
+      description: `Restarting automatically (attempt ${event.attempt ?? 1})…`
+    })
+  } else if (event.state === 'failed') {
+    toast.error('Backend crashed repeatedly', {
+      id: 'backend-lifecycle',
+      description: 'Automatic restarts stopped. Restart Videorc to recover.',
+      duration: Infinity
+    })
+  } else if (event.state === 'lost') {
+    toast.error('Backend shutdown could not be confirmed', {
+      id: 'backend-lifecycle',
+      description: 'A replacement was not started. Quit and reopen Videorc to recover safely.',
+      duration: Infinity
+    })
+  }
+}
+
+export function showBackendError(message: string, status: WsStatus): void {
+  // Permission grants intentionally restart the backend. During that brief
+  // reconnect window the Session badge already explains the state, so avoid a
+  // wall of duplicate transport errors. A connected-state blip stays visible.
+  if (!shouldToastBackendError(message, status)) return
+  toast.error(message, isTransientBackendError(message) ? { id: 'backend-transport' } : undefined)
+}
+
+export function showSessionFinished({
+  status,
+  lastSessionId,
+  activity,
+  currentNotice,
+  replaceNotice
+}: {
+  status: RecordingStatus
+  lastSessionId?: string
+  activity: SessionRuntimeActivity
+  currentNotice: SessionRuntimeNotice | null
+  replaceNotice: (notice: SessionRuntimeNotice) => void
+}): void {
+  if (currentNotice?.kind === 'microphone-input-lost' && currentNotice.phase !== 'ended') {
+    const endedNotice: SessionRuntimeNotice = { ...currentNotice, phase: 'ended' }
+    replaceNotice(endedNotice)
+    toast.warning(sessionRuntimeNoticeTitle(endedNotice), {
+      id: MICROPHONE_INPUT_LOST_TOAST_ID,
+      description: endedNotice.message,
+      duration: Infinity
+    })
+  }
+  if (activity !== 'recording') return
+
+  const sessionId = status.sessionId ?? lastSessionId
+  const openFinishedRecording = (): void => {
+    if (!sessionId || !window.videorc?.openSession) {
+      openLibrary(sessionId)
+      return
+    }
+    void window.videorc.openSession(sessionId).then((problem) => {
+      if (problem) openLibrary(sessionId)
+    })
+  }
+  toast.success('Recording saved', {
+    action: { label: 'Play', onClick: openFinishedRecording },
+    cancel: { label: 'Open in Library', onClick: () => openLibrary(sessionId) },
+    duration: 12_000
+  })
+}
+
+export function showSessionHealthEvent(
+  event: HealthEvent,
+  qualityToastAlreadyShown: boolean
+): string | null {
+  const startupToast = recordingStartupHealthToast(event)
+  if (startupToast) {
+    const show = startupToast.variant === 'warning' ? toast.warning : toast.error
+    show(startupToast.title, {
+      id: startupToast.id,
+      description: startupToast.description,
+      duration: startupToast.duration
+    })
+  }
+
+  if (event.code.startsWith('recording-quality-')) {
+    if (event.code !== 'recording-quality-not-100' || event.level !== 'warn') return null
+    const dedupeKey = event.sessionId ?? event.message
+    if (qualityToastAlreadyShown) return null
+    toast.warning('Recording is not 100%', {
+      description: event.message,
+      duration: 15_000,
+      action: { label: 'Open Library', onClick: () => openLibrary(event.sessionId ?? undefined) }
+    })
+    return dedupeKey
+  }
+  if (event.code === 'mic-silent') {
+    const show = event.level === 'error' ? toast.error : toast.warning
+    show(event.level === 'error' ? 'Recording has no sound' : 'Microphone is silent', {
+      description: event.message,
+      duration: 15_000
+    })
+  }
+  return null
+}
+
+export function showNoiseCleanupCompleted(jobId: string, outputSessionId: string): void {
+  toast.success('Noise cleanup complete', {
+    id: `noise-cleanup-completed-${jobId}`,
+    description: 'A separate cleaned copy is ready. The original was not changed.',
+    duration: 15_000,
+    action: {
+      label: 'Play',
+      onClick: () => {
+        const openSession = window.videorc?.openSession
+        if (!openSession) return
+        void openSession(outputSessionId).then((problem) => {
+          if (problem) toast.error(problem)
+        })
+      }
+    },
+    cancel: {
+      label: 'Show in Finder',
+      onClick: () => void window.videorc?.revealSession?.(outputSessionId)
+    }
+  })
+}
+
+export function showPremiumUpgrade(title: string, description?: string): void {
+  const openPremiumUpgradePage = (): void => {
+    const opener = window.videorc?.openOAuthUrl
+    if (opener) {
+      void opener(VIDEORC_PREMIUM_URL)
+      return
+    }
+    window.open(VIDEORC_PREMIUM_URL, '_blank', 'noopener,noreferrer')
+  }
+  toast.error(title, {
+    description,
+    duration: 15_000,
+    action: { label: 'View Premium', onClick: openPremiumUpgradePage }
+  })
+}
+
+export function showSourceFallbackActiveSession(state: RecordingStatus['state']): void {
+  toast.warning(
+    state === 'streaming'
+      ? 'Source changed while streaming. Check the output before continuing.'
+      : 'Source changed while recording. Check the output before continuing.',
+    { duration: 10_000, id: 'source-reconciliation:active-session' }
+  )
+}
+
+function latestMatchingEvent(
+  events: HealthEvent[],
+  matches: (event: HealthEvent) => boolean
+): HealthEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]
+    if (event && matches(event)) return event
+  }
+  return undefined
+}
+
+export function sessionRuntimeRecoveryPlan({
+  recording,
+  sessions,
+  priorSessionId,
+  priorSessionState
+}: {
+  recording: RecordingStatus
+  sessions: SessionSummary[]
+  priorSessionId?: string
+  priorSessionState: RecordingStatus['state']
+}): SessionRuntimeRecoveryPlan {
+  const priorSessionWasActive = ['recording', 'streaming', 'stopping'].includes(priorSessionState)
+  const currentSessionOwnsRuntime = ['recording', 'streaming', 'stopping'].includes(recording.state)
+  const priorSessionCanBeRecovered =
+    !currentSessionOwnsRuntime || recording.sessionId === priorSessionId
+  const missedFailureSummary =
+    priorSessionWasActive && priorSessionId && priorSessionCanBeRecovered
+      ? sessions.find((session) => session.id === priorSessionId && session.status === 'failed')
+      : undefined
+  const authoritativeFailureSummary =
+    recording.state === 'failed' && recording.sessionId
+      ? sessions.find(
+          (session) => session.id === recording.sessionId && session.status === 'failed'
+        )
+      : undefined
+  const failureSummary = authoritativeFailureSummary ?? missedFailureSummary
+  const failureSessionId =
+    recording.state === 'failed'
+      ? (recording.sessionId ??
+        failureSummary?.id ??
+        (priorSessionWasActive ? priorSessionId : undefined))
+      : missedFailureSummary?.id
+  const activeSessionSummary =
+    currentSessionOwnsRuntime && recording.sessionId
+      ? sessions.find((session) => session.id === recording.sessionId)
+      : undefined
+
+  return {
+    failureSessionId,
+    failureSummary,
+    healthSessionId:
+      failureSessionId ??
+      ((activeSessionSummary?.healthEventCount ?? 0) > 0 ? activeSessionSummary?.id : undefined)
+  }
+}
+
+export function completeSessionRuntimeRecovery({
+  plan,
+  recording,
+  events,
+  priorSessionState
+}: {
+  plan: SessionRuntimeRecoveryPlan
+  recording: RecordingStatus
+  events: HealthEvent[]
+  priorSessionState: RecordingStatus['state']
+}): SessionRuntimeRecovery {
+  if (plan.failureSessionId) {
+    const latestFailure = latestMatchingEvent(events, (event) => event.level === 'error')
+    const outputPath = recording.outputPath ?? plan.failureSummary?.outputPath
+    const message =
+      (recording.state === 'failed' ? recording.message : undefined) ?? latestFailure?.message
+    return {
+      kind: 'recording-failed',
+      status: {
+        ...(recording.state === 'failed' ? recording : { state: 'failed' }),
+        sessionId: plan.failureSessionId,
+        ...(outputPath ? { outputPath } : {}),
+        ...(message ? { message } : {})
+      },
+      activity: ['stream', 'streaming'].includes(plan.failureSummary?.mode.toLowerCase() ?? '')
+        ? 'live-stream'
+        : plan.failureSummary || priorSessionState !== 'streaming'
+          ? 'recording'
+          : 'live-stream'
+    }
+  }
+
+  const microphoneLoss = latestMatchingEvent(
+    events,
+    (event) => event.code === 'microphone-input-lost'
+  )
+  return microphoneLoss ? { kind: 'microphone-input-lost', event: microphoneLoss } : null
+}
+
+export async function recoverSessionRuntime({
+  recording,
+  sessions,
+  priorSessionId,
+  priorSessionState,
+  loadHealthEvents
+}: {
+  recording: RecordingStatus
+  sessions: SessionSummary[]
+  priorSessionId?: string
+  priorSessionState: RecordingStatus['state']
+  loadHealthEvents: (sessionId: string) => Promise<HealthEvent[]>
+}): Promise<SessionRuntimeRecovery> {
+  const plan = sessionRuntimeRecoveryPlan({
+    recording,
+    sessions,
+    ...(priorSessionId ? { priorSessionId } : {}),
+    priorSessionState
+  })
+  const events = plan.healthSessionId
+    ? await loadHealthEvents(plan.healthSessionId).catch(() => [])
+    : []
+  return completeSessionRuntimeRecovery({ plan, recording, events, priorSessionState })
+}

--- a/crates/videorc-backend/src/audio.rs
+++ b/crates/videorc-backend/src/audio.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -24,6 +24,10 @@ const AUDIO_RING_CAPACITY_PACKETS: usize = 1024;
 const METER_SAMPLE_DURATION: Duration = Duration::from_millis(700);
 const FIFO_OPEN_RETRY: Duration = Duration::from_millis(20);
 pub const NATIVE_AUDIO_FFMPEG_QUEUE_SIZE: u32 = 1024;
+/// Once a warmed native microphone stops producing callbacks for this long,
+/// end its FIFO as a source loss so FFmpeg can pad silence while video keeps
+/// the session clock. The source is deliberately not hot-reconnected mid-take.
+const NATIVE_AUDIO_SOURCE_STALL_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Reserved CoreAudio id used only by the maintained debug caption smoke.
 /// A release build does not compile the synthetic source or its RPC handle.
@@ -59,6 +63,42 @@ pub struct AudioFrame {
     pub sample_rate: u32,
     pub channels: u16,
     pub samples: Vec<f32>,
+}
+
+/// Authoritative lifecycle of the native microphone input feeding FFmpeg.
+///
+/// `SourceLost` is reserved for producer EOF or a confirmed callback stall.
+/// FIFO write failures are downstream failures, never microphone loss, and a
+/// user/application stop remains distinguishable from both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeAudioInputState {
+    Starting,
+    Live,
+    SourceLost,
+    DownstreamClosed,
+    Stopped,
+}
+
+impl NativeAudioInputState {
+    const fn as_u8(self) -> u8 {
+        match self {
+            Self::Starting => 0,
+            Self::Live => 1,
+            Self::SourceLost => 2,
+            Self::DownstreamClosed => 3,
+            Self::Stopped => 4,
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Live,
+            2 => Self::SourceLost,
+            3 => Self::DownstreamClosed,
+            4 => Self::Stopped,
+            _ => Self::Starting,
+        }
+    }
 }
 
 impl AudioFrame {
@@ -155,6 +195,7 @@ pub struct CaptionContractTestAudioInjector {
     packets_remaining: Arc<AtomicU64>,
     packets_generated: Arc<AtomicU64>,
     injection_active: Arc<AtomicBool>,
+    source_disconnect_requested: Arc<AtomicBool>,
     stop: Arc<AtomicBool>,
 }
 
@@ -167,6 +208,16 @@ pub struct CaptionContractTestAudioInjection {
 
 #[cfg(debug_assertions)]
 impl CaptionContractTestAudioInjector {
+    /// Ends the maintained synthetic producer without stopping the recording.
+    /// Dropping its sender makes the FIFO writer observe the same producer EOF
+    /// as a real native microphone disconnect. Returns true only for the first
+    /// request so debug callers can treat retries as idempotent.
+    pub fn disconnect_source(&self) -> bool {
+        self.source_disconnect_requested
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
     pub async fn inject(
         &self,
         duration_ms: u64,
@@ -209,6 +260,11 @@ impl CaptionContractTestAudioInjector {
                     "The active native audio session stopped during PCM injection."
                 ));
             }
+            if self.source_disconnect_requested.load(Ordering::Acquire) {
+                break Err(anyhow::anyhow!(
+                    "The synthetic native audio source disconnected during PCM injection."
+                ));
+            }
             if tokio::time::Instant::now() >= deadline {
                 break Err(anyhow::anyhow!(
                     "Timed out waiting for the synthetic native audio source."
@@ -235,6 +291,9 @@ pub struct AudioCaptureStats {
     dropped_frames: AtomicU64,
     fifo_write_errors: AtomicU64,
     recording_window_finished: AtomicBool,
+    input_state: AtomicU8,
+    source_loss_after_ms: AtomicU64,
+    source_loss_event_claimed: AtomicBool,
     // Peak amplitude of the most recent frame window (milli-units, 0..=1000):
     // the Studio mixer's live meter reads this via the diagnostics sampler —
     // no extra device open (post-0.9.4 fix batch F7).
@@ -272,6 +331,91 @@ impl AudioCaptureStats {
 
     pub fn session_peak(&self) -> f32 {
         self.session_peak_milli.load(Ordering::Relaxed) as f32 / 1000.0
+    }
+
+    fn input_state(&self) -> NativeAudioInputState {
+        NativeAudioInputState::from_u8(self.input_state.load(Ordering::Acquire))
+    }
+
+    fn source_loss_after_ms(&self) -> Option<u64> {
+        (self.input_state() == NativeAudioInputState::SourceLost)
+            .then(|| self.source_loss_after_ms.load(Ordering::Acquire))
+    }
+
+    fn claim_source_loss_event(&self) -> Option<u64> {
+        let source_loss_after_ms = self.source_loss_after_ms()?;
+        self.source_loss_event_claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| source_loss_after_ms)
+    }
+
+    fn mark_source_lost_at(&self, lost_at: Instant) {
+        let loss_after_ms = self
+            .recording_window_elapsed_at(lost_at)
+            .unwrap_or_default()
+            .as_millis()
+            .min(u128::from(u64::MAX)) as u64;
+        self.source_loss_after_ms
+            .store(loss_after_ms, Ordering::Release);
+        if self
+            .input_state
+            .compare_exchange(
+                NativeAudioInputState::Live.as_u8(),
+                NativeAudioInputState::SourceLost.as_u8(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            // Once this take has lost its source, later callbacks are not part
+            // of the recorded mic track. FFmpeg-generated padding therefore
+            // never inflates the native capture counters either.
+            self.finish_recording_window_at(lost_at);
+        }
+    }
+
+    fn mark_live(&self) {
+        let _ = self.input_state.compare_exchange(
+            NativeAudioInputState::Starting.as_u8(),
+            NativeAudioInputState::Live.as_u8(),
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    fn mark_downstream_closed(&self) {
+        for from in [NativeAudioInputState::Starting, NativeAudioInputState::Live] {
+            if self
+                .input_state
+                .compare_exchange(
+                    from.as_u8(),
+                    NativeAudioInputState::DownstreamClosed.as_u8(),
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                break;
+            }
+        }
+    }
+
+    fn mark_stopped(&self) {
+        for from in [NativeAudioInputState::Starting, NativeAudioInputState::Live] {
+            if self
+                .input_state
+                .compare_exchange(
+                    from.as_u8(),
+                    NativeAudioInputState::Stopped.as_u8(),
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                break;
+            }
+        }
     }
 
     fn record_live_peak(&self, peak: f32) {
@@ -460,11 +604,35 @@ impl NativeAudioCaptureSession {
         self.stats.session_peak()
     }
 
+    pub fn input_state(&self) -> NativeAudioInputState {
+        self.stats.input_state()
+    }
+
+    pub fn source_loss_after_ms(&self) -> Option<u64> {
+        self.stats.source_loss_after_ms()
+    }
+
+    /// Atomically reserves publication of the one source-loss health event.
+    /// The live sampler normally claims it; finalization may use the same
+    /// method as a fallback without ever duplicating the warning.
+    pub fn claim_source_loss_event(&self) -> Option<u64> {
+        self.stats.claim_source_loss_event()
+    }
+
     pub fn recording_window_elapsed_secs(&self) -> Option<f64> {
         self.stats.recording_window_elapsed_secs()
     }
 
     pub fn finish_recording_window(&self) {
+        self.stats.finish_recording_window();
+    }
+
+    /// Marks an intentional session stop before freezing counters and closing
+    /// the producer/FIFO. Terminal source/downstream failures remain
+    /// authoritative if they won the race before the stop request.
+    pub fn request_stop(&self) {
+        self.stats.mark_stopped();
+        self.stop.store(true, Ordering::Release);
         self.stats.finish_recording_window();
     }
 
@@ -483,7 +651,7 @@ impl NativeAudioCaptureSession {
 
 impl Drop for NativeAudioCaptureSession {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
+        self.request_stop();
         #[cfg(debug_assertions)]
         if let Some(producer) = self.caption_contract_test_producer.take() {
             let _ = producer.join();
@@ -692,9 +860,23 @@ fn trim_audio_frame_before_epoch(mut frame: AudioFrame, epoch: Instant) -> Trimm
 }
 
 pub fn attach_fifo_writer(
+    source: NativeAudioSource,
+    fifo_path: PathBuf,
+    video_epoch: Option<Arc<OnceLock<Instant>>>,
+) -> NativeAudioCaptureSession {
+    attach_fifo_writer_with_stall_timeout(
+        source,
+        fifo_path,
+        video_epoch,
+        NATIVE_AUDIO_SOURCE_STALL_TIMEOUT,
+    )
+}
+
+fn attach_fifo_writer_with_stall_timeout(
     mut source: NativeAudioSource,
     fifo_path: PathBuf,
     video_epoch: Option<Arc<OnceLock<Instant>>>,
+    source_stall_timeout: Duration,
 ) -> NativeAudioCaptureSession {
     source.stop_on_drop = false;
     let device_id = source.device_id;
@@ -726,6 +908,11 @@ pub fn attach_fifo_writer(
                 writer_stats
                     .fifo_write_errors
                     .fetch_add(1, Ordering::Relaxed);
+                if writer_stop.load(Ordering::Acquire) {
+                    writer_stats.mark_stopped();
+                } else {
+                    writer_stats.mark_downstream_closed();
+                }
                 tracing::warn!("Could not open native audio FIFO: {error}");
                 return;
             }
@@ -760,6 +947,8 @@ pub fn attach_fifo_writer(
         // only frames captured/dropped after the FIFO is open and pre-roll has been
         // discarded.
         writer_stats.reset_recording_window();
+        writer_stats.mark_live();
+        let mut last_source_frame_at = Instant::now();
 
         for frame in preroll.ready_frames {
             let frame_count = frame.frame_count() as u64;
@@ -767,15 +956,22 @@ pub fn attach_fifo_writer(
                 writer_stats
                     .fifo_write_errors
                     .fetch_add(1, Ordering::Relaxed);
+                if writer_stop.load(Ordering::Acquire) {
+                    writer_stats.mark_stopped();
+                } else {
+                    writer_stats.mark_downstream_closed();
+                }
                 tracing::warn!("Could not write native audio frame: {error}");
                 return;
             }
+            last_source_frame_at = Instant::now();
             writer_stats.record_captured_frames(frame_count);
         }
 
         while !writer_stop.load(Ordering::Relaxed) {
             match receiver.recv_timeout(Duration::from_millis(50)) {
                 Ok(frame) => {
+                    last_source_frame_at = Instant::now();
                     // Live captions listen on this same post-gain/post-mute mic
                     // bus; the offer is a relaxed-atomic no-op unless a caption
                     // session is active and never blocks this writer.
@@ -789,13 +985,44 @@ pub fn attach_fifo_writer(
                         writer_stats
                             .fifo_write_errors
                             .fetch_add(1, Ordering::Relaxed);
+                        if writer_stop.load(Ordering::Acquire) {
+                            writer_stats.mark_stopped();
+                        } else {
+                            // BrokenPipe/EPIPE says FFmpeg closed its reader; it
+                            // is downstream evidence, never microphone loss.
+                            writer_stats.mark_downstream_closed();
+                        }
                         tracing::warn!("Could not write native audio frame: {error}");
                         break;
                     }
                 }
-                Err(mpsc::RecvTimeoutError::Timeout) => continue,
-                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if last_source_frame_at.elapsed() >= source_stall_timeout {
+                        let lost_at = Instant::now();
+                        writer_stats.mark_source_lost_at(lost_at);
+                        writer_stop.store(true, Ordering::Release);
+                        tracing::warn!(
+                            "Native microphone input stopped producing frames; closing its FIFO so recording can continue with silence."
+                        );
+                        break;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    if writer_stop.load(Ordering::Acquire) {
+                        writer_stats.mark_stopped();
+                    } else {
+                        writer_stats.mark_source_lost_at(Instant::now());
+                        writer_stop.store(true, Ordering::Release);
+                        tracing::warn!(
+                            "Native microphone input disconnected; closing its FIFO so recording can continue with silence."
+                        );
+                    }
+                    break;
+                }
             }
+        }
+        if writer_stop.load(Ordering::Acquire) {
+            writer_stats.mark_stopped();
         }
     });
 
@@ -1007,6 +1234,7 @@ fn start_caption_contract_test_audio_source(
         packets_remaining: Arc::new(AtomicU64::new(0)),
         packets_generated: Arc::new(AtomicU64::new(0)),
         injection_active: Arc::new(AtomicBool::new(false)),
+        source_disconnect_requested: Arc::new(AtomicBool::new(false)),
         stop: stop.clone(),
     };
 
@@ -1023,7 +1251,11 @@ fn start_caption_contract_test_audio_source(
         let mut frame_cursor = 0_u64;
         let mut next_tick = Instant::now();
 
-        while !producer_stop.load(Ordering::Acquire) {
+        while !producer_stop.load(Ordering::Acquire)
+            && !producer_injector
+                .source_disconnect_requested
+                .load(Ordering::Acquire)
+        {
             let inject_tone = producer_injector
                 .packets_remaining
                 .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
@@ -1538,6 +1770,71 @@ fn utf16_z(value: &[u16]) -> Option<String> {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn test_fifo_path(label: &str) -> PathBuf {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        std::env::temp_dir().join(format!(
+            "videorc-audio-{label}-{}-{}.f32le",
+            std::process::id(),
+            NEXT_ID.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[cfg(unix)]
+    fn test_native_audio_source() -> (
+        NativeAudioSource,
+        mpsc::SyncSender<AudioFrame>,
+        Arc<AudioCaptureStats>,
+    ) {
+        let (sender, receiver) = mpsc::sync_channel(AUDIO_RING_CAPACITY_PACKETS);
+        let stats = Arc::new(AudioCaptureStats::default());
+        let stop = Arc::new(AtomicBool::new(false));
+        (
+            NativeAudioSource {
+                device_id: 42,
+                device_name: "Test microphone".to_string(),
+                receiver: Some(receiver),
+                stats: stats.clone(),
+                processing_settings: AudioProcessingSettingsHandle::new(
+                    AudioProcessingSettings::default(),
+                ),
+                stop,
+                stop_on_drop: true,
+                #[cfg(debug_assertions)]
+                caption_contract_test_injector: None,
+                #[cfg(debug_assertions)]
+                caption_contract_test_producer: None,
+                #[cfg(target_os = "macos")]
+                audio_unit: None,
+            },
+            sender,
+            stats,
+        )
+    }
+
+    #[cfg(unix)]
+    fn start_fifo_drain(path: &Path) -> thread::JoinHandle<Vec<u8>> {
+        let path = path.to_path_buf();
+        thread::spawn(move || {
+            use std::io::Read;
+
+            let mut file = File::open(path).expect("test FIFO reader opens");
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)
+                .expect("test FIFO reader drains");
+            bytes
+        })
+    }
+
+    #[cfg(unix)]
+    fn wait_for_input_state(session: &NativeAudioCaptureSession, expected: NativeAudioInputState) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while session.input_state() != expected && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(session.input_state(), expected);
+    }
+
     fn frame(samples: usize) -> AudioFrame {
         frame_at(Instant::now(), samples)
     }
@@ -1632,6 +1929,163 @@ mod tests {
         assert!((stalled - 0.5).abs() < 1e-6, "stalled coverage {stalled}");
         // Zero sample rate is undefined.
         assert_eq!(audio_capture_coverage(1000, 5.0, 0), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_audio_producer_eof_is_source_loss_and_claims_one_event() {
+        let path = test_fifo_path("source-eof");
+        create_native_audio_fifo(&path).unwrap();
+        let reader = start_fifo_drain(&path);
+        let (source, sender, _stats) = test_native_audio_source();
+        let session =
+            attach_fifo_writer_with_stall_timeout(source, path, None, Duration::from_secs(1));
+        wait_for_input_state(&session, NativeAudioInputState::Live);
+
+        sender.send(frame(480)).unwrap();
+        drop(sender);
+        wait_for_input_state(&session, NativeAudioInputState::SourceLost);
+
+        assert!(session.source_loss_after_ms().is_some());
+        assert!(session.claim_source_loss_event().is_some());
+        assert_eq!(session.claim_source_loss_event(), None);
+        drop(session);
+        assert!(!reader.join().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_audio_input_is_starting_until_fifo_is_ready() {
+        let path = test_fifo_path("starting");
+        create_native_audio_fifo(&path).unwrap();
+        let (source, _sender, _stats) = test_native_audio_source();
+        let session =
+            attach_fifo_writer_with_stall_timeout(source, path, None, Duration::from_secs(1));
+
+        assert_eq!(session.input_state(), NativeAudioInputState::Starting);
+        session.request_stop();
+        assert_eq!(session.input_state(), NativeAudioInputState::Stopped);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn brief_native_audio_gap_recovers_but_confirmed_stall_is_source_loss() {
+        let path = test_fifo_path("source-stall");
+        create_native_audio_fifo(&path).unwrap();
+        let reader = start_fifo_drain(&path);
+        let (source, sender, _stats) = test_native_audio_source();
+        let session =
+            attach_fifo_writer_with_stall_timeout(source, path, None, Duration::from_millis(250));
+        wait_for_input_state(&session, NativeAudioInputState::Live);
+
+        sender.send(frame(480)).unwrap();
+        thread::sleep(Duration::from_millis(75));
+        assert_eq!(session.input_state(), NativeAudioInputState::Live);
+        sender.send(frame(480)).unwrap();
+        thread::sleep(Duration::from_millis(75));
+        assert_eq!(
+            session.input_state(),
+            NativeAudioInputState::Live,
+            "a recoverable callback gap must not sacrifice the rest of the take"
+        );
+
+        wait_for_input_state(&session, NativeAudioInputState::SourceLost);
+        assert!(session.source_loss_after_ms().unwrap() >= 250);
+        let disconnect_deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            match sender.try_send(frame(480)) {
+                Err(mpsc::TrySendError::Disconnected(_)) => break,
+                Ok(()) | Err(mpsc::TrySendError::Full(_))
+                    if Instant::now() < disconnect_deadline =>
+                {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                outcome => panic!("source loss must remain terminal, got {outcome:?}"),
+            }
+        }
+        drop(session);
+        assert!(!reader.join().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn intentional_native_audio_stop_is_not_source_loss() {
+        let path = test_fifo_path("intentional-stop");
+        create_native_audio_fifo(&path).unwrap();
+        let reader = start_fifo_drain(&path);
+        let (source, _sender, _stats) = test_native_audio_source();
+        let session =
+            attach_fifo_writer_with_stall_timeout(source, path, None, Duration::from_secs(1));
+        wait_for_input_state(&session, NativeAudioInputState::Live);
+
+        session.request_stop();
+        wait_for_input_state(&session, NativeAudioInputState::Stopped);
+        assert_eq!(session.source_loss_after_ms(), None);
+        assert_eq!(session.claim_source_loss_event(), None);
+        drop(session);
+        assert!(reader.join().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_audio_broken_pipe_is_downstream_closed_not_source_loss() {
+        let path = test_fifo_path("broken-pipe");
+        create_native_audio_fifo(&path).unwrap();
+        let (reader_opened_sender, reader_opened_receiver) = mpsc::channel();
+        let reader_path = path.clone();
+        let reader = thread::spawn(move || {
+            let file = File::open(reader_path).expect("test FIFO reader opens");
+            reader_opened_sender.send(()).unwrap();
+            drop(file);
+        });
+        let (source, sender, _stats) = test_native_audio_source();
+        let session =
+            attach_fifo_writer_with_stall_timeout(source, path, None, Duration::from_secs(1));
+        reader_opened_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("reader opened before inducing EPIPE");
+        reader.join().unwrap();
+        wait_for_input_state(&session, NativeAudioInputState::Live);
+
+        sender.send(frame(480)).unwrap();
+        wait_for_input_state(&session, NativeAudioInputState::DownstreamClosed);
+        assert_eq!(session.source_loss_after_ms(), None);
+        assert_eq!(session.claim_source_loss_event(), None);
+    }
+
+    #[cfg(all(unix, debug_assertions))]
+    #[test]
+    fn caption_contract_disconnect_uses_real_source_loss_path_idempotently() {
+        let path = test_fifo_path("caption-disconnect");
+        create_native_audio_fifo(&path).unwrap();
+        let reader = start_fifo_drain(&path);
+        let source = start_caption_contract_test_audio_source(AudioProcessingSettings::default())
+            .expect("synthetic source starts");
+        let session =
+            attach_fifo_writer_with_stall_timeout(source, path, None, Duration::from_secs(1));
+        wait_for_input_state(&session, NativeAudioInputState::Live);
+        let injector = session
+            .caption_contract_test_injector()
+            .expect("caption contract source exposes its controller");
+        let first_packet_deadline = Instant::now() + Duration::from_secs(1);
+        while session.captured_frames() == 0 && Instant::now() < first_packet_deadline {
+            thread::sleep(Duration::from_millis(5));
+        }
+        let captured_before_disconnect = session.captured_frames();
+        assert!(captured_before_disconnect > 0);
+
+        assert!(injector.disconnect_source());
+        assert!(!injector.disconnect_source());
+        wait_for_input_state(&session, NativeAudioInputState::SourceLost);
+        let captured_at_loss = session.captured_frames();
+        thread::sleep(Duration::from_millis(60));
+        assert_eq!(session.captured_frames(), captured_at_loss);
+        assert!(captured_at_loss >= captured_before_disconnect);
+        assert!(session.claim_source_loss_event().is_some());
+        assert_eq!(session.claim_source_loss_event(), None);
+
+        drop(session);
+        let _captured_bytes = reader.join().unwrap();
     }
 
     #[test]
@@ -1742,6 +2196,21 @@ mod tests {
 
         assert_eq!(stats.captured_frames(), 240);
         assert_eq!(stats.dropped_frames(), 0);
+    }
+
+    #[test]
+    fn native_audio_recording_window_reset_cannot_revive_an_intentionally_stopped_input() {
+        let stats = AudioCaptureStats::default();
+        stats.reset_recording_window();
+        stats.mark_live();
+        stats.mark_stopped();
+
+        // Models the FIFO writer's second counter reset winning the scheduler
+        // immediately after the caller has requested an intentional stop.
+        stats.reset_recording_window();
+
+        assert_eq!(stats.input_state(), NativeAudioInputState::Stopped);
+        assert_eq!(stats.claim_source_loss_event(), None);
     }
 
     #[test]

--- a/crates/videorc-backend/src/backend_authority.rs
+++ b/crates/videorc-backend/src/backend_authority.rs
@@ -231,6 +231,7 @@ mod tests {
             "encoder_bridge.synthetic_record",
             "recording.start_test",
             "captions.test.inject-audio",
+            "audio.test.disconnect",
             "audio.test.inject-pcm",
             "test.future.mutation",
         ] {

--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -103,6 +103,12 @@ const STREAM_OUTPUT_SUSTAINED_FAIL_WINDOW: Duration = Duration::from_secs(2);
 const RAW_VIDEO_FIFO_QUEUE_MAX_FRAMES: usize = 0;
 #[cfg(not(target_os = "windows"))]
 const FIFO_FRAME_WRITE_HARD_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(target_os = "macos")]
+const VIDEOTOOLBOX_FIFO_WRITE_STALL_TOLERANCE: Duration = FIFO_FRAME_WRITE_HARD_TIMEOUT;
+#[cfg(all(target_os = "macos", debug_assertions))]
+const VIDEORC_TEST_VT_FIFO_PAUSE_AFTER_FRAMES_ENV: &str = "VIDEORC_TEST_VT_FIFO_PAUSE_AFTER_FRAMES";
+#[cfg(all(target_os = "macos", debug_assertions))]
+const VIDEORC_TEST_VT_FIFO_PAUSE_MS_ENV: &str = "VIDEORC_TEST_VT_FIFO_PAUSE_MS";
 // Media Foundation can stop draining the raw-video pipe for several seconds
 // while its MFT catches up. A raw YUV frame is indivisible once writing starts:
 // timing it out truncates a plane, kills FFmpeg, strands the recovery MKV, and
@@ -4776,7 +4782,63 @@ struct VideoToolboxFifoWriter {
 #[cfg(target_os = "macos")]
 struct QueuedVideoToolboxFrame {
     frame: VideoToolboxH264AnnexBFrame,
-    submitted_at: Instant,
+}
+
+#[cfg(target_os = "macos")]
+struct VideoToolboxFifoTestPause {
+    after_frames: u64,
+    duration: Duration,
+    fired: bool,
+}
+
+#[cfg(target_os = "macos")]
+impl VideoToolboxFifoTestPause {
+    fn take_before_write(&mut self, written_frames: u64) -> Option<Duration> {
+        if self.fired || written_frames < self.after_frames {
+            return None;
+        }
+        self.fired = true;
+        Some(self.duration)
+    }
+}
+
+#[cfg(all(target_os = "macos", debug_assertions))]
+fn parse_video_toolbox_fifo_test_pause(
+    role: EncoderBridgeOutputRole,
+    after_frames: Option<&str>,
+    pause_ms: Option<&str>,
+) -> Option<VideoToolboxFifoTestPause> {
+    if !matches!(
+        role,
+        EncoderBridgeOutputRole::Recording | EncoderBridgeOutputRole::Shared
+    ) {
+        return None;
+    }
+    let after_frames = after_frames?.trim().parse::<u64>().ok()?;
+    let pause_ms = pause_ms?.trim().parse::<u64>().ok()?;
+    if pause_ms == 0 {
+        return None;
+    }
+    Some(VideoToolboxFifoTestPause {
+        after_frames,
+        duration: Duration::from_millis(pause_ms),
+        fired: false,
+    })
+}
+
+#[cfg(all(target_os = "macos", debug_assertions))]
+fn video_toolbox_fifo_test_pause_from_env(
+    role: EncoderBridgeOutputRole,
+) -> Option<VideoToolboxFifoTestPause> {
+    parse_video_toolbox_fifo_test_pause(
+        role,
+        std::env::var(VIDEORC_TEST_VT_FIFO_PAUSE_AFTER_FRAMES_ENV)
+            .ok()
+            .as_deref(),
+        std::env::var(VIDEORC_TEST_VT_FIFO_PAUSE_MS_ENV)
+            .ok()
+            .as_deref(),
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -4811,17 +4873,10 @@ impl VideoToolboxFifoWriter {
         // One extra slot preserves a terminal flush error without deadlocking
         // close_and_join if the bridge is already tearing down.
         let (result_tx, result_rx) = std_mpsc::sync_channel(policy.max_frames + 2);
-        // The per-frame write deadline bounds COMPLETE-frame delivery. The
-        // stream role gets the sustained-violation grace on top of its queue
-        // budget so a transient downstream freeze degrades instead of killing
-        // the writer (a 500ms FFmpeg stall used to trip the 150ms budget and
-        // end the stream). Recording keeps its strict budget: silently
-        // buffering recording frames is the corruption its contract prevents.
-        let write_frame_age = if policy.role == EncoderBridgeOutputRole::Stream {
-            policy.max_age + STREAM_OUTPUT_SUSTAINED_FAIL_WINDOW
-        } else {
-            policy.max_age
-        };
+        #[cfg(debug_assertions)]
+        let test_pause = video_toolbox_fifo_test_pause_from_env(policy.role);
+        #[cfg(not(debug_assertions))]
+        let test_pause = None;
         let join = spawn_registered_fifo_writer(
             lifecycle.clone(),
             thread::Builder::new().name(format!("videorc-{:?}-h264-fifo-writer", policy.role)),
@@ -4832,7 +4887,8 @@ impl VideoToolboxFifoWriter {
                     frame_rx,
                     result_tx,
                     stop,
-                    write_frame_age,
+                    VIDEOTOOLBOX_FIFO_WRITE_STALL_TOLERANCE,
+                    test_pause,
                 );
             },
         )
@@ -4849,20 +4905,13 @@ impl VideoToolboxFifoWriter {
     fn enqueue(
         &self,
         frame: VideoToolboxH264AnnexBFrame,
-        submitted_at: Instant,
         capacity_pressure_events: &mut u64,
     ) -> io::Result<()> {
         let tx = self
             .frame_tx
             .as_ref()
             .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "H.264 FIFO writer closed"))?;
-        match offer_preserving_output_frame(
-            tx,
-            QueuedVideoToolboxFrame {
-                frame,
-                submitted_at,
-            },
-        ) {
+        match offer_preserving_output_frame(tx, QueuedVideoToolboxFrame { frame }) {
             Ok(PreservingOutputFrameOffer::Enqueued) => Ok(()),
             Ok(PreservingOutputFrameOffer::CapacityPressure(_frame)) => {
                 *capacity_pressure_events = capacity_pressure_events.saturating_add(1);
@@ -4958,20 +5007,40 @@ fn run_video_toolbox_fifo_writer_loop<W: StdWrite>(
     frame_rx: std_mpsc::Receiver<QueuedVideoToolboxFrame>,
     result_tx: std_mpsc::SyncSender<VideoToolboxFifoWriterResult>,
     stop: Arc<AtomicBool>,
-    max_frame_age: Duration,
+    write_stall_tolerance: Duration,
+    mut test_pause: Option<VideoToolboxFifoTestPause>,
 ) {
+    let mut written_frames = 0_u64;
     while let Ok(queued) = frame_rx.recv() {
         let encoded_bytes = queued.frame.bytes.len() as u64;
+        if let Some(duration) = test_pause
+            .as_mut()
+            .and_then(|pause| pause.take_before_write(written_frames))
+        {
+            tracing::warn!(
+                target: "videorc::encoder_bridge",
+                test_hook = "videotoolbox-fifo-pause",
+                written_frames,
+                pause_ms = duration.as_millis() as u64,
+                "VIDEORC_TEST_VT_FIFO_PAUSE_FIRED"
+            );
+            thread::sleep(duration);
+        }
         let write_started_at = Instant::now();
-        let deadline = queued.submitted_at + max_frame_age;
+        // Queue age is pressure diagnostics, not FIFO liveness. A recording
+        // access unit that waited behind transient encoder pressure is still
+        // valid content and must receive a fresh write window (#149's raw
+        // writer contract). The hard timeout still bounds the complete write.
+        let deadline = write_started_at + write_stall_tolerance;
         match h264_pipe_writer.write_frame_until(
             &mut sink,
             &queued.frame,
             &stop,
             deadline,
-            max_frame_age,
+            write_stall_tolerance,
         ) {
             Ok(()) => {
+                written_frames = written_frames.saturating_add(1);
                 let _ = result_tx.send(VideoToolboxFifoWriterResult::FrameWritten {
                     encoded_bytes,
                     write_ms: write_started_at.elapsed().as_secs_f64() * 1000.0,
@@ -5046,7 +5115,7 @@ impl VideoToolboxH264PipeWriter {
         frame: &VideoToolboxH264AnnexBFrame,
         stop: &AtomicBool,
         deadline: Instant,
-        max_frame_age: Duration,
+        write_stall_tolerance: Duration,
     ) -> io::Result<()> {
         let bytes = self.frame_bytes(frame)?;
         write_all_until(
@@ -5054,7 +5123,7 @@ impl VideoToolboxH264PipeWriter {
             bytes,
             stop,
             deadline,
-            max_frame_age,
+            write_stall_tolerance,
             FIFO_FRAME_WRITE_HARD_TIMEOUT,
             // Stop closes the sender and prevents new access units. Finish the
             // one already in flight so an ordinary user stop cannot manufacture
@@ -5751,7 +5820,7 @@ fn drain_video_toolbox_output_frames(
         match message.result {
             Ok(frame) => {
                 let enqueue_started_at = Instant::now();
-                fifo_writer.enqueue(frame, submitted_at, output_queue_capacity_pressure_events)?;
+                fifo_writer.enqueue(frame, output_queue_capacity_pressure_events)?;
                 let enqueue_ms = enqueue_started_at.elapsed().as_secs_f64() * 1000.0;
                 video_toolbox_fifo_enqueue_times_ms.push(enqueue_ms);
                 *max_video_toolbox_fifo_enqueue_ms = Some(
@@ -8684,6 +8753,71 @@ mod tests {
             | u64::from((bytes[4] >> 1) & 0x7f)
     }
 
+    #[cfg(all(target_os = "macos", debug_assertions))]
+    #[test]
+    fn videotoolbox_fifo_test_pause_is_disabled_for_missing_or_invalid_configuration() {
+        for (after_frames, pause_ms) in [
+            (None, None),
+            (Some("60"), None),
+            (None, Some("350")),
+            (Some(""), Some("350")),
+            (Some("sixty"), Some("350")),
+            (Some("60"), Some("")),
+            (Some("60"), Some("0")),
+            (Some("60"), Some("-1")),
+        ] {
+            assert!(
+                parse_video_toolbox_fifo_test_pause(
+                    EncoderBridgeOutputRole::Recording,
+                    after_frames,
+                    pause_ms,
+                )
+                .is_none(),
+                "invalid pause configuration must remain disabled"
+            );
+        }
+        assert!(
+            parse_video_toolbox_fifo_test_pause(
+                EncoderBridgeOutputRole::Stream,
+                Some("60"),
+                Some("350"),
+            )
+            .is_none(),
+            "the recording-pressure hook must never pause the stream-only writer"
+        );
+    }
+
+    #[cfg(all(target_os = "macos", debug_assertions))]
+    #[test]
+    fn videotoolbox_fifo_test_pause_parses_recording_and_shared_configuration() {
+        for role in [
+            EncoderBridgeOutputRole::Recording,
+            EncoderBridgeOutputRole::Shared,
+        ] {
+            let pause = parse_video_toolbox_fifo_test_pause(role, Some(" 60 "), Some(" 350 "))
+                .expect("valid recording pressure hook");
+            assert_eq!(pause.after_frames, 60);
+            assert_eq!(pause.duration, Duration::from_millis(350));
+        }
+    }
+
+    #[cfg(all(target_os = "macos", debug_assertions))]
+    #[test]
+    fn videotoolbox_fifo_test_pause_fires_once_before_the_selected_access_unit() {
+        let mut pause = parse_video_toolbox_fifo_test_pause(
+            EncoderBridgeOutputRole::Recording,
+            Some("2"),
+            Some("350"),
+        )
+        .expect("valid recording pressure hook");
+
+        assert_eq!(pause.take_before_write(0), None);
+        assert_eq!(pause.take_before_write(1), None);
+        assert_eq!(pause.take_before_write(2), Some(Duration::from_millis(350)));
+        assert_eq!(pause.take_before_write(2), None);
+        assert_eq!(pause.take_before_write(3), None);
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn videotoolbox_fifo_writer_reports_written_frames() {
@@ -8698,7 +8832,6 @@ mod tests {
                         nal_types: vec![1],
                         is_idr: false,
                     },
-                    submitted_at: Instant::now(),
                 })
                 .expect("queue frame");
         }
@@ -8713,6 +8846,7 @@ mod tests {
             result_tx,
             Arc::new(AtomicBool::new(false)),
             Duration::from_millis(250),
+            None,
         );
 
         let results = result_rx.try_iter().collect::<Vec<_>>();
@@ -8735,6 +8869,64 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn videotoolbox_fifo_writer_writes_an_access_unit_older_than_the_queue_age_budget() {
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(3);
+        let bytes = vec![0x44; 64];
+        frame_tx
+            .send(QueuedVideoToolboxFrame {
+                frame: VideoToolboxH264AnnexBFrame {
+                    timing: VideoToolboxFrameTiming::new(0, 30, 1, 30),
+                    bytes: bytes.clone(),
+                    nal_types: vec![1],
+                    is_idr: false,
+                },
+            })
+            .expect("queue frame");
+        drop(frame_tx);
+        // Model an access unit that has already waited behind transient
+        // encoder/FIFO pressure for longer than the queue-health budget.
+        thread::sleep(RECORDING_OUTPUT_QUEUE_MAX_AGE + Duration::from_millis(50));
+        let sink = SharedCountingSink::default();
+
+        run_video_toolbox_fifo_writer_loop(
+            sink.clone(),
+            VideoToolboxH264PipeWriter::for_output(
+                EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
+            ),
+            frame_rx,
+            result_tx,
+            Arc::new(AtomicBool::new(false)),
+            RECORDING_OUTPUT_QUEUE_MAX_AGE,
+            None,
+        );
+
+        assert_eq!(
+            sink.bytes(),
+            bytes,
+            "a late recording access unit must still be written completely"
+        );
+        assert!(matches!(
+            result_rx.recv().expect("written frame result"),
+            VideoToolboxFifoWriterResult::FrameWritten { .. }
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn videotoolbox_fifo_write_stall_tolerance_is_not_the_queue_age_budget() {
+        assert!(
+            VIDEOTOOLBOX_FIFO_WRITE_STALL_TOLERANCE > RECORDING_OUTPUT_QUEUE_MAX_AGE,
+            "queue pressure must not become a FIFO liveness verdict"
+        );
+        assert_eq!(
+            VIDEOTOOLBOX_FIFO_WRITE_STALL_TOLERANCE,
+            FIFO_FRAME_WRITE_HARD_TIMEOUT
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn videotoolbox_fifo_writer_finishes_in_flight_access_unit_after_stop() {
         let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
         let (result_tx, result_rx) = std_mpsc::sync_channel(3);
@@ -8747,7 +8939,6 @@ mod tests {
                     nal_types: vec![1],
                     is_idr: false,
                 },
-                submitted_at: Instant::now(),
             })
             .expect("queue frame");
         drop(frame_tx);
@@ -8763,6 +8954,7 @@ mod tests {
             result_tx,
             stop,
             Duration::from_millis(250),
+            None,
         );
 
         assert_eq!(sink.bytes(), bytes);
@@ -8785,7 +8977,6 @@ mod tests {
                     nal_types: vec![1],
                     is_idr: false,
                 },
-                submitted_at: Instant::now(),
             })
             .expect("queue frame");
         drop(frame_tx);
@@ -8800,6 +8991,7 @@ mod tests {
             result_tx,
             Arc::new(AtomicBool::new(false)),
             Duration::from_millis(20),
+            None,
         );
 
         assert!(started_at.elapsed() < Duration::from_millis(500));
@@ -8819,6 +9011,48 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn videotoolbox_fifo_writer_finishes_an_access_unit_while_the_sink_makes_progress() {
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(3);
+        let bytes = vec![0x44; 8];
+        frame_tx
+            .send(QueuedVideoToolboxFrame {
+                frame: VideoToolboxH264AnnexBFrame {
+                    timing: VideoToolboxFrameTiming::new(0, 30, 1, 30),
+                    bytes: bytes.clone(),
+                    nal_types: vec![1],
+                    is_idr: false,
+                },
+            })
+            .expect("queue frame");
+        drop(frame_tx);
+        let written = SharedCountingSink::default();
+
+        run_video_toolbox_fifo_writer_loop(
+            SlowProgressSink {
+                written: written.clone(),
+                chunk_size: 2,
+                delay: Duration::from_millis(10),
+            },
+            VideoToolboxH264PipeWriter::for_output(
+                EncoderBridgeVideoOutput::VideoToolboxH264AnnexB,
+            ),
+            frame_rx,
+            result_tx,
+            Arc::new(AtomicBool::new(false)),
+            Duration::from_millis(25),
+            None,
+        );
+
+        assert_eq!(written.bytes(), bytes);
+        assert!(matches!(
+            result_rx.recv().expect("written frame result"),
+            VideoToolboxFifoWriterResult::FrameWritten { .. }
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn videotoolbox_fifo_writer_classifies_a_closed_downstream() {
         let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
         let (result_tx, result_rx) = std_mpsc::sync_channel(3);
@@ -8830,7 +9064,6 @@ mod tests {
                     nal_types: vec![1],
                     is_idr: false,
                 },
-                submitted_at: Instant::now(),
             })
             .expect("queue frame");
         drop(frame_tx);
@@ -8854,6 +9087,7 @@ mod tests {
             result_tx,
             Arc::new(AtomicBool::new(false)),
             Duration::from_millis(250),
+            None,
         );
 
         let result = result_rx.recv().expect("terminal writer result");

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -5642,6 +5642,36 @@ async fn handle_text_message_with_role(
             }
         }
         #[cfg(debug_assertions)]
+        "audio.test.disconnect" => {
+            let session_id = command
+                .params
+                .get("sessionId")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let injector = {
+                let recording = state.recording.lock().await;
+                recording
+                    .as_ref()
+                    .filter(|active| active.session_id == session_id)
+                    .and_then(|active| active.native_audio.as_ref())
+                    .and_then(|native_audio| native_audio.caption_contract_test_injector())
+            };
+            match injector {
+                Some(injector) => ServerResponse::ok(
+                    command.id,
+                    serde_json::json!({
+                        "disconnected": injector.disconnect_source(),
+                    }),
+                ),
+                None => ServerResponse::error(
+                    command.id,
+                    "caption-contract-test-disabled",
+                    "The matching caption contract test microphone session is not active.",
+                ),
+            }
+        }
+        #[cfg(debug_assertions)]
         "audio.test.inject-pcm" => {
             let session_id = command
                 .params

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -19,9 +19,9 @@ use uuid::Uuid;
 
 use crate::audio::{
     AudioCaptureStats, AudioProcessingSettings, NATIVE_AUDIO_CHANNELS, NATIVE_AUDIO_SAMPLE_RATE,
-    NativeAudioCaptureSession, NativeAudioSource, attach_fifo_writer, audio_capture_coverage,
-    create_native_audio_fifo, native_audio_fifo_path, parse_coreaudio_microphone_id,
-    parse_windows_dshow_microphone_id, start_native_audio_source,
+    NativeAudioCaptureSession, NativeAudioInputState, NativeAudioSource, attach_fifo_writer,
+    audio_capture_coverage, create_native_audio_fifo, native_audio_fifo_path,
+    parse_coreaudio_microphone_id, parse_windows_dshow_microphone_id, start_native_audio_source,
 };
 use crate::camera_capture::{
     native_camera_name_for_id, parse_native_camera_id, parse_windows_dshow_camera_id,
@@ -3451,7 +3451,7 @@ pub async fn stop_recording(state: AppState) -> Result<RecordingStatus> {
     #[cfg(target_os = "windows")]
     release_direct_d3d11_consumer(&state, active);
     if let Some(native_audio) = active.native_audio.as_ref() {
-        native_audio.finish_recording_window();
+        native_audio.request_stop();
     }
     active
         .pipeline
@@ -5083,7 +5083,7 @@ async fn stop_recording_process_for_shutdown(
         let _ = stdin.shutdown().await;
     }
     if let Some(native_audio) = recording.native_audio.as_ref() {
-        native_audio.finish_recording_window();
+        native_audio.request_stop();
     }
 
     if recording.pid != 0 {
@@ -5319,6 +5319,8 @@ async fn sample_native_audio_during_recording(state: AppState, session_id: Strin
                             audio.session_peak(),
                             audio.device_name.clone(),
                             audio.recording_window_elapsed_secs(),
+                            audio.input_state(),
+                            audio.claim_source_loss_event(),
                         )
                     })
                 }
@@ -5332,17 +5334,30 @@ async fn sample_native_audio_during_recording(state: AppState, session_id: Strin
             session_peak,
             device_name,
             capture_elapsed_secs,
+            input_state,
+            source_loss_event_after_ms,
         )) = counters
         else {
             return;
         };
+
+        if let Some(source_loss_after_ms) = source_loss_event_after_ms {
+            silent_mic_reported = true;
+            emit_microphone_input_lost_health_event(
+                &state,
+                &session_id,
+                &device_name,
+                source_loss_after_ms,
+            );
+        }
 
         // Early truthful warning (plan 021 F3): a mic that has produced nothing
         // this deep into the recording will not fix itself — tell the user NOW,
         // while stopping and fixing still saves the take. A TCC-unauthorized
         // process receives silent zeros (frames count, peak stays 0), so both
         // "no frames" and "all-silence" trip the check. Fires at most once.
-        if !silent_mic_reported
+        if input_state != NativeAudioInputState::SourceLost
+            && !silent_mic_reported
             && started_at.elapsed() >= MIC_SILENT_CHECK_AFTER
             && let Some(kind) = silent_mic_verdict(captured_frames, session_peak)
         {
@@ -5383,6 +5398,30 @@ async fn sample_native_audio_during_recording(state: AppState, session_id: Strin
             apply_runtime_diagnostics_snapshot(diagnostic_stats, state.ffmpeg_work.snapshot()),
         );
     }
+}
+
+fn emit_microphone_input_lost_health_event(
+    state: &AppState,
+    session_id: &str,
+    device_name: &str,
+    source_loss_after_ms: u64,
+) {
+    let message = microphone_input_lost_message(device_name, source_loss_after_ms);
+    state.emit_log("warn", &message);
+    let _ = emit_health_event(
+        state,
+        Some(session_id),
+        HealthLevel::Warn,
+        "microphone-input-lost",
+        &message,
+    );
+}
+
+fn microphone_input_lost_message(device_name: &str, source_loss_after_ms: u64) -> String {
+    format!(
+        "Microphone \"{device_name}\" stopped after {:.1} seconds. Videorc replaced the missing input with silence.",
+        source_loss_after_ms as f64 / 1_000.0
+    )
 }
 
 /// Whether the session's own pipeline counters say the recorded output was
@@ -5635,6 +5674,9 @@ async fn monitor_session(
                     captured_frames: audio.captured_frames(),
                     dropped_frames: audio.dropped_frames(),
                     session_peak: audio.session_peak(),
+                    input_state: audio.input_state(),
+                    source_loss_after_ms: audio.source_loss_after_ms(),
+                    unreported_source_loss_after_ms: audio.claim_source_loss_event(),
                 }
             });
             MonitoredRecording {
@@ -5852,6 +5894,14 @@ async fn monitor_session(
             "diagnostics.stats",
             apply_runtime_diagnostics_snapshot(diagnostic_stats, state.ffmpeg_work.snapshot()),
         );
+        if let Some(source_loss_after_ms) = native_audio_stats.unreported_source_loss_after_ms {
+            emit_microphone_input_lost_health_event(
+                &state,
+                &session_id,
+                &native_audio_stats.device_name,
+                source_loss_after_ms,
+            );
+        }
         state.emit_log(
             if native_audio_stats.dropped_frames > 0 {
                 "warn"
@@ -5859,8 +5909,12 @@ async fn monitor_session(
                 "info"
             },
             format!(
-                "Native microphone capture ended for {}: {} frames captured, {} frames dropped.",
+                "Native microphone capture ended for {}: state={:?}, sourceLossAfterMs={}, {} frames captured, {} frames dropped.",
                 native_audio_stats.device_name,
+                native_audio_stats.input_state,
+                native_audio_stats
+                    .source_loss_after_ms
+                    .map_or_else(|| "none".to_string(), |value| value.to_string()),
                 native_audio_stats.captured_frames,
                 native_audio_stats.dropped_frames
             ),
@@ -5880,10 +5934,12 @@ async fn monitor_session(
         }
         // Silent-mic verdict at finalize (plan 021 F3): the user must learn the
         // file has no sound from the app, not from playing it back.
-        if let Some(kind) = silent_mic_verdict(
-            native_audio_stats.captured_frames,
-            native_audio_stats.session_peak,
-        ) {
+        if native_audio_stats.input_state != NativeAudioInputState::SourceLost
+            && let Some(kind) = silent_mic_verdict(
+                native_audio_stats.captured_frames,
+                native_audio_stats.session_peak,
+            )
+        {
             let message = match kind {
                 SilentMicKind::NoFrames => format!(
                     "Microphone \"{}\" captured no audio — this recording has a silent audio track. Check the input device in Settings.",
@@ -7175,6 +7231,9 @@ struct NativeAudioStats {
     captured_frames: u64,
     dropped_frames: u64,
     session_peak: f32,
+    input_state: NativeAudioInputState,
+    source_loss_after_ms: Option<u64>,
+    unreported_source_loss_after_ms: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -11684,13 +11743,13 @@ fn bridge_compositor_ffmpeg_args_with_encoder(
                 }
             }
         }
-        append_audio_encoding_args(
+        append_audio_encoding_with_video_clock(
             &mut args,
             &input_layout,
             &params.audio,
             !stream_targets.is_empty(),
+            true,
         );
-        args.push("-shortest".to_string());
     }
 
     let stream_legs = stream_targets
@@ -11832,8 +11891,7 @@ fn bridge_compositor_split_output_ffmpeg_args(
     ) {
         append_media_foundation_h264_color_metadata_args(&mut args);
     }
-    append_audio_encoding_args(&mut args, &input_layout, &params.audio, true);
-    args.push("-shortest".to_string());
+    append_audio_encoding_with_video_clock(&mut args, &input_layout, &params.audio, true, true);
     args.push(ffmpeg_file_path(output_path));
 
     let stream_input_layout = InputLayout {
@@ -12160,8 +12218,7 @@ fn append_bridge_copy_output_args(
     ) {
         append_media_foundation_h264_color_metadata_args(args);
     }
-    append_audio_encoding_args(args, input_layout, audio, streaming_audio);
-    args.push("-shortest".to_string());
+    append_audio_encoding_with_video_clock(args, input_layout, audio, streaming_audio, true);
 }
 
 fn append_media_foundation_h264_color_metadata_args(args: &mut Vec<String>) {
@@ -12301,11 +12358,12 @@ fn ffmpeg_args_with_encoder(
         encoder.platform,
         !stream_targets.is_empty(),
     );
-    append_audio_encoding_args(
+    append_audio_encoding_with_video_clock(
         &mut args,
         &input_layout,
         &params.audio,
         !stream_targets.is_empty(),
+        false,
     );
 
     let stream_legs = stream_targets
@@ -12790,6 +12848,30 @@ fn append_audio_encoding_args(
     }
 }
 
+/// Applies audio encoding and its duration contract as one inseparable output
+/// policy. Microphone inputs are padded after their existing processing, so a
+/// microphone output must use video EOF as its authoritative clock. Encoder-
+/// bridge outputs also retain their pre-existing shortest-input contract for
+/// synthetic/test audio. Keeping both decisions here prevents a future caller
+/// from enabling unbounded `apad` without the matching output terminator while
+/// leaving unrelated legacy audio duration unchanged.
+fn append_audio_encoding_with_video_clock(
+    args: &mut Vec<String>,
+    input_layout: &InputLayout,
+    audio: &AudioSettings,
+    streaming: bool,
+    preserve_bridge_shortest: bool,
+) {
+    append_audio_encoding_args(args, input_layout, audio, streaming);
+    let microphone_is_padded = input_layout
+        .audio_inputs
+        .iter()
+        .any(|input| input.track.source == AudioTrackSource::Microphone);
+    if preserve_bridge_shortest || microphone_is_padded {
+        args.push("-shortest".to_string());
+    }
+}
+
 fn capture_audio_filter(input_layout: &InputLayout, audio: &AudioSettings) -> String {
     let has_microphone = input_layout
         .audio_inputs
@@ -12839,6 +12921,12 @@ fn capture_audio_filter(input_layout: &InputLayout, audio: &AudioSettings) -> St
         filters.push(MONO_TO_STEREO_FILTER.to_string());
     }
     filters.push(CAPTURE_AUDIO_FILTER.to_string());
+    if has_microphone {
+        // EOF from a disconnected/stalled microphone becomes generated silence
+        // inside FFmpeg. The paired `-shortest` output policy above makes video
+        // EOF authoritative, so padding can never keep a session alive by itself.
+        filters.push("apad".to_string());
+    }
     filters.join(",")
 }
 
@@ -15847,6 +15935,14 @@ mod tests {
         // Real audio, however quiet, is not a silent track.
         assert_eq!(silent_mic_verdict(48_000, 0.002), None);
         assert_eq!(silent_mic_verdict(48_000, 0.9), None);
+    }
+
+    #[test]
+    fn microphone_input_lost_message_is_activity_neutral() {
+        assert_eq!(
+            microphone_input_lost_message("Desk Mic", 92_345),
+            "Microphone \"Desk Mic\" stopped after 92.3 seconds. Videorc replaced the missing input with silence."
+        );
     }
 
     fn starting_test_status() -> RecordingStatus {
@@ -20184,7 +20280,7 @@ mod tests {
         assert!(args.iter().any(|arg| arg == "0:a?"));
         assert_eq!(
             arg_value(&args, "-af"),
-            Some("aresample=async=1:first_pts=0")
+            Some("aresample=async=1:first_pts=0,apad")
         );
     }
 
@@ -22880,7 +22976,7 @@ mod tests {
         assert!(args.iter().any(|arg| arg == "title=Microphone"));
         assert_eq!(
             arg_value(&args, "-af"),
-            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
+            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0,apad")
         );
         assert_eq!(arg_value(&args, "-ar"), Some("48000"));
         assert_eq!(arg_value(&args, "-ac"), Some("2"));
@@ -23299,7 +23395,7 @@ mod tests {
         assert!(args.iter().any(|arg| arg == "title=Microphone"));
         assert_eq!(
             arg_value(&args, "-af"),
-            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
+            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0,apad")
         );
         assert_eq!(arg_value(&args, "-ar"), Some("48000"));
         assert_eq!(arg_value(&args, "-ac"), Some("2"));
@@ -23349,10 +23445,44 @@ mod tests {
         assert!(args.iter().any(|arg| arg == "1:a?"));
         assert_eq!(
             arg_value(&args, "-af"),
-            Some("aresample=async=1:first_pts=0")
+            Some("aresample=async=1:first_pts=0,apad")
         );
         assert_eq!(arg_value(&args, "-ac"), Some("2"));
         assert_eq!(arg_value(&args, "-c:a"), Some("pcm_s16le"));
+    }
+
+    #[test]
+    fn microphone_eof_is_padded_while_video_remains_the_output_clock() {
+        let params = base_params(true, false);
+        let output = Path::new("/tmp/videorc-microphone-continuity.mkv");
+        let args = ffmpeg_args(
+            &CaptureInputs {
+                video: VideoInput::MacScreen { index: 3 },
+                camera_index: None,
+                microphone: Some(MicrophoneInput::CoreAudio {
+                    device_id: 42,
+                    fifo_path: Some(PathBuf::from("/tmp/videorc-audio-continuity.f32le")),
+                }),
+            },
+            &params,
+            Some(output),
+            &[],
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            arg_value(&args, "-af"),
+            Some("aresample=async=1:first_pts=0,apad")
+        );
+        let output_position = args
+            .iter()
+            .position(|arg| arg == output.to_str().unwrap())
+            .expect("recording output is present");
+        assert!(
+            args[..output_position].iter().any(|arg| arg == "-shortest"),
+            "apad must always be paired with output-scoped -shortest: {args:?}"
+        );
     }
 
     #[test]
@@ -23402,17 +23532,17 @@ mod tests {
 
         assert_eq!(
             arg_value(&delayed, "-af"),
-            Some("adelay=120:all=1,pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
+            Some("adelay=120:all=1,pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0,apad")
         );
         assert_eq!(
             arg_value(&trimmed, "-af"),
             Some(
-                "atrim=start=0.120,asetpts=PTS-STARTPTS,pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0"
+                "atrim=start=0.120,asetpts=PTS-STARTPTS,pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0,apad"
             )
         );
         assert_eq!(
             arg_value(&disabled, "-af"),
-            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
+            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0,apad")
         );
     }
 
@@ -23437,7 +23567,7 @@ mod tests {
         // chain carries the channel/resample processing only — no compensating trim.
         assert_eq!(
             arg_value(&args, "-af"),
-            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
+            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0,apad")
         );
     }
 
@@ -23467,7 +23597,7 @@ mod tests {
 
         assert_eq!(
             arg_value(&args, "-af"),
-            Some("aresample=async=1:first_pts=0")
+            Some("aresample=async=1:first_pts=0,apad")
         );
 
         // An explicit user trim still flows into the chain.
@@ -23489,7 +23619,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             arg_value(&trimmed, "-af"),
-            Some("atrim=start=0.250,asetpts=PTS-STARTPTS,aresample=async=1:first_pts=0")
+            Some("atrim=start=0.250,asetpts=PTS-STARTPTS,aresample=async=1:first_pts=0,apad")
         );
     }
 
@@ -23539,7 +23669,56 @@ mod tests {
             arg_value(&args, "-af"),
             Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
         );
+        assert!(
+            !args.iter().any(|arg| arg == "-shortest"),
+            "legacy non-microphone audio must preserve its existing duration policy"
+        );
         assert_eq!(arg_value(&args, "-ac"), Some("2"));
+    }
+
+    #[test]
+    fn legacy_non_microphone_audio_preserves_its_existing_duration_policy() {
+        let params = base_params(true, false);
+        let args = ffmpeg_args(
+            &CaptureInputs {
+                video: VideoInput::TestPattern,
+                camera_index: None,
+                microphone: None,
+            },
+            &params,
+            Some(Path::new("/tmp/videorc-test-tone-duration.mkv")),
+            &[],
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            arg_value(&args, "-af"),
+            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
+        );
+        assert!(!args.iter().any(|arg| arg == "-shortest"));
+    }
+
+    #[test]
+    fn bridge_preserves_its_shortest_policy_without_audio_inputs() {
+        let input_layout = InputLayout {
+            video_input_index: 0,
+            camera_input_index: None,
+            screen_overlay_input_index: None,
+            audio_inputs: Vec::new(),
+            microphone_graph_gain: false,
+        };
+        let mut args = Vec::new();
+
+        append_audio_encoding_with_video_clock(
+            &mut args,
+            &input_layout,
+            &AudioSettings::default(),
+            true,
+            true,
+        );
+
+        assert_eq!(args, vec!["-shortest"]);
     }
 
     #[test]
@@ -23745,6 +23924,73 @@ mod tests {
         assert_eq!(std::fs::read(&preexisting).unwrap(), b"must survive");
 
         cleanup_prepared_mp4_export_staging(&staging).unwrap();
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// Runs the production microphone filter/duration policy through real
+    /// FFmpeg: a one-second mic EOF must become silence until the three-second
+    /// video EOF, then `-shortest` must terminate the padded output.
+    #[test]
+    #[ignore = "spawns ffmpeg and ffprobe; run on recording-studio hosts"]
+    fn real_ffmpeg_microphone_eof_keeps_video_as_the_output_clock() {
+        let directory = std::env::temp_dir().join(format!(
+            "videorc-real-microphone-continuity-test-{}",
+            Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&directory).unwrap();
+        let output = directory.join("microphone-continuity.mkv");
+        let input_layout = microphone_input_layout(false);
+        let audio = AudioSettings::default();
+        let mut args = vec![
+            "-y".to_string(),
+            "-hide_banner".to_string(),
+            "-loglevel".to_string(),
+            "error".to_string(),
+            "-f".to_string(),
+            "lavfi".to_string(),
+            "-i".to_string(),
+            "color=size=64x64:rate=10:duration=3".to_string(),
+            "-f".to_string(),
+            "lavfi".to_string(),
+            "-i".to_string(),
+            "sine=frequency=440:sample_rate=48000:duration=1".to_string(),
+            "-map".to_string(),
+            "0:v".to_string(),
+        ];
+        append_audio_output_args(&mut args, &input_layout);
+        args.extend(["-c:v".to_string(), "mpeg4".to_string()]);
+        append_audio_encoding_with_video_clock(&mut args, &input_layout, &audio, true, false);
+        args.push(output.display().to_string());
+
+        let status = std::process::Command::new("ffmpeg")
+            .args(&args)
+            .status()
+            .expect("ffmpeg should be on PATH for this ignored test");
+        assert!(status.success(), "microphone continuity FFmpeg failed");
+
+        let probe = std::process::Command::new("ffprobe")
+            .args([
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+            ])
+            .arg(&output)
+            .output()
+            .expect("ffprobe should be on PATH for this ignored test");
+        assert!(probe.status.success(), "microphone continuity probe failed");
+        let duration = String::from_utf8(probe.stdout)
+            .unwrap()
+            .trim()
+            .parse::<f64>()
+            .unwrap();
+        assert!(
+            (2.9..=3.1).contains(&duration),
+            "audio EOF shortened the {duration:.3}s output instead of padding to video EOF"
+        );
+
         std::fs::remove_dir_all(directory).unwrap();
     }
 
@@ -23977,7 +24223,7 @@ mod tests {
         assert!(with_mic.iter().any(|arg| arg == "title=Microphone"));
         assert_eq!(
             arg_value(&with_mic, "-af"),
-            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0")
+            Some("pan=stereo|c0=c0|c1=c0,aresample=async=1:first_pts=0,apad")
         );
         assert_eq!(arg_value(&with_mic, "-ac"), Some("2"));
         assert_eq!(arg_value(&with_mic, "-c:a"), Some("pcm_s16le"));

--- a/scripts/lib/app-launcher.mjs
+++ b/scripts/lib/app-launcher.mjs
@@ -31,6 +31,33 @@ export function performanceAppSpawnSpec(env = process.env) {
   return { command, args: [], cwd: dirname(command) }
 }
 
+/**
+ * Turns arbitrary text-stream chunks into complete lines. stdout and stderr
+ * need separate instances: a trailing fragment from one stream must never be
+ * joined to the next chunk delivered by the other.
+ */
+export function createLineBuffer(onLine) {
+  let remainder = ''
+
+  const emit = (line) => {
+    onLine(line.endsWith('\r') ? line.slice(0, -1) : line)
+  }
+
+  return {
+    write(text) {
+      const lines = `${remainder}${text}`.split('\n')
+      remainder = lines.pop() ?? ''
+      for (const line of lines) emit(line)
+    },
+    flush() {
+      if (!remainder) return
+      const line = remainder
+      remainder = ''
+      emit(line)
+    }
+  }
+}
+
 export function windowsAcceptanceProfileDir({
   env = {},
   platform = process.platform,
@@ -311,51 +338,58 @@ export function launchDevApp({
       }
     }
 
-    const handle = (text) => {
-      for (const line of text.split(/\r?\n/)) {
-        if (!line.trim()) continue
-        rememberRecentOutput(recentOutput, line)
-        if (onLine && !stopping) onLine(line)
-        const idx = line.indexOf(MARKER_PREFIX)
-        if (idx === -1) continue
-        const rest = line.slice(idx + MARKER_PREFIX.length)
-        const spaceIdx = rest.indexOf(' ')
-        if (spaceIdx === -1) continue
-        const marker = rest.slice(0, spaceIdx)
-        if (!requiredMarkers.includes(marker)) continue
-        let connection
-        try {
-          connection = JSON.parse(rest.slice(spaceIdx + 1))
-        } catch {
-          // A non-JSON tail for a known marker: ignore and keep waiting.
-          continue
-        }
-        if (marker === 'preview-motion-ready') {
-          if (packagedSmokeCommandCapability && connection?.capability === undefined) {
-            connection = { ...connection, capability: packagedSmokeCommandCapability }
-          }
-          try {
-            assertSmokeCommandConnection(connection)
-          } catch (error) {
-            void rejectAfterStop(
-              `Invalid [smoke] preview-motion-ready marker: ${error?.message ?? error}`
-            )
-            return
-          }
-        }
-        connections[marker] = connection
-        settleIfReady()
+    const handleLine = (line) => {
+      if (!line.trim()) return
+      rememberRecentOutput(recentOutput, line)
+      if (onLine && !stopping) onLine(line)
+      const idx = line.indexOf(MARKER_PREFIX)
+      if (idx === -1) return
+      const rest = line.slice(idx + MARKER_PREFIX.length)
+      const spaceIdx = rest.indexOf(' ')
+      if (spaceIdx === -1) return
+      const marker = rest.slice(0, spaceIdx)
+      if (!requiredMarkers.includes(marker)) return
+      let connection
+      try {
+        connection = JSON.parse(rest.slice(spaceIdx + 1))
+      } catch {
+        // A non-JSON tail for a known marker: ignore and keep waiting.
+        return
       }
+      if (marker === 'preview-motion-ready') {
+        if (packagedSmokeCommandCapability && connection?.capability === undefined) {
+          connection = { ...connection, capability: packagedSmokeCommandCapability }
+        }
+        try {
+          assertSmokeCommandConnection(connection)
+        } catch (error) {
+          void rejectAfterStop(
+            `Invalid [smoke] preview-motion-ready marker: ${error?.message ?? error}`
+          )
+          return
+        }
+      }
+      connections[marker] = connection
+      settleIfReady()
     }
+
+    const stdoutLines = createLineBuffer(handleLine)
+    const stderrLines = createLineBuffer(handleLine)
 
     child.stdout.setEncoding('utf8')
     child.stderr.setEncoding('utf8')
-    child.stdout.on('data', handle)
-    child.stderr.on('data', handle)
+    child.stdout.on('data', (text) => stdoutLines.write(text))
+    child.stderr.on('data', (text) => stderrLines.write(text))
+    child.stdout.on('end', () => stdoutLines.flush())
+    child.stderr.on('end', () => stderrLines.flush())
     child.on('error', (error) => {
       void rejectAfterStop(error.message)
     })
-    child.on('exit', (code, signal) => {
+    // `close` follows both `exit` and stdio shutdown. Waiting for it keeps the
+    // final output chunks in order before flushing a possible unterminated line.
+    child.on('close', (code, signal) => {
+      stdoutLines.flush()
+      stderrLines.flush()
       void rejectAfterStop(
         `Dev app exited before handshake completed: code=${code} signal=${signal}`
       )

--- a/scripts/lib/app-launcher.test.mjs
+++ b/scripts/lib/app-launcher.test.mjs
@@ -6,6 +6,7 @@ import { resolve } from 'node:path'
 
 import {
   appSpawnSpec,
+  createLineBuffer,
   devAppFailureMessage,
   devAppSpawnOptions,
   devAppSpawnSpec,
@@ -16,6 +17,10 @@ import {
   stopProcess,
   windowsAcceptanceProfileDir
 } from './app-launcher.mjs'
+import {
+  countTransientFifoPauseMarkers,
+  TRANSIENT_FIFO_PAUSE_FIRED_MARKER
+} from './transient-fifo-pressure-gates.mjs'
 
 const SMOKE_ENV_KEYS = [
   'VIDEORC_APP_DATA_DIR',
@@ -312,6 +317,27 @@ test('dev app launch failures include the latest child output', () => {
   assert.match(message, /vite failed to bind port 5173/)
   assert.match(message, /electron-vite exited with code 1/)
   assert.equal(devAppFailureMessage('plain failure', []), 'plain failure')
+})
+
+test('line buffering preserves a FIFO hook marker split across stdout chunks', () => {
+  const stdoutLines = []
+  const stderrLines = []
+  const stdout = createLineBuffer((line) => stdoutLines.push(line))
+  const stderr = createLineBuffer((line) => stderrLines.push(line))
+
+  const splitAt = Math.floor(TRANSIENT_FIFO_PAUSE_FIRED_MARKER.length / 2)
+  stdout.write(`WARN ${TRANSIENT_FIFO_PAUSE_FIRED_MARKER.slice(0, splitAt)}`)
+  stderr.write('independent stderr fragment')
+  stdout.write(`${TRANSIENT_FIFO_PAUSE_FIRED_MARKER.slice(splitAt)}\r`)
+  stdout.write('\nnext stdout line\n')
+  stderr.flush()
+
+  assert.deepEqual(stdoutLines, [`WARN ${TRANSIENT_FIFO_PAUSE_FIRED_MARKER}`, 'next stdout line'])
+  assert.deepEqual(stderrLines, ['independent stderr fragment'])
+  assert.equal(
+    stdoutLines.reduce((count, line) => count + countTransientFifoPauseMarkers(line), 0),
+    1
+  )
 })
 
 test(

--- a/scripts/lib/audio-amplitude.mjs
+++ b/scripts/lib/audio-amplitude.mjs
@@ -79,15 +79,25 @@ export function inspectMultipartPcm16Wav(body) {
 
 export async function analyzeMediaAudioAmplitude(
   filePath,
-  { ffmpegPath = 'ffmpeg', sampleRate = 16_000 } = {}
+  { ffmpegPath = 'ffmpeg', sampleRate = 16_000, startSeconds, durationSeconds } = {}
 ) {
+  const windowArgs = []
+  if (startSeconds !== undefined) {
+    assertNonNegativeSeconds(startSeconds, 'startSeconds')
+    windowArgs.push('-ss', String(startSeconds))
+  }
+  if (durationSeconds !== undefined) {
+    assertPositiveSeconds(durationSeconds, 'durationSeconds')
+  }
   const pcm = await runBinary(ffmpegPath, [
     '-nostdin',
     '-hide_banner',
     '-loglevel',
     'error',
+    ...windowArgs,
     '-i',
     filePath,
+    ...(durationSeconds === undefined ? [] : ['-t', String(durationSeconds)]),
     '-map',
     '0:a:0',
     '-vn',
@@ -104,7 +114,21 @@ export async function analyzeMediaAudioAmplitude(
     channels: 1,
     sampleRate,
     bitsPerSample: 16,
+    ...(startSeconds === undefined ? {} : { startSeconds }),
+    ...(durationSeconds === undefined ? {} : { durationSeconds }),
     ...measurePcm16Le(pcm)
+  }
+}
+
+function assertNonNegativeSeconds(value, name) {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new TypeError(`${name} must be a finite, non-negative number.`)
+  }
+}
+
+function assertPositiveSeconds(value, name) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new TypeError(`${name} must be a finite, positive number.`)
   }
 }
 

--- a/scripts/lib/audio-amplitude.test.mjs
+++ b/scripts/lib/audio-amplitude.test.mjs
@@ -75,6 +75,61 @@ describe('caption audio amplitude evidence', () => {
       }
     }
   )
+
+  it(
+    'measures a bounded time window from a finished media artifact',
+    { skip: ffmpegAvailable(ffmpegPath) ? false : 'ffmpeg not installed' },
+    async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'videorc-caption-audio-window-'))
+      const artifact = join(directory, 'tone-then-silence.wav')
+      try {
+        const encoded = spawnSync(
+          ffmpegPath,
+          [
+            '-y',
+            '-hide_banner',
+            '-loglevel',
+            'error',
+            '-f',
+            'lavfi',
+            '-i',
+            'sine=frequency=440:sample_rate=48000:duration=0.25',
+            '-f',
+            'lavfi',
+            '-i',
+            'anullsrc=r=48000:cl=mono:d=0.25',
+            '-filter_complex',
+            '[0:a][1:a]concat=n=2:v=0:a=1[out]',
+            '-map',
+            '[out]',
+            artifact
+          ],
+          { encoding: 'utf8' }
+        )
+        assert.equal(encoded.status, 0, encoded.stderr)
+
+        const tone = await analyzeMediaAudioAmplitude(artifact, {
+          ffmpegPath,
+          startSeconds: 0,
+          durationSeconds: 0.2
+        })
+        const silence = await analyzeMediaAudioAmplitude(artifact, {
+          ffmpegPath,
+          startSeconds: 0.3,
+          durationSeconds: 0.15
+        })
+
+        assert.ok(tone.peak > 0.1, `tone peak=${tone.peak}`)
+        assert.ok(silence.sampleCount >= 2_300)
+        assert.equal(silence.peak, 0)
+        assert.equal(silence.rms, 0)
+        assert.equal(silence.startSeconds, 0.3)
+        assert.equal(silence.durationSeconds, 0.15)
+      } finally {
+        rmSync(directory, { force: true, recursive: true })
+      }
+    }
+  )
 })
 
 function pcm16(samples) {

--- a/scripts/lib/microphone-loss-gates.mjs
+++ b/scripts/lib/microphone-loss-gates.mjs
@@ -1,0 +1,63 @@
+import { extname } from 'node:path'
+
+const SILENT_AUDIO_PEAK_MAX = 0.001
+const SILENT_AUDIO_RMS_MAX = 0.0005
+
+export function evaluateMicrophoneLossContinuity({
+  sessionId,
+  disconnectResult,
+  healthEvents,
+  statusAfterLoss,
+  stoppedStatus,
+  postLossAudio
+}) {
+  const failures = []
+  if (disconnectResult?.disconnected !== true) {
+    failures.push('synthetic microphone source did not disconnect')
+  }
+
+  const matchingLossEvents = (healthEvents ?? []).filter(
+    (event) => event?.sessionId === sessionId && event?.code === 'microphone-input-lost'
+  )
+  if (matchingLossEvents.length !== 1) {
+    failures.push(
+      `expected exactly one microphone-input-lost health event, observed ${matchingLossEvents.length}`
+    )
+  } else if (matchingLossEvents[0].level !== 'warn') {
+    failures.push(
+      `microphone-input-lost health event was ${matchingLossEvents[0].level ?? 'unclassified'}, not warn`
+    )
+  }
+
+  if (statusAfterLoss?.state !== 'recording') {
+    failures.push(
+      `recording did not remain active after microphone loss ` +
+        `(state=${statusAfterLoss?.state ?? 'missing'}; ${statusAfterLoss?.message ?? 'no message'})`
+    )
+  }
+  if (stoppedStatus?.state !== 'idle') {
+    failures.push(
+      `microphone-loss session did not return to idle after user stop ` +
+        `(state=${stoppedStatus?.state ?? 'missing'})`
+    )
+  }
+  if (extname(stoppedStatus?.outputPath ?? '').toLowerCase() !== '.mp4') {
+    failures.push(
+      `microphone-loss session did not produce a finalized MP4 ` +
+        `(path=${stoppedStatus?.outputPath ?? 'missing'})`
+    )
+  }
+
+  if (!(postLossAudio?.sampleCount > 0)) {
+    failures.push('post-loss audio tail contained no decodable samples')
+  } else if (
+    postLossAudio.peak > SILENT_AUDIO_PEAK_MAX ||
+    postLossAudio.rms > SILENT_AUDIO_RMS_MAX
+  ) {
+    failures.push(
+      `post-loss padded audio was not silent ` +
+        `(peak=${postLossAudio.peak}, rms=${postLossAudio.rms})`
+    )
+  }
+  return failures
+}

--- a/scripts/lib/microphone-loss-gates.test.mjs
+++ b/scripts/lib/microphone-loss-gates.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { evaluateMicrophoneLossContinuity } from './microphone-loss-gates.mjs'
+
+describe('microphone source-loss recording continuity gate', () => {
+  it('accepts one loss event, an active session, idle finalization, and a silent tail', () => {
+    assert.deepEqual(
+      evaluateMicrophoneLossContinuity({
+        sessionId: 'session-1',
+        disconnectResult: { disconnected: true },
+        healthEvents: [
+          {
+            sessionId: 'session-1',
+            code: 'microphone-input-lost',
+            level: 'warn',
+            message: 'Microphone stopped.'
+          }
+        ],
+        statusAfterLoss: { state: 'recording', sessionId: 'session-1' },
+        stoppedStatus: {
+          state: 'idle',
+          sessionId: 'session-1',
+          outputPath: '/tmp/recording.mp4'
+        },
+        postLossAudio: { sampleCount: 16_000, peak: 0.0001, rms: 0.00001 }
+      }),
+      []
+    )
+  })
+
+  it('rejects a disconnect that kills recording or leaves a recovery MKV', () => {
+    const failures = evaluateMicrophoneLossContinuity({
+      sessionId: 'session-1',
+      disconnectResult: { disconnected: false },
+      healthEvents: [],
+      statusAfterLoss: { state: 'failed', message: 'audio FIFO closed' },
+      stoppedStatus: { state: 'failed', outputPath: '/tmp/recording.mkv' },
+      postLossAudio: { sampleCount: 0, peak: 0, rms: 0 }
+    })
+
+    assert.ok(failures.some((failure) => failure.includes('did not disconnect')))
+    assert.ok(failures.some((failure) => failure.includes('exactly one')))
+    assert.ok(failures.some((failure) => failure.includes('did not remain active')))
+    assert.ok(failures.some((failure) => failure.includes('did not return to idle')))
+    assert.ok(failures.some((failure) => failure.includes('finalized MP4')))
+    assert.ok(failures.some((failure) => failure.includes('no decodable samples')))
+  })
+
+  it('rejects non-silent padded audio and duplicate source-loss events', () => {
+    const loss = {
+      sessionId: 'session-1',
+      code: 'microphone-input-lost',
+      level: 'warn',
+      message: 'Microphone stopped.'
+    }
+    const failures = evaluateMicrophoneLossContinuity({
+      sessionId: 'session-1',
+      disconnectResult: { disconnected: true },
+      healthEvents: [loss, { ...loss, id: 'duplicate' }],
+      statusAfterLoss: { state: 'recording' },
+      stoppedStatus: { state: 'idle', outputPath: '/tmp/recording.mp4' },
+      postLossAudio: { sampleCount: 16_000, peak: 0.02, rms: 0.01 }
+    })
+
+    assert.ok(failures.some((failure) => failure.includes('exactly one')))
+    assert.ok(failures.some((failure) => failure.includes('not silent')))
+  })
+})

--- a/scripts/lib/native-preview-window-gates.mjs
+++ b/scripts/lib/native-preview-window-gates.mjs
@@ -14,9 +14,11 @@ export function previewWindowSurfaceReady(
     bounds.width > 0 &&
     Number.isFinite(bounds?.height) &&
     bounds.height > 0
+  const nativePresenterHostKindReady =
+    expectedHostKind === undefined || surfaceStatus?.nativePreviewHostKind === expectedHostKind
   const placementReady = expectNativePresenter
     ? windowState?.nativeOwnsPlacement === true &&
-      surfaceStatus?.nativePreviewHostKind === expectedHostKind &&
+      nativePresenterHostKindReady &&
       surfaceStatus?.framePollingSuppressed === true
     : windowState?.surface?.visible === true &&
       surfaceStatus?.nativePreviewHostKind === 'proof-surface' &&
@@ -68,8 +70,7 @@ export function nativePreviewSurfaceStatusReady(
   { expectedTransport, expectedBacking, expectedHostKind, previousFrames = 0 } = {}
 ) {
   const isProofSurface =
-    expectedTransport === 'electron-proof-surface' &&
-    expectedBacking === 'electron-browser-window'
+    expectedTransport === 'electron-proof-surface' && expectedBacking === 'electron-browser-window'
   const hostKindReady =
     expectedHostKind === undefined ||
     status?.nativePreviewHostKind === expectedHostKind ||

--- a/scripts/lib/native-preview-window-gates.test.mjs
+++ b/scripts/lib/native-preview-window-gates.test.mjs
@@ -154,6 +154,36 @@ test('native Metal readiness accepts hidden proof host only with native placemen
     }),
     true
   )
+
+  evidence.surfaceStatus.nativePreviewHostKind = 'external-module'
+  assert.equal(
+    previewWindowSurfaceReady(evidence, {
+      expectedTransport: 'native-surface',
+      expectedBacking: 'cametal-layer',
+      expectedHostKind: 'in-process',
+      expectNativeMetalPreview: true
+    }),
+    false
+  )
+})
+
+test('native Metal readiness accepts an in-process host when host kind is not pinned', () => {
+  const evidence = windowsEvidence()
+  evidence.windowState.surface.visible = false
+  evidence.windowState.nativeOwnsPlacement = true
+  evidence.surfaceStatus.transport = 'native-surface'
+  evidence.surfaceStatus.backing = 'cametal-layer'
+  evidence.surfaceStatus.nativePreviewHostKind = 'in-process'
+  evidence.surfaceStatus.framePollingSuppressed = true
+
+  assert.equal(
+    previewWindowSurfaceReady(evidence, {
+      expectedTransport: 'native-surface',
+      expectedBacking: 'cametal-layer',
+      expectNativeMetalPreview: true
+    }),
+    true
+  )
 })
 
 test('native Windows D3D11 readiness requires the canonical presenter triple and polling suppression', () => {

--- a/scripts/lib/recording-studio-gates.test.mjs
+++ b/scripts/lib/recording-studio-gates.test.mjs
@@ -238,9 +238,35 @@ describe('buildRecordingStudioGateSteps', () => {
     )
     for (const flow of [scenarioFlow, stopRaceFlow]) {
       assert.match(flow, /await resolveFinalRecordingPath\(\{[\s\S]*?started,[\s\S]*?stopped,/)
-      assert.match(flow, /recordingStatusEvents,[\s\S]*?healthEvents,[\s\S]*?stopRequestedAt,[\s\S]*?timeoutMs/)
+      assert.match(
+        flow,
+        /recordingStatusEvents,[\s\S]*?healthEvents,[\s\S]*?stopRequestedAt,[\s\S]*?timeoutMs/
+      )
     }
     assert.match(source, /recordingStatusEvents\.push\(\{ \.\.\.message\.payload, receivedAt \}\)/)
     assert.match(source, /healthEvents\.push\(\{ \.\.\.message\.payload, receivedAt \}\)/)
+  })
+
+  it('keeps deterministic FIFO pressure and microphone-loss artifact coverage maintained', () => {
+    const matrixSource = readFileSync(
+      new URL('../smoke-recording-matrix-app.mjs', import.meta.url),
+      'utf8'
+    )
+    assert.match(matrixSource, /VIDEORC_TEST_VT_FIFO_PAUSE_AFTER_FRAMES/)
+    assert.match(matrixSource, /VIDEORC_TEST_VT_FIFO_PAUSE_MS/)
+    assert.match(matrixSource, /evaluateTransientFifoPressure/)
+    assert.match(matrixSource, /requireTransientFifoPressure: true/)
+
+    const captionsSource = readFileSync(
+      new URL('../smoke-captions-live-app.mjs', import.meta.url),
+      'utf8'
+    )
+    assert.match(captionsSource, /audio\.test\.disconnect/)
+    assert.match(captionsSource, /microphone-input-lost/)
+    assert.match(captionsSource, /evaluateMicrophoneLossContinuity/)
+    assert.match(captionsSource, /postLossAudio/)
+    assert.match(captionsSource, /Microphone stopped — recording continues with silence/)
+    assert.match(captionsSource, /data-testid=\"session-runtime-notice\"/)
+    assert.match(captionsSource, /notice\?\.getAttribute\('role'\) === 'alert'/)
   })
 })

--- a/scripts/lib/transient-fifo-pressure-gates.mjs
+++ b/scripts/lib/transient-fifo-pressure-gates.mjs
@@ -1,0 +1,77 @@
+import { extname } from 'node:path'
+
+export const TRANSIENT_FIFO_PAUSE_FIRED_MARKER = 'VIDEORC_TEST_VT_FIFO_PAUSE_FIRED'
+
+export function countTransientFifoPauseMarkers(line) {
+  if (typeof line !== 'string' || line.length === 0) return 0
+  return line.split(TRANSIENT_FIFO_PAUSE_FIRED_MARKER).length - 1
+}
+
+export function evaluateTransientFifoPressure({
+  activeStatus,
+  stoppedStatus,
+  diagnostics,
+  testPauseFiredCount
+}) {
+  const failures = []
+  if (testPauseFiredCount !== 1) {
+    failures.push(
+      `transient FIFO test pause hook fired ${testPauseFiredCount ?? 'unknown'} time(s); ` +
+        'expected exactly once'
+    )
+  }
+  if (activeStatus?.state !== 'recording') {
+    failures.push(
+      `recording stopped before user stop during transient FIFO pressure ` +
+        `(state=${activeStatus?.state ?? 'missing'}; ${activeStatus?.message ?? 'no message'})`
+    )
+  }
+  if (stoppedStatus?.state !== 'idle') {
+    failures.push(
+      `transient FIFO pressure session did not return to idle after user stop ` +
+        `(state=${stoppedStatus?.state ?? 'missing'})`
+    )
+  }
+  if (extname(stoppedStatus?.outputPath ?? '').toLowerCase() !== '.mp4') {
+    failures.push(
+      `transient FIFO pressure session did not produce a finalized MP4 ` +
+        `(path=${stoppedStatus?.outputPath ?? 'missing'})`
+    )
+  }
+  if (!(diagnostics?.encoderBridgeOutputQueueCapacityPressureEvents > 0)) {
+    failures.push('transient FIFO pressure pass did not exercise FIFO pressure')
+  }
+  if ((diagnostics?.encoderBridgeOutputQueueDroppedFrames ?? 0) !== 0) {
+    failures.push(
+      `transient FIFO pressure dropped ${diagnostics.encoderBridgeOutputQueueDroppedFrames} ` +
+        'output access unit(s)'
+    )
+  }
+  if ((diagnostics?.encoderBridgeDroppedFrames ?? 0) !== 0) {
+    failures.push(
+      `transient FIFO pressure dropped ${diagnostics.encoderBridgeDroppedFrames} bridge frames`
+    )
+  }
+  if ((diagnostics?.encoderBridgeEncodedOutputErrors ?? 0) !== 0) {
+    failures.push(
+      `transient FIFO pressure reported ${diagnostics.encoderBridgeEncodedOutputErrors} ` +
+        'encoded output errors'
+    )
+  }
+  if (diagnostics?.encoderBridgeError) {
+    failures.push(
+      `transient FIFO pressure reported encoder bridge error: ${diagnostics.encoderBridgeError}`
+    )
+  }
+  return failures
+}
+
+export function missingRecordingMatrixResultFailures({ expectedLabels, results }) {
+  const observed = new Set(results.map((result) => result.combo))
+  return expectedLabels
+    .filter((label) => !observed.has(label))
+    .map((label) => ({
+      combo: label,
+      failures: [`required recording matrix pass ${label} produced no result`]
+    }))
+}

--- a/scripts/lib/transient-fifo-pressure-gates.test.mjs
+++ b/scripts/lib/transient-fifo-pressure-gates.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  countTransientFifoPauseMarkers,
+  evaluateTransientFifoPressure,
+  missingRecordingMatrixResultFailures
+} from './transient-fifo-pressure-gates.mjs'
+
+describe('transient VideoToolbox FIFO pressure gate', () => {
+  it('accepts one recovered pressure burst with no drops or encoder error', () => {
+    assert.deepEqual(
+      evaluateTransientFifoPressure({
+        activeStatus: { state: 'recording' },
+        stoppedStatus: { state: 'idle', outputPath: '/tmp/recording.mp4' },
+        testPauseFiredCount: 1,
+        diagnostics: {
+          encoderBridgeOutputQueueCapacityPressureEvents: 7,
+          encoderBridgeOutputQueueDroppedFrames: 0,
+          encoderBridgeDroppedFrames: 0,
+          encoderBridgeEncodedOutputErrors: 0,
+          encoderBridgeError: null
+        }
+      }),
+      []
+    )
+  })
+
+  it('counts only the explicit backend pause-fired marker', () => {
+    assert.equal(
+      countTransientFifoPauseMarkers(
+        'WARN test_hook="videotoolbox-fifo-pause" VIDEORC_TEST_VT_FIFO_PAUSE_FIRED'
+      ),
+      1
+    )
+    assert.equal(countTransientFifoPauseMarkers('WARN encoder output over its age budget'), 0)
+    assert.equal(
+      countTransientFifoPauseMarkers(
+        'VIDEORC_TEST_VT_FIFO_PAUSE_FIRED VIDEORC_TEST_VT_FIFO_PAUSE_FIRED'
+      ),
+      2
+    )
+  })
+
+  it('rejects generic queue pressure when the explicit test hook did not fire exactly once', () => {
+    for (const testPauseFiredCount of [0, 2]) {
+      const failures = evaluateTransientFifoPressure({
+        activeStatus: { state: 'recording' },
+        stoppedStatus: { state: 'idle', outputPath: '/tmp/recording.mp4' },
+        testPauseFiredCount,
+        diagnostics: {
+          encoderBridgeOutputQueueCapacityPressureEvents: 7,
+          encoderBridgeOutputQueueDroppedFrames: 0,
+          encoderBridgeDroppedFrames: 0,
+          encoderBridgeEncodedOutputErrors: 0,
+          encoderBridgeError: null
+        }
+      })
+
+      assert.ok(failures.some((failure) => failure.includes('pause hook fired')))
+    }
+  })
+
+  it('rejects a pass that never created pressure or ended in a recovery container', () => {
+    const failures = evaluateTransientFifoPressure({
+      activeStatus: { state: 'recording' },
+      stoppedStatus: { state: 'idle', outputPath: '/tmp/recording.mkv' },
+      testPauseFiredCount: 1,
+      diagnostics: {
+        encoderBridgeOutputQueueCapacityPressureEvents: 0,
+        encoderBridgeOutputQueueDroppedFrames: 0,
+        encoderBridgeDroppedFrames: 0,
+        encoderBridgeEncodedOutputErrors: 0
+      }
+    })
+
+    assert.ok(failures.some((failure) => failure.includes('did not exercise FIFO pressure')))
+    assert.ok(failures.some((failure) => failure.includes('finalized MP4')))
+  })
+
+  it('rejects early termination, dropped access units, and encoder errors', () => {
+    const failures = evaluateTransientFifoPressure({
+      activeStatus: { state: 'failed', message: 'fifo timed out' },
+      stoppedStatus: { state: 'failed', outputPath: '/tmp/recording.mp4' },
+      testPauseFiredCount: 1,
+      diagnostics: {
+        encoderBridgeOutputQueueCapacityPressureEvents: 2,
+        encoderBridgeOutputQueueDroppedFrames: 1,
+        encoderBridgeDroppedFrames: 3,
+        encoderBridgeEncodedOutputErrors: 1,
+        encoderBridgeError: 'complete-frame delivery budget'
+      }
+    })
+
+    assert.ok(failures.some((failure) => failure.includes('stopped before user stop')))
+    assert.ok(failures.some((failure) => failure.includes('did not return to idle')))
+    assert.ok(failures.some((failure) => failure.includes('output access unit')))
+    assert.ok(failures.some((failure) => failure.includes('bridge frames')))
+    assert.ok(failures.some((failure) => failure.includes('encoded output errors')))
+    assert.ok(failures.some((failure) => failure.includes('encoder bridge error')))
+  })
+
+  it('turns a skipped required pass into an explicit matrix failure result', () => {
+    assert.deepEqual(
+      missingRecordingMatrixResultFailures({
+        expectedLabels: ['4K30', '4K30:hard', '4K30:transient-fifo-pressure'],
+        results: [
+          { combo: '4K30', failures: [] },
+          { combo: '4K30:hard', failures: [] }
+        ]
+      }),
+      [
+        {
+          combo: '4K30:transient-fifo-pressure',
+          failures: [
+            'required recording matrix pass 4K30:transient-fifo-pressure produced no result'
+          ]
+        }
+      ]
+    )
+  })
+})

--- a/scripts/smoke-captions-live-app.mjs
+++ b/scripts/smoke-captions-live-app.mjs
@@ -20,6 +20,7 @@ import {
 } from './lib/captions-live-artifact.mjs'
 import { startFakeCaptionService } from './lib/fake-caption-service.mjs'
 import { resolveFinalRecordingPath } from './lib/final-recording-path.mjs'
+import { evaluateMicrophoneLossContinuity } from './lib/microphone-loss-gates.mjs'
 import { connectBackend, request } from './smoke-recording-session.mjs'
 
 // Maintained viewer-facing live-caption gate. Unlike smoke:captions-contract,
@@ -274,9 +275,32 @@ try {
   }
   const overlaySnapshot = await waitForCaptionOverlay(smoke)
 
-  // Leave the settled line on screen long enough for multiple independently
-  // decoded frames. Its readable dwell is longer than this capture window.
+  // Disconnect the actual synthetic native producer, not the caption bus.
+  // This exercises the same sender EOF and NativeAudioInputState transition as
+  // a physical microphone disappearing mid-recording. FFmpeg must keep video
+  // authoritative and pad the now-finite microphone leg with silence.
+  const disconnectResult = await requestDebugBackend(smoke, 'audio.test.disconnect', {
+    sessionId: started.sessionId
+  })
+  await waitFor(
+    () =>
+      observed.healthEvents.some(
+        (event) => event.sessionId === started.sessionId && event.code === 'microphone-input-lost'
+      ),
+    timeoutMs,
+    'microphone-input-lost health event'
+  )
+  await waitForRendererRuntimeNotice(
+    smoke,
+    'Microphone stopped — recording continues with silence',
+    'persistent microphone-loss warning'
+  )
+
+  // Leave the settled caption on screen and the microphone disconnected long
+  // enough for multiple independently decoded video frames plus a measurable
+  // padded-silence tail.
   await sleep(captionCaptureMs)
+  const statusAfterLoss = await request(backend, timeoutMs, 'recording.status', {})
   const stopRequestedAt = Date.now()
   const stopped = await request(backend, timeoutMs, 'session.stop', {})
   sessionActive = false
@@ -328,12 +352,23 @@ try {
     height: 360,
     minDurationSeconds
   })
-  const [streamArtifact, cleanRecording, captionedArtifact, recordingAudio] = await Promise.all([
-    analyzeCaptionsLiveArtifact(receivedPath, { ffmpegPath }),
-    analyzeCaptionsAbsentArtifact(recordingPath, { ffmpegPath }),
-    analyzeCaptionsLiveArtifact(captionedCopyPath, { ffmpegPath }),
-    analyzeMediaAudioAmplitude(recordingPath, { ffmpegPath })
-  ])
+  const postLossWindowSeconds = Math.min(1, recordingProbe.format.durationSeconds / 4)
+  const postLossWindowStartSeconds = Math.max(
+    0,
+    recordingProbe.format.durationSeconds - postLossWindowSeconds - 0.1
+  )
+  const [streamArtifact, cleanRecording, captionedArtifact, recordingAudio, postLossAudio] =
+    await Promise.all([
+      analyzeCaptionsLiveArtifact(receivedPath, { ffmpegPath }),
+      analyzeCaptionsAbsentArtifact(recordingPath, { ffmpegPath }),
+      analyzeCaptionsLiveArtifact(captionedCopyPath, { ffmpegPath }),
+      analyzeMediaAudioAmplitude(recordingPath, { ffmpegPath }),
+      analyzeMediaAudioAmplitude(recordingPath, {
+        ffmpegPath,
+        startSeconds: postLossWindowStartSeconds,
+        durationSeconds: postLossWindowSeconds
+      })
+    ])
   const srt = readFileSync(srtPath, 'utf8')
   if (!srt.includes(finalText)) {
     throw new Error(`SRT sidecar omitted the settled caption: ${srtPath}`)
@@ -351,6 +386,17 @@ try {
     throw new Error(
       `Original recording did not contain the post-gain native PCM: ${JSON.stringify(recordingAudio)}`
     )
+  }
+  const microphoneLossFailures = evaluateMicrophoneLossContinuity({
+    sessionId: started.sessionId,
+    disconnectResult,
+    healthEvents: observed.healthEvents,
+    statusAfterLoss,
+    stoppedStatus: { ...stopped, outputPath: recordingPath },
+    postLossAudio
+  })
+  if (microphoneLossFailures.length > 0) {
+    throw new Error(`Microphone-loss continuity failed: ${microphoneLossFailures.join('; ')}`)
   }
   const diagnostics = await request(backend, timeoutMs, 'diagnostics.stats', {})
   writeFileSync(
@@ -373,6 +419,7 @@ try {
         observed,
         proof: {
           injections: { mutedInjection, baselineInjection, gainedInjection },
+          microphoneLoss: { disconnectResult, statusAfterLoss, postLossAudio },
           captionWavAmplitude: { muted: mutedAudio, baseline: baselineAudio, gained: gainedAudio },
           gainRatio,
           recordingAudio,
@@ -396,7 +443,8 @@ try {
 
   console.log(
     `Captions live smoke PASS — pre-controls PCM proved mute and +${gainDb}dB ordering, the renderer ` +
-      `published captions to RTMP, the original recording stayed clean, and finalization produced ` +
+      `published captions to RTMP, microphone loss continued with padded silence, the original ` +
+      `recording stayed clean, and finalization produced ` +
       `both SRT and a captioned copy (${streamProbe.video.width}x${streamProbe.video.height}, ` +
       `${streamProbe.format.durationSeconds.toFixed(2)}s stream). ` +
       `Evidence: ${outputDirectory}`
@@ -651,6 +699,28 @@ async function waitForCaptionOverlay(smoke) {
     await sleep(50)
   }
   throw new Error(`Timed out waiting for renderer caption overlay: ${JSON.stringify(latest)}`)
+}
+
+async function waitForRendererRuntimeNotice(smoke, expectedText, label) {
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000)
+  let latest = null
+  while (Date.now() < deadline) {
+    latest = await smokeCommand(smoke, 'eval-js', {
+      code: `
+        const notice = document.querySelector('[data-testid="session-runtime-notice"]')
+        return {
+          present: notice !== null,
+          role: notice?.getAttribute('role') ?? null,
+          text: notice?.textContent?.trim() ?? null,
+          visible: notice?.getAttribute('role') === 'alert' &&
+            notice?.textContent?.includes(${JSON.stringify(expectedText)}) === true
+        }
+      `
+    }).catch(() => null)
+    if (latest?.result?.visible) return
+    await sleep(50)
+  }
+  throw new Error(`Timed out waiting for ${label}: ${JSON.stringify(latest)}`)
 }
 
 function safeFakeCounters(state) {

--- a/scripts/smoke-recording-matrix-app.mjs
+++ b/scripts/smoke-recording-matrix-app.mjs
@@ -27,6 +27,11 @@ import { launchDevApp } from './lib/app-launcher.mjs'
 import { analyzeRecording, writeReports } from './lib/recording-analyzer.mjs'
 import { siblingFfprobePath } from './lib/ffmpeg-sibling-paths.mjs'
 import { requestSmokeCommand } from './lib/smoke-command-client.mjs'
+import {
+  countTransientFifoPauseMarkers,
+  evaluateTransientFifoPressure,
+  missingRecordingMatrixResultFailures
+} from './lib/transient-fifo-pressure-gates.mjs'
 import { connectBackend, request } from './smoke-recording-session.mjs'
 
 const outputDirectory = resolve(
@@ -64,6 +69,18 @@ const MATRIX = [
     !process.env.VIDEORC_MATRIX_ONLY ||
     process.env.VIDEORC_MATRIX_ONLY.split(',').includes(combo.label)
 )
+
+const HARD_COMBOS = MATRIX.filter((combo) => ['4K30', '1080p60'].includes(combo.label)).map(
+  (combo) => (combo.label === '4K30' ? { ...combo, stress: true } : combo)
+)
+const TRANSIENT_FIFO_COMBO = MATRIX.find((combo) => combo.label === '4K30')
+const EXPECTED_RESULT_LABELS = [
+  ...MATRIX.map((combo) => combo.label),
+  ...HARD_COMBOS.map((combo) => `${combo.label}:hard`),
+  ...(process.platform === 'darwin' && TRANSIENT_FIFO_COMBO
+    ? [`${TRANSIENT_FIFO_COMBO.label}:transient-fifo-pressure`]
+    : [])
+]
 
 // The strict quality-law gates. requireMotion stays off: the test pattern is
 // deliberately reused from the layout smoke and can be near-static.
@@ -123,7 +140,15 @@ const STRESS_GATES = Object.freeze({
   maxTailMismatchMs: null
 })
 
-async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, stress = false }) {
+async function recordCombo({
+  ws,
+  smoke,
+  combo,
+  assertPreviewLiveness = false,
+  stress = false,
+  requireTransientFifoPressure = false,
+  getTransientFifoPauseFiredCount = () => 0
+}) {
   // The output-directory capability is single-use: one grant per session.start.
   const { capabilityId } = await requestSmokeCommand(
     smoke,
@@ -131,6 +156,7 @@ async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, st
     { kind: 'output-directory', path: outputDirectory },
     { timeoutMs }
   )
+  const transientFifoPauseFiredBefore = getTransientFifoPauseFiredCount()
   const started = await request(
     ws,
     timeoutMs,
@@ -163,6 +189,7 @@ async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, st
   } else {
     await new Promise((resolveSleep) => setTimeout(resolveSleep, recordingMs))
   }
+  const activeStatus = await request(ws, timeoutMs, 'recording.status')
   const diagnostics = await request(ws, timeoutMs, 'diagnostics.stats')
   const bridgeDiagnostics = Object.fromEntries(
     [
@@ -171,6 +198,7 @@ async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, st
       'encoderBridgeQueueDepth',
       'encoderBridgeOutputQueueOldestFrameAgeMs',
       'encoderBridgeOutputQueueCapacityPressureEvents',
+      'encoderBridgeOutputQueueDroppedFrames',
       'encoderBridgeDroppedFrames',
       'encoderBridgeRepeatedFrames',
       'encoderBridgeEncodedOutputFrames',
@@ -188,6 +216,11 @@ async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, st
       .filter((key) => diagnostics[key] !== undefined)
       .map((key) => [key, diagnostics[key]])
   )
+  const transientFifoPauseFiredCount =
+    getTransientFifoPauseFiredCount() - transientFifoPauseFiredBefore
+  if (requireTransientFifoPressure) {
+    bridgeDiagnostics.transientFifoTestPauseFiredCount = transientFifoPauseFiredCount
+  }
   if (
     process.env.VIDEORC_MATRIX_PRINT_BRIDGE_DIAGNOSTICS === '1' ||
     process.env.VIDEORC_SMOKE_PRINT_APP_OUTPUT === '1'
@@ -213,6 +246,16 @@ async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, st
   if (livenessFailure) {
     failures.push(livenessFailure)
   }
+  if (requireTransientFifoPressure) {
+    failures.push(
+      ...evaluateTransientFifoPressure({
+        activeStatus,
+        stoppedStatus: stopped,
+        diagnostics,
+        testPauseFiredCount: transientFifoPauseFiredCount
+      })
+    )
+  }
   const { width, height } = quality.metrics
   if (width !== combo.width || height !== combo.height) {
     failures.push(`dimensions ${width}x${height} != requested ${combo.width}x${combo.height}`)
@@ -228,12 +271,20 @@ async function recordCombo({ ws, smoke, combo, assertPreviewLiveness = false, st
     failures,
     warnings: quality.verdict.warnings,
     metrics: quality.metrics,
-    bridgeDiagnostics
+    bridgeDiagnostics,
+    transientFifoPauseFiredCount
   }
 }
 
-async function runPass({ passLabel, combos, extraEnv = {}, assertPreviewLiveness = false }) {
+async function runPass({
+  passLabel,
+  combos,
+  extraEnv = {},
+  assertPreviewLiveness = false,
+  requireTransientFifoPressure = false
+}) {
   const passResults = []
+  let transientFifoPauseFiredCount = 0
   let stopApp = async () => {}
   try {
     const launch = await launchDevApp({
@@ -246,6 +297,7 @@ async function runPass({ passLabel, combos, extraEnv = {}, assertPreviewLiveness
       timeoutMs,
       requiredMarkers: ['backend-ready', 'preview-motion-ready'],
       onLine: (line) => {
+        transientFifoPauseFiredCount += countTransientFifoPauseMarkers(line)
         if (process.env.VIDEORC_SMOKE_PRINT_APP_OUTPUT === '1') console.log(line)
       }
     })
@@ -261,7 +313,9 @@ async function runPass({ passLabel, combos, extraEnv = {}, assertPreviewLiveness
           smoke,
           combo,
           assertPreviewLiveness,
-          stress: combo.stress ?? false
+          stress: combo.stress ?? false,
+          requireTransientFifoPressure,
+          getTransientFifoPauseFiredCount: () => transientFifoPauseFiredCount
         })
         result.combo = label
         passResults.push(result)
@@ -304,22 +358,45 @@ try {
   // exactly that way. Preview must stay live THROUGH the recording.
   // 1080p60 must hold FULL cadence under noise (proven headroom); 4K noise is
   // beyond any real content, so 4K30 runs as a survival stress combo.
-  const hardCombos = MATRIX.filter((combo) => ['4K30', '1080p60'].includes(combo.label)).map(
-    (combo) => (combo.label === '4K30' ? { ...combo, stress: true } : combo)
-  )
-  if (hardCombos.length > 0) {
+  if (HARD_COMBOS.length > 0) {
     results.push(
       ...(await runPass({
         passLabel: 'hard',
-        combos: hardCombos,
+        combos: HARD_COMBOS,
         extraEnv: { VIDEORC_SYNTHETIC_HARD_CONTENT: '1' },
         assertPreviewLiveness: true
+      }))
+    )
+  }
+  // Deterministic reproduction for the 2026-08-25 owner failure: pause the
+  // macOS VideoToolbox FIFO worker once for 350ms after the session is warm.
+  // The queue becomes older than the 250ms admission budget but stays below
+  // its 16-frame ceiling. Recovery must preserve every access unit, keep the
+  // compositor and session live, and finish as MP4 on the user's stop.
+  if (process.platform === 'darwin' && TRANSIENT_FIFO_COMBO) {
+    results.push(
+      ...(await runPass({
+        passLabel: 'transient-fifo-pressure',
+        combos: [TRANSIENT_FIFO_COMBO],
+        extraEnv: {
+          VIDEORC_TEST_VT_FIFO_PAUSE_AFTER_FRAMES: '60',
+          VIDEORC_TEST_VT_FIFO_PAUSE_MS: '350'
+        },
+        assertPreviewLiveness: true,
+        requireTransientFifoPressure: true
       }))
     )
   }
 } catch (error) {
   console.error(`Recording matrix pass failed to launch: ${String(error?.message ?? error)}`)
 }
+
+results.push(
+  ...missingRecordingMatrixResultFailures({
+    expectedLabels: EXPECTED_RESULT_LABELS,
+    results
+  })
+)
 
 const resultsPath = join(outputDirectory, 'recording-matrix-results.json')
 try {


### PR DESCRIPTION
## Summary

- give each complete VideoToolbox access unit a fresh, bounded FIFO write window instead of treating queue age as a write failure
- classify native microphone EOF/stall separately from user stop and downstream pipe closure, pad a lost microphone with silence until video ends, and emit one durable health event
- keep recording/streaming active after microphone loss and show a persistent, session-correlated warning that survives renderer reconnects
- add deterministic live-app coverage for transient FIFO pressure and native microphone disconnection, with final MP4 and A/V artifact analysis

## Root causes fixed

The recording FIFO writer reused an access unit's queue timestamp as its delivery deadline. Temporary downstream pressure could therefore make a still-valid, complete access unit arrive at the writer with no time left and terminate the recording.

Native microphone producer EOF was not distinguished from an intentional stop or a closed FFmpeg pipe. FFmpeg could then see audio EOF as session EOF, and the UI had no durable, correlated explanation for the degraded recording.

## Verification

- desktop: 1,533 passed, 1 existing skip
- Node/script logic: 1,106 passed
- Rust: 1,715 passed, 9 ignored; focused real-FFmpeg microphone EOF test also passed
- `smoke:recording-studio` and physical ScreenCaptureKit/native-preview/device gates passed
- microphone-disconnect live-app smoke passed twice: recording stayed active, stopped normally, finalized MP4, tone before loss, padded silence afterward
- recording matrix: 13/13, including 4K hard content and `4K30:transient-fifo-pressure`
- `smoke:local-gates`, dependency audits, typecheck, lint, format, build, clippy, and renderer asset budget all passed (369,830 / 370,000 gzip bytes)
- preview lifecycle completed 100 cycles on retry; the first broad device bundle had one transient “main window not ready” startup failure, while the focused physical native-preview run and retry passed

## Known limitation

FFmpeg-owned microphone fallbacks (macOS AVFoundation fallback and Windows DirectShow) receive the padding policy but do not yet use the native source-loss monitor, so a clean EOF there has no `microphone-input-lost` health event; a fatal DirectShow demux/driver error may still terminate FFmpeg. The affected macOS CoreAudio/native path is covered here. A physical Windows host was not available for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent in-session alerts for recording failures and microphone interruptions.
  * Alerts provide relevant recovery actions, including retrying, dismissing, opening the Library, or revealing saved files.
  * Microphone interruptions now clearly identify affected recording or live-stream sessions.

* **Bug Fixes**
  * Improved recording continuity after temporary microphone loss.
  * Improved handling of brief output or encoding interruptions so recordings can complete successfully.
  * Reduced duplicate or outdated notifications during session recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->