### PR TITLE
release: 0.9.78-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.78-beta.1.md
+++ b/changelog/0.9.78-beta.1.md
@@ -1,0 +1,37 @@
+---
+version: 0.9.78-beta.1
+date: 2026-08-25
+channel: beta
+platforms:
+  - macos
+title: A recording no longer dies when the microphone does
+summary: Unplugging a microphone mid-recording used to end the whole session. Now the recording keeps going, the audio track is padded with silence from the moment the mic vanished, and a warning stays on screen explaining what happened — so you finish the take and keep the video. Recordings also survive brief encoder backpressure that could previously cut a session short.
+highlights:
+  - Losing a microphone mid-session no longer stops the recording — it keeps rolling, pads the audio with silence, and tells you what happened.
+  - The warning about a lost microphone stays put and survives a reconnect, so you are not left guessing why the audio went quiet.
+  - Short bursts of encoder backpressure no longer end a recording that was otherwise healthy.
+---
+
+## Fixed
+
+- **Microphone loss no longer ends the session.** Native microphone EOF or a
+  stall was indistinguishable from an intentional stop or a closed pipe, so
+  FFmpeg treated it as end-of-session. The three cases are now classified
+  separately: a lost microphone pads the audio track with silence until the
+  video ends, recording and streaming continue, and one durable,
+  session-correlated `microphone-input-lost` warning is raised that survives
+  renderer reconnects.
+- **Transient encoder backpressure no longer kills a recording.** The FIFO
+  writer reused an access unit's queue timestamp as its delivery deadline, so
+  a complete, still-valid frame could arrive with no time left and terminate
+  the session. Each complete access unit now gets a fresh, bounded write
+  window.
+
+## Known limitation
+
+FFmpeg-owned microphone fallbacks (the macOS AVFoundation fallback and Windows
+DirectShow) receive the silence-padding policy but do not yet use the native
+source-loss monitor, so a clean end-of-stream there raises no
+`microphone-input-lost` event, and a fatal DirectShow driver error can still
+end the FFmpeg process. The macOS CoreAudio native path — the default — is
+fully covered. Windows was not verified on physical hardware for this change.


### PR DESCRIPTION
Version bump + changelog for 0.9.78-beta.1: microphone-loss continuity and FIFO pressure survival (#293).

Gates on merged main: typecheck, lint, format, desktop 1533 tests / 163 files, test:scripts 1107, renderer build, cargo 1637 tests, clippy -D warnings, cargo fmt.

Note: a full local `cargo test` initially showed 3 YouTube-OAuth failures — traced to a stale machine-wide `VIDEORC_ENABLE_YOUTUBE_OAUTH=1` set via launchctl during earlier testing, not to this change (it fails identically on the pre-merge commit). Cleared; suite is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recording and streaming now continue with silence when a native microphone disconnects or stalls.
  * Microphone loss warnings persist after reconnecting the app.
  * Temporary encoder backpressure no longer unexpectedly stops recordings.
* **Known Limitations**
  * Some FFmpeg-based microphone fallbacks may not report clean input loss, and fatal driver errors can still stop recording.
* **Release**
  * Updated the desktop application to version 0.9.78.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->