### PR TITLE
docs: 0.9.78 release record

### DIFF
--- a/docs/releases/0.9.78.md
+++ b/docs/releases/0.9.78.md
@@ -1,0 +1,71 @@
+# Videorc 0.9.78 Beta 1 (macOS)
+
+A recording survives losing its microphone, and survives transient encoder
+backpressure that previously ended a healthy session.
+
+## Scope (PRs #293, #294)
+
+- **Microphone loss no longer ends the session.** Native microphone EOF or a
+  stall was indistinguishable from an intentional stop or a closed FFmpeg
+  pipe, so FFmpeg treated it as end-of-session. The three cases are now
+  classified separately: a lost microphone pads the audio track with silence
+  until the video ends, recording and streaming continue, and one durable,
+  session-correlated `microphone-input-lost` warning is raised that survives
+  renderer reconnects.
+- **Transient FIFO pressure no longer kills a recording.** The writer reused an
+  access unit's queue timestamp as its delivery deadline, so a complete,
+  still-valid access unit could reach the writer with no time left and
+  terminate the session. Each complete access unit now gets a fresh, bounded
+  write window.
+- Adds deterministic live-app coverage for transient FIFO pressure and native
+  microphone disconnection, with final MP4 and A/V artifact analysis.
+
+## Ship record
+
+Built from the clean worktree checkout of `main` @ 0.9.78 bump. Signed with
+Developer ID Application: Uros Miric (C2PA37RB58), notarized and stapled,
+uploaded and verified 2026-08-25; feed serves 0.9.78 and the updater zip
+returns 206. R2 TLS issuer verified genuine (Google Trust Services) before
+upload. Discord announced.
+
+Gates on merged main: typecheck, lint, format:check, desktop 1533 tests / 163
+files, `test:scripts` 1107, renderer build, `cargo test -p videorc-backend`
+1637 passed / 9 ignored, `clippy -D warnings`, `cargo fmt --check`.
+
+### A local-environment trap worth remembering
+
+A full `cargo test` first reported 3 failures, all YouTube-OAuth
+("paused until Google approval") assertions. They were NOT caused by #293 —
+they fail identically on the pre-merge commit. Cause: `VIDEORC_ENABLE_YOUTUBE_OAUTH=1`
+had been set MACHINE-WIDE via `launchctl setenv` during 0.9.58-era testing, so
+every process on the box — including `cargo test` — inherited it and the
+runtime OAuth gate opened. Cleared with `launchctl unsetenv`; the suite is
+green (1637/1637). Note that already-running shells keep the inherited value
+until relaunched, which is why the first re-run still failed.
+
+## YouTube OAuth status
+
+This build bakes in the public installed-app client ID (now present in the
+release env), but **YouTube OAuth remains OFF for users**: the compile-time
+`VIDEORC_BUNDLED_YOUTUBE_OAUTH_ENABLED` flag is deliberately absent while
+Google verification is pending (submitted 2026-08-25, under review). Approval
+day is a one-line env addition plus a build — no code change.
+
+## Known limitation (carried from #293)
+
+FFmpeg-owned microphone fallbacks (macOS AVFoundation fallback, Windows
+DirectShow) receive the silence-padding policy but do not use the native
+source-loss monitor, so a clean EOS there raises no `microphone-input-lost`
+event, and a fatal DirectShow driver error can still end FFmpeg. The macOS
+CoreAudio native path — the default — is fully covered. Windows was not
+verified on physical hardware.
+
+## Still open
+
+- The 4K screen+camera source decay remains unconfirmed (see 0.9.75/0.9.77
+  records); owner acceptance recordings outstanding.
+- Windows is still on 0.9.72-alpha.1; #293 and the camera-chooser fix are
+  shared code awaiting the next Windows pilot.
+- GitGuardian alert for the July secret rotation still needs closing as
+  rotated/revoked (the old secret itself was deleted from the Console
+  2026-08-25).


### PR DESCRIPTION
Release record for 0.9.78-beta.1 (macOS): microphone-loss continuity and FIFO pressure survival (#293), plus the launchctl environment trap that made a full cargo test look broken.