### PR TITLE
docs: 0.9.78-alpha.1 Windows changelog

### DIFF
--- a/changelog/0.9.78-alpha.1.md
+++ b/changelog/0.9.78-alpha.1.md
@@ -1,0 +1,46 @@
+---
+version: 0.9.78-alpha.1
+date: 2026-08-25
+channel: alpha
+platforms:
+  - windows
+title: Six releases of fixes land on Windows
+summary: The Windows pilot catches up from 0.9.72 to 0.9.78. The biggest one for anyone using a capture card: Videorc was recording 1080p and enlarging it to fill a 4K canvas, because cards run at 29.97 frames per second and a 30 fps request rejected them by three hundredths of a frame. Also here — recordings survive a lost microphone, frozen recordings get reported instead of passing silently, the sidebar shows keyboard shortcuts only while you hold Ctrl, and scrollbars lost their heavy backgrounds.
+highlights:
+  - Capture cards record at their native resolution again instead of a 1080p image stretched to fit — 4K recordings through a Cam Link or similar were soft and now are not.
+  - Losing a microphone mid-recording no longer ends the session on the native audio path; the recording continues and pads the audio with silence.
+  - A recording whose frames froze is now flagged after capture instead of passing quietly as fine.
+  - The microphone meter works before you record, so you can check the mic without starting a session.
+  - Hold Ctrl to see the sidebar's keyboard shortcuts; release it and they fade away.
+  - Scrollbars are a faint thumb with no track, Settings lost its blank gap, and the co-host no longer appears during recording-only sessions.
+---
+
+## What Windows gets in this jump (0.9.72 → 0.9.78)
+
+- **Capture-card resolution (0.9.77).** The camera format chooser required an
+  exact frame-rate match, and capture devices advertise the fractional NTSC
+  rates broadcast video uses. A 2160p mode at 29.97 missed a 30 fps request by
+  0.03, was discarded, and lost to 1080p60 — so 4K sessions captured 1080p and
+  upscaled it. Now tolerant to one frame, and resolution-covering formats win.
+  This is shared code, so the fix arrives on Windows exactly as on macOS.
+- **Microphone loss continuity (0.9.78).** A lost microphone pads the audio
+  track with silence and the session continues, with a durable warning. See
+  the limitation below for what this does *not* yet cover on Windows.
+- **Honest recording checks (0.9.73).** The post-recording check now uses the
+  pipeline's own counters, so a majority-frozen recording is reported rather
+  than passing as clean. Per-source frame-freshness counters are in every
+  support bundle.
+- **Interface (0.9.76–0.9.77).** Shortcut hints reveal only while Ctrl is
+  held; the sidebar is narrower and the header simplified; scrollbars have no
+  track; Settings lost its blank gap; the co-host is streaming-only.
+- **Reliability (0.9.74–0.9.75).** Deterministic encoder teardown at session
+  end, per-session capture ownership, and fail-closed recording analysis.
+
+## Known limitation on Windows
+
+The microphone-loss work covers the native audio path. Windows DirectShow
+receives the silence-padding policy but does not yet use the native
+source-loss monitor, so a clean end-of-stream there raises no
+`microphone-input-lost` warning, and a fatal DirectShow driver error can still
+end the capture process. This pilot was not verified on physical Windows
+hardware.


### PR DESCRIPTION
Windows pilot changelog for 0.9.78-alpha.1, built from the same commit as macOS 0.9.78. Covers the 0.9.72→0.9.78 catch-up, led by the capture-card native-resolution fix (shared code). Records the DirectShow limitation and the lack of physical-hardware verification.