### PR TITLE
release: 0.9.79-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.79-beta.1.md
+++ b/changelog/0.9.79-beta.1.md
@@ -1,0 +1,39 @@
+---
+version: 0.9.79-beta.1
+date: 2026-08-25
+channel: beta
+platforms:
+  - macos
+title: Live controls keep up, and recordings keep every frame
+summary: Under output pressure the recorder used to throw away frames it had already encoded — the reported case reached a full queue with the oldest frame more than half a second late. It now protects every encoded frame and sheds only work it has not done yet, stopping only after a genuine stall. Live controls also stop getting stuck: switching scenes, screens, captions or chat now reconciles against what the backend actually did instead of blindly replaying a command whose outcome was unknown.
+highlights:
+  - Recordings under heavy load no longer lose frames that were already encoded — only unrendered work is skipped, and only while real progress continues.
+  - Scene, screen, caption, chat and takeover changes no longer stick or double-apply when a command's outcome was unclear; they reconcile against the backend's real state.
+  - Backend commands run in separate lanes, so a slow chat or account request can no longer delay going live or stopping a recording.
+  - Recording and streaming get their own encoder roles where supported, with per-role diagnostics reset between sessions and stale files cleaned up safely.
+---
+
+## Fixed
+
+- **Encoded frames survive output pressure.** The bridge shed whole access
+  units when the output queue filled, so a burst of downstream pressure cost
+  finished work. It now preserves every encoded access unit and drops only
+  unencoded compositor ticks, and it stops only after a bounded no-progress
+  stall rather than at the first sign of pressure. Includes exact regression
+  coverage for the reported incident (queue depth 16/16, oldest frame 528 ms
+  against a 250 ms budget).
+- **Live-control stalls.** Backend commands are split into explicit
+  observation, account, chat, live-control and stop lanes with reconnect-safe
+  ordering, so one slow lane cannot block another. Mutations whose outcome was
+  unknown — screen, scene, caption, chat, takeover — are reconciled against
+  authoritative backend state instead of replayed.
+- Hardened account-refresh generations, screen-activation persistence,
+  comments timeouts, avatar fetches, and takeover microphone ownership.
+
+## Known limitations
+
+The physical ScreenCaptureKit motion-source stage could not run on the
+development machine (its Screen Recording grant sees wallpaper only), so that
+gate is unverified here; the rest of the recording-studio suite passed through
+native preview reattach. The account-auth live smoke was skipped for want of a
+one-time test token; those paths are covered by desktop and Rust tests.


### PR DESCRIPTION
Version bump + changelog for 0.9.79-beta.1: encoder-pressure frame preservation and live-control lane isolation (#297).

Gates on merged main: typecheck, lint, format, desktop 1566 tests / 167 files, test:scripts 1113, renderer build, cargo 1683 tests / 9 ignored, clippy -D warnings, cargo fmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the macOS 0.9.79 beta release with improved media processing, live-control reliability, diagnostics, account refresh, screen activation, comments, avatars, and microphone takeover handling.
* **Bug Fixes**
  * Improved cleanup of stale files and handling of output pressure.
  * Documented known limitations for motion-source verification and account authentication testing.
* **Chores**
  * Updated the desktop app version to 0.9.79.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->