### PR TITLE
docs: 0.9.79 release record

### DIFF
--- a/docs/releases/0.9.79.md
+++ b/docs/releases/0.9.79.md
@@ -1,0 +1,60 @@
+# Videorc 0.9.79 Beta 1 (macOS)
+
+Encoded frames survive output pressure, and live controls stop stalling.
+
+## Scope (PRs #297, #298)
+
+- **Encoded access units are no longer shed under pressure.** The bridge
+  dropped whole access units when the output queue filled, discarding work the
+  encoder had already done. It now preserves every encoded access unit and
+  sheds only unencoded compositor ticks, and stops only after a bounded
+  no-progress stall rather than at the first sign of pressure. Ships exact
+  regression coverage for the reported incident: queue depth 16/16, oldest
+  frame 528 ms against a 250 ms budget — the same
+  "Recording encoder output over its age budget" warnings seen in the owner's
+  2026-08-24 logs.
+- **Live-control stalls.** Backend commands are split into explicit
+  observation, account, chat, live-control and stop lanes with reconnect-safe
+  ordering and lifecycle fences, so a slow lane cannot block another.
+  Outcome-unknown screen, scene, caption, chat and takeover mutations are
+  reconciled against authoritative backend state instead of replayed blindly.
+- Recording and streaming encoder roles are split where supported, per-role
+  diagnostics reset between sessions, and stale FIFO resources are cleaned up
+  safely.
+- Hardened account-refresh generations, screen-activation persistence,
+  comments timeouts, avatar fetches, and takeover microphone ownership.
+
+## Ship record
+
+Built from the clean worktree checkout of `main` @ 0.9.79 bump (source
+`b81707c4`). Signed with Developer ID Application: Uros Miric (C2PA37RB58),
+notarized and stapled, uploaded and verified 2026-08-25; feed serves 0.9.79
+and the updater zip returns 206. R2 TLS issuer verified genuine (Google Trust
+Services) before upload. Discord announced.
+
+Gates on merged main: typecheck, lint, format:check, desktop 1566 tests / 167
+files, `test:scripts` 1113, renderer build, `cargo test -p videorc-backend`
+1683 passed / 9 ignored, `clippy -D warnings`, `cargo fmt --check`. Rust tests
+were run with `env -u VIDEORC_ENABLE_YOUTUBE_OAUTH` because this shell still
+inherits the value cleared in 0.9.78 (see that record).
+
+## Not verified
+
+- The physical ScreenCaptureKit motion-source stage did not run: this
+  development build's Screen Recording grant sees wallpaper only. The rest of
+  the recording-studio suite passed through native preview reattach.
+- The account-auth live smoke was skipped for want of a one-time test token;
+  those paths are covered by desktop and Rust tests.
+- No adversarial pre-release review was run for this change, unlike 0.9.77.
+  #297 is 49 files across the encoder and command paths; the 0.9.77 review
+  found three real defects in a smaller change, so a review here remains
+  worthwhile and was offered to the owner.
+
+## Still open
+
+- The 4K screen+camera source decay remains unconfirmed; owner acceptance
+  recordings outstanding. #297's encoder-pressure work may or may not bear on
+  it — do not assume it does.
+- Windows pilot is 0.9.78-alpha.1; this change has not shipped there.
+- GitGuardian alert for the July secret rotation still needs closing as
+  rotated/revoked.


### PR DESCRIPTION
Release record for 0.9.79-beta.1 (macOS): encoder-pressure frame preservation and live-control lane isolation (#297). Records the two gates that could not run locally and the absence of an adversarial pre-release review.