### PR TITLE
Fix idle encoder diagnostics blocking Studio startup

### DIFF
--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -803,6 +803,7 @@ describe('backend RPC contract', () => {
       encoderBridgeMfInputCreditTimeouts: 2,
       encoderBridgeMfInputCreditWaitP95Ms: 12.5,
       encoderBridgeOutputQueueHighWaterFrames: 16,
+      encoderBridgeOutputQueueOldestFrameAgeMs: 240,
       encoderBridgeOutputQueueOldestFrameAgeHighWaterMs: 528,
       encoderBridgeOutputLastProgressAgeMs: 12,
       encoderBridgeOutputPressureRecoveryEvents: 1,
@@ -822,6 +823,26 @@ describe('backend RPC contract', () => {
     }
     expect(validateBackendRpcResult('diagnostics.stats', diagnostics)).toEqual(diagnostics)
     expect(validateBackendEventPayload('diagnostics.stats', diagnostics)).toEqual(diagnostics)
+    for (const field of [
+      'encoderBridgeOutputQueueOldestFrameAgeMs',
+      'encoderBridgeOutputQueueOldestFrameAgeHighWaterMs',
+      'encoderBridgeOutputLastProgressAgeMs'
+    ]) {
+      for (const invalid of [null, -1, Number.POSITIVE_INFINITY]) {
+        expect(() =>
+          validateBackendRpcResult('diagnostics.stats', {
+            ...diagnostics,
+            [field]: invalid
+          })
+        ).toThrow(field)
+        expect(() =>
+          validateBackendEventPayload('diagnostics.stats', {
+            ...diagnostics,
+            [field]: invalid
+          })
+        ).toThrow(field)
+      }
+    }
     for (const field of requiredCapturePressureDiagnosticFields) {
       const missing = { ...diagnostics }
       Reflect.deleteProperty(missing, field)

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -1049,6 +1049,7 @@ const diagnosticStatsSchema = boundedSemanticValue(
       // regresses the skip_serializing_if on this Windows-only field.
       encoderBridgeMfInputCreditWaitP95Ms: optionalSchema(nullableSchema(numberSchema({ min: 0 }))),
       encoderBridgeOutputQueueHighWaterFrames: optionalSchema(nonNegativeInteger),
+      encoderBridgeOutputQueueOldestFrameAgeMs: optionalSchema(nonNegativeInteger),
       encoderBridgeOutputQueueOldestFrameAgeHighWaterMs: optionalSchema(nonNegativeInteger),
       encoderBridgeOutputLastProgressAgeMs: optionalSchema(nonNegativeInteger),
       encoderBridgeOutputPressureRecoveryEvents: optionalSchema(nonNegativeInteger),

--- a/crates/videorc-backend/src/diagnostics.rs
+++ b/crates/videorc-backend/src/diagnostics.rs
@@ -3257,8 +3257,16 @@ mod tests {
         assert!(wire["encoderBridgeRecordingEncoderSpeed"].is_null());
         assert!(wire["encoderBridgeStreamEncoderSpeed"].is_null());
         assert_eq!(wire["encoderBridgeOutputQueueHighWaterFrames"], 0);
-        assert!(wire["encoderBridgeOutputQueueOldestFrameAgeHighWaterMs"].is_null());
-        assert!(wire["encoderBridgeOutputLastProgressAgeMs"].is_null());
+        for field in [
+            "encoderBridgeOutputQueueOldestFrameAgeMs",
+            "encoderBridgeOutputQueueOldestFrameAgeHighWaterMs",
+            "encoderBridgeOutputLastProgressAgeMs",
+        ] {
+            assert!(
+                wire.get(field).is_none(),
+                "unobserved encoder output age {field} must be absent, not null"
+            );
+        }
         assert_eq!(wire["encoderBridgeOutputPressureRecoveryEvents"], 0);
         assert_eq!(wire["encoderBridgeOutputPreEncodeSkippedFrames"], 0);
         assert_eq!(wire["encoderBridgeEncodedAccessUnitDroppedFrames"], 0);

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -1605,13 +1605,13 @@ pub struct DiagnosticStats {
     #[serde(default)]
     pub encoder_bridge_output_queue_high_water_frames: u64,
     /// Oldest frame currently waiting for VideoToolbox completion or FIFO output.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encoder_bridge_output_queue_oldest_frame_age_ms: Option<u64>,
     /// Peak oldest-frame age retained after a pressured queue recovers.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encoder_bridge_output_queue_oldest_frame_age_high_water_ms: Option<u64>,
     /// Milliseconds since the most recent encoder completion or complete FIFO AU write.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encoder_bridge_output_last_progress_age_ms: Option<u64>,
     /// Cumulative enqueue attempts that encountered a full bounded output queue.
     #[serde(default)]


### PR DESCRIPTION
## Summary\n\n- omit unobserved encoder output age diagnostics instead of serializing Rust None values as JSON null\n- explicitly validate current, high-water, and last-progress ages as finite non-negative integers when present\n- correct the idle wire regression test and cover RPC result/event rejection of null, negative, and infinite values\n\n## Root cause\n\nPR #297 added optional integer diagnostics with serde defaults but without omit-on-None serialization. The initial idle payload therefore contained null. Studio validates diagnostics during bootstrap and rejected the first field as not a finite number, blocking the initial load before any recording began. Fixing only the reported high-water field would have exposed the same defect in last-progress age, so all three sibling ages are covered.\n\n## Verification\n\n- Rust format and clippy passed\n- Full Rust suite: 1761 passed, 9 ignored\n- Desktop suite: 1564 passed, 1 skipped; localhost security tests 10/10 passed separately\n- Node and web TypeScript checks, ESLint, Prettier, text integrity, and production build passed\n- Live rebuilt-app screens smoke passed: clean Studio startup, red to green to Normal scene changes, recording, and MP4 finalization\n- Shadscan: 41/100 baseline and 41/100 immediately before commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic data handling by omitting unavailable encoder queue-age metrics instead of displaying them as `null`.
  * Added validation to reject invalid diagnostic values, including negative, infinite, or null queue and progress ages.
  * Improved consistency of diagnostic results and events across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->