### PR TITLE
release: 0.9.80-beta.1 (macOS) — hotfix 0.9.79 Studio startup

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.80-beta.1.md
+++ b/changelog/0.9.80-beta.1.md
@@ -1,0 +1,29 @@
+---
+version: 0.9.80-beta.1
+date: 2026-08-25
+channel: beta
+platforms:
+  - macos
+title: Fixes Studio failing to load on 0.9.79
+summary: If you updated to 0.9.79, Studio could fail to finish loading before you did anything at all. A diagnostic value that is simply absent while idle was being sent as an empty value, and the app's own safety check rejected it and stopped the load. Update to 0.9.80 — this is the only change.
+highlights:
+  - Studio loads normally again after the 0.9.79 update, which could stall on startup before any recording began.
+---
+
+## Fixed
+
+- **Studio startup could stall on 0.9.79.** Three encoder queue-age
+  diagnostics added in 0.9.79 were declared optional but serialized as `null`
+  when unobserved, which is every value in the first idle payload. The
+  renderer validates diagnostics during bootstrap and treats `null` as invalid
+  for a numeric field, so the initial load was rejected before any recording
+  started. The values are now omitted when absent, and current, high-water and
+  last-progress ages are each validated as finite, non-negative integers when
+  present.
+
+## Note
+
+This is the same defect class as the 0.9.68–0.9.70 record-button outage: a
+Rust `Option` field without omit-on-`None` reaching a renderer schema that
+accepts undefined but not null. A serialization-parity gate that would catch
+it automatically is designed but not yet built.


### PR DESCRIPTION
Urgent: 0.9.79 could stall Studio startup for every user (null-serialized optional diagnostics rejected by the bootstrap contract). #301 fixes it; this bumps and ships.

Gates: typecheck, lint, format, desktop 1566 tests, cargo 1683 tests, test:scripts 1113, build.