### PR TITLE
docs: 0.9.80-alpha.1 Windows changelog

### DIFF
--- a/changelog/0.9.80-alpha.1.md
+++ b/changelog/0.9.80-alpha.1.md
@@ -1,0 +1,30 @@
+---
+version: 0.9.80-alpha.1
+date: 2026-08-25
+channel: alpha
+platforms:
+  - windows
+title: Fixes Studio failing to load on 0.9.79
+summary: If you installed the 0.9.79 pilot, Studio could fail to finish loading before you did anything at all. A diagnostic value that is simply absent while idle was being sent as an empty value, and the app's own safety check rejected it and stopped the load. Update to 0.9.80 — this is the only change.
+highlights:
+  - Studio loads normally again after the 0.9.79 pilot, which could stall on startup before any recording began.
+---
+
+## Fixed
+
+- **Studio startup could stall on 0.9.79.** Three encoder queue-age
+  diagnostics added in 0.9.79 were declared optional but serialized as `null`
+  when unobserved, which is every value in the first idle payload. The
+  renderer validates diagnostics during bootstrap and treats `null` as invalid
+  for a numeric field, so the initial load was rejected before any recording
+  started. The values are now omitted when absent, and current, high-water and
+  last-progress ages are each validated as finite, non-negative integers when
+  present.
+
+## Known limitations on Windows
+
+Unchanged from 0.9.79: this pilot was not verified on physical Windows
+hardware, and Windows DirectShow still lacks the native microphone
+source-loss monitor, so a clean end-of-stream raises no
+`microphone-input-lost` warning and a fatal driver error can still end the
+capture process.


### PR DESCRIPTION
Windows pilot hotfix for the 0.9.79 Studio startup stall (#301), same commit as macOS 0.9.80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.9.80-alpha.1.
  * Documented a Windows Studio startup fix related to missing encoder diagnostics.
  * Clarified validation of queue-age diagnostics.
  * Noted that Windows DirectShow microphone-monitoring limitations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->