### PR TITLE
release: 0.9.81-alpha.1 (Windows) — Intel iGPU hardware encoding

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.80",
+  "version": "0.9.81",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.81-alpha.1.md
+++ b/changelog/0.9.81-alpha.1.md
@@ -1,0 +1,27 @@
+---
+version: 0.9.81-alpha.1
+date: 2026-08-26
+channel: alpha
+platforms:
+  - windows
+title: Intel laptops can use hardware encoding again
+summary: On Intel integrated graphics, Videorc was falling back to software encoding and working the CPU harder than it needed to. Hardware H.264 encoding now starts correctly on those machines.
+highlights:
+  - Intel integrated GPUs (Iris Xe and similar) now use hardware H.264 encoding instead of falling back to the CPU.
+---
+
+## Fixed
+
+- **Intel integrated graphics can hardware-encode again.** On Intel iGPU
+  systems the hardware H.264 encoder asked to renegotiate its output format
+  during startup, and Videorc treated that request as a fatal error. It now
+  completes the renegotiation and keeps hardware encoding. NVIDIA systems
+  were never affected.
+
+## Known limitations on Windows
+
+Unchanged from 0.9.80: this pilot was not verified on physical Windows
+hardware, and Windows DirectShow still lacks the native microphone
+source-loss monitor, so a clean end-of-stream raises no
+`microphone-input-lost` warning and a fatal driver error can still end the
+capture process.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
0.9.80-alpha.1 was already built, signed, and promoted from `cd1d771a` (Actions run 32907728953, promote 32910901948). Every Windows candidate must bump the numeric package version, so this prepares `0.9.81-alpha.1` to carry #304.

## Changes
- Bump `apps/desktop/package.json` from `0.9.80` to `0.9.81`
- Add `changelog/0.9.81-alpha.1.md` for the Intel iGPU hardware-encoding fix

`pnpm changelog:check` passes (89 entries, latest `0.9.81-alpha.1`).

After this lands on protected `main`, dispatch **Build Windows Alpha Candidate** with `release_id=0.9.81-alpha.1`. Do not promote until the signed candidate exists.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fc11fb8-0b84-45d4-a532-965b89daf050?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fc11fb8-0b84-45d4-a532-965b89daf050&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored hardware H.264 video encoding for Intel integrated GPUs on Windows.
  * Improved startup handling when renegotiating video connections.
  * NVIDIA hardware encoding remains unaffected.

* **Documentation**
  * Added Windows alpha release notes, including current DirectShow microphone-monitoring limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->