### PR TITLE
fix(scripts): treat absent Windows D3D11 verify stage as preview

### DIFF
--- a/scripts/lib/windows-d3d11-media.mjs
+++ b/scripts/lib/windows-d3d11-media.mjs
@@ -413,6 +413,7 @@ export function assertWindowsD3d11RustDiscovery(
   discovered,
   { stage = 'preview', allowUnimplementedStages = false } = {}
 ) {
+  const resolvedStage = stage ?? 'preview'
   if (!Array.isArray(discovered) || discovered.length === 0) {
     throw new Error('Windows D3D11 Rust discovery returned zero tests.')
   }
@@ -420,9 +421,9 @@ export function assertWindowsD3d11RustDiscovery(
   if (duplicates.length > 0) {
     throw new Error(`Windows D3D11 Rust discovery returned duplicate test: ${duplicates[0]}`)
   }
-  const expected = requiredWindowsD3d11TestsThrough(stage)
+  const expected = requiredWindowsD3d11TestsThrough(resolvedStage)
   if (expected.length === 0) {
-    throw new Error(`Windows D3D11 Rust manifest for ${stage} contained zero tests.`)
+    throw new Error(`Windows D3D11 Rust manifest for ${resolvedStage} contained zero tests.`)
   }
   const expectedSet = new Set(expected)
   const missing = expected.filter((name) => !discovered.includes(name))
@@ -436,7 +437,7 @@ export function assertWindowsD3d11RustDiscovery(
   if (!allowUnimplementedStages) {
     const through = WINDOWS_D3D11_MEDIA_STAGES.slice(
       0,
-      WINDOWS_D3D11_MEDIA_STAGES.indexOf(stage) + 1
+      WINDOWS_D3D11_MEDIA_STAGES.indexOf(resolvedStage) + 1
     )
     const empty = through.find((name) => WINDOWS_D3D11_REQUIRED_RUST_TESTS[name].length === 0)
     if (empty) throw new Error(`Windows D3D11 Rust manifest stage ${empty} is not implemented.`)

--- a/scripts/lib/windows-d3d11-media.test.mjs
+++ b/scripts/lib/windows-d3d11-media.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import {
   WINDOWS_D3D11_AGGREGATE_SCHEMA,
   WINDOWS_D3D11_HOST_SCHEMA,
+  WINDOWS_D3D11_MEDIA_STAGES,
   WINDOWS_D3D11_NATURAL_FALLBACK_SCENARIOS,
   WINDOWS_D3D11_PATH_SCHEMA,
   WINDOWS_D3D11_REQUIRED_RUST_TESTS,
@@ -278,6 +279,23 @@ describe('Windows D3D11 Rust discovery', () => {
           allowUnimplementedStages: true
         }),
       /unexpected/
+    )
+  })
+
+  it('treats an explicit null stage as the default preview depth', () => {
+    // smoke-windows-d3d11-media.mjs forwards parseWindowsD3d11MediaArgs output
+    // directly, so `--verify-windows-rust` without `--stage` reaches here with
+    // an explicit null that must resolve to the 'preview' default.
+    const expected = WINDOWS_D3D11_MEDIA_STAGES.slice(
+      0,
+      WINDOWS_D3D11_MEDIA_STAGES.indexOf('preview') + 1
+    ).flatMap((name) => WINDOWS_D3D11_REQUIRED_RUST_TESTS[name])
+    assert.deepEqual(
+      assertWindowsD3d11RustDiscovery(expected, {
+        stage: null,
+        allowUnimplementedStages: true
+      }),
+      expected
     )
   })
 })


### PR DESCRIPTION
## Summary
`pnpm smoke:local-gates-windows` currently dies at its first Windows step for every checkout of `main`:

```
Error: Unknown Windows D3D11 media stage: null
    at requiredWindowsD3d11TestsThrough (scripts/lib/windows-d3d11-media.mjs:397)
    at assertWindowsD3d11RustDiscovery (.../windows-d3d11-media.mjs:423)
    at verifyWindowsRust (.../smoke-windows-d3d11-media.mjs:101)
```

Root cause: the local-gates wrapper invokes `--verify-windows-rust` without `--stage`; `parseWindowsD3d11MediaArgs` leaves `stage: null`, and that explicit `null` defeats the `stage = 'preview'` destructuring default in `verifyWindowsRust`/`assertWindowsD3d11RustDiscovery` (defaults only apply to `undefined`). This is unrelated to Node version (reproduces on v24 too).

Fix: `assertWindowsD3d11RustDiscovery` resolves `null ?? 'preview'`. No behavior change when a stage is supplied.

## Testing
- New regression test `treats an explicit null stage as the default preview depth`
- `pnpm test:scripts`: 1114 passed / 0 failed

This blocks Windows testers from running local gates against #307, hence the small standalone PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Windows D3D11 media test discovery when no stage is specified or when the stage is explicitly set to null.
  * Ensured discovery consistently uses the default preview stage for expected test selection, validation, and filtering.

* **Tests**
  * Added coverage confirming that a null stage returns the expected Rust tests through the preview stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->