### PR TITLE
fix: capture-decay telemetry, honest quality gates, camera cadence, OAuth store self-heal

### DIFF
--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -823,6 +823,19 @@ describe('backend RPC contract', () => {
     }
     expect(validateBackendRpcResult('diagnostics.stats', diagnostics)).toEqual(diagnostics)
     expect(validateBackendEventPayload('diagnostics.stats', diagnostics)).toEqual(diagnostics)
+    // capturePipelineDegradedStage: absent while healthy (the wire omits it),
+    // a stage label while degraded, and null tolerated for defense in depth
+    // against the serde-null trap (0.9.68 / 0.9.79 outage class).
+    for (const degradedStage of ['camera-delivery', 'compositor-render', null]) {
+      const flagged = { ...diagnostics, capturePipelineDegradedStage: degradedStage }
+      expect(validateBackendEventPayload('diagnostics.stats', flagged)).toEqual(flagged)
+    }
+    expect(() =>
+      validateBackendEventPayload('diagnostics.stats', {
+        ...diagnostics,
+        capturePipelineDegradedStage: ''
+      })
+    ).toThrow('capturePipelineDegradedStage')
     for (const field of [
       'encoderBridgeOutputQueueOldestFrameAgeMs',
       'encoderBridgeOutputQueueOldestFrameAgeHighWaterMs',

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -1079,6 +1079,11 @@ const diagnosticStatsSchema = boundedSemanticValue(
       previewScreenLatestSequence: optionalSchema(nonNegativeInteger),
       previewScreenFrameStatuses: previewScreenFrameStatusStatsSchema,
       previewScreenSurfaceBacking: previewSourceSurfaceBackingStatsSchema,
+      // Absent while the capture pipeline is healthy; nullable for defense in
+      // depth against the serde-null trap (0.9.68 / 0.9.79 outage class).
+      capturePipelineDegradedStage: optionalSchema(
+        nullableSchema(stringSchema({ minLength: 1, maxLength: 64 }))
+      ),
       updatedAt: optionalSchema(timestamp)
     },
     { allowUnknown: true }

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -2326,6 +2326,12 @@ export interface DiagnosticStats {
   compositorScreenSourceHeldServes: number
   /** Oldest capture age (ms) of any screen/window frame the compositor served. */
   compositorScreenSourceServedAgeMaxMs: number
+  /**
+   * The pipeline stage the backend's capture-health monitor currently
+   * declares degraded ('camera-delivery' / 'compositor-render'); absent while
+   * healthy. Nullable for defense in depth against the serde-null trap.
+   */
+  capturePipelineDegradedStage?: string | null
   previewRepeatedFrames: number
   previewSurfaceResizeCount: number
   previewLatencyMs?: number

--- a/crates/videorc-backend/src/camera_capture.rs
+++ b/crates/videorc-backend/src/camera_capture.rs
@@ -225,6 +225,80 @@ fn format_supports_fps(format: &CameraFormatSummary, target_fps: f64) -> bool {
     format.min_fps <= target_fps + FPS_TOLERANCE && format.max_fps >= target_fps - FPS_TOLERANCE
 }
 
+/// Which part of an advertised frame-rate range a resolved request landed on.
+///
+/// AVFoundation validates a requested frame duration against the range's own
+/// CMTime rationals EXACTLY — for a fixed fractional range (29.97..29.97,
+/// 30.00003..30.00003) no decimal approximation of the endpoint survives the
+/// comparison. The caller must therefore request the range's own
+/// `minFrameDuration`/`maxFrameDuration` CMTime verbatim when the request
+/// resolves to an endpoint, and may only build its own rational for a value
+/// strictly inside an open range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CameraFrameRateEndpoint {
+    /// Use the range's `minFrameDuration` (the CMTime for its MAX fps).
+    RangeMax,
+    /// Use the range's `maxFrameDuration` (the CMTime for its MIN fps).
+    RangeMin,
+    /// Strictly inside the range: a self-built rational duration is safe.
+    Interior,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CameraFrameRateResolution {
+    /// Index into the ranges slice the request resolved against.
+    pub range_index: usize,
+    /// The fps the device will actually be asked for.
+    pub effective_fps: f64,
+    pub endpoint: CameraFrameRateEndpoint,
+}
+
+/// Resolves a requested integer fps against a format's advertised
+/// `(min_fps, max_fps)` ranges: picks the closest range, clamps into it, and
+/// names which endpoint (if any) the clamp landed on.
+///
+/// The old integer clamp — `requested.min(max.floor()).max(min.ceil())` —
+/// inverts on fractional fixed ranges: `30.00003..=30.00003` gives
+/// `floor(max) = 30 < ceil(min) = 31`, the empty interval lets `.max(31)`
+/// win, and the device rejects `1/31` with an NSException on every camera
+/// start (the field-logged 31-on-30 and 61-on-60 requests).
+pub fn resolve_camera_frame_rate(
+    requested_fps: u32,
+    ranges: &[(f64, f64)],
+) -> Option<CameraFrameRateResolution> {
+    let requested = f64::from(requested_fps.clamp(1, 240));
+    let mut best: Option<(usize, f64, f64, f64)> = None;
+    for (index, &(raw_min, raw_max)) in ranges.iter().enumerate() {
+        let min = raw_min.max(0.001);
+        let max = raw_max.max(min);
+        let clamped = requested.clamp(min, max);
+        let distance = (clamped - requested).abs();
+        let better = match &best {
+            None => true,
+            Some((_, _, _, best_distance)) => distance < *best_distance,
+        };
+        if better {
+            best = Some((index, min, max, distance));
+        }
+    }
+    let (range_index, min, max, _) = best?;
+    let effective_fps = requested.clamp(min, max);
+    // Endpoint detection is by identity of the clamp, not float tolerance: the
+    // clamp returns exactly `min` or `max` when it saturates.
+    let endpoint = if effective_fps >= max {
+        CameraFrameRateEndpoint::RangeMax
+    } else if effective_fps <= min {
+        CameraFrameRateEndpoint::RangeMin
+    } else {
+        CameraFrameRateEndpoint::Interior
+    };
+    Some(CameraFrameRateResolution {
+        range_index,
+        effective_fps,
+        endpoint,
+    })
+}
+
 fn camera_format_pixels(format: &CameraFormatSummary) -> u64 {
     u64::from(format.width) * u64::from(format.height)
 }
@@ -1016,5 +1090,46 @@ mod tests {
                 },
             ]
         );
+    }
+    #[test]
+    fn frame_rate_resolution_lands_on_the_fractional_fixed_range_endpoint() {
+        // Field log 2026-08-27: range 30.00003..=30.00003 (1000000/30000030).
+        // The old integer clamp produced 31 fps — outside the range — and the
+        // device rejected it with an NSException on every camera start.
+        let resolved = super::resolve_camera_frame_rate(30, &[(30.000_03, 30.000_03)]).unwrap();
+        assert_eq!(resolved.range_index, 0);
+        assert_eq!(resolved.endpoint, super::CameraFrameRateEndpoint::RangeMax);
+        assert!((resolved.effective_fps - 30.000_03).abs() < 1e-9);
+    }
+
+    #[test]
+    fn frame_rate_resolution_handles_the_sixty_on_fifty_nine_ninety_four_sibling() {
+        let resolved = super::resolve_camera_frame_rate(60, &[(59.94, 59.94)]).unwrap();
+        assert_eq!(resolved.endpoint, super::CameraFrameRateEndpoint::RangeMax);
+        assert!((resolved.effective_fps - 59.94).abs() < 1e-9);
+    }
+
+    #[test]
+    fn frame_rate_resolution_picks_the_closest_of_several_ranges() {
+        let ranges = [(25.0, 25.0), (30.0, 30.0), (50.0, 50.0)];
+        let resolved = super::resolve_camera_frame_rate(30, &ranges).unwrap();
+        assert_eq!(resolved.range_index, 1);
+        // An interior hit inside a wide range self-builds its duration.
+        let wide = super::resolve_camera_frame_rate(30, &[(1.0, 60.0)]).unwrap();
+        assert_eq!(wide.endpoint, super::CameraFrameRateEndpoint::Interior);
+        assert!((wide.effective_fps - 30.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn frame_rate_resolution_clamps_and_survives_degenerate_input() {
+        let low = super::resolve_camera_frame_rate(5, &[(24.0, 60.0)]).unwrap();
+        assert_eq!(low.endpoint, super::CameraFrameRateEndpoint::RangeMin);
+        assert!((low.effective_fps - 24.0).abs() < f64::EPSILON);
+        let high = super::resolve_camera_frame_rate(120, &[(1.0, 30.0)]).unwrap();
+        assert_eq!(high.endpoint, super::CameraFrameRateEndpoint::RangeMax);
+        assert!(super::resolve_camera_frame_rate(30, &[]).is_none());
+        // Junk ranges never panic and never resolve below the sane floor.
+        let junk = super::resolve_camera_frame_rate(30, &[(-5.0, -1.0)]).unwrap();
+        assert!(junk.effective_fps > 0.0);
     }
 }

--- a/crates/videorc-backend/src/capture_health.rs
+++ b/crates/videorc-backend/src/capture_health.rs
@@ -1,0 +1,341 @@
+//! Rate-collapse detection for the always-on capture → compositor pipeline.
+//!
+//! 2026-08-27 field incident: after minutes-to-hours of app uptime (no
+//! sessions required), the shared snapshot path settles into a stable
+//! degraded equilibrium — ~6 fresh frames/second served at a healthy 30fps
+//! encoder cadence — and every existing watchdog stays silent, because they
+//! all detect *liveness* (is presentation advancing at all), not *rate*. The
+//! owner's 33-minute idle decay produced zero log lines.
+//!
+//! This monitor watches the per-window numbers the compositor already
+//! computes and names the first degraded stage upstream→downstream:
+//!
+//! - `camera-delivery`: the camera fetch stopped yielding fresh frames at
+//!   rate. Webcams stream continuously, so a collapsed fresh-serve rate is
+//!   decay, full stop.
+//! - `compositor-render`: the snapshot loop itself fell below cadence.
+//!
+//! The screen source is deliberately NOT a verdict stage: ScreenCaptureKit
+//! delivers frames on display damage, so a static desktop legitimately
+//! produces ~0 fresh screen frames. Screen numbers ride along in the detail
+//! string as evidence, never as a judgment.
+
+/// Fraction of the target rate below which a stage counts as degraded.
+pub const DEGRADED_RATE_FRACTION: f64 = 0.6;
+/// Consecutive degraded windows before a transition is declared (2s windows
+/// → ≈6s of sustained collapse; single-window blips never flap).
+pub const DEGRADED_WINDOW_THRESHOLD: u32 = 3;
+/// Consecutive healthy windows before recovery is declared.
+pub const RECOVERED_WINDOW_THRESHOLD: u32 = 3;
+
+/// One diagnostics window of pipeline rates, cumulative counters included.
+#[derive(Debug, Clone, Copy)]
+pub struct CaptureHealthSample {
+    /// The session/preview target fps; a sample with a non-positive target is
+    /// ignored (no cadence to judge against).
+    pub target_fps: f64,
+    /// Compositor snapshot production rate over this window.
+    pub render_fps: f64,
+    /// Whether a camera source is attached to the scene this window.
+    pub camera_present: bool,
+    /// CUMULATIVE fresh camera serves (compositor fetch counter).
+    pub camera_fresh_serves: u64,
+    /// Whether a screen source is attached to the scene this window.
+    pub screen_present: bool,
+    /// CUMULATIVE fresh screen serves (advisory only — see module docs).
+    pub screen_fresh_serves: u64,
+    /// Window length in seconds (non-positive samples are ignored).
+    pub window_secs: f64,
+}
+
+/// The stage a degradation verdict names, most-upstream first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureStage {
+    CameraDelivery,
+    CompositorRender,
+}
+
+impl CaptureStage {
+    pub fn label(self) -> &'static str {
+        match self {
+            CaptureStage::CameraDelivery => "camera-delivery",
+            CaptureStage::CompositorRender => "compositor-render",
+        }
+    }
+}
+
+/// A state transition worth telling somebody about. Emitted once per edge —
+/// steady states (healthy or degraded) stay quiet.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CaptureHealthTransition {
+    Degraded { stage: CaptureStage, detail: String },
+    Recovered { detail: String },
+}
+
+#[derive(Debug, Default)]
+pub struct CaptureHealthMonitor {
+    last_camera_fresh: Option<u64>,
+    last_screen_fresh: Option<u64>,
+    degraded_streak: u32,
+    healthy_streak: u32,
+    /// The currently-declared degraded stage, if any.
+    current: Option<CaptureStage>,
+    /// The stage the running degraded streak is accumulating toward.
+    pending_stage: Option<CaptureStage>,
+}
+
+impl CaptureHealthMonitor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The stage currently declared degraded, for diagnostics publication.
+    pub fn degraded_stage(&self) -> Option<CaptureStage> {
+        self.current
+    }
+
+    /// Feed one diagnostics window; returns a transition when an edge fires.
+    pub fn observe(&mut self, sample: CaptureHealthSample) -> Option<CaptureHealthTransition> {
+        if sample.window_secs <= 0.0 || sample.target_fps <= 0.0 {
+            return None;
+        }
+
+        let camera_fresh_fps = if sample.camera_present {
+            delta_rate(
+                &mut self.last_camera_fresh,
+                sample.camera_fresh_serves,
+                sample.window_secs,
+            )
+        } else {
+            self.last_camera_fresh = None;
+            None
+        };
+        let screen_fresh_fps = if sample.screen_present {
+            delta_rate(
+                &mut self.last_screen_fresh,
+                sample.screen_fresh_serves,
+                sample.window_secs,
+            )
+        } else {
+            self.last_screen_fresh = None;
+            None
+        };
+
+        let floor = sample.target_fps * DEGRADED_RATE_FRACTION;
+        // Upstream before downstream: a starving camera fetch is the cause
+        // even when the render loop is dutifully re-serving held frames at
+        // full cadence (the exact 2026-08-27 signature).
+        let degraded_stage = match camera_fresh_fps {
+            Some(rate) if rate < floor => Some(CaptureStage::CameraDelivery),
+            _ if sample.render_fps < floor => Some(CaptureStage::CompositorRender),
+            _ => None,
+        };
+
+        let detail = format!(
+            "target={:.1}fps render={:.1}fps camera_fresh={} screen_fresh={}",
+            sample.target_fps,
+            sample.render_fps,
+            camera_fresh_fps.map_or_else(|| "n/a".to_string(), |rate| format!("{rate:.1}fps")),
+            screen_fresh_fps.map_or_else(|| "n/a".to_string(), |rate| format!("{rate:.1}fps")),
+        );
+
+        match degraded_stage {
+            Some(stage) => {
+                self.healthy_streak = 0;
+                if self.pending_stage == Some(stage) {
+                    self.degraded_streak = self.degraded_streak.saturating_add(1);
+                } else {
+                    self.pending_stage = Some(stage);
+                    self.degraded_streak = 1;
+                }
+                if self.degraded_streak >= DEGRADED_WINDOW_THRESHOLD && self.current != Some(stage)
+                {
+                    self.current = Some(stage);
+                    return Some(CaptureHealthTransition::Degraded { stage, detail });
+                }
+                None
+            }
+            None => {
+                self.pending_stage = None;
+                self.degraded_streak = 0;
+                if self.current.is_some() {
+                    self.healthy_streak = self.healthy_streak.saturating_add(1);
+                    if self.healthy_streak >= RECOVERED_WINDOW_THRESHOLD {
+                        self.current = None;
+                        self.healthy_streak = 0;
+                        return Some(CaptureHealthTransition::Recovered { detail });
+                    }
+                }
+                None
+            }
+        }
+    }
+}
+
+/// Fresh-serve rate from a cumulative counter. A counter that moved BACKWARD
+/// (compositor instance swap resets it to zero) invalidates the window: the
+/// baseline is re-armed and no rate is reported rather than a bogus one.
+fn delta_rate(last: &mut Option<u64>, current: u64, window_secs: f64) -> Option<f64> {
+    let rate = match *last {
+        Some(previous) if current >= previous => Some((current - previous) as f64 / window_secs),
+        _ => None,
+    };
+    *last = Some(current);
+    rate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn healthy_sample(camera_fresh: u64, screen_fresh: u64) -> CaptureHealthSample {
+        CaptureHealthSample {
+            target_fps: 30.0,
+            render_fps: 30.0,
+            camera_present: true,
+            camera_fresh_serves: camera_fresh,
+            screen_present: true,
+            screen_fresh_serves: screen_fresh,
+            window_secs: 2.0,
+        }
+    }
+
+    /// Replays the measured 2026-08-27 decay shape: healthy windows, then the
+    /// camera fetch collapses to ~6.4 fresh fps while render cadence stays at
+    /// target (held frames re-served) — the monitor must name camera-delivery.
+    #[test]
+    fn names_camera_delivery_on_the_field_decay_signature() {
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut camera = 0_u64;
+        let mut screen = 0_u64;
+        // Baseline + healthy windows: 30fps × 2s = 60 fresh serves per window.
+        for _ in 0..4 {
+            camera += 60;
+            screen += 60;
+            assert_eq!(monitor.observe(healthy_sample(camera, screen)), None);
+        }
+        // Decay: ~6.4 fresh fps → ~13 fresh serves per 2s window.
+        let mut transition = None;
+        for _ in 0..DEGRADED_WINDOW_THRESHOLD {
+            camera += 13;
+            screen += 13;
+            let mut sample = healthy_sample(camera, screen);
+            sample.render_fps = 30.0; // render cadence stays healthy
+            transition = monitor.observe(sample);
+        }
+        match transition {
+            Some(CaptureHealthTransition::Degraded { stage, detail }) => {
+                assert_eq!(stage, CaptureStage::CameraDelivery);
+                assert!(detail.contains("camera_fresh=6.5fps"), "detail: {detail}");
+            }
+            other => panic!("expected a camera-delivery degradation, got {other:?}"),
+        }
+        assert_eq!(monitor.degraded_stage(), Some(CaptureStage::CameraDelivery));
+    }
+
+    #[test]
+    fn a_single_bad_window_never_flaps() {
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut camera = 0_u64;
+        camera += 60;
+        assert_eq!(monitor.observe(healthy_sample(camera, 0)), None);
+        camera += 60;
+        assert_eq!(monitor.observe(healthy_sample(camera, 0)), None);
+        // One collapsed window…
+        camera += 5;
+        assert_eq!(monitor.observe(healthy_sample(camera, 0)), None);
+        // …followed by recovery: nothing was ever declared.
+        camera += 60;
+        assert_eq!(monitor.observe(healthy_sample(camera, 0)), None);
+        assert_eq!(monitor.degraded_stage(), None);
+    }
+
+    #[test]
+    fn recovery_needs_sustained_health_and_fires_once() {
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut camera = 0_u64;
+        camera += 60;
+        monitor.observe(healthy_sample(camera, 0));
+        for _ in 0..DEGRADED_WINDOW_THRESHOLD {
+            camera += 5;
+            monitor.observe(healthy_sample(camera, 0));
+        }
+        assert_eq!(monitor.degraded_stage(), Some(CaptureStage::CameraDelivery));
+        let mut recovered = None;
+        for _ in 0..RECOVERED_WINDOW_THRESHOLD {
+            camera += 60;
+            recovered = monitor.observe(healthy_sample(camera, 0));
+        }
+        assert!(matches!(
+            recovered,
+            Some(CaptureHealthTransition::Recovered { .. })
+        ));
+        assert_eq!(monitor.degraded_stage(), None);
+        // Steady health after recovery stays quiet.
+        camera += 60;
+        assert_eq!(monitor.observe(healthy_sample(camera, 0)), None);
+    }
+
+    /// A screen-only scene (notes-mode recording) with a static desktop must
+    /// never be declared degraded off screen numbers — SCK is damage-driven.
+    #[test]
+    fn static_screen_without_camera_is_not_a_verdict() {
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut sample = healthy_sample(0, 0);
+        sample.camera_present = false;
+        sample.screen_fresh_serves = 0;
+        for _ in 0..10 {
+            assert_eq!(monitor.observe(sample), None);
+        }
+    }
+
+    #[test]
+    fn render_collapse_is_named_when_sources_are_fine() {
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut camera = 0_u64;
+        camera += 60;
+        monitor.observe(healthy_sample(camera, 0));
+        let mut transition = None;
+        for _ in 0..DEGRADED_WINDOW_THRESHOLD {
+            camera += 60;
+            let mut sample = healthy_sample(camera, 0);
+            sample.render_fps = 6.0;
+            transition = monitor.observe(sample);
+        }
+        assert!(matches!(
+            transition,
+            Some(CaptureHealthTransition::Degraded {
+                stage: CaptureStage::CompositorRender,
+                ..
+            })
+        ));
+    }
+
+    /// A cumulative counter that moves backward (compositor swap) re-arms the
+    /// baseline instead of producing a bogus negative-delta verdict.
+    #[test]
+    fn counter_resets_invalidate_the_window() {
+        let mut monitor = CaptureHealthMonitor::new();
+        monitor.observe(healthy_sample(1000, 1000));
+        monitor.observe(healthy_sample(1060, 1060));
+        // Reset to a small value: window skipped, no verdict accumulates.
+        for _ in 0..5 {
+            assert_eq!(monitor.observe(healthy_sample(3, 3)), None);
+            assert_eq!(monitor.degraded_stage(), None);
+            break;
+        }
+        // The window after the reset has a valid baseline again.
+        assert_eq!(monitor.observe(healthy_sample(63, 63)), None);
+    }
+
+    #[test]
+    fn zero_target_or_zero_window_is_ignored() {
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut sample = healthy_sample(0, 0);
+        sample.target_fps = 0.0;
+        assert_eq!(monitor.observe(sample), None);
+        let mut sample = healthy_sample(0, 0);
+        sample.window_secs = 0.0;
+        assert_eq!(monitor.observe(sample), None);
+    }
+}

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -12,11 +12,12 @@ use tokio::task::JoinHandle;
 use tokio::time::{Duration, MissedTickBehavior, sleep};
 use uuid::Uuid;
 
+use crate::capture_health::{CaptureHealthMonitor, CaptureHealthSample, CaptureHealthTransition};
 use crate::color::rgb_to_yuv_video_range_bt709 as rgb_to_yuv;
 use crate::compositor_synthetic::SyntheticMovingSource;
 use crate::diagnostics::{
     CompositorCpuFrameCounts, CompositorLiveSourceFetchStats, CompositorOutsideRenderTimingStats,
-    CompositorSourceImportStats, apply_active_scene_revision,
+    CompositorSourceImportStats, apply_active_scene_revision, apply_capture_health,
     apply_compositor_live_source_fetch_stats, apply_compositor_outside_render_timing_stats,
     apply_compositor_source_import_stats, apply_compositor_stats, apply_compositor_timing_stats,
     apply_runtime_diagnostics_snapshot,
@@ -2100,6 +2101,10 @@ async fn run_synthetic_compositor_loop(
     let mut gpu_compositor = new_gpu_compositor(smooth_preview_scaling);
     let mut stream_gpu_compositor = stream_output.and_then(|_| new_gpu_compositor(false));
     let mut live_sources = CompositorLiveSources::refresh(&state).await;
+    // Rate-collapse watchdog for the always-on pipeline: the 2026-08-27
+    // incident (33 idle minutes of silent decay to ~6 fresh fps) is exactly
+    // the state every liveness-only watchdog ignores.
+    let mut capture_health = CaptureHealthMonitor::new();
     let mut render_cache = CompositorRenderCache::refresh_initial(&state).await;
     let mut next_live_source_refresh_at = Instant::now() + COMPOSITOR_LIVE_SOURCE_REFRESH_INTERVAL;
 
@@ -2282,6 +2287,30 @@ async fn run_synthetic_compositor_loop(
                 if window_started_at.elapsed() >= COMPOSITOR_DIAGNOSTIC_WINDOW {
                     let elapsed = window_started_at.elapsed().as_secs_f64().max(0.001);
                     let measured_fps = frames_in_window as f64 / elapsed;
+                    {
+                        let fetch = live_sources.fetch_stats();
+                        let transition = capture_health.observe(CaptureHealthSample {
+                            target_fps: f64::from(target_fps),
+                            render_fps: measured_fps,
+                            camera_present: live_sources.camera.is_some(),
+                            camera_fresh_serves: fetch.camera_fresh_serves,
+                            screen_present: live_sources.screen.is_some(),
+                            screen_fresh_serves: fetch.screen_fresh_serves,
+                            window_secs: elapsed,
+                        });
+                        match transition {
+                            Some(CaptureHealthTransition::Degraded { stage, detail }) => {
+                                tracing::warn!(
+                                    "[capture-health] pipeline degraded at {}: {detail}",
+                                    stage.label()
+                                );
+                            }
+                            Some(CaptureHealthTransition::Recovered { detail }) => {
+                                tracing::info!("[capture-health] pipeline recovered: {detail}");
+                            }
+                            None => {}
+                        }
+                    }
                     let (p50, p95, p99) = frame_time_percentiles(&frame_times_ms);
                     let (_, source_fetch_p95, _) = frame_time_percentiles(&source_fetch_times_ms);
                     let (_, scene_snapshot_p95, _) =
@@ -2435,6 +2464,10 @@ async fn run_synthetic_compositor_loop(
                         );
                         let next =
                             apply_compositor_live_source_fetch_stats(next, live_sources.fetch_stats());
+                        let next = apply_capture_health(
+                            next,
+                            capture_health.degraded_stage().map(|stage| stage.label()),
+                        );
                         *diagnostics = next.clone();
                         next
                     };

--- a/crates/videorc-backend/src/diagnostics.rs
+++ b/crates/videorc-backend/src/diagnostics.rs
@@ -727,6 +727,7 @@ pub fn idle_diagnostics() -> DiagnosticStats {
         compositor_screen_source_fresh_serves: 0,
         compositor_screen_source_held_serves: 0,
         compositor_screen_source_served_age_max_ms: 0,
+        capture_pipeline_degraded_stage: None,
         preview_repeated_frames: 0,
         preview_surface_resize_count: 0,
         preview_latency_ms: None,
@@ -1955,6 +1956,18 @@ pub fn apply_compositor_live_source_fetch_stats(
     stats.compositor_screen_source_fresh_serves = fetch.screen_fresh_serves;
     stats.compositor_screen_source_held_serves = fetch.screen_held_serves;
     stats.compositor_screen_source_served_age_max_ms = fetch.screen_served_age_max_ms;
+    stats.updated_at = Utc::now().to_rfc3339();
+    stats
+}
+
+/// Publishes the capture-health monitor's verdict: the currently degraded
+/// stage label, or `None` while the pipeline is healthy (field omitted on the
+/// wire — see the serde note on the struct field).
+pub fn apply_capture_health(
+    mut stats: DiagnosticStats,
+    degraded_stage: Option<&'static str>,
+) -> DiagnosticStats {
+    stats.capture_pipeline_degraded_stage = degraded_stage.map(str::to_string);
     stats.updated_at = Utc::now().to_rfc3339();
     stats
 }

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -12,6 +12,7 @@ mod audio;
 mod backend_authority;
 mod camera_capture;
 mod captions;
+mod capture_health;
 mod capture_input;
 mod capture_interruption;
 mod cohost;
@@ -1287,18 +1288,30 @@ async fn drive_loopback_oauth_callback(
 
 async fn resume_pending_oauth_completions(state: AppState) {
     const MAINTENANCE_INTERVAL: Duration = Duration::from_secs(5);
+    // A maintenance error is usually static for the whole process (a store
+    // that failed to load stays failed until restart). Logging it on every
+    // 5-second tick wrote the same ERROR line ~17k times a day into field
+    // logs (2026-08-27); log each distinct message once, and again only when
+    // the message changes or after recovery.
+    let mut last_maintenance_error: Option<String> = None;
     loop {
         let states = match state
             .oauth
             .maintain_pending(chrono::Utc::now(), secrets::delete_secret)
             .await
         {
-            Ok(states) => states,
+            Ok(states) => {
+                if last_maintenance_error.take().is_some() {
+                    state.emit_log("info", "OAuth recovery maintenance recovered.".to_string());
+                }
+                states
+            }
             Err(error) => {
-                state.emit_log(
-                    "error",
-                    format!("Could not maintain durable OAuth recovery work: {error}"),
-                );
+                let message = format!("Could not maintain durable OAuth recovery work: {error}");
+                if last_maintenance_error.as_deref() != Some(message.as_str()) {
+                    state.emit_log("error", message.clone());
+                    last_maintenance_error = Some(message);
+                }
                 tokio::time::sleep(MAINTENANCE_INTERVAL).await;
                 continue;
             }

--- a/crates/videorc-backend/src/oauth.rs
+++ b/crates/videorc-backend/src/oauth.rs
@@ -716,16 +716,107 @@ fn restore_oauth_work(
     })
 }
 
-fn restore_persisted_sessions(
+/// Secret references named by a persisted work checkpoint, readable without
+/// restoring the work (restoration needs the platform's provider config, which
+/// a gated platform cannot supply).
+fn persisted_oauth_work_secret_refs(work: &PersistedOAuthWork) -> Vec<String> {
+    let checkpoint_refs = |checkpoint: &PendingOAuthTokenCheckpoint| {
+        let mut refs = vec![checkpoint.secret_ref.clone()];
+        if let Some(pkce) = checkpoint.pkce_verifier_secret_ref.clone() {
+            refs.push(pkce);
+        }
+        if !checkpoint.candidate_access_secret_ref.is_empty() {
+            refs.push(checkpoint.candidate_access_secret_ref.clone());
+        }
+        if !checkpoint.candidate_refresh_secret_ref.is_empty() {
+            refs.push(checkpoint.candidate_refresh_secret_ref.clone());
+        }
+        refs
+    };
+    match work {
+        PersistedOAuthWork::Generic => Vec::new(),
+        PersistedOAuthWork::ProviderExchange {
+            code_verifier_secret_ref,
+            ..
+        } => code_verifier_secret_ref.clone().into_iter().collect(),
+        PersistedOAuthWork::ProviderExchangeStarted { checkpoint }
+        | PersistedOAuthWork::ProviderToken { checkpoint } => checkpoint_refs(checkpoint),
+        PersistedOAuthWork::AccountStorage {
+            checkpoint_secret_ref,
+            pkce_verifier_secret_ref,
+            candidate_access_secret_ref,
+            candidate_refresh_secret_ref,
+            superseded_secret_refs,
+            ..
+        } => checkpoint_secret_ref
+            .clone()
+            .into_iter()
+            .chain(pkce_verifier_secret_ref.clone())
+            .chain(candidate_access_secret_ref.clone())
+            .chain(candidate_refresh_secret_ref.clone())
+            .chain(superseded_secret_refs.iter().cloned())
+            .collect(),
+    }
+}
+
+/// Outcome of loading the persisted sessions: the restorable ones, plus
+/// whether any were dropped (so the caller rewrites the store without them).
+struct RestoredPersistedSessions {
+    pending: HashMap<String, PendingOAuthSession>,
+    dropped_any: bool,
+}
+
+fn restore_persisted_sessions<D>(
     sessions: Vec<PersistedOAuthSession>,
-) -> Result<HashMap<String, PendingOAuthSession>> {
+    delete_secret: &mut D,
+) -> Result<RestoredPersistedSessions>
+where
+    D: FnMut(&str) -> Result<()>,
+{
     let mut pending = HashMap::with_capacity(sessions.len());
+    let mut dropped_any = false;
     for session in sessions {
         if session.state.is_empty() || session.state.len() > 2048 {
             anyhow::bail!("OAuth transaction recovery store contains an invalid state.");
         }
-        let work = restore_oauth_work(&session.state, session.platform, session.work)
-            .context("OAuth transaction recovery store contains an invalid work checkpoint")?;
+        let secret_refs = persisted_oauth_work_secret_refs(&session.work);
+        let platform = session.platform;
+        let work = match restore_oauth_work(&session.state, platform, session.work) {
+            Ok(work) => work,
+            // A checkpoint whose restoration fails ONLY because the platform's
+            // OAuth is currently gated off (a YouTube pre-exchange flow
+            // recorded while the integration was enabled, loaded after it was
+            // disabled again) is not corruption: the flow can never resume
+            // while the gate is closed, so the checkpoint is dropped and its
+            // secrets are cleaned up. Later stages (token / account storage)
+            // restore without provider config and MUST survive restarts, so
+            // the drop is keyed to the restoration error, not the platform.
+            // Failing the whole store here put every backend into a 5-second
+            // "storage is unavailable" ERROR loop for the life of the process
+            // (2026-08-27 field log).
+            Err(error)
+                if provider_oauth_unavailable_message(platform)
+                    .is_some_and(|message| format!("{error:#}").contains(message)) =>
+            {
+                tracing::warn!(
+                    "Dropped a pending {platform:?} OAuth recovery checkpoint: the platform's OAuth is currently disabled, so the interrupted flow can never resume."
+                );
+                for secret_ref in secret_refs {
+                    if let Err(error) = delete_secret(&secret_ref) {
+                        tracing::warn!(
+                            "Could not delete an orphaned OAuth secret ({secret_ref}): {error:#}"
+                        );
+                    }
+                }
+                dropped_any = true;
+                continue;
+            }
+            Err(error) => {
+                return Err(error.context(
+                    "OAuth transaction recovery store contains an invalid work checkpoint",
+                ));
+            }
+        };
         let previous = pending.insert(
             session.state,
             PendingOAuthSession {
@@ -738,7 +829,10 @@ fn restore_persisted_sessions(
             anyhow::bail!("OAuth transaction recovery store contains a duplicate state.");
         }
     }
-    Ok(pending)
+    Ok(RestoredPersistedSessions {
+        pending,
+        dropped_any,
+    })
 }
 
 fn migrate_legacy_oauth_store<P, D>(
@@ -822,10 +916,10 @@ where
                 work,
             });
         }
-        let pending = restore_persisted_sessions(sessions)?;
-        persist_pending_oauth_sessions(path, &pending)
+        let restored = restore_persisted_sessions(sessions, delete_secret)?;
+        persist_pending_oauth_sessions(path, &restored.pending)
             .context("Could not commit protected OAuth transaction migration")?;
-        Ok(pending)
+        Ok(restored.pending)
     })();
     if migration.is_err() {
         for secret_ref in newly_protected_refs.iter().rev() {
@@ -869,12 +963,12 @@ where
     {
         anyhow::bail!("OAuth transaction recovery store version is unsupported.");
     }
-    let pending = restore_persisted_sessions(store.sessions)?;
-    if store.version < OAUTH_PENDING_STORE_VERSION {
-        persist_pending_oauth_sessions(path, &pending)
-            .context("Could not commit OAuth candidate-reference migration")?;
+    let restored = restore_persisted_sessions(store.sessions, delete_secret)?;
+    if store.version < OAUTH_PENDING_STORE_VERSION || restored.dropped_any {
+        persist_pending_oauth_sessions(path, &restored.pending)
+            .context("Could not commit OAuth recovery store maintenance")?;
     }
-    Ok(pending)
+    Ok(restored.pending)
 }
 
 fn persist_pending_oauth_sessions(
@@ -3097,6 +3191,72 @@ mod tests {
             );
             let _ = std::fs::remove_file(store_path);
         }
+    }
+
+    #[tokio::test]
+    async fn gate_closed_youtube_checkpoint_is_dropped_not_fatal() {
+        // 2026-08-27 field incident: a YouTube checkpoint persisted while the
+        // OAuth gate was open failed restoration once the gate closed, which
+        // failed the WHOLE store load and put every backend into a 5-second
+        // "storage is unavailable" ERROR loop for the life of the process.
+        // (This test assumes the ambient environment leaves the YouTube gate
+        // closed, like every other gate-dependent test in this file.)
+        let store_path = pending_store_path();
+        let store = format!(
+            concat!(
+                "{{\"version\":{version},\"sessions\":[",
+                "{{\"state\":\"stale-youtube-state\",\"platform\":\"youtube\",",
+                "\"expiresAt\":\"2026-08-25T14:00:00Z\",",
+                "\"work\":{{\"kind\":\"provider-exchange\",",
+                "\"redirectUri\":\"http://127.0.0.1:17995/callback\",",
+                "\"codeVerifierSecretRef\":\"videorc-oauth-pkce-stale-youtube-state-youtube\"}}}},",
+                "{{\"state\":\"live-twitch-state\",\"platform\":\"twitch\",",
+                "\"expiresAt\":\"2099-01-01T00:00:00Z\",",
+                "\"work\":{{\"kind\":\"generic\"}}}}",
+                "]}}"
+            ),
+            version = OAUTH_PENDING_STORE_VERSION
+        );
+        std::fs::write(&store_path, store.as_bytes()).unwrap();
+
+        let deleted = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let deleted_sink = deleted.clone();
+        let sessions =
+            OAuthSessions::new_with_secret_cleanup(Some(store_path.clone()), move |secret_ref| {
+                deleted_sink.lock().unwrap().push(secret_ref.to_string());
+                Ok(())
+            });
+
+        // The store loaded: operations work instead of failing with
+        // "storage is unavailable".
+        sessions
+            .start(
+                OAuthStartParams {
+                    platform: StreamPlatform::Twitch,
+                    ..start_params()
+                },
+                61234,
+            )
+            .await
+            .unwrap();
+
+        // The dead checkpoint's secret was cleaned up…
+        assert!(
+            deleted
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|secret_ref| secret_ref.contains("stale-youtube-state")),
+            "expected the stale PKCE secret to be deleted, saw {:?}",
+            deleted.lock().unwrap()
+        );
+        // …and the rewritten store no longer names the YouTube session, so
+        // the next launch does not re-drop (and re-warn about) it. The
+        // unrelated Twitch session survives.
+        let rewritten = std::fs::read_to_string(&store_path).unwrap();
+        assert!(!rewritten.contains("stale-youtube-state"));
+        assert!(rewritten.contains("live-twitch-state"));
+        let _ = std::fs::remove_file(store_path);
     }
 
     #[tokio::test]

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -12,8 +12,8 @@ use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
 
 use crate::camera_capture::{
-    CameraFormatSummary, camera_capability_matrix_for_id, parse_native_camera_id,
-    parse_windows_dshow_camera_id,
+    CameraFormatSummary, CameraFrameRateEndpoint, camera_capability_matrix_for_id,
+    parse_native_camera_id, parse_windows_dshow_camera_id, resolve_camera_frame_rate,
 };
 use crate::color::{ycbcr_bt709_full_to_bgr, ycbcr_bt709_video_to_bgr};
 use crate::diagnostics::{
@@ -2619,23 +2619,44 @@ mod macos {
             )));
         }
 
-        let fps = requested_fps
-            .clamp(1, 120)
-            .min(format.format.max_fps.floor().max(1.0) as u32)
-            .max(format.format.min_fps.ceil().max(1.0) as u32)
-            .max(1);
-        let frame_duration = unsafe { CMTime::new(1, fps as i32) };
-        let frame_rate_result = unsafe {
-            objc2::exception::catch(std::panic::AssertUnwindSafe(|| {
-                device.setActiveVideoMinFrameDuration(frame_duration);
-                device.setActiveVideoMaxFrameDuration(frame_duration);
-            }))
-        };
-        if let Err(exception) = frame_rate_result {
-            tracing::warn!(
-                "Camera kept its native frame cadence ({fps} fps frame duration was rejected): {}",
-                describe_camera_exception(exception)
-            );
+        // Resolve the requested rate against the ACTIVE format's own advertised
+        // ranges, and at a range endpoint request the range's own CMTime
+        // verbatim — AVFoundation validates the duration against those
+        // rationals exactly, so no decimal approximation of a fractional
+        // endpoint (29.97, 30.00003) survives the comparison.
+        let ranges = unsafe { format.native_format.videoSupportedFrameRateRanges() };
+        let range_bounds = (0..ranges.count())
+            .map(|index| {
+                let range = ranges.objectAtIndex(index);
+                unsafe { (range.minFrameRate(), range.maxFrameRate()) }
+            })
+            .collect::<Vec<_>>();
+        if let Some(resolution) = resolve_camera_frame_rate(requested_fps, &range_bounds) {
+            let range = ranges.objectAtIndex(resolution.range_index);
+            let frame_duration = match resolution.endpoint {
+                CameraFrameRateEndpoint::RangeMax => unsafe { range.minFrameDuration() },
+                CameraFrameRateEndpoint::RangeMin => unsafe { range.maxFrameDuration() },
+                CameraFrameRateEndpoint::Interior => {
+                    // Nanosecond timescale keeps an interior rate within any
+                    // range wide enough to contain it.
+                    let timescale = 1_000_000_000_i32;
+                    let value = (f64::from(timescale) / resolution.effective_fps).round() as i64;
+                    unsafe { CMTime::new(value.max(1), timescale) }
+                }
+            };
+            let effective_fps = resolution.effective_fps;
+            let frame_rate_result = unsafe {
+                objc2::exception::catch(std::panic::AssertUnwindSafe(|| {
+                    device.setActiveVideoMinFrameDuration(frame_duration);
+                    device.setActiveVideoMaxFrameDuration(frame_duration);
+                }))
+            };
+            if let Err(exception) = frame_rate_result {
+                tracing::warn!(
+                    "Camera kept its native frame cadence ({effective_fps:.3} fps frame duration was rejected): {}",
+                    describe_camera_exception(exception)
+                );
+            }
         }
 
         unsafe { device.unlockForConfiguration() };

--- a/crates/videorc-backend/src/protocol.rs
+++ b/crates/videorc-backend/src/protocol.rs
@@ -2151,6 +2151,13 @@ pub struct DiagnosticStats {
     /// Oldest capture age (ms) of any screen/window frame the compositor served.
     #[serde(default)]
     pub compositor_screen_source_served_age_max_ms: u64,
+    /// The pipeline stage the capture-health monitor currently declares
+    /// degraded (`camera-delivery` / `compositor-render`), or absent while
+    /// healthy. skip_serializing_if is load-bearing: the renderer contract
+    /// accepts undefined, and a serialized `null` here is the app-killing
+    /// defect class of 0.9.68 and 0.9.79 ([[videorc-serde-null-contract-trap]]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_pipeline_degraded_stage: Option<String>,
     pub preview_repeated_frames: u64,
     pub preview_surface_resize_count: u64,
     pub preview_latency_ms: Option<u64>,
@@ -4848,6 +4855,28 @@ mod tests {
                 "required {field} counters must never serialize as null"
             );
         }
+    }
+
+    #[test]
+    fn capture_pipeline_degraded_stage_is_omitted_when_healthy_and_a_string_when_set() {
+        // The serde-null → contract trap (0.9.68, 0.9.79): an Option without
+        // skip_serializing_if serializes null, and the renderer contract's
+        // optionalSchema rejects null. Healthy pipelines must OMIT the field.
+        let wire = serde_json::to_value(crate::diagnostics::idle_diagnostics())
+            .expect("idle diagnostics serialize");
+        assert!(
+            wire.get("capturePipelineDegradedStage").is_none(),
+            "healthy capturePipelineDegradedStage must be omitted rather than null"
+        );
+
+        let mut degraded = crate::diagnostics::idle_diagnostics();
+        degraded.capture_pipeline_degraded_stage = Some("camera-delivery".to_string());
+        let wire = serde_json::to_value(degraded).expect("degraded diagnostics serialize");
+        assert_eq!(
+            wire.get("capturePipelineDegradedStage")
+                .and_then(serde_json::Value::as_str),
+            Some("camera-delivery")
+        );
     }
 
     #[test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -372,8 +372,72 @@ const SCREEN_OVERLAY_FIFO_WRITE_RETRY: std::time::Duration = std::time::Duration
 const SCREEN_OVERLAY_FIFO_WRITE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
 const SCREEN_OVERLAY_FIFO_FRAME_WRITE_HARD_TIMEOUT: Duration = Duration::from_secs(2);
 const POST_RECORDING_GATE_IDLE_DELAY: Duration = Duration::from_secs(30);
-const POST_RECORDING_FAST_ASSESSMENT_TIMEOUT: Duration = Duration::from_secs(60);
-const POST_RECORDING_REPAIR_TIMEOUT: Duration = Duration::from_secs(180);
+const POST_RECORDING_FAST_ASSESSMENT_MIN_TIMEOUT: Duration = Duration::from_secs(60);
+const POST_RECORDING_FAST_ASSESSMENT_MAX_TIMEOUT: Duration = Duration::from_secs(900);
+const POST_RECORDING_REPAIR_MIN_TIMEOUT: Duration = Duration::from_secs(180);
+const POST_RECORDING_REPAIR_MAX_TIMEOUT: Duration = Duration::from_secs(1800);
+
+/// Quality budgets scale with the media: the analyzer decodes the whole file
+/// (freezedetect + exact-repeat runs), so a flat budget is a guarantee that
+/// long recordings fail unexamined — the 2026-08-27 field incident's 2-minute
+/// 4K recording could not finish inside the old flat 60s and the owner's
+/// frozen file shipped with no verdict at all. The gate runs on the idle
+/// maintenance lane, where a long bound beats a guaranteed failure; unknown
+/// duration (boot-resumed jobs) gets the cap.
+fn scaled_media_timeout(
+    duration_ms: Option<u64>,
+    min: Duration,
+    factor: u32,
+    max: Duration,
+) -> Duration {
+    match duration_ms {
+        Some(duration_ms) => {
+            let scaled = Duration::from_millis(duration_ms.saturating_mul(u64::from(factor)));
+            scaled.clamp(min, max)
+        }
+        None => max,
+    }
+}
+
+fn post_recording_assessment_timeout(duration_ms: Option<u64>) -> Duration {
+    scaled_media_timeout(
+        duration_ms,
+        POST_RECORDING_FAST_ASSESSMENT_MIN_TIMEOUT,
+        3,
+        POST_RECORDING_FAST_ASSESSMENT_MAX_TIMEOUT,
+    )
+}
+
+fn post_recording_repair_timeout(duration_ms: Option<u64>) -> Duration {
+    scaled_media_timeout(
+        duration_ms,
+        POST_RECORDING_REPAIR_MIN_TIMEOUT,
+        6,
+        POST_RECORDING_REPAIR_MAX_TIMEOUT,
+    )
+}
+
+/// The health event for a recording whose live pipeline counters reported
+/// frozen output but whose file-level check could not run to a verdict. The
+/// never-toast rule for tooling failures does not apply: the pipeline itself
+/// is the evidence, and staying info-level here is how the owner recorded a
+/// 55%-frozen file with no signal (2026-08-24) and a 79%-held one with none
+/// again (2026-08-27).
+fn emit_unverified_frozen_recording_health(
+    state: &AppState,
+    session_id: Option<&str>,
+    reason: &str,
+) {
+    let _ = emit_health_event(
+        state,
+        session_id,
+        HealthLevel::Warn,
+        "recording-quality-unverified",
+        &format!(
+            "This recording likely contains frozen frames — the live pipeline reported held frames during capture, and the automated check could not verify the file: {reason}"
+        ),
+    );
+}
 // Raw compositor frames arrive over a live FIFO alongside live device audio.
 // FFmpeg needs a dedicated demux thread for that input; without one, Windows
 // dshow polling can leave the named-pipe reader idle until its buffer fills,
@@ -6398,6 +6462,7 @@ async fn monitor_session(
                     final_path,
                     gate,
                     pipeline_reported_frozen_output(&final_diagnostics),
+                    duration_ms.and_then(|ms| u64::try_from(ms).ok()),
                 );
             }
             terminal_status
@@ -6541,6 +6606,7 @@ fn enqueue_post_recording_gate(
     final_path: PathBuf,
     gate: PostRecordingGate,
     pipeline_reported_freezes: bool,
+    duration_ms: Option<u64>,
 ) {
     tokio::spawn(async move {
         let path_str = final_path.display().to_string();
@@ -6573,8 +6639,9 @@ fn enqueue_post_recording_gate(
             format!("Running idle post-recording quality check on {path_str}."),
         );
 
+        let assessment_budget = post_recording_assessment_timeout(duration_ms);
         let fast_assessment = timeout(
-            POST_RECORDING_FAST_ASSESSMENT_TIMEOUT,
+            assessment_budget,
             run_quality_assessment(
                 ffmpeg_path.clone(),
                 path_str.clone(),
@@ -6586,7 +6653,7 @@ fn enqueue_post_recording_gate(
         .map_err(|_| {
             format!(
                 "quality assessment timed out after {}s",
-                POST_RECORDING_FAST_ASSESSMENT_TIMEOUT.as_secs()
+                assessment_budget.as_secs()
             )
         })
         .and_then(|result| result);
@@ -6623,6 +6690,9 @@ fn enqueue_post_recording_gate(
                     "warn",
                     format!("Fast post-recording quality assessment could not run: {error}"),
                 );
+                if expectations.pipeline_reported_freezes {
+                    emit_unverified_frozen_recording_health(&state, Some(&session_id), &error);
+                }
                 job.fail(
                     format!("quality assessment task failed: {error}"),
                     Utc::now().to_rfc3339(),
@@ -6641,15 +6711,16 @@ fn enqueue_post_recording_gate(
             return;
         }
 
+        let repair_budget = post_recording_repair_timeout(duration_ms);
         match timeout(
-            POST_RECORDING_REPAIR_TIMEOUT,
+            repair_budget,
             run_quality_gate(ffmpeg_path, path_str, expectations, cancel_token),
         )
         .await
         .map_err(|_| {
             format!(
                 "quality repair timed out after {}s",
-                POST_RECORDING_REPAIR_TIMEOUT.as_secs()
+                repair_budget.as_secs()
             )
         })
         .and_then(|result| result)
@@ -6909,8 +6980,11 @@ pub async fn resume_pending_repair_jobs(state: AppState) {
             job.mark_running(Utc::now().to_rfc3339());
             let _ = state.database.upsert_repair_job(&job);
 
+            // A boot-resumed job has no session duration on hand; the capped
+            // budget applies (see post_recording_assessment_timeout).
+            let assessment_budget = post_recording_assessment_timeout(None);
             let fast_assessment = timeout(
-                POST_RECORDING_FAST_ASSESSMENT_TIMEOUT,
+                assessment_budget,
                 run_quality_assessment(
                     ffmpeg_path.clone(),
                     job.file_path.clone(),
@@ -6922,7 +6996,7 @@ pub async fn resume_pending_repair_jobs(state: AppState) {
             .map_err(|_| {
                 format!(
                     "quality assessment timed out after {}s",
-                    POST_RECORDING_FAST_ASSESSMENT_TIMEOUT.as_secs()
+                    assessment_budget.as_secs()
                 )
             })
             .and_then(|result| result);
@@ -6962,6 +7036,9 @@ pub async fn resume_pending_repair_jobs(state: AppState) {
                             job.file_path
                         ),
                     );
+                    if job.expectations().pipeline_reported_freezes {
+                        emit_unverified_frozen_recording_health(&state, None, &error);
+                    }
                     job.fail(
                         format!("resume assessment failed: {error}"),
                         Utc::now().to_rfc3339(),
@@ -6980,8 +7057,9 @@ pub async fn resume_pending_repair_jobs(state: AppState) {
                 return;
             }
 
+            let repair_budget = post_recording_repair_timeout(None);
             let gate = timeout(
-                POST_RECORDING_REPAIR_TIMEOUT,
+                repair_budget,
                 run_quality_gate(
                     ffmpeg_path,
                     job.file_path.clone(),
@@ -6993,7 +7071,7 @@ pub async fn resume_pending_repair_jobs(state: AppState) {
             .map_err(|_| {
                 format!(
                     "quality repair timed out after {}s",
-                    POST_RECORDING_REPAIR_TIMEOUT.as_secs()
+                    repair_budget.as_secs()
                 )
             })
             .and_then(|result| result);
@@ -26421,5 +26499,40 @@ mod tests {
         assert_eq!(new_session.session_id, "session-b");
         assert_eq!(new_session.total_bytes, None);
         assert_eq!(new_session.duplicated_frames, None);
+    }
+    #[test]
+    fn quality_budgets_scale_with_media_duration() {
+        use std::time::Duration;
+        // The 2026-08-27 field case: a ~125s 4K recording under the old flat
+        // 60s budget was guaranteed to time out unexamined. 3× media length
+        // gives the analyzer's full decode real headroom.
+        assert_eq!(
+            super::post_recording_assessment_timeout(Some(125_466)),
+            Duration::from_millis(376_398)
+        );
+        // Short clips keep the old floor…
+        assert_eq!(
+            super::post_recording_assessment_timeout(Some(5_000)),
+            Duration::from_secs(60)
+        );
+        // …hour-long recordings are capped, not unbounded…
+        assert_eq!(
+            super::post_recording_assessment_timeout(Some(3_600_000)),
+            Duration::from_secs(900)
+        );
+        // …and boot-resumed jobs with no duration on hand get the cap rather
+        // than a budget that guarantees failure.
+        assert_eq!(
+            super::post_recording_assessment_timeout(None),
+            Duration::from_secs(900)
+        );
+        assert_eq!(
+            super::post_recording_repair_timeout(Some(10_000)),
+            Duration::from_secs(180)
+        );
+        assert_eq!(
+            super::post_recording_repair_timeout(None),
+            Duration::from_secs(1800)
+        );
     }
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "smoke:dev": "node scripts/smoke-dev-app.mjs",
     "smoke:recording-matrix": "node scripts/smoke-recording-matrix-app.mjs",
     "smoke:session-decay": "node scripts/smoke-recording-session-decay.mjs",
+    "smoke:capture-decay-soak": "node scripts/smoke-capture-decay-soak.mjs",
     "smoke:session-decay:gate": "node scripts/run-with-env.mjs VIDEORC_DECAY_SESSIONS=3 VIDEORC_DECAY_RECORDING_MS=10000 VIDEORC_DECAY_IDLE_MS=1000 -- node scripts/smoke-recording-session-decay.mjs",
     "smoke:linux-encoder-acceptance": "node scripts/smoke-linux-encoder-acceptance.mjs",
     "smoke:remote-control": "node scripts/smoke-remote-control-app.mjs",

--- a/scripts/smoke-capture-decay-soak.mjs
+++ b/scripts/smoke-capture-decay-soak.mjs
@@ -1,0 +1,176 @@
+// Long-uptime capture decay soak (2026-08-27 capture decay plan, D2).
+//
+// The field failure this hunts: after minutes-to-hours of app uptime — NO
+// recordings required — the always-on capture → compositor pipeline settles
+// into a stable degraded equilibrium (~6 fresh fps served at a healthy 30fps
+// cadence). Preview and any later recording/livestream inherit it, restart
+// clears it, and every liveness-only watchdog stays silent throughout. The
+// owner's 33-minute idle decay produced zero log lines on 0.9.80.
+//
+// This soak launches the app once, starts NO sessions, and samples
+// `diagnostics.stats` on an interval for a configurable duration. The
+// backend's own capture-health monitor is the oracle: any sample with
+// `capturePipelineDegradedStage` set fails the soak, and the whole rate
+// series is written out as CSV so a passing run still yields the decay curve
+// (time-to-onset, settled rates) when eyeballed.
+//
+// Synthetic scenes have no live camera/screen fetch sources, so the monitor's
+// camera-delivery verdict only engages with real devices; the render-cadence
+// verdict engages everywhere. Run the real-source variant on a box with TCC
+// grants for the full tripwire.
+//
+// Usage: pnpm smoke:capture-decay-soak
+//   VIDEORC_SOAK_MINUTES=60          soak length (default 60)
+//   VIDEORC_SOAK_SAMPLE_SECONDS=10   sampling interval (default 10)
+//   VIDEORC_SOAK_REAL_SOURCES=1      use the packaged app + real devices
+//                                    (VIDEORC_PACKAGED_APP_EXECUTABLE to point
+//                                    at a build; needs TCC grants; captures
+//                                    your real screen — run intentionally)
+//   VIDEORC_SMOKE_OUTPUT_DIR=...     report directory
+
+import { randomBytes } from 'node:crypto'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { launchDevApp } from './lib/app-launcher.mjs'
+import { connectBackend, request } from './smoke-recording-session.mjs'
+
+const outputDirectory = resolve(
+  process.env.VIDEORC_SMOKE_OUTPUT_DIR ?? join(tmpdir(), `videorc-capture-soak-${Date.now()}`)
+)
+mkdirSync(outputDirectory, { recursive: true })
+const userDataDir = mkdtempSync(join(tmpdir(), 'videorc-capture-soak-user-data-'))
+const timeoutMs = Number(process.env.VIDEORC_SMOKE_TIMEOUT_MS ?? 90000)
+const soakMinutes = Number(process.env.VIDEORC_SOAK_MINUTES ?? 60)
+const sampleSeconds = Number(process.env.VIDEORC_SOAK_SAMPLE_SECONDS ?? 10)
+
+const realSources = process.env.VIDEORC_SOAK_REAL_SOURCES === '1'
+const packagedAppExecutable = realSources
+  ? (process.env.VIDEORC_PACKAGED_APP_EXECUTABLE ??
+    '/Applications/Videorc.app/Contents/MacOS/Videorc')
+  : null
+const packagedSmokeCapability = packagedAppExecutable
+  ? randomBytes(32).toString('base64url')
+  : undefined
+
+const sleep = (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms))
+
+let stopApp = null
+let exitCode = 0
+try {
+  const launch = await launchDevApp({
+    spawnSpec: packagedAppExecutable ? { command: packagedAppExecutable, args: [] } : undefined,
+    packagedSmokeCommandCapability: packagedSmokeCapability,
+    env: {
+      VIDEORC_SMOKE_COMMAND_SERVER: '1',
+      VIDEORC_SMOKE_STATE_DIR: outputDirectory,
+      VIDEORC_USER_DATA_DIR: userDataDir,
+      ...(packagedAppExecutable
+        ? {
+            VIDEORC_PACKAGED_SMOKE_TEST: '1',
+            VIDEORC_SMOKE_COMMAND_CAPABILITY: packagedSmokeCapability,
+            VIDEORC_SMOKE_PRINT_BACKEND_READY: '1'
+          }
+        : {}),
+      VIDEORC_SYNTHETIC_HARD_CONTENT: '1'
+    },
+    timeoutMs,
+    requiredMarkers: ['backend-ready', 'preview-motion-ready'],
+    onLine: (line) => {
+      if (process.env.VIDEORC_SMOKE_PRINT_APP_OUTPUT === '1') console.log(line)
+    }
+  })
+  stopApp = launch.stop
+  const ws = await connectBackend(launch.connections['backend-ready'], timeoutMs)
+
+  const startedAt = Date.now()
+  const deadline = startedAt + soakMinutes * 60_000
+  const samples = []
+  let previous = null
+  let degradedSamples = 0
+
+  console.log(
+    `[capture-soak] soaking idle for ${soakMinutes}m, sampling every ${sampleSeconds}s ` +
+      `(${realSources ? 'REAL sources' : 'synthetic scene'}); no sessions will be started`
+  )
+
+  while (Date.now() < deadline) {
+    await sleep(sampleSeconds * 1000)
+    const stats = await request(ws, timeoutMs, 'diagnostics.stats', undefined)
+    const now = Date.now()
+    const uptimeSec = Math.round((now - startedAt) / 1000)
+    const windowSec = previous ? (now - previous.at) / 1000 : null
+    const rate = (field) =>
+      previous && windowSec > 0 && stats[field] >= previous.stats[field]
+        ? (stats[field] - previous.stats[field]) / windowSec
+        : null
+    const sample = {
+      uptimeSec,
+      renderFps: stats.renderFps ?? null,
+      targetFps: stats.targetFps ?? null,
+      cameraFreshFps: rate('compositorCameraSourceFreshServes'),
+      screenFreshFps: rate('compositorScreenSourceFreshServes'),
+      cameraHeldFps: rate('compositorCameraSourceHeldServes'),
+      screenHeldFps: rate('compositorScreenSourceHeldServes'),
+      degradedStage: stats.capturePipelineDegradedStage ?? null
+    }
+    samples.push(sample)
+    previous = { at: now, stats }
+    if (sample.degradedStage) {
+      degradedSamples += 1
+      console.error(
+        `[capture-soak] DEGRADED at uptime ${uptimeSec}s: stage=${sample.degradedStage} ` +
+          `render=${sample.renderFps?.toFixed?.(1)}fps camera_fresh=${sample.cameraFreshFps?.toFixed?.(1) ?? 'n/a'}fps`
+      )
+    } else if (samples.length % 30 === 0) {
+      console.log(
+        `[capture-soak] healthy at uptime ${uptimeSec}s: render=${sample.renderFps?.toFixed?.(1)}fps ` +
+          `camera_fresh=${sample.cameraFreshFps?.toFixed?.(1) ?? 'n/a'}fps screen_fresh=${sample.screenFreshFps?.toFixed?.(1) ?? 'n/a'}fps`
+      )
+    }
+  }
+
+  const csvHeader =
+    'uptimeSec,renderFps,targetFps,cameraFreshFps,screenFreshFps,cameraHeldFps,screenHeldFps,degradedStage'
+  const csv = [csvHeader]
+    .concat(
+      samples.map((sample) =>
+        [
+          sample.uptimeSec,
+          sample.renderFps ?? '',
+          sample.targetFps ?? '',
+          sample.cameraFreshFps?.toFixed?.(2) ?? '',
+          sample.screenFreshFps?.toFixed?.(2) ?? '',
+          sample.cameraHeldFps?.toFixed?.(2) ?? '',
+          sample.screenHeldFps?.toFixed?.(2) ?? '',
+          sample.degradedStage ?? ''
+        ].join(',')
+      )
+    )
+    .join('\n')
+  const reportPath = join(outputDirectory, 'capture-decay-soak.csv')
+  writeFileSync(reportPath, `${csv}\n`)
+  writeFileSync(
+    join(outputDirectory, 'capture-decay-soak.json'),
+    JSON.stringify({ soakMinutes, sampleSeconds, realSources, degradedSamples, samples }, null, 2)
+  )
+
+  if (degradedSamples > 0) {
+    console.error(
+      `[capture-soak] FAIL: ${degradedSamples} degraded sample(s) over ${soakMinutes}m — curve at ${reportPath}`
+    )
+    exitCode = 1
+  } else {
+    console.log(
+      `[capture-soak] PASS: ${samples.length} samples over ${soakMinutes}m, no degradation declared — curve at ${reportPath}`
+    )
+  }
+  ws.close()
+} catch (error) {
+  console.error(`[capture-soak] harness failure: ${error?.stack ?? error}`)
+  exitCode = 1
+} finally {
+  await stopApp?.()
+}
+process.exit(exitCode)


### PR DESCRIPTION
Executes D1/D2/D4/D5 of the 2026-08-27 Long-Uptime Capture Decay Plan. D3 (the root fix) is deliberately absent: it is shaped by the data this PR starts collecting.

## The incident this instruments

Owner on 0.9.80: app open ~33 min **without ever recording** → preview lagging; a recording made then is 28% unique frames. After restart, decay returned at ~100s of uptime: file `152028` is healthy for 50s then locks at **21% unique ≈ 6.4 fresh fps** to the end, onset exactly overlapping a backend-initiated screen-capture restart. Same rot mid-livestream. The idle decay produced **zero log lines** — every watchdog we have detects liveness, not rate — and the post-recording quality check **timed out at its flat 60s** on the 2-minute 4K file, so the owner had no signal from either net.

## D1 — the pipeline can now see its own decay (`capture_health.rs`)

- Fed from the compositor's existing 2s diagnostic windows; zero new sampling machinery.
- Judges camera-delivery (fresh-serve rate; webcams stream continuously so collapse = decay) and compositor-render (snapshot fps), upstream-first — a starving camera fetch is named even while render dutifully re-serves held frames at full cadence, which is exactly the field signature.
- **Screen is advisory only, never a verdict**: SCK delivers on display damage, so a static desktop legitimately produces ~0 fresh screen frames.
- 3 consecutive degraded windows (~6s) to declare, 3 healthy to recover; single-window blips never flap; cumulative-counter resets (compositor swap) re-arm the baseline instead of producing bogus verdicts.
- One `[capture-health]` WARN with the numbers on the degrade edge, one INFO on recovery — the field diagnosis for every future report.
- `capturePipelineDegradedStage` published in `diagnostics.stats` **under the serde rails**: `skip_serializing_if` + omission test on the Rust side, `optionalSchema(nullableSchema(...))` + wire tests on the TS side (the 0.9.68/0.9.79 outage class, guarded on both ends).

## D2 — `pnpm smoke:capture-decay-soak`

Launches the app once, starts **no sessions**, samples diagnostics on an interval for `VIDEORC_SOAK_MINUTES`, writes the whole rate series as CSV (time-to-onset and settled rates readable even from a passing run), and fails on any degraded sample. A 30s synthetic run passes on this box — which also live-validates the D1 wiring (healthy 60fps render, no false verdict). Real-source variant drives the packaged app for the full camera tripwire.

## D4 — the two nets that failed, mended

- Quality budgets scale with the media: assessment = 3× duration clamped to [60s, 15m] (repair 6× in [3m, 30m]); boot-resumed jobs, which have no duration on hand, get the cap instead of a budget that guarantees failure.
- When the assessment still cannot reach a verdict on a file whose **live pipeline already reported frozen output**, a WARN-level `recording-quality-unverified` health event fires (toasts). That combination — pipeline says frozen, checker says timeout — previously collapsed to an info-level line nobody sees; it is how both the 55%-frozen 0.9.71 file and this week's 79%-held file shipped silently.

## D5 — two bystanders from the same field log

- **Camera cadence overshoot (every start, since ≤0.9.70):** the integer clamp inverts on fractional fixed ranges — `floor(30.00003)=30 < ceil(30.00003)=31` leaves an empty interval and `.max(31)` wins — requesting 31fps on a 30fps camera and eating an NSException on every camera start (the 61-on-60 sibling from the Aug 24 log). `resolve_camera_frame_rate` resolves against the active format's advertised ranges and, at an endpoint, requests the range's **own CMTime verbatim** — AVFoundation compares those rationals exactly, so no decimal approximation survives (a µs-rounded 59.9412 would be rejected just like the 61 was; unit-tested against the field matrices).
- **OAuth recovery store self-heal:** a YouTube pre-exchange checkpoint persisted while the gate was open failed the *whole* store load once the gate closed → every backend ran a 5-second `storage is unavailable` ERROR loop for the life of the process (~17k lines/day since Aug 25). A restoration failure **caused by the gate** now drops that checkpoint once — secrets cleaned via the persisted refs, store rewritten so the next boot is quiet, single WARN. The drop is keyed to the restoration error, not the platform: later-stage checkpoints (token/account-storage) restore without provider config and still survive restarts — the existing restart-survival tests caught my first, broader version of this and forced the narrowing. The maintenance loop also deduplicates repeated identical errors.

## Verification

- `cargo test -p videorc-backend`: 1699 + 77 + 1, including 7 new capture-health tests (one replays the measured field decay shape), 4 frame-rate-resolver tests, the gate-closed-checkpoint store test, serde omission tests, and budget-scaling tests
- `cargo fmt --check`, `cargo clippy -D warnings` clean
- `pnpm typecheck` / `lint` / `format:check`; desktop 1566/167; scripts 1114; `pnpm build`
- `smoke:capture-decay-soak` 30s synthetic run: PASS with curve artifact
- Camera-format change is unit-tested against real device matrices; live-camera confirmation rides the next owner build (the per-start NSException WARN should vanish from backend.log)

## Explicitly not in this PR

- D3 (root fix) — blocked on the curve this telemetry produces
- The in-app degraded chip + one-click verified capture restart (D4 tail) — depends on D3's restart machinery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Diagnostics now identify whether capture issues originate from camera delivery or compositor rendering.
  - Recording quality checks and repairs use time limits based on recording duration.

- **Bug Fixes**
  - Improved camera frame-rate handling for fractional and fixed-rate formats, reducing device rejection and cadence issues.
  - Disabled OAuth integrations no longer prevent recovery data from loading.
  - Repeated maintenance errors are logged less noisily, with recovery notifications when service resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->