### PR TITLE
docs: 0.9.80 and 0.9.82 release records

### DIFF
--- a/docs/releases/0.9.80.md
+++ b/docs/releases/0.9.80.md
@@ -1,0 +1,28 @@
+# Videorc 0.9.80 Beta 1 (macOS) + 0.9.80-alpha.1 (Windows pilot)
+
+Hotfix for the 0.9.79 Studio startup stall, shipped same-day on both platforms
+from the identical commit.
+
+## Scope (PRs #301, #302, #303)
+
+- **Studio startup could stall on 0.9.79 (both platforms).** Three encoder
+  queue-age diagnostics added in 0.9.79 were declared optional but serialized
+  `null` when unobserved — every value in the first idle payload. The renderer
+  validates diagnostics during bootstrap and rejects `null` for numeric
+  fields, so the load stalled before any recording. Fields are now omitted
+  when absent (#301). Third shipped occurrence of the serde-null → contract
+  defect class (0.9.68–0.9.70 record-button outage, 0.9.79 startup stall);
+  three further latent null-serializing protocol fields were identified and
+  are tracked for the same treatment before any contract exposure.
+
+## Ship record
+
+- macOS 0.9.80-beta.1 built from `ccf216b4` (post-#301) + bump #302; signed/notarized
+  (Developer ID Uros Miric C2PA37RB58), uploaded and feed-verified
+  (`latest-mac.yml` → 0.9.80, zip 206), Discord announced 2026-08-25.
+- Windows 0.9.80-alpha.1 pilot: changelog #303 (`cd1d771a`), candidate run
+  32907728953 (success), identity
+  `windows:0.9.80-alpha.1:cd1d771a…:sha256:0d8a7666…4b79cf`, pilot promotion
+  32910901948 (success, upload PASS). Public promotion pending physical
+  acceptance. Discord pilot note posted.
+- Exposure window of the 0.9.79 defect: ~2 hours on beta + pilot channels.

--- a/docs/releases/0.9.82.md
+++ b/docs/releases/0.9.82.md
@@ -1,0 +1,69 @@
+# Videorc 0.9.82 Beta 1 (macOS)
+
+The capture pipeline can now see its own slowdowns, the quality gate stops
+failing honest work, and two long-standing background defects are fixed.
+(The 0.9.81 numeric was burned by an abandoned Windows candidate — see below.)
+
+## Scope (PRs #309, #310)
+
+- **Capture-health monitoring (plan D1).** The 2026-08-27 field incident:
+  after minutes-to-hours of uptime — no sessions required — the pipeline
+  settles at ~6 fresh fps under a healthy 30fps encoder cadence, invisible to
+  every liveness-only watchdog (a 33-minute idle decay produced zero log
+  lines). A rate-collapse monitor now rides the compositor's 2s diagnostic
+  windows, names the first degraded stage upstream-first (`camera-delivery`
+  before `compositor-render`; screen advisory only — SCK is damage-driven),
+  logs one WARN on the degrade edge with the numbers, and publishes
+  `capturePipelineDegradedStage` under full serde rails on both sides.
+- **`pnpm smoke:capture-decay-soak` (plan D2).** App up, no sessions, samples
+  the rates for N minutes, emits the decay curve as CSV, fails on any
+  degraded sample.
+- **Honest quality gates (plan D4).** Budgets scale with media duration
+  (assessment 3× in [60s, 15m], repair 6× in [3m, 30m]; boot-resumed jobs get
+  the cap) — the flat 60s guaranteed the owner's 2-minute 4K file timed out
+  unexamined. When the pipeline reported frozen output and the check still
+  cannot verify, a WARN-level `recording-quality-unverified` event now fires
+  instead of an invisible info line.
+- **Fractional-rate camera start fix (plan D5a).** The integer clamp inverts
+  on fixed fractional ranges (`floor(30.00003)=30 < ceil(30.00003)=31` → empty
+  interval → `.max(31)` wins), requesting an impossible rate and eating an
+  NSException on every camera start (the 61-on-60 sibling).
+  `resolve_camera_frame_rate` requests the range's own CMTime at endpoints —
+  AVFoundation compares those rationals exactly.
+- **OAuth recovery-store self-heal (plan D5b).** A YouTube pre-exchange
+  checkpoint persisted while the OAuth gate was open failed the whole store
+  load once the gate closed → a 5-second `storage is unavailable` ERROR loop
+  for the life of every backend (~17k lines/day since Aug 25). Gate-caused
+  restoration failures now drop that checkpoint once (secrets cleaned, store
+  rewritten, single WARN); later-stage checkpoints still survive restarts.
+- **Explicitly deferred:** plan D3 (the decay root fix) is shaped by the
+  curve this release starts collecting; the in-app degraded chip + verified
+  capture restart defer with it.
+
+## The burned 0.9.81 numeric
+
+`0.9.81-alpha.1` (Windows, Intel iGPU hardware-encoding fix, #305) built a
+successful candidate from `fd49a359` on Aug 26 but was never promoted; a
+roll-forward re-dispatch of the same release ID from `20e6c8ea` (post-#307)
+failed Windows clippy on Aug 27. Per the windows-alpha runbook correction
+rule the ID is burned: the unpublished changelog entry was removed in #310,
+the numeric bumped to 0.9.82, and the Intel fixes (#305/#307) ride the next
+Windows alpha once Windows clippy on `main` is green. The abandoned entry was
+never published (last upload predated it), so no changelog recovery was
+needed.
+
+## Ship record
+
+- Source: `main` @ `9c9c84dc` (#310, on top of #309 `8bb3950b`).
+- Gates: cargo 1699+77+1 (16 new tests incl. a replay of the measured field
+  decay curve), clippy `-D warnings`, fmt; pnpm typecheck/lint/format,
+  desktop 1566/167, scripts 1114, build; 30s synthetic soak PASS.
+- Signed/notarized/stapled (Developer ID Uros Miric C2PA37RB58), Gatekeeper
+  assessed, artifact validation PASS.
+- Uploaded with TLS-issuer guard (Google Trust Services verified) and
+  bucket-less endpoint; all objects verified; `latest-mac.yml` serves 0.9.82,
+  zip range-check 206; Discord announced 2026-08-27.
+- Owner acceptance: pending (long-idle + long-recording runs are themselves
+  the D1 data collection).
+- Windows: intentionally not released (owner requested macOS-only); next
+  Windows alpha must be `0.9.82-alpha.1` or later from a clippy-green main.


### PR DESCRIPTION
Release records: the 0.9.80 cross-platform hotfix (closing an overdue gap) and today's macOS 0.9.82-beta.1 (capture-decay instrumentation), including the burned-0.9.81 explanation and the runbook-correction trail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for the Videorc 0.9.80 macOS beta and Windows pilot.
  * Documented the 0.9.79 startup-stall hotfix and improved handling of unavailable encoder diagnostics.
  * Added 0.9.82 Beta 1 macOS release details, including capture-health monitoring, quality validation, fractional-rate camera fixes, and OAuth recovery improvements.
  * Recorded platform build, distribution, testing, and release-status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->