### PR TITLE
fix(windows): finalize fallback recordings as MP4

### DIFF
--- a/crates/videorc-backend/src/encoder_bridge.rs
+++ b/crates/videorc-backend/src/encoder_bridge.rs
@@ -4472,13 +4472,20 @@ fn write_synthetic_recording_frames(params: SyntheticRecordingWriterParams) {
                 &mut metal_target_handle_frames,
                 &mut raw_video_fifo_write_times_ms,
             ) {
-                let error = record_encoder_bridge_terminal_failure(
-                    &terminal_failure,
+                let error = if io_error_is_downstream_closed(&error) {
                     format!(
-                        "{} raw-video encoder output stopped: {error}",
+                        "{} raw-video encoder output ended: downstream closed ({error})",
                         encoder_bridge_output_role_label(output_queue_policy.role)
-                    ),
-                );
+                    )
+                } else {
+                    record_encoder_bridge_terminal_failure(
+                        &terminal_failure,
+                        format!(
+                            "{} raw-video encoder output stopped: {error}",
+                            encoder_bridge_output_role_label(output_queue_policy.role)
+                        ),
+                    )
+                };
                 terminal_writer_error = Some(error.clone());
                 emit_encoder_bridge_diagnostics_from_thread(
                     &diagnostics_tx,
@@ -5270,6 +5277,7 @@ enum RawVideoFifoWriterResult {
     Error {
         synthetic_buffer: Option<Vec<u8>>,
         message: String,
+        downstream_closed: bool,
     },
 }
 
@@ -5520,16 +5528,25 @@ fn run_raw_video_fifo_writer_loop_with_receiver_and_progress<W, F>(
                 });
             }
             Err(error) => {
-                let message = record_encoder_bridge_terminal_failure(
-                    &terminal_failure,
+                let downstream_closed = io_error_is_downstream_closed(&error);
+                let message = if downstream_closed {
                     format!(
-                        "{} raw-video encoder output stopped: {error}",
+                        "{} raw-video encoder output ended: downstream closed ({error})",
                         encoder_bridge_output_role_label(role)
-                    ),
-                );
+                    )
+                } else {
+                    record_encoder_bridge_terminal_failure(
+                        &terminal_failure,
+                        format!(
+                            "{} raw-video encoder output stopped: {error}",
+                            encoder_bridge_output_role_label(role)
+                        ),
+                    )
+                };
                 let _ = result_tx.send(RawVideoFifoWriterResult::Error {
                     synthetic_buffer: frame.into_synthetic_buffer(),
                     message,
+                    downstream_closed,
                 });
                 return;
             }
@@ -5538,16 +5555,25 @@ fn run_raw_video_fifo_writer_loop_with_receiver_and_progress<W, F>(
     if !stop.load(Ordering::Relaxed)
         && let Err(error) = sink.flush()
     {
-        let message = record_encoder_bridge_terminal_failure(
-            &terminal_failure,
+        let downstream_closed = io_error_is_downstream_closed(&error);
+        let message = if downstream_closed {
             format!(
-                "{} raw-video encoder output flush failed: {error}",
+                "{} raw-video encoder output ended: downstream closed ({error})",
                 encoder_bridge_output_role_label(role)
-            ),
-        );
+            )
+        } else {
+            record_encoder_bridge_terminal_failure(
+                &terminal_failure,
+                format!(
+                    "{} raw-video encoder output flush failed: {error}",
+                    encoder_bridge_output_role_label(role)
+                ),
+            )
+        };
         let _ = result_tx.send(RawVideoFifoWriterResult::Error {
             synthetic_buffer: None,
             message,
+            downstream_closed,
         });
     }
 }
@@ -5590,11 +5616,17 @@ fn drain_raw_video_fifo_writer_results(
             RawVideoFifoWriterResult::Error {
                 synthetic_buffer,
                 message,
+                downstream_closed,
             } => {
                 retain_recycled_synthetic_buffer(recycled_synthetic_buffer, synthetic_buffer);
                 *pending_frames = 0;
                 pending_started_at.clear();
-                return Err(io::Error::other(message));
+                let kind = if downstream_closed {
+                    io::ErrorKind::BrokenPipe
+                } else {
+                    io::ErrorKind::Other
+                };
+                return Err(io::Error::new(kind, message));
             }
         }
     }
@@ -5932,10 +5964,15 @@ fn run_video_toolbox_fifo_writer_loop<W: StdWrite>(
 /// EPIPE/EOF class: the reader (FFmpeg) went away. The writer must stop, but
 /// the SESSION verdict belongs to the process exit status, not this error.
 fn io_error_is_downstream_closed(error: &io::Error) -> bool {
+    #[cfg(target_os = "windows")]
+    let windows_pipe_closing = error.raw_os_error() == Some(232); // ERROR_NO_DATA
+    #[cfg(not(target_os = "windows"))]
+    let windows_pipe_closing = false;
+
     matches!(
         error.kind(),
         io::ErrorKind::BrokenPipe | io::ErrorKind::WriteZero | io::ErrorKind::UnexpectedEof
-    )
+    ) || windows_pipe_closing
 }
 
 #[cfg(target_os = "macos")]
@@ -7796,6 +7833,14 @@ mod tests {
         );
         assert!(drain_state.downstream_closed);
         assert!(!drain_state.pending_timeout_is_terminal(3, 2));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_error_no_data_is_classified_as_a_closed_downstream() {
+        let error = io::Error::from_raw_os_error(232); // ERROR_NO_DATA
+
+        assert!(io_error_is_downstream_closed(&error));
     }
 
     fn test_session_with_writer(
@@ -9680,6 +9725,56 @@ mod tests {
             panic!("raw frame must be reported as written")
         };
         assert_eq!(synthetic_buffer, Some(vec![1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn raw_fifo_writer_does_not_promote_a_closed_downstream_to_terminal_failure() {
+        struct DownstreamClosedSink;
+
+        impl StdWrite for DownstreamClosedSink {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "The pipe is being closed.",
+                ))
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let (frame_tx, frame_rx) = std_mpsc::sync_channel(1);
+        let (result_tx, result_rx) = std_mpsc::sync_channel(2);
+        frame_tx
+            .send(QueuedRawVideoFrame::synthetic(vec![1, 2, 3]))
+            .expect("queue raw frame");
+        drop(frame_tx);
+        let terminal_failure = Arc::new(StdMutex::new(None));
+
+        run_raw_video_fifo_writer_loop(
+            DownstreamClosedSink,
+            frame_rx,
+            result_tx,
+            Arc::new(AtomicBool::new(false)),
+            terminal_failure.clone(),
+            EncoderBridgeOutputRole::Shared,
+        );
+
+        let RawVideoFifoWriterResult::Error {
+            downstream_closed,
+            message,
+            ..
+        } = result_rx.recv().expect("closed downstream result")
+        else {
+            panic!("closed downstream must surface as a writer error")
+        };
+        assert!(downstream_closed);
+        assert!(message.contains("downstream closed"));
+        assert_eq!(
+            read_encoder_bridge_terminal_failure(&terminal_failure),
+            None
+        );
     }
 
     #[test]

--- a/crates/videorc-backend/src/ffmpeg_work.rs
+++ b/crates/videorc-backend/src/ffmpeg_work.rs
@@ -150,7 +150,13 @@ impl FfmpegWorkCoordinator {
 
     /// Wait for the next idle maintenance slot ahead of background maintenance.
     /// This is for short, user-visible work such as poster extraction. Capture
-    /// and finalization still take precedence.
+    /// and finalization still take precedence. An in-flight background
+    /// maintenance job (post-recording quality gate, repair scan, ...) is
+    /// asked to cancel — those jobs observe the token, defer, and re-run
+    /// later — instead of queueing behind a multi-minute analysis, which
+    /// would push a stateful caller such as sessions.poster past its
+    /// execution contract and restart the backend (2026-08-29 tester log:
+    /// poster queued behind a 110s-recording quality assessment).
     pub async fn begin_priority_maintenance_when_idle(self: &Arc<Self>) -> MaintenancePermit {
         let mut waiter = PriorityMaintenanceWaiter::new(self.clone());
         loop {
@@ -177,6 +183,12 @@ impl FfmpegWorkCoordinator {
                     waiter.registered = false;
                     Some(self.begin_maintenance_locked(&mut state))
                 } else {
+                    if state.maintenance_running && !state.maintenance_cancel_requested {
+                        state.maintenance_cancel_generation =
+                            state.maintenance_cancel_generation.saturating_add(1);
+                        state.maintenance_cancel_requested = true;
+                        self.notify.notify_waiters();
+                    }
                     None
                 }
             };
@@ -688,6 +700,38 @@ mod tests {
                 .expect("capture waiter must acquire after the release")
                 .expect("capture waiter task");
             drop(capture);
+        }
+    }
+
+    /// 2026-08-29 tester log: a priority waiter (sessions.poster) queued
+    /// behind a still-running post-recording quality assessment for minutes
+    /// and blew its 25s execution contract, restarting the backend. Priority
+    /// maintenance is short, user-visible work: it must request cancellation
+    /// of the active background job (which defers and re-runs later) instead
+    /// of queueing behind it.
+    #[tokio::test]
+    async fn priority_maintenance_cancels_the_active_maintenance_and_acquires() {
+        let coordinator = Arc::new(FfmpegWorkCoordinator::new());
+        for _ in 0..25 {
+            let maintenance = coordinator.try_begin_maintenance().unwrap();
+            let cancel_token = maintenance.cancel_token();
+            let waiter = tokio::spawn({
+                let coordinator = coordinator.clone();
+                async move { coordinator.begin_priority_maintenance_when_idle().await }
+            });
+            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                while !cancel_token.is_cancelled() {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("priority waiter must request cancellation of the active maintenance");
+            drop(maintenance);
+            let permit = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+                .await
+                .expect("priority waiter must acquire after the cancelled job releases")
+                .expect("priority waiter task");
+            drop(permit);
         }
     }
 

--- a/crates/videorc-backend/src/ffmpeg_work.rs
+++ b/crates/videorc-backend/src/ffmpeg_work.rs
@@ -52,29 +52,40 @@ impl FfmpegWorkCoordinator {
     pub async fn begin_capture_when_available(self: &Arc<Self>) -> CapturePermit {
         let mut waiting_registered = false;
         loop {
-            let notified = {
+            // Register the wakeup BEFORE inspecting the state: a permit
+            // released between the state check and this waiter's first poll
+            // must never be missed (lost wakeup), same contract as
+            // begin_maintenance_when_idle_after_wait_registered.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            let _ = notified.as_mut().enable();
+            let acquired = {
                 let mut state = self.state.lock().expect("ffmpeg work state poisoned");
                 if !state.maintenance_running && !state.finalizing_active {
                     if waiting_registered {
                         state.capture_waiting = state.capture_waiting.saturating_sub(1);
                     }
                     state.capture_active = true;
-                    return CapturePermit {
-                        coordinator: self.clone(),
-                    };
+                    true
+                } else {
+                    if !waiting_registered {
+                        state.capture_waiting += 1;
+                        waiting_registered = true;
+                    }
+                    if state.maintenance_running && !state.maintenance_cancel_requested {
+                        state.maintenance_cancel_generation =
+                            state.maintenance_cancel_generation.saturating_add(1);
+                        state.maintenance_cancel_requested = true;
+                        self.notify.notify_waiters();
+                    }
+                    false
                 }
-                if !waiting_registered {
-                    state.capture_waiting += 1;
-                    waiting_registered = true;
-                }
-                if state.maintenance_running && !state.maintenance_cancel_requested {
-                    state.maintenance_cancel_generation =
-                        state.maintenance_cancel_generation.saturating_add(1);
-                    state.maintenance_cancel_requested = true;
-                    self.notify.notify_waiters();
-                }
-                self.notify.notified()
             };
+            if acquired {
+                return CapturePermit {
+                    coordinator: self.clone(),
+                };
+            }
             notified.await;
         }
     }
@@ -143,7 +154,16 @@ impl FfmpegWorkCoordinator {
     pub async fn begin_priority_maintenance_when_idle(self: &Arc<Self>) -> MaintenancePermit {
         let mut waiter = PriorityMaintenanceWaiter::new(self.clone());
         loop {
-            let notified = {
+            // Register the wakeup BEFORE inspecting the state. Otherwise a
+            // permit released between the state check and the waiter's first
+            // poll is missed forever: later background maintenance stays
+            // excluded by the priority waiter, nothing ever notifies again,
+            // and a stateful caller such as sessions.poster wedges until its
+            // execution contract restarts the backend (2026-08-29 Windows CI).
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            let _ = notified.as_mut().enable();
+            let acquired = {
                 let mut state = self.state.lock().expect("ffmpeg work state poisoned");
                 if !state.capture_active
                     && state.capture_waiting == 0
@@ -155,10 +175,14 @@ impl FfmpegWorkCoordinator {
                     state.priority_maintenance_waiting =
                         state.priority_maintenance_waiting.saturating_sub(1);
                     waiter.registered = false;
-                    return self.begin_maintenance_locked(&mut state);
+                    Some(self.begin_maintenance_locked(&mut state))
+                } else {
+                    None
                 }
-                self.notify.notified()
             };
+            if let Some(permit) = acquired {
+                return permit;
+            }
             notified.await;
         }
     }
@@ -186,25 +210,36 @@ impl FfmpegWorkCoordinator {
     ) -> RecordingFileMutationPermit {
         let mut waiter = RecordingFileMutationWaiter::new(self.clone());
         loop {
-            let notified = {
+            // Register the wakeup BEFORE inspecting the state: a permit
+            // released between the state check and this waiter's first poll
+            // must never be missed (lost wakeup), same contract as
+            // begin_maintenance_when_idle_after_wait_registered.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            let _ = notified.as_mut().enable();
+            let acquired = {
                 let mut state = self.state.lock().expect("ffmpeg work state poisoned");
                 if !state.maintenance_running && !state.recording_file_mutation_active {
                     state.recording_file_mutation_waiting =
                         state.recording_file_mutation_waiting.saturating_sub(1);
                     waiter.registered = false;
                     state.recording_file_mutation_active = true;
-                    return RecordingFileMutationPermit {
-                        coordinator: self.clone(),
-                    };
+                    true
+                } else {
+                    if state.maintenance_running && !state.maintenance_cancel_requested {
+                        state.maintenance_cancel_generation =
+                            state.maintenance_cancel_generation.saturating_add(1);
+                        state.maintenance_cancel_requested = true;
+                        self.notify.notify_waiters();
+                    }
+                    false
                 }
-                if state.maintenance_running && !state.maintenance_cancel_requested {
-                    state.maintenance_cancel_generation =
-                        state.maintenance_cancel_generation.saturating_add(1);
-                    state.maintenance_cancel_requested = true;
-                    self.notify.notify_waiters();
-                }
-                self.notify.notified()
             };
+            if acquired {
+                return RecordingFileMutationPermit {
+                    coordinator: self.clone(),
+                };
+            }
             notified.await;
         }
     }
@@ -606,6 +641,54 @@ mod tests {
 
         drop(priority_permit);
         drop(background.await.unwrap());
+    }
+
+    /// 2026-08-29 Windows CI: a priority waiter that checked the state while a
+    /// maintenance permit was still held could miss the release notification
+    /// (its Notify future registered only on first poll), stay wedged behind
+    /// its own `priority_maintenance_waiting` registration forever, and force
+    /// the backend to restart on the mutation execution contract. The waiter
+    /// must always acquire after the release, across many interleavings.
+    #[tokio::test]
+    async fn released_maintenance_wakes_a_waiting_priority_waiter() {
+        let coordinator = Arc::new(FfmpegWorkCoordinator::new());
+        for _ in 0..200 {
+            let maintenance = coordinator.try_begin_maintenance().unwrap();
+            let waiter = tokio::spawn({
+                let coordinator = coordinator.clone();
+                async move { coordinator.begin_priority_maintenance_when_idle().await }
+            });
+            for _ in 0..4 {
+                tokio::task::yield_now().await;
+            }
+            drop(maintenance);
+            let permit = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+                .await
+                .expect("priority waiter must acquire after the release")
+                .expect("priority waiter task");
+            drop(permit);
+        }
+    }
+
+    #[tokio::test]
+    async fn released_maintenance_wakes_a_waiting_capture() {
+        let coordinator = Arc::new(FfmpegWorkCoordinator::new());
+        for _ in 0..200 {
+            let maintenance = coordinator.try_begin_maintenance().unwrap();
+            let waiter = tokio::spawn({
+                let coordinator = coordinator.clone();
+                async move { coordinator.begin_capture_when_available().await }
+            });
+            for _ in 0..4 {
+                tokio::task::yield_now().await;
+            }
+            drop(maintenance);
+            let capture = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+                .await
+                .expect("capture waiter must acquire after the release")
+                .expect("capture waiter task");
+            drop(capture);
+        }
     }
 
     #[tokio::test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -5224,7 +5224,7 @@ fn mp4_export_args(input: &Path, output: &Path, trim_seconds: Option<f64>) -> Ve
         "-loglevel".to_string(),
         "warning".to_string(),
         "-i".to_string(),
-        input.display().to_string(),
+        ffmpeg_file_path(input),
         "-map".to_string(),
         "0".to_string(),
         "-c:v".to_string(),
@@ -5239,11 +5239,17 @@ fn mp4_export_args(input: &Path, output: &Path, trim_seconds: Option<f64>) -> Ve
         "-movflags".to_string(),
         "+faststart".to_string(),
     ];
+    args.extend(h264_bt709_color_tag_args());
+    args.extend([
+        "-bsf:v".to_string(),
+        "h264_metadata=video_full_range_flag=0:colour_primaries=1:transfer_characteristics=1:matrix_coefficients=1"
+            .to_string(),
+    ]);
     if let Some(trim_seconds) = trim_seconds {
         // Bound the stop tail: end the delivered file at the shorter stream.
         args.extend(["-t".to_string(), format!("{trim_seconds:.3}")]);
     }
-    args.push(output.display().to_string());
+    args.push(ffmpeg_file_path(output));
     args
 }
 
@@ -6957,34 +6963,77 @@ async fn monitor_session(
     #[cfg(target_os = "windows")]
     if let Some(mut active) = retired_active {
         let mut final_snapshot_phase = WindowsD3d11FinalSnapshotPhase::default();
-        let bridge_persistence_gate = gate_encoder_bridge_lifecycle_persistence(
-            active
-                .encoder_bridge
-                .iter()
-                .chain(active.encoder_bridge_stream.iter()),
+        // The process may have been terminated after its normal stop grace
+        // expired while a raw fallback writer was still draining a complete
+        // frame. Reap both legs behind one absolute deadline; the old direct
+        // JoinHandle::join here could hold the monitor until the writer's
+        // thirty-second frame timeout (or forever on a wedged pipe), which
+        // prevented MP4 export from ever running.
+        let bridge_teardown = begin_recording_encoder_bridge_teardown(
+            &mut active.encoder_bridge,
+            &mut active.encoder_bridge_stream,
+            ENCODER_BRIDGE_TEARDOWN_GRACE,
         );
-        if let Some(stream_bridge) = active.encoder_bridge_stream.as_ref() {
-            stream_bridge.stop();
+        if let Some(report) = finish_recording_encoder_bridge_teardown(
+            &state,
+            bridge_teardown,
+            "recording-process-exit",
+        )
+        .await
+        {
+            encoder_bridge_teardown_duration_ms = report.teardown_duration_ms;
+            for bridge in &report.reports {
+                if let Some(failure) = bridge.terminal_failure.clone() {
+                    match bridge.role {
+                        Some(EncoderBridgeOutputRole::Stream) => {
+                            monitored_recording.stream_bridge_terminal_failure = Some(failure);
+                        }
+                        Some(
+                            EncoderBridgeOutputRole::Recording | EncoderBridgeOutputRole::Shared,
+                        )
+                        | None => {
+                            monitored_recording.recording_bridge_terminal_failure = Some(failure);
+                        }
+                    }
+                }
+            }
+            encoder_bridge_lifecycle = report.lifecycle;
+            if encoder_bridge_lifecycle.live_resources > 0 {
+                let message = format!(
+                    "Encoder bridge teardown left {} capture-relevant resource(s) live (outer={}, FIFO={}, detached={}); restart Videorc before recording again.",
+                    encoder_bridge_lifecycle.live_resources,
+                    encoder_bridge_lifecycle.live_outer_writers,
+                    encoder_bridge_lifecycle.live_fifo_writers,
+                    encoder_bridge_lifecycle.detached_writers,
+                );
+                state.emit_log("warn", message.clone());
+                let _ = emit_health_event(
+                    &state,
+                    Some(&session_id),
+                    HealthLevel::Warn,
+                    "encoder-bridge-writer-leaked",
+                    &message,
+                );
+            }
+            let _ = emit_session_log(
+                &state,
+                &session_id,
+                HealthLevel::Info,
+                "encoder-bridge-writer-lifecycle",
+                &format!(
+                    "state=teardown-complete durationMs={} liveOuter={} liveFifo={} liveResources={} detached={}",
+                    encoder_bridge_teardown_duration_ms,
+                    encoder_bridge_lifecycle.live_outer_writers,
+                    encoder_bridge_lifecycle.live_fifo_writers,
+                    encoder_bridge_lifecycle.live_resources,
+                    encoder_bridge_lifecycle.detached_writers,
+                ),
+                None,
+            );
         }
-        if let Some(recording_bridge) = active.encoder_bridge.as_ref() {
-            recording_bridge.stop();
-        }
-        if let Some(stream_bridge) = active.encoder_bridge_stream.as_mut() {
-            stream_bridge.stop_and_join_writer();
-        }
-        if let Some(recording_bridge) = active.encoder_bridge.as_mut() {
-            recording_bridge.stop_and_join_writer();
-        }
-        drop(bridge_persistence_gate);
         final_snapshot_phase
             .writers_joined()
             .expect("Windows D3D11 writers join exactly once before final diagnostics");
-        // Terminal bridge failures may be published only as the writer exits;
-        // refresh them after the bounded MF drain/flush has completed.
-        monitored_recording.recording_bridge_terminal_failure =
-            active.recording_bridge_terminal_failure();
-        monitored_recording.stream_bridge_terminal_failure =
-            active.stream_bridge_terminal_failure();
         let mut retained_snapshot = None;
         if let Some(mut monitor) = active.windows_d3d11_monitor.take() {
             monitor.request_stop();
@@ -8549,12 +8598,15 @@ fn should_finalize_recording_session(
     // before the user asks to stop is still an early termination (for example,
     // a source/pipe that silently ended) and must never publish a shortened
     // artifact as successful.
-    // Stop intent must win the monitor's exit-ready race, but that alone is not
-    // proof that muxer flush completed. A forced
-    // TERM/KILL or any non-zero FFmpeg exit keeps the artifact as recovery
-    // media and marks the session failed unless a future explicit verifier can
-    // prove the container is complete.
-    if recording_bridge_terminal_failure.is_some() || !ffmpeg_exit_success {
+    // Stop intent must win the monitor's exit-ready race. Windows FFmpeg can
+    // report a non-zero status while closing a stopped graph even though the
+    // local MKV is still exportable; let the MP4 exporter validate that output
+    // instead of unconditionally marooning it as recovery media. A recording
+    // bridge failure remains terminal because it means the video producer did
+    // not finish its contract.
+    if recording_bridge_terminal_failure.is_some()
+        || (!ffmpeg_exit_success && !stop_intent_preceded_exit)
+    {
         return false;
     }
     // A dead STREAM output ends FFmpeg without a user stop, but the RECORDING
@@ -26292,8 +26344,8 @@ mod tests {
     fn only_an_explicit_graceful_stop_can_finalize_an_unbounded_capture() {
         assert!(!should_finalize_recording_session(true, false, None, None));
         assert!(
-            !should_finalize_recording_session(false, true, None, None),
-            "a non-zero/forced FFmpeg exit after stop must remain failed"
+            should_finalize_recording_session(false, true, None, None),
+            "a stopped Windows graph may have a non-zero exit while its MKV remains exportable"
         );
         assert!(should_finalize_recording_session(true, true, None, None));
 
@@ -27198,6 +27250,33 @@ mod tests {
             args.last().map(String::as_str),
             Some("/tmp/videorc-test.mp4")
         );
+    }
+
+    #[test]
+    fn mp4_export_normalizes_windows_verbatim_paths() {
+        #[cfg(target_os = "windows")]
+        {
+            let args = mp4_export_args(
+                Path::new(r"\\?\C:\recordings\capture.mkv"),
+                Path::new(r"\\?\C:\recordings\.videorc-export.partial\export.mp4"),
+                None,
+            );
+            assert_eq!(arg_value(&args, "-i"), Some(r"C:\recordings\capture.mkv"));
+            assert_eq!(
+                args.last().map(String::as_str),
+                Some(r"C:\recordings\.videorc-export.partial\export.mp4")
+            );
+            assert_eq!(arg_value(&args, "-colorspace"), Some("bt709"));
+            assert_eq!(arg_value(&args, "-color_primaries"), Some("bt709"));
+            assert_eq!(arg_value(&args, "-color_trc"), Some("bt709"));
+            assert_eq!(arg_value(&args, "-color_range"), Some("tv"));
+            assert_eq!(
+                arg_value(&args, "-bsf:v"),
+                Some(
+                    "h264_metadata=video_full_range_flag=0:colour_primaries=1:transfer_characteristics=1:matrix_coefficients=1"
+                )
+            );
+        }
     }
 
     #[test]

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -5239,12 +5239,7 @@ fn mp4_export_args(input: &Path, output: &Path, trim_seconds: Option<f64>) -> Ve
         "-movflags".to_string(),
         "+faststart".to_string(),
     ];
-    args.extend(h264_bt709_color_tag_args());
-    args.extend([
-        "-bsf:v".to_string(),
-        "h264_metadata=video_full_range_flag=0:colour_primaries=1:transfer_characteristics=1:matrix_coefficients=1"
-            .to_string(),
-    ]);
+    append_media_foundation_h264_color_metadata_args(&mut args);
     if let Some(trim_seconds) = trim_seconds {
         // Bound the stop tail: end the delivered file at the shorter stream.
         args.extend(["-t".to_string(), format!("{trim_seconds:.3}")]);
@@ -27253,30 +27248,38 @@ mod tests {
     }
 
     #[test]
+    fn mp4_export_includes_bt709_h264_metadata() {
+        let args = mp4_export_args(
+            Path::new("/tmp/videorc-test.mkv"),
+            Path::new("/tmp/videorc-test.mp4"),
+            None,
+        );
+
+        assert_eq!(arg_value(&args, "-colorspace"), Some("bt709"));
+        assert_eq!(arg_value(&args, "-color_primaries"), Some("bt709"));
+        assert_eq!(arg_value(&args, "-color_trc"), Some("bt709"));
+        assert_eq!(arg_value(&args, "-color_range"), Some("tv"));
+        assert_eq!(
+            arg_value(&args, "-bsf:v"),
+            Some(
+                "h264_metadata=video_full_range_flag=0:colour_primaries=1:transfer_characteristics=1:matrix_coefficients=1"
+            )
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
     fn mp4_export_normalizes_windows_verbatim_paths() {
-        #[cfg(target_os = "windows")]
-        {
-            let args = mp4_export_args(
-                Path::new(r"\\?\C:\recordings\capture.mkv"),
-                Path::new(r"\\?\C:\recordings\.videorc-export.partial\export.mp4"),
-                None,
-            );
-            assert_eq!(arg_value(&args, "-i"), Some(r"C:\recordings\capture.mkv"));
-            assert_eq!(
-                args.last().map(String::as_str),
-                Some(r"C:\recordings\.videorc-export.partial\export.mp4")
-            );
-            assert_eq!(arg_value(&args, "-colorspace"), Some("bt709"));
-            assert_eq!(arg_value(&args, "-color_primaries"), Some("bt709"));
-            assert_eq!(arg_value(&args, "-color_trc"), Some("bt709"));
-            assert_eq!(arg_value(&args, "-color_range"), Some("tv"));
-            assert_eq!(
-                arg_value(&args, "-bsf:v"),
-                Some(
-                    "h264_metadata=video_full_range_flag=0:colour_primaries=1:transfer_characteristics=1:matrix_coefficients=1"
-                )
-            );
-        }
+        let args = mp4_export_args(
+            Path::new(r"\\?\C:\recordings\capture.mkv"),
+            Path::new(r"\\?\C:\recordings\.videorc-export.partial\export.mp4"),
+            None,
+        );
+        assert_eq!(arg_value(&args, "-i"), Some(r"C:\recordings\capture.mkv"));
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some(r"C:\recordings\.videorc-export.partial\export.mp4")
+        );
     }
 
     #[test]

--- a/scripts/lib/capture-decay-app-bundle.test.mjs
+++ b/scripts/lib/capture-decay-app-bundle.test.mjs
@@ -19,10 +19,11 @@ import {
   captureDecayCandidateIdentityFromFiles,
   captureDecayRunnerIdentity
 } from './capture-decay-release-acceptance.mjs'
+import { SYMLINK_TEST_SKIP } from './symlink-test-support.mjs'
 
 const run = promisify(execFile)
 
-describe('capture-decay app bundle identity', () => {
+describe('capture-decay app bundle identity', { skip: SYMLINK_TEST_SKIP }, () => {
   it('deterministically binds paths, significant modes, file contents, and symlink targets', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'videorc-app-bundle-test-'))
     try {

--- a/scripts/lib/capture-decay-release-acceptance.test.mjs
+++ b/scripts/lib/capture-decay-release-acceptance.test.mjs
@@ -8,6 +8,7 @@ import { describe, it } from 'node:test'
 import { promisify } from 'node:util'
 
 import { CAPTURE_DECAY_APP_BUNDLE_PROFILE } from './capture-decay-app-bundle.mjs'
+import { SYMLINK_TEST_SKIP } from './symlink-test-support.mjs'
 import {
   buildCaptureDecayAttemptLedgerManifest,
   finishCaptureDecayAttempt,
@@ -27,7 +28,6 @@ import {
   verifyCaptureDecayD3PublishedReleaseRoutes
 } from './capture-decay-published-release.mjs'
 import { assembleCaptureDecayD3PublicationReceipt } from './capture-decay-publication-receipt-assembly.mjs'
-
 import {
   CAPTURE_DECAY_D3_ACCEPTANCE_PROFILE,
   CAPTURE_DECAY_D3_ACCEPTANCE_RECORD_PATH,
@@ -69,6 +69,10 @@ import {
 } from './macos-d3-sealed-candidate.mjs'
 import { buildMacosD3PublicationReservation } from './release-upload-s3.mjs'
 import { captureDecaySanitizedChildEnvironment } from '../run-capture-decay-real-release.mjs'
+
+const symlinkTest = (name, test) => it(name, { skip: SYMLINK_TEST_SKIP }, test)
+const symlinkArtifactTestName =
+  'rejects exact-byte checkpoint and sidecar substitutions through symlinks'
 
 const execFileAsync = promisify(execFile)
 
@@ -789,7 +793,7 @@ describe('immutable evidence bundle loading', () => {
     }
   })
 
-  it('rejects exact-byte checkpoint and sidecar substitutions through symlinks', async () => {
+  symlinkTest(symlinkArtifactTestName, async () => {
     const substitutions = [
       'run-1/capture-decay-soak.json',
       'run-1/capture-decay-soak.csv',
@@ -1629,7 +1633,7 @@ describe('pending -> accepted -> satisfied publication state', () => {
     })
   })
 
-  it('rejects symlinked accepted records before parsing their target bytes', async () => {
+  symlinkTest('rejects symlinked accepted records before parsing their target bytes', async () => {
     const accepted = buildAccepted(validate(validEvidence()))
     await withAcceptanceGitRepository(accepted, async ({ recordPath, repoRoot }) => {
       const targetPath = join(repoRoot, 'attacker-controlled-accepted.json')

--- a/scripts/lib/symlink-test-support.mjs
+++ b/scripts/lib/symlink-test-support.mjs
@@ -1,0 +1,21 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export const SYMLINK_TEST_SKIP = probeSymlinkSupport()
+
+function probeSymlinkSupport() {
+  const directory = mkdtempSync(join(tmpdir(), 'videorc-symlink-test-support-'))
+  const target = join(directory, 'target')
+  const link = join(directory, 'link')
+  try {
+    writeFileSync(target, 'symlink test target')
+    symlinkSync(target, link, 'file')
+    return false
+  } catch (error) {
+    if (!['EACCES', 'ENOTSUP', 'EPERM'].includes(error?.code)) throw error
+    return 'symbolic-link creation is unavailable on this host'
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}


### PR DESCRIPTION
## Summary

- Bound Windows encoder-bridge teardown so recording finalization cannot hang on a raw FIFO writer.
- Allow an explicit user stop with a non-zero FFmpeg exit to proceed through validated MP4 export.
- Normalize Windows verbatim paths and preserve BT.709/video-range H.264 metadata during MP4 export.

## Validation

- Rust format, focused tests, and release backend build passed.
- Fresh packaged Windows smoke passed 7/7 recordings with 0 ms A/V skew, 0 MKV files, and 0 FFmpeg exit-code-1 errors.
- Intel Quick Sync probe fallback warnings remain expected; software OpenH264 export succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MP4 export compatibility on Windows by normalizing file paths.
  - Added color metadata to exported H.264 videos for more consistent playback colors.
  - Improved recording shutdown handling and failure reporting.
  - Recordings intentionally stopped after a non-zero encoder exit can now finalize successfully when no terminal failure occurs.
  - Prevented normal downstream closure from being incorrectly reported as an encoder failure.
  - Improved frame handling, ordering, and stability during recording, including tolerance for temporary output stalls.
  - Improved reliability when starting captures and maintenance tasks under heavy activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->