### PR TITLE
fix: surface-lane starvation — bounded lifecycle, named jams, silent background retry

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-studio.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-studio.tsx
@@ -96,6 +96,7 @@ import {
   shouldAutoRefreshYouTubeChannels
 } from '@/lib/youtube-channels'
 import { providerOAuthRetryDelayMs } from '@/lib/provider-oauth-retry'
+import { isRetryableBackgroundSurfaceSyncError } from '@/lib/surface-sync-retry'
 import { accountCallbackRetryDelayMs } from '@/lib/account-callback-retry'
 import {
   INITIAL_ACCOUNT_READY_REFRESH_STATE,
@@ -7224,15 +7225,42 @@ export function StudioProvider({ children }: { children: ReactNode }): ReactElem
           // Main is the sole live placement writer. Renderer reports the latest
           // bounds to backend telemetry/lifecycle state, but never sends movement to
           // the native host directly or replays the backend's delayed bounds echo.
-          const backendStatus = surfaceAlreadyCreated
-            ? await client.request<PreviewSurfaceStatus>('preview.surface.update_bounds', {
-                bounds: nextBounds
-              })
-            : await client.request<PreviewSurfaceStatus>('preview.surface.create', {
-                bounds: nextBounds,
-                targetFps: 60,
-                source: surfaceSource
-              })
+          let backendStatus: PreviewSurfaceStatus
+          try {
+            backendStatus = surfaceAlreadyCreated
+              ? await client.request<PreviewSurfaceStatus>('preview.surface.update_bounds', {
+                  bounds: nextBounds
+                })
+              : await client.request<PreviewSurfaceStatus>('preview.surface.create', {
+                  bounds: nextBounds,
+                  targetFps: 60,
+                  source: surfaceSource
+                })
+          } catch (error) {
+            // Background bounds sync is latest-wins maintenance. A busy
+            // surface, a full lane, or an outcome-unknown timeout is
+            // retryable: restore the pending bounds so the periodic window
+            // reconciler re-drives them, and stay silent — the 2026-08-27
+            // live incident surfaced exactly these as alarming error toasts
+            // mid-stream while the backend healed itself. Anything else is a
+            // real failure and still propagates to reportError.
+            if (isRetryableBackgroundSurfaceSyncError(error)) {
+              if (
+                generationIsCurrent(nextGeneration) &&
+                nativePreviewSurfaceBoundsPendingRef.current === null
+              ) {
+                nativePreviewSurfaceBoundsPendingRef.current = nextBounds
+                nativePreviewSurfaceBoundsPendingGenerationRef.current = nextGeneration
+              }
+              // Stay inside the single-flight loop: a window event may never
+              // arrive to re-drive a stale-bounds retry, so pace and go again.
+              // Generation checks end the loop naturally when the surface is
+              // torn down or replaced.
+              await new Promise((resolveRetry) => setTimeout(resolveRetry, 1500))
+              continue
+            }
+            throw error
+          }
           if (!surfaceAlreadyCreated) {
             nativePreviewCompositorSuppressedPresentsRef.current = 0
             resetNativePreviewCompositorTiming()

--- a/apps/desktop/src/renderer/src/lib/surface-sync-retry.test.ts
+++ b/apps/desktop/src/renderer/src/lib/surface-sync-retry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { BackendRequestError } from '../backendClient'
+import { isRetryableBackgroundSurfaceSyncError } from './surface-sync-retry'
+
+describe('isRetryableBackgroundSurfaceSyncError', () => {
+  it('treats the 2026-08-27 incident outcomes as silent retries', () => {
+    for (const code of [
+      'surface-busy',
+      'command-lane-full',
+      'command-expired-before-dispatch',
+      'request-outcome-unknown'
+    ]) {
+      expect(isRetryableBackgroundSurfaceSyncError(new BackendRequestError(code, 'not now'))).toBe(
+        true
+      )
+    }
+  })
+
+  it('keeps real failures loud', () => {
+    expect(
+      isRetryableBackgroundSurfaceSyncError(
+        new BackendRequestError('invalid-params', 'bounds were malformed')
+      )
+    ).toBe(false)
+    expect(isRetryableBackgroundSurfaceSyncError(new Error('surface-busy'))).toBe(false)
+    expect(isRetryableBackgroundSurfaceSyncError(undefined)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/surface-sync-retry.ts
+++ b/apps/desktop/src/renderer/src/lib/surface-sync-retry.ts
@@ -1,0 +1,26 @@
+import { BackendRequestError } from '../backendClient'
+
+/**
+ * Background preview-surface bounds sync is latest-wins maintenance: the
+ * newest bounds always supersede, and the periodic window reconciler
+ * re-drives them within a tick. These backend outcomes mean "not now", not
+ * "broken" — they are absorbed silently instead of surfacing an error toast
+ * to a user who did nothing (the 2026-08-27 live-stream incident showed a
+ * raw 30s outcome-unknown timeout and a lane-full rejection as alarming
+ * errors while the stream itself was healthy).
+ */
+const RETRYABLE_BACKGROUND_SYNC_CODES: ReadonlySet<string> = new Set([
+  // Bounded lifecycle acquisition: another surface lifecycle operation
+  // (create/destroy/heal) holds the lock; retry lands after it.
+  'surface-busy',
+  // The ordered command lane rejected the enqueue outright.
+  'command-lane-full',
+  // The command sat queued past its dispatch deadline and was not applied.
+  'command-expired-before-dispatch',
+  // The client-side timeout fired after send; the outcome is unknown, and
+  // for latest-wins bounds a re-send is always safe.
+  'request-outcome-unknown'
+])
+
+export const isRetryableBackgroundSurfaceSyncError = (error: unknown): boolean =>
+  error instanceof BackendRequestError && RETRYABLE_BACKGROUND_SYNC_CODES.has(error.code)

--- a/crates/videorc-backend/src/main.rs
+++ b/crates/videorc-backend/src/main.rs
@@ -128,9 +128,10 @@ use preview_screen::{
     start_preview_screen, stop_preview_screen,
 };
 use preview_surface::{
-    apply_main_owned_preview_surface_bounds, create_preview_surface, destroy_preview_surface,
-    preview_surface_status, register_preview_surface_resize, take_native_preview_host_commands,
-    update_preview_surface_bounds, update_preview_surface_present,
+    PreviewSurfaceBusy, apply_main_owned_preview_surface_bounds, create_preview_surface,
+    destroy_preview_surface, preview_surface_status, register_preview_surface_resize,
+    take_native_preview_host_commands, update_preview_surface_bounds,
+    update_preview_surface_present,
 };
 use protocol::{
     BackendConnection, BackendHealth, ClientCommand, RecordingState, ServerEvent, ServerResponse,
@@ -4348,6 +4349,51 @@ fn websocket_command_id(text: &str) -> String {
         .unwrap_or_else(|_| "unknown".to_string())
 }
 
+fn websocket_command_method(text: &str) -> String {
+    serde_json::from_str::<ClientCommand>(text)
+        .map(|command| command.method)
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// A stateful mutation that outlives this budget gets named in the log — the
+/// 2026-08-27 live incident produced 30 seconds of silence because the stuck
+/// command was the RUNNING stateful mutation, invisible to the queue-age
+/// expiry that covers only QUEUED commands.
+const WEBSOCKET_SLOW_STATEFUL_COMMAND_THRESHOLD: Duration = Duration::from_secs(2);
+
+/// The ordered dispatcher's currently-running stateful mutation, shared with
+/// the enqueue side so a `command-lane-full` rejection can name what is
+/// actually jamming the lane instead of only telling the client "full".
+#[derive(Clone, Default)]
+struct WebSocketRunningStatefulCommand(
+    std::sync::Arc<std::sync::Mutex<Option<(String, std::time::Instant)>>>,
+);
+
+impl WebSocketRunningStatefulCommand {
+    fn set(&self, method: String) {
+        *self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            Some((method, std::time::Instant::now()));
+    }
+
+    fn clear(&self) {
+        *self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+
+    fn snapshot(&self) -> Option<(String, u128)> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .map(|(method, started)| (method.clone(), started.elapsed().as_millis()))
+    }
+}
+
 async fn drain_websocket_layout_commands(tasks: &mut tokio::task::JoinSet<()>) {
     while let Some(completed) = tasks.join_next().await {
         if let Err(error) = completed {
@@ -4638,6 +4684,7 @@ async fn run_websocket_command_dispatcher(
     command_handler: WebSocketCommandHandler,
 ) {
     let (ordered_tx, ordered_rx) = mpsc::channel(WEBSOCKET_COMMAND_QUEUE_CAPACITY);
+    let running_stateful = WebSocketRunningStatefulCommand::default();
     let ordered_task = tokio::spawn(run_websocket_ordered_command_dispatcher(
         state.clone(),
         ordered_rx,
@@ -4645,6 +4692,7 @@ async fn run_websocket_command_dispatcher(
         reliable_metrics.clone(),
         slow_pressure.clone(),
         command_handler.clone(),
+        running_stateful.clone(),
     ));
     let (lanes, lane_receivers) =
         WebSocketIsolatedCommandLanes::new(&state.websocket_transport_metrics);
@@ -4777,6 +4825,15 @@ async fn run_websocket_command_dispatcher(
                 | mpsc::error::TrySendError::Closed(command) => command,
             };
             let command_id = websocket_command_id(command.text.as_str());
+            let rejected_method = websocket_command_method(command.text.as_str());
+            match running_stateful.snapshot() {
+                Some((running_method, elapsed_ms)) => tracing::warn!(
+                    "[command-lane] ordered lane full: rejected {rejected_method}; running stateful command {running_method} has held the lane for {elapsed_ms}ms"
+                ),
+                None => tracing::warn!(
+                    "[command-lane] ordered lane full: rejected {rejected_method}; no stateful command running (queue backlog)"
+                ),
+            }
             // Rejected work is definitely not applied, so release its global
             // completion fences before awaiting a potentially slow peer.
             drop(command);
@@ -4812,6 +4869,7 @@ async fn run_websocket_ordered_command_dispatcher(
     reliable_metrics: TrackedWebSocketQueueMetrics,
     slow_pressure: WebSocketSlowPressureSignal,
     command_handler: WebSocketCommandHandler,
+    running_stateful: WebSocketRunningStatefulCommand,
 ) {
     let mut layout_tasks = tokio::task::JoinSet::new();
     let mut audio_processing_tasks = tokio::task::JoinSet::new();
@@ -4973,8 +5031,32 @@ async fn run_websocket_ordered_command_dispatcher(
         let response_metrics = reliable_metrics.clone();
         let response_pressure = slow_pressure.clone();
         let handler = command_handler.clone();
+        let stateful_tracker = running_stateful.clone();
         stateful_task = Some(tokio::spawn(async move {
+            let method = websocket_command_method(text.as_str());
+            let started = std::time::Instant::now();
+            stateful_tracker.set(method.clone());
+            // One live line the moment the running mutation crosses the
+            // budget, aborted on completion — so a wedged command is named
+            // WHILE it is wedged, not only in the post-mortem.
+            let slow_method = method.clone();
+            let slow_watch = tokio::spawn(async move {
+                tokio::time::sleep(WEBSOCKET_SLOW_STATEFUL_COMMAND_THRESHOLD).await;
+                tracing::warn!(
+                    "[command-lane] stateful command {slow_method} still running after {}ms; later ordered commands are barriered behind it",
+                    WEBSOCKET_SLOW_STATEFUL_COMMAND_THRESHOLD.as_millis()
+                );
+            });
             let response = handler(command_state, text).await;
+            slow_watch.abort();
+            let elapsed = started.elapsed();
+            if elapsed >= WEBSOCKET_SLOW_STATEFUL_COMMAND_THRESHOLD {
+                tracing::warn!(
+                    "[command-lane] stateful command {method} completed after {}ms",
+                    elapsed.as_millis()
+                );
+            }
+            stateful_tracker.clear();
             drop(_operator_mutation);
             drop(_session_start);
             queue_websocket_response(
@@ -6530,10 +6612,14 @@ async fn handle_text_message_with_role(
         }
         "preview.surface.create" => {
             match serde_json::from_value::<protocol::PreviewSurfaceCreateParams>(command.params) {
-                Ok(params) => {
-                    let status = create_preview_surface(state.clone(), params).await;
-                    ServerResponse::ok(command.id, status)
-                }
+                Ok(params) => match create_preview_surface(state.clone(), params).await {
+                    Ok(status) => ServerResponse::ok(command.id, status),
+                    Err(PreviewSurfaceBusy) => ServerResponse::error(
+                        command.id,
+                        PreviewSurfaceBusy::CODE,
+                        PreviewSurfaceBusy::MESSAGE.to_string(),
+                    ),
+                },
                 Err(error) => {
                     ServerResponse::error(command.id, "invalid-params", error.to_string())
                 }
@@ -6541,10 +6627,14 @@ async fn handle_text_message_with_role(
         }
         "preview.surface.update_bounds" => {
             match serde_json::from_value::<protocol::PreviewSurfaceBoundsParams>(command.params) {
-                Ok(params) => {
-                    let status = update_preview_surface_bounds(state, params).await;
-                    ServerResponse::ok(command.id, status)
-                }
+                Ok(params) => match update_preview_surface_bounds(state, params).await {
+                    Ok(status) => ServerResponse::ok(command.id, status),
+                    Err(PreviewSurfaceBusy) => ServerResponse::error(
+                        command.id,
+                        PreviewSurfaceBusy::CODE,
+                        PreviewSurfaceBusy::MESSAGE.to_string(),
+                    ),
+                },
                 Err(error) => {
                     ServerResponse::error(command.id, "invalid-params", error.to_string())
                 }
@@ -6561,10 +6651,14 @@ async fn handle_text_message_with_role(
                 }
             }
         }
-        "preview.surface.destroy" => {
-            let status = destroy_preview_surface(state).await;
-            ServerResponse::ok(command.id, status)
-        }
+        "preview.surface.destroy" => match destroy_preview_surface(state).await {
+            Ok(status) => ServerResponse::ok(command.id, status),
+            Err(PreviewSurfaceBusy) => ServerResponse::error(
+                command.id,
+                PreviewSurfaceBusy::CODE,
+                PreviewSurfaceBusy::MESSAGE.to_string(),
+            ),
+        },
         "preview.surface.status" => {
             let status = preview_surface_status(state).await;
             ServerResponse::ok(command.id, status)
@@ -13470,6 +13564,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn busy_surface_lifecycle_answers_surface_busy_instead_of_stalling() {
+        // 2026-08-27 live incident: with the lifecycle mutex held by a healing
+        // destroy/create cycle, an update_bounds sat as the running stateful
+        // mutation for 30+ seconds with no response, barriering the whole
+        // ordered lane until it filled. Bounded acquisition must answer fast
+        // with a retryable error instead.
+        let state = test_state();
+        let _lifecycle_held = state.preview_surface_lifecycle.clone().lock_owned().await;
+        let bounds = json!({
+            "id": "bounds",
+            "method": "preview.surface.update_bounds",
+            "params": {
+                "bounds": {
+                    "screenX": 10.0,
+                    "screenY": 20.0,
+                    "width": 640.0,
+                    "height": 360.0,
+                    "scaleFactor": 2.0,
+                    "screenHeight": 1000.0
+                }
+            }
+        });
+        let started = std::time::Instant::now();
+        let response = handle_text_message(&state, &bounds.to_string()).await;
+        assert!(started.elapsed() < Duration::from_secs(5));
+        assert!(!response.ok);
+        let error = response.error.expect("busy error");
+        assert_eq!(error.code, PreviewSurfaceBusy::CODE);
+
+        let destroy = json!({ "id": "destroy", "method": "preview.surface.destroy" });
+        let response = handle_text_message(&state, &destroy.to_string()).await;
+        assert!(!response.ok);
+        assert_eq!(
+            response.error.expect("busy error").code,
+            PreviewSurfaceBusy::CODE
+        );
+    }
+
+    #[tokio::test]
     async fn preview_surface_native_host_commands_drain_over_ws() {
         let state = test_state();
         let create = json!({
@@ -13511,6 +13644,8 @@ mod tests {
         assert!(empty_response.ok);
         assert_eq!(empty_response.payload.unwrap(), json!([]));
 
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
     }
 }

--- a/crates/videorc-backend/src/preview_surface.rs
+++ b/crates/videorc-backend/src/preview_surface.rs
@@ -395,7 +395,9 @@ pub async fn apply_main_owned_preview_surface_bounds(
     state: &AppState,
     params: MainOwnedPreviewSurfaceBoundsParams,
 ) -> Result<PreviewSurfaceStatus, String> {
-    let _lifecycle = state.preview_surface_lifecycle.lock().await;
+    let _lifecycle = acquire_preview_surface_lifecycle(state)
+        .await
+        .map_err(|_| PreviewSurfaceBusy::MESSAGE.to_string())?;
     validate_main_owned_preview_window(&params.bounds)?;
 
     let status = {
@@ -506,16 +508,48 @@ fn validate_main_owned_preview_window(
     Ok(())
 }
 
+/// How long a surface RPC may wait for the lifecycle mutex before answering
+/// `surface-busy`. 2026-08-27 live incident: a healing destroy/create cycle
+/// held the lifecycle lock while an `update_bounds` sat inside the ordered
+/// dispatcher's single stateful-mutation slot for 30+ seconds — silently
+/// barriering every later command until the lane filled. A bounded wait turns
+/// that into a fast, retryable error the renderer's latest-wins bounds loop
+/// absorbs without user-visible noise.
+const PREVIEW_SURFACE_LIFECYCLE_ACQUIRE_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(3);
+
+/// The lifecycle mutex could not be acquired inside the budget: another
+/// surface lifecycle operation (create/destroy/heal) is still running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreviewSurfaceBusy;
+
+impl PreviewSurfaceBusy {
+    pub const CODE: &'static str = "surface-busy";
+    pub const MESSAGE: &'static str =
+        "The preview surface is busy with another lifecycle operation; retry shortly.";
+}
+
+async fn acquire_preview_surface_lifecycle(
+    state: &AppState,
+) -> Result<tokio::sync::OwnedMutexGuard<()>, PreviewSurfaceBusy> {
+    tokio::time::timeout(
+        PREVIEW_SURFACE_LIFECYCLE_ACQUIRE_TIMEOUT,
+        state.preview_surface_lifecycle.clone().lock_owned(),
+    )
+    .await
+    .map_err(|_| PreviewSurfaceBusy)
+}
+
 pub async fn create_preview_surface(
     state: AppState,
     params: PreviewSurfaceCreateParams,
-) -> PreviewSurfaceStatus {
-    let _lifecycle = state.preview_surface_lifecycle.lock().await;
+) -> Result<PreviewSurfaceStatus, PreviewSurfaceBusy> {
+    let _lifecycle = acquire_preview_surface_lifecycle(&state).await?;
     let target_fps = params.target_fps.clamp(30, 120);
     let capture_active = capture_owns_compositor(&state);
     if let Some(status) = try_reuse_live_surface(&state, &params, target_fps, capture_active).await
     {
-        return status;
+        return Ok(status);
     }
 
     stop_current_surface(&state).await;
@@ -597,7 +631,7 @@ pub async fn create_preview_surface(
         state.preview_surface.lock().await.run_id = compositor_status.run_id;
     }
     state.emit_event("preview.surface.status", status.clone());
-    status
+    Ok(status)
 }
 
 /// Treat a repeated create request as an update while its existing preview
@@ -670,8 +704,8 @@ async fn try_reuse_live_surface(
 pub async fn update_preview_surface_bounds(
     state: &AppState,
     params: PreviewSurfaceBoundsParams,
-) -> PreviewSurfaceStatus {
-    let _lifecycle = state.preview_surface_lifecycle.lock().await;
+) -> Result<PreviewSurfaceStatus, PreviewSurfaceBusy> {
+    let _lifecycle = acquire_preview_surface_lifecycle(state).await?;
     let (status, preview_run_id) = {
         let mut slot = state.preview_surface.lock().await;
         let mut next = slot.status.clone();
@@ -703,11 +737,13 @@ pub async fn update_preview_surface_bounds(
             resize_preview_compositor_if_run_id(state, &run_id, status.width, status.height).await;
     }
     state.emit_event("preview.surface.status", status.clone());
-    status
+    Ok(status)
 }
 
-pub async fn destroy_preview_surface(state: &AppState) -> PreviewSurfaceStatus {
-    let _lifecycle = state.preview_surface_lifecycle.lock().await;
+pub async fn destroy_preview_surface(
+    state: &AppState,
+) -> Result<PreviewSurfaceStatus, PreviewSurfaceBusy> {
+    let _lifecycle = acquire_preview_surface_lifecycle(state).await?;
     stop_current_surface(state).await;
     let status = {
         let mut slot = state.preview_surface.lock().await;
@@ -767,7 +803,7 @@ pub async fn destroy_preview_surface(state: &AppState) -> PreviewSurfaceStatus {
         apply_runtime_diagnostics_snapshot(diagnostic_stats, state.ffmpeg_work.snapshot()),
     );
     state.emit_event("preview.surface.status", status.clone());
-    status
+    Ok(status)
 }
 
 pub async fn preview_surface_status(state: &AppState) -> PreviewSurfaceStatus {
@@ -1362,7 +1398,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let first = apply_main_owned_preview_surface_bounds(
             &state,
@@ -1403,7 +1440,9 @@ mod tests {
             Some(7)
         );
 
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
     }
 
     #[tokio::test]
@@ -1417,7 +1456,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let surface = state.preview_surface.lock().await;
         let last_command_kind = surface.native_host.last_command_kind();
@@ -1427,7 +1467,9 @@ mod tests {
             .map(|bounds| bounds.drawable_size());
         drop(surface);
         let compositor = compositor_status(&state).await;
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.state, PreviewSurfaceState::Live);
         assert_eq!(status.transport, PreviewTransport::ElectronProofSurface);
@@ -1460,7 +1502,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         take_native_preview_host_commands(&state).await;
         let first_compositor = compositor_status(&state).await;
         update_preview_surface_present(
@@ -1497,11 +1540,14 @@ mod tests {
                 source: PreviewSurfaceSource::Screen,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let second_compositor = compositor_status(&state).await;
         let commands = take_native_preview_host_commands(&state).await;
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(second_compositor.run_id, first_compositor.run_id);
         assert_eq!(second_compositor.width, 1280);
@@ -1533,7 +1579,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         take_native_preview_host_commands(&state).await;
         let first_compositor = compositor_status(&state).await;
 
@@ -1545,11 +1592,14 @@ mod tests {
                 source: PreviewSurfaceSource::Screen,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let second_compositor = compositor_status(&state).await;
         let commands = take_native_preview_host_commands(&state).await;
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_ne!(second_compositor.run_id, first_compositor.run_id);
         assert_eq!(second_compositor.target_fps, 30);
@@ -1587,6 +1637,7 @@ mod tests {
                     },
                 )
                 .await
+                .expect("preview surface lifecycle available")
             }));
         }
         barrier.wait().await;
@@ -1598,7 +1649,9 @@ mod tests {
 
         let compositor = compositor_status(&state).await;
         let commands = take_native_preview_host_commands(&state).await;
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(compositor.state, CompositorState::Live);
         assert_eq!(
@@ -1635,7 +1688,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let status = update_preview_surface_bounds(
             &state,
@@ -1643,7 +1697,8 @@ mod tests {
                 bounds: bounds(640.0, 360.0),
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let resize_count = state.diagnostics.lock().await.preview_surface_resize_count;
         let surface = state.preview_surface.lock().await;
@@ -1653,7 +1708,9 @@ mod tests {
             .bounds()
             .map(|bounds| bounds.drawable_size());
         drop(surface);
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.state, PreviewSurfaceState::Live);
         assert_eq!(status.width, 1280);
@@ -1677,7 +1734,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         let original_run = compositor_status(&state).await.run_id.unwrap();
 
         let suspension = suspend_preview_compositor_for_d3d11(&state, 11)
@@ -1693,7 +1751,9 @@ mod tests {
             state.preview_surface.lock().await.run_id.as_deref(),
             Some(restored_run.as_str())
         );
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
     }
 
     #[tokio::test]
@@ -1707,7 +1767,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         let suspension = suspend_preview_compositor_for_d3d11(&state, 11)
             .await
             .expect("live preview owns a suspendable compositor");
@@ -1731,7 +1792,9 @@ mod tests {
         assert_eq!(compositor_status(&state).await.run_id, newer.run_id);
         assert!(state.preview_surface.lock().await.run_id.is_none());
         stop_compositor(&state).await;
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
     }
 
     #[tokio::test]
@@ -1745,7 +1808,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let retired = suspend_preview_compositor_for_d3d11(&state, 21)
             .await
@@ -1774,7 +1838,9 @@ mod tests {
             state.preview_surface.lock().await.run_id.as_deref(),
             Some(restored_run.as_str())
         );
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
     }
 
     #[tokio::test]
@@ -1792,7 +1858,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         let suspension = suspend_preview_compositor_for_d3d11(&state, 31)
             .await
             .expect("live preview owns a suspendable compositor");
@@ -1829,7 +1896,9 @@ mod tests {
                     .contains("Started a replacement CPU preview compositor")),
             "fallback start must be logged: {logs:?}"
         );
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
     }
 
     #[tokio::test]
@@ -1845,11 +1914,14 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         let suspension = suspend_preview_compositor_for_d3d11(&state, 41)
             .await
             .expect("live preview owns a suspendable compositor");
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         suspension.restore().await;
 
@@ -2101,7 +2173,9 @@ mod tests {
                 });
         }
 
-        let destroyed = destroy_preview_surface(&state).await;
+        let destroyed = destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
         assert_eq!(destroyed.state, PreviewSurfaceState::Stopped);
         assert_eq!(destroyed.transport, PreviewTransport::Unavailable);
         assert_eq!(destroyed.backing, PreviewSurfaceBacking::None);
@@ -2128,7 +2202,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let recording_status = start_synthetic_compositor(
             state.clone(),
@@ -2146,7 +2221,9 @@ mod tests {
         )
         .await;
 
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
         let status = compositor_status(&state).await;
         stop_compositor(&state).await;
 
@@ -2197,7 +2274,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         let verification = async {
             let initial = wait_for_frame_dimensions_after(&state, 320, 180, None).await?;
             let initial_status = compositor_status(&state).await;
@@ -2208,7 +2286,8 @@ mod tests {
                     bounds: bounds(90.0, 160.0),
                 },
             )
-            .await;
+            .await
+            .expect("preview surface lifecycle available");
             let portrait =
                 wait_for_frame_dimensions_after(&state, 180, 320, Some(initial.sequence)).await?;
 
@@ -2221,14 +2300,17 @@ mod tests {
                     bounds: bounds(160.0, 90.0),
                 },
             )
-            .await;
+            .await
+            .expect("preview surface lifecycle available");
             let landscape =
                 wait_for_frame_dimensions_after(&state, 320, 180, Some(portrait.sequence)).await?;
             let final_status = compositor_status(&state).await;
             Ok::<_, String>((initial_status, portrait, landscape, final_status))
         }
         .await;
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         let (initial_status, portrait, landscape, final_status) =
             verification.expect("preview compositor should follow both orientation changes");
@@ -2252,7 +2334,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         wait_for_frame_dimensions_after(&state, 320, 180, None)
             .await
             .expect("preview compositor should publish before ownership changes");
@@ -2283,7 +2366,8 @@ mod tests {
                 bounds: bounds(90.0, 160.0),
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         let stale_run_resize =
             resize_preview_compositor_if_run_id(&state, &preview_run_id, 90, 160).await;
         let recording_run_resize = resize_preview_compositor_if_run_id(
@@ -2338,14 +2422,16 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         update_preview_surface_bounds(
             &state,
             PreviewSurfaceBoundsParams {
                 bounds: bounds(1280.0, 720.0),
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let status = compositor_status(&state).await;
         let preview_run_id = state.preview_surface.lock().await.run_id.clone();
@@ -2369,15 +2455,19 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         update_preview_surface_bounds(
             &state,
             PreviewSurfaceBoundsParams {
                 bounds: bounds(640.0, 360.0),
             },
         )
-        .await;
-        let destroyed = destroy_preview_surface(&state).await;
+        .await
+        .expect("preview surface lifecycle available");
+        let destroyed = destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(destroyed.pending_host_command_count, 3);
 
@@ -2418,7 +2508,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let status = update_preview_surface_present(
             &state,
@@ -2447,7 +2538,9 @@ mod tests {
         .await;
 
         let diagnostics = state.diagnostics.lock().await.clone();
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.transport, PreviewTransport::NativeSurface);
         assert_eq!(status.backing, PreviewSurfaceBacking::CaMetalLayer);
@@ -2502,7 +2595,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let status = activate_native_preview_host(
             &state,
@@ -2511,7 +2605,9 @@ mod tests {
         .await;
 
         let diagnostics = state.diagnostics.lock().await.clone();
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.transport, PreviewTransport::NativeSurface);
         assert_eq!(status.backing, PreviewSurfaceBacking::CaMetalLayer);
@@ -2548,7 +2644,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         activate_native_preview_host(
             &state,
             NativePreviewHostActivation::cametal_layer_presented(12),
@@ -2560,7 +2657,9 @@ mod tests {
             NativePreviewHostActivation::cametal_layer_presented(10),
         )
         .await;
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.presented_frame_id, Some(12));
         assert!(status.frames_rendered >= 12);
@@ -2599,7 +2698,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         let status = update_preview_surface_present(
             &state,
@@ -2628,7 +2728,9 @@ mod tests {
         .await;
 
         let diagnostics = state.diagnostics.lock().await.clone();
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.transport, PreviewTransport::ElectronProofSurface);
         assert_eq!(status.backing, PreviewSurfaceBacking::ElectronBrowserWindow);
@@ -2660,7 +2762,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
 
         update_preview_surface_present(
             &state,
@@ -2714,7 +2817,9 @@ mod tests {
         )
         .await;
 
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.transport, PreviewTransport::NativeSurface);
         assert_eq!(status.backing, PreviewSurfaceBacking::CaMetalLayer);
@@ -2734,7 +2839,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         update_preview_surface_present(
             &state,
             PreviewSurfacePresentParams {
@@ -2788,7 +2894,9 @@ mod tests {
         .await;
 
         let diagnostics = state.diagnostics.lock().await.clone();
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(stale.transport, PreviewTransport::NativeSurface);
         assert_eq!(stale.backing, PreviewSurfaceBacking::CaMetalLayer);
@@ -2822,7 +2930,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         update_preview_surface_present(
             &state,
             PreviewSurfacePresentParams {
@@ -2876,7 +2985,9 @@ mod tests {
         .await;
 
         let diagnostics = state.diagnostics.lock().await.clone();
-        destroy_preview_surface(&state).await;
+        destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.presented_frame_id, Some(43));
         assert_eq!(status.compositor_frame_lag, Some(0));
@@ -2897,7 +3008,8 @@ mod tests {
                 source: PreviewSurfaceSource::Synthetic,
             },
         )
-        .await;
+        .await
+        .expect("preview surface lifecycle available");
         update_preview_surface_present(
             &state,
             PreviewSurfacePresentParams {
@@ -2924,7 +3036,9 @@ mod tests {
         )
         .await;
 
-        let status = destroy_preview_surface(&state).await;
+        let status = destroy_preview_surface(&state)
+            .await
+            .expect("preview surface lifecycle available");
 
         assert_eq!(status.state, PreviewSurfaceState::Stopped);
         assert_eq!(status.transport, PreviewTransport::Unavailable);


### PR DESCRIPTION
Executes S0+S1+S4 of the 2026-08-27 Surface Lane Starvation Fix Plan — the slices that remove both user-visible symptoms from tonight's live-stream incident. S2 (presents reclassified off the stateful barrier) is deliberately a separate PR; S3 (the presenter-wedge root) rides its instrumentation first.

## The incident this fixes

Mid-livestream on 0.9.82: `Backend request "preview.surface.update_bounds" timed out after 30000ms; its outcome is unknown`, followed by `The ordered command lane is full; this command was not applied`. Live diagnosis (backend.log + `sample` of the running backend): the native preview presenter was wedging cyclically, the preview-watch healing ladder's destroy/create cycles held the `preview_surface_lifecycle` mutex, and an `update_bounds` sat as the ordered dispatcher's **single running stateful mutation** for 30+ seconds. Queued commands expire at 5s *with a response* — the running one had no bound and no visibility, so it silently barriered every later command until the lane filled. The stream never blinked: the encoder path shares none of those locks.

## S1 — bounded lifecycle acquisition (`preview_surface.rs`)

`create` / `update_bounds` / `destroy` / the main-owned bounds RPC acquire the lifecycle mutex with a 3s budget and answer a retryable **`surface-busy`** error instead of stalling the barrier. Everything inside the lock is already bounded below that budget (compositor stop: 2s). Behavioral test: with the mutex held, both RPCs answer `surface-busy` in well under 5s through the real `handle_text_message` path.

## S0 — the jam gets named (`main.rs` dispatcher)

- A shared running-stateful-command tracker around the ordered dispatcher's single mutation slot.
- One WARN **the moment** the running mutation crosses 2s (an abortable watchdog — the wedge is named while it is happening, not only post-mortem), plus a completion WARN with the total.
- `command-lane-full` rejections now log the rejected method and whatever is holding the lane and for how long. The next occurrence of anything in this class arrives pre-diagnosed.

## S4 — background sync stops alarming the streamer (renderer)

The latest-wins bounds loop classifies `surface-busy`, `command-lane-full`, `command-expired-before-dispatch`, and `request-outcome-unknown` as silent retries (`lib/surface-sync-retry.ts`, unit-tested): pending bounds are restored and the single-flight loop paces a 1.5s in-loop retry (a window event may never arrive to re-drive it, so it re-drives itself; generation checks end it naturally on teardown). Real failures — malformed bounds, genuine create rejections — still reach `reportError` loudly.

## Verification

- `cargo test -p videorc-backend`: 1700 + 77 + 1 (new: `busy_surface_lifecycle_answers_surface_busy_instead_of_stalling`), clippy `-D warnings`, fmt
- `pnpm typecheck` / `lint` / `format:check`; desktop 1568/168 (new: `surface-sync-retry.test.ts`); `pnpm build`
- ~55 existing preview-surface tests mechanically updated for the fallible signatures (`.expect(...)` — they hold no lock, so busy is impossible there)

## Owner acceptance (next livestream)

Deliberate preview-window moves/minimize cycles during a stream: zero timeout toasts, zero lane-full errors; if anything jams again, backend.log now names the method and the hold time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview surface synchronization during temporary backend congestion.
  * Automatically retries recoverable surface updates after a short delay instead of immediately showing an error.
  * Preview surface operations now respond promptly when another lifecycle operation is in progress.
  * Added clearer diagnostics for long-running and blocked commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->