### PR TITLE
release: 0.9.83-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.82",
+  "version": "0.9.83",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.83-beta.1.md
+++ b/changelog/0.9.83-beta.1.md
@@ -1,0 +1,34 @@
+---
+version: 0.9.83-beta.1
+date: 2026-08-27
+channel: beta
+platforms:
+  - macos
+title: Controls stay responsive when the preview is struggling
+summary: During a livestream, a struggling preview window could silently jam the app's command pipeline — controls timed out with "outcome is unknown" errors and eventually "command lane is full", even though the stream itself was healthy. Preview operations now fail fast and retry quietly in the background instead of blocking everything behind them, and the errors you saw are gone.
+highlights:
+  - Preview-surface operations can no longer jam the command pipeline — they answer quickly and retry in the background instead of blocking other controls for 30+ seconds.
+  - The background preview-position sync no longer surfaces alarming error toasts mid-stream for conditions that resolve themselves.
+  - When a command does run long, Videorc now records exactly which one and for how long, so a report from the field pinpoints the cause immediately.
+---
+
+## Fixed
+
+- **A struggling preview could jam every control.** Preview-surface
+  operations (create, move, destroy) waited without limit for an internal
+  lock while preview self-healing held it, and the one running command
+  silently blocked everything queued behind it — producing the
+  "timed out after 30000ms" and "command lane is full" errors seen during
+  livestreams. These operations now give up after 3 seconds with a quiet,
+  retryable result, and the rest of the app keeps responding.
+- **Background sync errors no longer toast.** The preview window's
+  position sync is background maintenance; transient "busy" or timeout
+  outcomes now retry silently with the newest position instead of raising
+  errors for something you didn't do. Real failures still surface.
+
+## Added
+
+- **Slow-command diagnostics.** Any backend command that runs longer than
+  two seconds is now named in the log while it is still running, along with
+  what a full command queue was actually stuck behind — so the next report
+  of sluggish controls arrives with the culprit already identified.


### PR DESCRIPTION
Version bump + macOS changelog for the surface-lane starvation fixes (#313). Gates: changelog:check green (90 entries, latest 0.9.83-beta.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the desktop app to version 0.9.83.

* **Improvements**
  * Preview operations now stop waiting after three seconds and continue retrying in the background.
  * Preview position updates retry using the latest position without showing transient error notifications.
  * Long-running backend commands are identified in logs, including queued commands waiting behind them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->