### PR TITLE
docs: 0.9.83 release record

### DIFF
--- a/docs/releases/0.9.83.md
+++ b/docs/releases/0.9.83.md
@@ -1,0 +1,51 @@
+# Videorc 0.9.83 Beta 1 (macOS)
+
+Controls stay responsive when the preview is struggling — the surface-lane
+starvation fixes from the same-day live-stream incident.
+
+## Scope (PRs #313, #314, #315)
+
+- **Bounded surface lifecycle (S1).** preview.surface create/update_bounds/
+  destroy acquire the lifecycle mutex with a 3s budget and answer a
+  retryable `surface-busy` instead of silently barriering the ordered
+  command lane — the mechanism behind the live-stream "timed out after
+  30000ms / outcome is unknown" and "ordered command lane is full" errors
+  (2026-08-27 incident; diagnosed live via backend.log + `sample` while the
+  owner streamed).
+- **Named jams (S0).** The ordered dispatcher tracks its single running
+  stateful mutation: a WARN the moment it crosses 2s (while wedged, not
+  post-mortem), a completion total, and lane-full rejections that name the
+  rejected method plus what is holding the lane and for how long.
+- **Silent background retry (S4).** The renderer's latest-wins bounds sync
+  classifies surface-busy / lane-full / dispatch-expiry / outcome-unknown as
+  paced silent retries (lib/surface-sync-retry, unit-tested); real failures
+  still surface loudly.
+- **Windows lane unblocked (#315).** The `clippy::collapsible_if` in the
+  Windows-only Media Foundation encoder module — which failed the
+  0.9.81-alpha.1 roll-forward candidate and burned that release ID — is
+  fixed; the next Windows alpha (≥0.9.83-alpha.1, carrying the Intel iGPU
+  encoding fixes #305/#307 plus everything since) can now build.
+- Deferred per plan: S2 (presents off the stateful barrier — next PR),
+  S3 (presenter-wedge root — instrumentation first; prime hypothesis is
+  CAMetalLayer drawable starvation on an occluded preview window).
+
+## Ship record
+
+- Source: `main` @ `3fc660c2` (#314, on top of #313 `912b28a0`).
+- Gates: cargo 1700+77+1 (new busy-path RPC test), clippy `-D warnings`,
+  fmt; pnpm typecheck/lint/format, desktop 1568/168, build.
+- Signed/notarized/stapled (Developer ID Uros Miric C2PA37RB58),
+  validation PASS.
+- **Upload was blocked ~50 minutes by the recurring evening TLS
+  interception** (forged "Packetland / core1.netops.test" issuer on
+  `*.r2.cloudflarestorage.com` — third occurrence after Aug 16 and Aug 22).
+  The pre-upload issuer guard aborted; an automated watcher polled the
+  chain and ran the full upload → feed-verify → Discord pipeline the moment
+  the real Google Trust Services chain returned (23:19 local). All objects
+  verified, `latest-mac.yml` serves 0.9.83, zip range-check 206, Discord
+  announced. Never bypass TLS; the durable fix (Cloudflare API-token upload
+  fallback) remains open.
+- Owner acceptance: next livestream with deliberate preview-window
+  moves/minimize — zero timeout toasts, zero lane-full errors.
+- Windows: not released in this pass; next alpha is one dispatch away on a
+  clippy-green main.


### PR DESCRIPTION
Release record for macOS 0.9.83-beta.1 (surface-lane starvation fixes), including the third TLS-interception incident and the watcher-driven delayed upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Videorc 0.9.83 Beta 1 on macOS.
  * Documented lifecycle operations, renderer retry behavior, upload completion, notarization, ship gates, acceptance criteria, and Windows release status.
  * Noted deferred S2/S3 work and the Windows clippy fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->