### PR TITLE
fix: camera-decay discriminators + verified camera auto-heal (D3a/D3b)

### DIFF
--- a/crates/videorc-backend/src/capture_health.rs
+++ b/crates/videorc-backend/src/capture_health.rs
@@ -46,6 +46,20 @@ pub struct CaptureHealthSample {
     pub screen_fresh_serves: u64,
     /// Window length in seconds (non-positive samples are ignored).
     pub window_secs: f64,
+    /// Device-level camera delivery fps as measured at the capture callback
+    /// (already computed by the camera poll task). Discriminates "the device
+    /// stopped delivering" from "the app is starving its buffer pool".
+    pub camera_source_fps: Option<f64>,
+    /// CUMULATIVE capture callbacks (device deliveries incl. dropped ones).
+    pub camera_callback_count: Option<u64>,
+    /// CUMULATIVE frames the capture output dropped for want of a free
+    /// buffer. A rate here ≈ (device fps − fresh fps) is the pool-exhaustion
+    /// signature (H1-camera): the app retains zero-copy pool buffers until
+    /// the camera can only deliver as buffers trickle back.
+    pub camera_out_of_buffers: Option<u64>,
+    /// Live / peak retained camera-backed surfaces (the leak counter).
+    pub camera_pool_live: Option<u64>,
+    pub camera_pool_peak: Option<u64>,
 }
 
 /// The stage a degradation verdict names, most-upstream first.
@@ -76,6 +90,8 @@ pub enum CaptureHealthTransition {
 pub struct CaptureHealthMonitor {
     last_camera_fresh: Option<u64>,
     last_screen_fresh: Option<u64>,
+    last_camera_callbacks: Option<u64>,
+    last_camera_out_of_buffers: Option<u64>,
     degraded_streak: u32,
     healthy_streak: u32,
     /// The currently-declared degraded stage, if any.
@@ -121,6 +137,27 @@ impl CaptureHealthMonitor {
             None
         };
 
+        let camera_callback_fps = match sample.camera_callback_count {
+            Some(count) if sample.camera_present => {
+                delta_rate(&mut self.last_camera_callbacks, count, sample.window_secs)
+            }
+            _ => {
+                self.last_camera_callbacks = None;
+                None
+            }
+        };
+        let camera_out_of_buffers_rate = match sample.camera_out_of_buffers {
+            Some(count) if sample.camera_present => delta_rate(
+                &mut self.last_camera_out_of_buffers,
+                count,
+                sample.window_secs,
+            ),
+            _ => {
+                self.last_camera_out_of_buffers = None;
+                None
+            }
+        };
+
         let floor = sample.target_fps * DEGRADED_RATE_FRACTION;
         // Upstream before downstream: a starving camera fetch is the cause
         // even when the render loop is dutifully re-serving held frames at
@@ -131,12 +168,25 @@ impl CaptureHealthMonitor {
             _ => None,
         };
 
+        let optional_rate = |rate: Option<f64>| {
+            rate.map_or_else(|| "n/a".to_string(), |rate| format!("{rate:.1}fps"))
+        };
         let detail = format!(
-            "target={:.1}fps render={:.1}fps camera_fresh={} screen_fresh={}",
+            "target={:.1}fps render={:.1}fps camera_fresh={} screen_fresh={} camera_dev={} camera_cb={} camera_oob={} camera_pool={}/{}",
             sample.target_fps,
             sample.render_fps,
-            camera_fresh_fps.map_or_else(|| "n/a".to_string(), |rate| format!("{rate:.1}fps")),
-            screen_fresh_fps.map_or_else(|| "n/a".to_string(), |rate| format!("{rate:.1}fps")),
+            optional_rate(camera_fresh_fps),
+            optional_rate(screen_fresh_fps),
+            optional_rate(sample.camera_source_fps),
+            optional_rate(camera_callback_fps),
+            camera_out_of_buffers_rate
+                .map_or_else(|| "n/a".to_string(), |rate| format!("+{rate:.1}/s")),
+            sample
+                .camera_pool_live
+                .map_or_else(|| "?".to_string(), |live| live.to_string()),
+            sample
+                .camera_pool_peak
+                .map_or_else(|| "?".to_string(), |peak| peak.to_string()),
         );
 
         match degraded_stage {
@@ -184,6 +234,88 @@ fn delta_rate(last: &mut Option<u64>, current: u64, window_secs: f64) -> Option<
     rate
 }
 
+/// Windows to wait after an auto-restart before judging it (camera warm-up
+/// plus monitor hysteresis; 2s windows → ≈16s of grace).
+pub const AUTO_HEAL_RECOVERY_GRACE_WINDOWS: u64 = 8;
+/// Attempts per degradation episode before escalating to the user.
+pub const AUTO_HEAL_MAX_ATTEMPTS: u32 = 2;
+
+/// What the auto-heal driver should do this window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoHealAction {
+    None,
+    /// Restart the camera source now (attempt number for the log).
+    RestartCamera {
+        attempt: u32,
+    },
+    /// Both restarts failed to restore cadence: tell the user, once.
+    Escalate,
+}
+
+/// Decides camera auto-restarts from the monitor's camera-delivery verdict.
+///
+/// The restart is the known-good manual cure for the quantized ~6fps camera
+/// collapse (2026-08-28 field data): the process-restart the owner performs
+/// tears down the capture session and its buffer pool. This policy automates
+/// exactly that at source scope, with hysteresis so a restart is judged only
+/// after the camera has had time to warm up and the monitor to recover, and
+/// a hard attempt ceiling so a broken camera cannot cause a restart loop.
+#[derive(Debug, Default)]
+pub struct CameraAutoHealPolicy {
+    window: u64,
+    attempts: u32,
+    last_attempt_window: Option<u64>,
+    escalated: bool,
+    /// Attempts were made in the episode that most recently recovered —
+    /// lets the driver log "recovered after automatic restart" once.
+    recovered_after_heal: bool,
+}
+
+impl CameraAutoHealPolicy {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one diagnostics window; `camera_degraded` is whether the monitor
+    /// currently declares camera-delivery degraded.
+    pub fn on_window(&mut self, camera_degraded: bool) -> AutoHealAction {
+        self.window = self.window.wrapping_add(1);
+        if !camera_degraded {
+            if self.attempts > 0 {
+                self.recovered_after_heal = true;
+            }
+            self.attempts = 0;
+            self.last_attempt_window = None;
+            self.escalated = false;
+            return AutoHealAction::None;
+        }
+        self.recovered_after_heal = false;
+        let in_grace = self
+            .last_attempt_window
+            .is_some_and(|at| self.window.saturating_sub(at) < AUTO_HEAL_RECOVERY_GRACE_WINDOWS);
+        if in_grace {
+            return AutoHealAction::None;
+        }
+        if self.attempts < AUTO_HEAL_MAX_ATTEMPTS {
+            self.attempts += 1;
+            self.last_attempt_window = Some(self.window);
+            return AutoHealAction::RestartCamera {
+                attempt: self.attempts,
+            };
+        }
+        if !self.escalated {
+            self.escalated = true;
+            return AutoHealAction::Escalate;
+        }
+        AutoHealAction::None
+    }
+
+    /// True exactly once after an episode that needed restarts recovers.
+    pub fn take_recovered_after_heal(&mut self) -> bool {
+        std::mem::take(&mut self.recovered_after_heal)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -197,6 +329,102 @@ mod tests {
             screen_present: true,
             screen_fresh_serves: screen_fresh,
             window_secs: 2.0,
+            camera_source_fps: None,
+            camera_callback_count: None,
+            camera_out_of_buffers: None,
+            camera_pool_live: None,
+            camera_pool_peak: None,
+        }
+    }
+
+    /// The 2026-08-28 pool-exhaustion signature must be readable from the
+    /// degrade detail: device delivering ~30, out-of-buffers eating ~24/s.
+    #[test]
+    fn degrade_detail_carries_the_pool_discriminators() {
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut camera = 0_u64;
+        let mut callbacks = 0_u64;
+        let mut oob = 0_u64;
+        let mut sample = |camera: u64, callbacks: u64, oob: u64| CaptureHealthSample {
+            camera_source_fps: Some(29.9),
+            camera_callback_count: Some(callbacks),
+            camera_out_of_buffers: Some(oob),
+            camera_pool_live: Some(14),
+            camera_pool_peak: Some(16),
+            ..healthy_sample(camera, 0)
+        };
+        camera += 60;
+        callbacks += 60;
+        monitor.observe(sample(camera, callbacks, oob));
+        let mut transition = None;
+        for _ in 0..DEGRADED_WINDOW_THRESHOLD {
+            camera += 12; // ~6 fresh fps
+            callbacks += 60; // device still delivering 30
+            oob += 48; // ~24/s starved
+            transition = monitor.observe(sample(camera, callbacks, oob));
+        }
+        match transition {
+            Some(CaptureHealthTransition::Degraded { detail, .. }) => {
+                assert!(detail.contains("camera_dev=29.9fps"), "{detail}");
+                assert!(detail.contains("camera_cb=30.0fps"), "{detail}");
+                assert!(detail.contains("camera_oob=+24.0/s"), "{detail}");
+                assert!(detail.contains("camera_pool=14/16"), "{detail}");
+            }
+            other => panic!("expected degrade, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn auto_heal_restarts_twice_with_grace_then_escalates_once() {
+        let mut policy = CameraAutoHealPolicy::new();
+        assert_eq!(policy.on_window(false), AutoHealAction::None);
+        // Degradation begins: first restart immediately.
+        assert_eq!(
+            policy.on_window(true),
+            AutoHealAction::RestartCamera { attempt: 1 }
+        );
+        // Grace: no second attempt while the restart warms up.
+        for _ in 0..(AUTO_HEAL_RECOVERY_GRACE_WINDOWS - 1) {
+            assert_eq!(policy.on_window(true), AutoHealAction::None);
+        }
+        assert_eq!(
+            policy.on_window(true),
+            AutoHealAction::RestartCamera { attempt: 2 }
+        );
+        for _ in 0..(AUTO_HEAL_RECOVERY_GRACE_WINDOWS - 1) {
+            assert_eq!(policy.on_window(true), AutoHealAction::None);
+        }
+        assert_eq!(policy.on_window(true), AutoHealAction::Escalate);
+        // Escalation fires once; the episode then stays quiet.
+        for _ in 0..5 {
+            assert_eq!(policy.on_window(true), AutoHealAction::None);
+        }
+        assert!(!policy.take_recovered_after_heal());
+    }
+
+    #[test]
+    fn auto_heal_reports_recovery_after_a_restart_and_rearms() {
+        let mut policy = CameraAutoHealPolicy::new();
+        assert_eq!(
+            policy.on_window(true),
+            AutoHealAction::RestartCamera { attempt: 1 }
+        );
+        // The restart worked: monitor recovers inside the grace period.
+        assert_eq!(policy.on_window(false), AutoHealAction::None);
+        assert!(policy.take_recovered_after_heal());
+        assert!(!policy.take_recovered_after_heal(), "reported once");
+        // A fresh episode gets a fresh attempt budget.
+        assert_eq!(
+            policy.on_window(true),
+            AutoHealAction::RestartCamera { attempt: 1 }
+        );
+    }
+
+    #[test]
+    fn auto_heal_never_fires_while_healthy() {
+        let mut policy = CameraAutoHealPolicy::new();
+        for _ in 0..50 {
+            assert_eq!(policy.on_window(false), AutoHealAction::None);
         }
     }
 

--- a/crates/videorc-backend/src/compositor.rs
+++ b/crates/videorc-backend/src/compositor.rs
@@ -12,7 +12,10 @@ use tokio::task::JoinHandle;
 use tokio::time::{Duration, MissedTickBehavior, sleep};
 use uuid::Uuid;
 
-use crate::capture_health::{CaptureHealthMonitor, CaptureHealthSample, CaptureHealthTransition};
+use crate::capture_health::{
+    AutoHealAction, CameraAutoHealPolicy, CaptureHealthMonitor, CaptureHealthSample,
+    CaptureHealthTransition, CaptureStage,
+};
 use crate::color::rgb_to_yuv_video_range_bt709 as rgb_to_yuv;
 use crate::compositor_synthetic::SyntheticMovingSource;
 use crate::diagnostics::{
@@ -2105,6 +2108,7 @@ async fn run_synthetic_compositor_loop(
     // incident (33 idle minutes of silent decay to ~6 fresh fps) is exactly
     // the state every liveness-only watchdog ignores.
     let mut capture_health = CaptureHealthMonitor::new();
+    let mut camera_auto_heal = CameraAutoHealPolicy::new();
     let mut render_cache = CompositorRenderCache::refresh_initial(&state).await;
     let mut next_live_source_refresh_at = Instant::now() + COMPOSITOR_LIVE_SOURCE_REFRESH_INTERVAL;
 
@@ -2288,6 +2292,26 @@ async fn run_synthetic_compositor_loop(
                     let elapsed = window_started_at.elapsed().as_secs_f64().max(0.001);
                     let measured_fps = frames_in_window as f64 / elapsed;
                     {
+                        // Device-level camera evidence (published continuously
+                        // by the camera poll task): discriminates a device that
+                        // stopped delivering from an app starving the camera's
+                        // zero-copy buffer pool (the 2026-08-28 6fps quantum).
+                        let (
+                            camera_source_fps,
+                            camera_callback_count,
+                            camera_out_of_buffers,
+                            camera_pool_live,
+                            camera_pool_peak,
+                        ) = {
+                            let diagnostics = state.diagnostics.lock().await;
+                            (
+                                diagnostics.preview_camera_source_fps,
+                                Some(diagnostics.preview_camera_capture_callback_count),
+                                Some(diagnostics.preview_camera_drop_reasons.out_of_buffers),
+                                Some(diagnostics.preview_camera_surface_backing.live_count),
+                                Some(diagnostics.preview_camera_surface_backing.peak_count),
+                            )
+                        };
                         let fetch = live_sources.fetch_stats();
                         let transition = capture_health.observe(CaptureHealthSample {
                             target_fps: f64::from(target_fps),
@@ -2297,6 +2321,11 @@ async fn run_synthetic_compositor_loop(
                             screen_present: live_sources.screen.is_some(),
                             screen_fresh_serves: fetch.screen_fresh_serves,
                             window_secs: elapsed,
+                            camera_source_fps,
+                            camera_callback_count,
+                            camera_out_of_buffers,
+                            camera_pool_live,
+                            camera_pool_peak,
                         });
                         match transition {
                             Some(CaptureHealthTransition::Degraded { stage, detail }) => {
@@ -2309,6 +2338,53 @@ async fn run_synthetic_compositor_loop(
                                 tracing::info!("[capture-health] pipeline recovered: {detail}");
                             }
                             None => {}
+                        }
+                        // Verified auto-heal: the restart is the known-good
+                        // manual cure; the policy bounds attempts and judges
+                        // recovery through the monitor's own verdict.
+                        let camera_degraded =
+                            capture_health.degraded_stage() == Some(CaptureStage::CameraDelivery);
+                        match camera_auto_heal.on_window(camera_degraded) {
+                            AutoHealAction::RestartCamera { attempt } => {
+                                tracing::warn!(
+                                    "[capture-health] auto-restarting the camera source (attempt {attempt}/{})",
+                                    crate::capture_health::AUTO_HEAL_MAX_ATTEMPTS
+                                );
+                                let heal_state = state.clone();
+                                tokio::spawn(async move {
+                                    if !crate::preview_camera::restart_preview_camera_for_health(
+                                        &heal_state,
+                                    )
+                                    .await
+                                    {
+                                        tracing::warn!(
+                                            "[capture-health] camera auto-restart skipped: no retained start parameters"
+                                        );
+                                    }
+                                });
+                            }
+                            AutoHealAction::Escalate => {
+                                tracing::warn!(
+                                    "[capture-health] camera stayed degraded after {} automatic restarts; surfacing to the user",
+                                    crate::capture_health::AUTO_HEAL_MAX_ATTEMPTS
+                                );
+                                let escalate_state = state.clone();
+                                tokio::task::spawn_blocking(move || {
+                                    let _ = crate::recording::emit_health_event(
+                                        &escalate_state,
+                                        None,
+                                        crate::protocol::HealthLevel::Warn,
+                                        "camera-degraded-restart-failed",
+                                        "The camera is delivering frames far below its target rate and automatic restarts did not recover it. Check the camera connection, or restart Videorc.",
+                                    );
+                                });
+                            }
+                            AutoHealAction::None => {}
+                        }
+                        if camera_auto_heal.take_recovered_after_heal() {
+                            tracing::info!(
+                                "[capture-health] camera recovered after automatic restart"
+                            );
                         }
                     }
                     let (p50, p95, p99) = frame_time_percentiles(&frame_times_ms);

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -109,6 +109,10 @@ pub type PreviewCameraSlot = Arc<tokio::sync::Mutex<PreviewCameraRuntime>>;
 #[derive(Debug)]
 pub struct PreviewCameraRuntime {
     pub status: PreviewCameraStatus,
+    /// The params of the most recent start, retained so capture-health can
+    /// restart the source with the user's exact configuration (auto-heal for
+    /// the 2026-08-28 quantized-6fps camera collapse).
+    last_start_params: Option<PreviewCameraStartParams>,
     /// Source-level ownership keeps surface-backed frames observable while a
     /// capture session replaces its per-session `FrameStore`.
     surface_backing_tracker: SurfaceBackingTrackerHandle,
@@ -396,6 +400,7 @@ fn max_sample(samples: &[f64]) -> Option<f64> {
 pub fn initial_preview_camera_state() -> PreviewCameraRuntime {
     PreviewCameraRuntime {
         status: idle_status(Some("Native camera preview is not running.".to_string())),
+        last_start_params: None,
         surface_backing_tracker: SurfaceBackingTrackerHandle::default(),
         run_id: None,
         source_key: None,
@@ -505,6 +510,7 @@ pub async fn start_preview_camera(
     };
 
     stop_current_camera_for_restart(&state).await;
+    state.preview_camera.lock().await.last_start_params = Some(params.clone());
 
     let run_id = Uuid::new_v4().to_string();
     let surface_backing_tracker = state
@@ -799,6 +805,29 @@ pub(crate) async fn finish_preview_camera_stop(mut stop: PreviewCameraStop) -> P
         let _ = tokio::task::spawn_blocking(move || join_handle.join()).await;
     }
     stop.status
+}
+
+/// Restarts the camera with its retained start parameters — the capture-health
+/// auto-heal path. Returns false when there is nothing to restart (no camera
+/// was started this run, or it was deliberately stopped).
+pub async fn restart_preview_camera_for_health(state: &AppState) -> bool {
+    let params = {
+        let slot = state.preview_camera.lock().await;
+        if slot.run_id.is_none() {
+            None
+        } else {
+            slot.last_start_params.clone()
+        }
+    };
+    let Some(params) = params else {
+        return false;
+    };
+    let status = start_preview_camera(state.clone(), params).await;
+    tracing::info!(
+        "Camera auto-restart requested by capture-health finished with state {:?}.",
+        status.state
+    );
+    true
 }
 
 pub async fn preview_camera_status(state: &AppState) -> PreviewCameraStatus {
@@ -2631,6 +2660,15 @@ mod macos {
                 unsafe { (range.minFrameRate(), range.maxFrameRate()) }
             })
             .collect::<Vec<_>>();
+        tracing::info!(
+            "Camera capture configured: {}x{} (requested {}x{}), advertised ranges {:?}, requesting {} fps",
+            format.format.width,
+            format.format.height,
+            format.requested_width,
+            format.requested_height,
+            range_bounds,
+            requested_fps,
+        );
         if let Some(resolution) = resolve_camera_frame_rate(requested_fps, &range_bounds) {
             let range = ranges.objectAtIndex(resolution.range_index);
             let frame_duration = match resolution.endpoint {
@@ -2651,11 +2689,16 @@ mod macos {
                     device.setActiveVideoMaxFrameDuration(frame_duration);
                 }))
             };
-            if let Err(exception) = frame_rate_result {
-                tracing::warn!(
+            match frame_rate_result {
+                Ok(()) => tracing::info!(
+                    "Camera frame duration set: {effective_fps:.3} fps ({:?} of range {})",
+                    resolution.endpoint,
+                    resolution.range_index,
+                ),
+                Err(exception) => tracing::warn!(
                     "Camera kept its native frame cadence ({effective_fps:.3} fps frame duration was rejected): {}",
                     describe_camera_exception(exception)
-                );
+                ),
             }
         }
 

--- a/crates/videorc-backend/src/recording.rs
+++ b/crates/videorc-backend/src/recording.rs
@@ -6631,6 +6631,21 @@ fn enqueue_post_recording_gate(
         sleep(POST_RECORDING_GATE_IDLE_DELAY).await;
         let _maintenance = state.ffmpeg_work.begin_maintenance_when_idle().await;
         let cancel_token = _maintenance.cancel_token();
+        // A user deleting a test recording before the idle gate runs is
+        // routine, not a failure (2026-08-28: six WARNs in one second for
+        // deliberately deleted test files). Cancel quietly.
+        if !final_path.exists() {
+            job.cancel_with_reason(
+                "The recording was deleted before the quality check ran.".to_string(),
+                Utc::now().to_rfc3339(),
+            );
+            let _ = state.database.upsert_repair_job(&job);
+            state.emit_log(
+                "info",
+                format!("Skipped quality check for deleted recording {path_str}."),
+            );
+            return;
+        }
         job.mark_running(Utc::now().to_rfc3339());
         let _ = state.database.upsert_repair_job(&job);
 
@@ -6977,6 +6992,21 @@ pub async fn resume_pending_repair_jobs(state: AppState) {
             sleep(POST_RECORDING_GATE_IDLE_DELAY).await;
             let _maintenance = state.ffmpeg_work.begin_maintenance_when_idle().await;
             let cancel_token = _maintenance.cancel_token();
+            if !std::path::Path::new(&job.file_path).exists() {
+                job.cancel_with_reason(
+                    "The recording was deleted before the quality check ran.".to_string(),
+                    Utc::now().to_rfc3339(),
+                );
+                let _ = state.database.upsert_repair_job(&job);
+                state.emit_log(
+                    "info",
+                    format!(
+                        "Skipped quality check for deleted recording {}.",
+                        job.file_path
+                    ),
+                );
+                return;
+            }
             job.mark_running(Utc::now().to_rfc3339());
             let _ = state.database.upsert_repair_job(&job);
 

--- a/scripts/smoke-capture-decay-soak.mjs
+++ b/scripts/smoke-capture-decay-soak.mjs
@@ -113,6 +113,19 @@ try {
       screenFreshFps: rate('compositorScreenSourceFreshServes'),
       cameraHeldFps: rate('compositorCameraSourceHeldServes'),
       screenHeldFps: rate('compositorScreenSourceHeldServes'),
+      // H1-camera discriminators (2026-08-28): device-level delivery vs
+      // pool starvation, and the retained-surface leak counters.
+      cameraSourceFps: stats.previewCameraSourceFps ?? null,
+      cameraCallbackFps: rate('previewCameraCaptureCallbackCount'),
+      cameraOutOfBuffersPerSec:
+        previous && windowSec > 0
+          ? (stats.previewCameraDropReasons.outOfBuffers -
+              previous.stats.previewCameraDropReasons.outOfBuffers) /
+            windowSec
+          : null,
+      cameraPoolLive: stats.previewCameraSurfaceBacking.liveCount,
+      cameraPoolPeak: stats.previewCameraSurfaceBacking.peakCount,
+      previewFrameAgeMs: stats.previewFrameAgeMs ?? null,
       degradedStage: stats.capturePipelineDegradedStage ?? null
     }
     samples.push(sample)
@@ -132,7 +145,9 @@ try {
   }
 
   const csvHeader =
-    'uptimeSec,renderFps,targetFps,cameraFreshFps,screenFreshFps,cameraHeldFps,screenHeldFps,degradedStage'
+    'uptimeSec,renderFps,targetFps,cameraFreshFps,screenFreshFps,cameraHeldFps,screenHeldFps,' +
+    'cameraSourceFps,cameraCallbackFps,cameraOutOfBuffersPerSec,cameraPoolLive,cameraPoolPeak,' +
+    'previewFrameAgeMs,degradedStage'
   const csv = [csvHeader]
     .concat(
       samples.map((sample) =>
@@ -144,6 +159,12 @@ try {
           sample.screenFreshFps?.toFixed?.(2) ?? '',
           sample.cameraHeldFps?.toFixed?.(2) ?? '',
           sample.screenHeldFps?.toFixed?.(2) ?? '',
+          sample.cameraSourceFps?.toFixed?.(2) ?? '',
+          sample.cameraCallbackFps?.toFixed?.(2) ?? '',
+          sample.cameraOutOfBuffersPerSec?.toFixed?.(2) ?? '',
+          sample.cameraPoolLive ?? '',
+          sample.cameraPoolPeak ?? '',
+          sample.previewFrameAgeMs ?? '',
           sample.degradedStage ?? ''
         ].join(',')
       )


### PR DESCRIPTION
Executes D3a+D3b of the capture-decay plan, unblocked by this morning's field data.

## What the 0.9.82 telemetry proved today

**13 of 13 degradation events are `camera-delivery`, settling at a quantized ~6.0fps** (5.4–6.5 across events) while the screen holds 23–29 fresh fps and render holds target — and a freshly restarted backend re-trips within ~5 minutes of recording several short sessions. The failure is camera-scoped and session-count-correlated, not wall-clock aging; yesterday's whole-composite 6.4fps was the camera tile dominating the measure. The owner's original "second recording lags" framing was right all along — for the camera.

**Sharpened hypothesis (H1-camera):** the capture path imports device buffers zero-copy, so every downstream hold (adopt-by-key held frame, ring, retired per-session compositor instances, encoder refs) pins a buffer from the camera's own small fixed CVPixelBuffer pool. Leak a few per session and delivery quantizes at ~6fps until a process restart tears the pool down.

## D3a — the discriminators, in every health line

`preview_camera_source_fps`, `capture_callback_count`, `drop_reasons.out_of_buffers`, and `surface_backing.live/peak` were all already computed and published into diagnostics — and logged nowhere. The capture-health sample now carries them, and degrade/recover lines print `camera_dev= camera_cb= camera_oob= camera_pool=live/peak`. The next single occurrence reads either as "device at 30, out-of-buffers +24/s, pool climbing" (pool starvation → D3c bounds the holds) or "device itself at 6" (USB/format renegotiation → D3c reconfigures capture). The camera start path also logs advertised ranges + the exact frame duration set (previously silent on the happy path).

## D3b — verified auto-heal

On a sustained camera-delivery verdict, the backend restarts the camera source itself using retained start params (`restart_preview_camera_for_health` — the same start path as the user's own camera reset, lease-protected). Recovery is judged by the monitor's own verdict after an 8-window warm-up grace; one retry; then a single WARN health event (`camera-degraded-restart-failed`) telling the user to check the connection. `CameraAutoHealPolicy` is a pure state machine: bounded attempts per episode, escalate-once, re-arms only after genuine recovery — a broken camera cannot cause a restart loop (unit-tested, including the grace windows and the recovered-after-heal single-shot).

No protocol/contract changes — everything reads existing diagnostics fields (no serde-rails exposure).

## Bystander

Quality checks whose recording was deleted before the idle gate ran cancel quietly (`cancel_with_reason`) instead of WARN-spamming — this morning produced six spurious WARNs in one second for deliberately deleted test files.

## Verification

- cargo 1704+77+1 (11 capture_health tests: 4 new — pool-discriminator detail, restart/grace/escalate sequencing, recovered-after-heal single-shot, healthy-never-fires), clippy `-D warnings`, fmt
- pnpm typecheck/lint, desktop 1568/168, build
- Field acceptance: the owner's next few recording sessions — the degrade line now carries the verdict, and the camera should self-recover within ~20s instead of requiring an app restart

## Follow-up (D3c, data-gated)

The actual leak fix lands once one instrumented occurrence picks pool-vs-device; the escalation health event and auto-restart keep the owner productive meanwhile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added camera health diagnostics for frame delivery, buffer usage, and capture performance.
  - Camera sources can automatically restart after sustained delivery issues, with escalation warnings when recovery fails.
  - Added detailed camera diagnostics to capture health reports.
  - Improved camera configuration logging on macOS.

- **Bug Fixes**
  - Prevented quality checks from running on deleted recordings; affected repair jobs are cancelled with a clear explanation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->