### PR TITLE
release: 0.9.84-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.83",
+  "version": "0.9.84",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.84-beta.1.md
+++ b/changelog/0.9.84-beta.1.md
@@ -1,0 +1,34 @@
+---
+version: 0.9.84-beta.1
+date: 2026-08-28
+channel: beta
+platforms:
+  - macos
+title: The camera heals itself when it starts lagging
+summary: The "after a couple of videos the camera lags" problem now has a self-repair - when camera frame delivery collapses, Videorc automatically restarts the camera with your exact settings and verifies it recovered, instead of limping along until you restart the app. The diagnostics behind it also got much sharper, so the remaining root cause is being pinned down with every session you record.
+highlights:
+  - When camera frame delivery collapses mid-session, Videorc now restarts the camera automatically and verifies the recovery - no more app restarts to fix a lagging camera.
+  - If automatic recovery fails twice, you get a clear warning instead of silent degradation.
+  - Camera diagnostics now record the negotiated frame rate at every start and distinguish a starving buffer pool from a camera that genuinely slowed down.
+  - Deleting a recording right after making it no longer produces warning noise from its pending quality check.
+---
+
+## Added
+
+- **Verified camera self-repair.** The capture-health monitor already detects
+  when camera frame delivery collapses (the ~6fps lag some of you have hit
+  after several recordings). Videorc now responds: it automatically restarts
+  the camera with the same settings, then verifies frame delivery actually
+  recovered before trusting it. Two failed attempts raise a visible camera
+  warning. Previously the only cure was restarting the whole app.
+- **Sharper camera diagnostics.** Every camera start logs the negotiated
+  format and exact frame rate, and degradation reports now include the
+  camera's own delivery rate, buffer-pool counters, and dropped-frame
+  reasons - enough to tell a starving buffer pool from a device that
+  renegotiated its rate, from a single occurrence.
+
+## Fixed
+
+- **Quality checks on deleted recordings are quiet.** Checking a recording
+  you had already deleted produced a warning and a failed-check record; the
+  check now cancels cleanly when the file is gone.


### PR DESCRIPTION
Version bump + changelog for the camera self-heal and decay-discriminator batch (#317).