### PR TITLE
docs: 0.9.84 release record

### DIFF
--- a/docs/releases/0.9.84.md
+++ b/docs/releases/0.9.84.md
@@ -1,0 +1,42 @@
+# Videorc 0.9.84 Beta 1 (macOS)
+
+The camera heals itself when it starts lagging — verified auto-restart plus
+the discriminators that will convict the root cause.
+
+## Scope (PRs #317, #318)
+
+- **D3a — camera-decay discriminators.** The 2026-08-28 telemetry breakthrough:
+  13/13 degradation events were camera-only, quantized at ~6.0fps, re-tripping
+  within minutes of a fresh backend and correlated with session count — while
+  screen and render held target. Capture-health lines now carry the camera's
+  own callback rate, out-of-buffers drop rate, and retained-surface pool
+  counters; every camera start logs the negotiated format and exact frame
+  rate. One future occurrence distinguishes H1-camera (zero-copy pins
+  exhausting the device CVPixelBuffer pool) from device-side renegotiation.
+- **D3b — verified camera auto-heal.** Sustained camera-delivery degradation
+  triggers an automatic camera source restart with identical settings;
+  recovery is judged by the same monitor (sustained restored cadence), and
+  two failed attempts raise a visible camera health warning. Pure state
+  machine, loop-bounded, unit-tested. Previously the only cure was an app
+  restart.
+- Soak harness records the same discriminator columns + preview frame age.
+- Quality checks on user-deleted recordings cancel quietly (no WARN spam).
+- Deferred: D3c (the leak fix itself) — deliberately gated on one
+  instrumented occurrence naming pool-vs-device.
+
+## Ship record
+
+- Source: `main` @ `015be683` (#318, on top of #317 `ec1d51f4`).
+- Gates: cargo (full suite + new capture-health/auto-heal tests), clippy
+  `-D warnings`, fmt; pnpm typecheck/lint, desktop tests, build; 12s soak
+  run verifying the new CSV columns live.
+- Signed/notarized/stapled (Developer ID Uros Miric C2PA37RB58), validation
+  PASS, uploaded with TLS-issuer guard (clean chain this time), all objects
+  verified; `latest-mac.yml` serves 0.9.84, zip range-check 206; Discord
+  announced 2026-08-28.
+- Owner acceptance: record several consecutive camera sessions; expect
+  either no lag (auto-heal working silently — check backend.log for
+  `[capture-health] restarting camera` lines) or a camera warning naming
+  the failure. Either outcome also produces the D3c-deciding counters.
+- Windows: not in this pass; lane is clippy-green and one dispatch away
+  (≥0.9.84-alpha.1, carrying Intel iGPU fixes #305/#307 + this batch).


### PR DESCRIPTION
Release record for macOS 0.9.84-beta.1 (camera self-heal + decay discriminators).