### PR TITLE
release: 0.9.85-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.85-beta.1.md
+++ b/changelog/0.9.85-beta.1.md
@@ -1,0 +1,33 @@
+---
+version: 0.9.85-beta.1
+date: 2026-08-28
+channel: beta
+platforms:
+  - macos
+title: Capture recovery grows up
+summary: The automatic capture self-repair introduced in 0.9.84 is now a full recovery system - it covers the screen source as well as the camera, walks a staged restart-verify-recover flow you can observe in Diagnostics, and the session lifecycle around it was hardened end to end. Releases now also have to pass a 60-minute idle soak and an analyzed 15-minute recording before they ship, so this class of degradation cannot quietly return.
+highlights:
+  - Automatic capture recovery now covers both camera and screen sources, with a staged restart that verifies real frame delivery before declaring recovery.
+  - Recovery progress is observable - each attempt reports its phase, attempt count, and outcome instead of happening invisibly.
+  - Session start/stop lifecycle hardening around recovery, teardown, and process ownership.
+  - Every release build must now pass a 60-minute idle capture soak and an analyzed 15-minute recording gate before it can ship.
+---
+
+## Added
+
+- **Full capture recovery system.** When camera or screen frame delivery
+  degrades mid-session, Videorc now runs a staged recovery: restart the
+  source with identical settings, verify frames are actually flowing at the
+  negotiated rate, then declare recovery - with each phase, attempt, and
+  outcome reported as observable status instead of an invisible retry.
+- **Release-blocking capture gates.** A release build must pass a 60-minute
+  idle capture soak and a fully analyzed 15-minute recording (bridge
+  accounting, artifact analysis, surface-ownership tracking) before it can
+  ship. The lag problem this hunts can no longer quietly regress.
+
+## Fixed
+
+- **Session lifecycle hardening.** Start/stop ordering, teardown, process
+  ownership, and preview-driver lifecycle edge cases found during the
+  capture-decay investigation are closed, so recovery work can never race a
+  session ending or leave orphaned capture state behind.


### PR DESCRIPTION
Version bump + changelog for the capture-recovery hardening batch (#320). Held until the new 60m idle + 15m recording release sentinels pass locally per the amended runbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatic capture recovery now supports both camera and screen sources.
  - Recovery progress, attempt counts, and outcomes are visible in Diagnostics.
- **Bug Fixes**
  - Improved session start and stop handling during capture recovery.
  - Enhanced resilience for interrupted or failed capture sessions.
- **Chores**
  - Updated the desktop application to version 0.9.85.
  - Added release readiness checks for extended idle capture and recording stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->