### PR TITLE
fix: D3 satisfied-release drift guard + nullable retention diagnostics

### DIFF
--- a/apps/desktop/src/shared/backend-rpc-contract.test.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.test.ts
@@ -930,12 +930,13 @@ describe('backend RPC contract', () => {
           [field]: -1
         })
       ).toThrow(field)
-      expect(() =>
-        validateBackendEventPayload('diagnostics.stats', {
-          ...diagnostics,
-          [field]: null
-        })
-      ).toThrow(field)
+      const nullablePayload = { ...diagnostics, [field]: null }
+      expect(validateBackendRpcResult('diagnostics.stats', nullablePayload)).toEqual(
+        nullablePayload
+      )
+      expect(validateBackendEventPayload('diagnostics.stats', nullablePayload)).toEqual(
+        nullablePayload
+      )
     }
     // capturePipelineDegradedStage: absent while healthy (the wire omits it),
     // a stage label while degraded, and null tolerated for defense in depth

--- a/apps/desktop/src/shared/backend-rpc-contract.ts
+++ b/apps/desktop/src/shared/backend-rpc-contract.ts
@@ -1105,18 +1105,30 @@ const diagnosticStatsSchema = boundedSemanticValue(
       compositorCameraSourceCaptureTextureReuses: nonNegativeInteger,
       compositorScreenSourceCaptureTextureReuses: nonNegativeInteger,
       compositorSourceTextureCacheFlushes: nonNegativeInteger,
-      compositorMetalCachedCaptureSourceImportsLiveCount: optionalSchema(nonNegativeInteger),
-      compositorMetalCachedCaptureSourceImportsPeakCount: optionalSchema(nonNegativeInteger),
-      compositorMetalCachedCaptureSourceImportsCeiling: optionalSchema(nonNegativeInteger),
-      compositorMetalTargetRingSlotsLiveCount: optionalSchema(nonNegativeInteger),
-      compositorMetalTargetRingSlotsPeakCount: optionalSchema(nonNegativeInteger),
-      compositorMetalTargetRingSlotsCeiling: optionalSchema(nonNegativeInteger),
-      encoderBridgeMetalTargetRefsInFlightLiveCount: optionalSchema(nonNegativeInteger),
-      encoderBridgeMetalTargetRefsInFlightPeakCount: optionalSchema(nonNegativeInteger),
-      encoderBridgeMetalTargetRefsInFlightCeiling: optionalSchema(nonNegativeInteger),
-      nativePreviewIosurfaceImportLiveCount: optionalSchema(nonNegativeInteger),
-      nativePreviewIosurfaceImportPeakCount: optionalSchema(nonNegativeInteger),
-      nativePreviewIosurfaceImportCeiling: optionalSchema(nonNegativeInteger),
+      compositorMetalCachedCaptureSourceImportsLiveCount: optionalSchema(
+        nullableSchema(nonNegativeInteger)
+      ),
+      compositorMetalCachedCaptureSourceImportsPeakCount: optionalSchema(
+        nullableSchema(nonNegativeInteger)
+      ),
+      compositorMetalCachedCaptureSourceImportsCeiling: optionalSchema(
+        nullableSchema(nonNegativeInteger)
+      ),
+      compositorMetalTargetRingSlotsLiveCount: optionalSchema(nullableSchema(nonNegativeInteger)),
+      compositorMetalTargetRingSlotsPeakCount: optionalSchema(nullableSchema(nonNegativeInteger)),
+      compositorMetalTargetRingSlotsCeiling: optionalSchema(nullableSchema(nonNegativeInteger)),
+      encoderBridgeMetalTargetRefsInFlightLiveCount: optionalSchema(
+        nullableSchema(nonNegativeInteger)
+      ),
+      encoderBridgeMetalTargetRefsInFlightPeakCount: optionalSchema(
+        nullableSchema(nonNegativeInteger)
+      ),
+      encoderBridgeMetalTargetRefsInFlightCeiling: optionalSchema(
+        nullableSchema(nonNegativeInteger)
+      ),
+      nativePreviewIosurfaceImportLiveCount: optionalSchema(nullableSchema(nonNegativeInteger)),
+      nativePreviewIosurfaceImportPeakCount: optionalSchema(nullableSchema(nonNegativeInteger)),
+      nativePreviewIosurfaceImportCeiling: optionalSchema(nullableSchema(nonNegativeInteger)),
       previewCameraCaptureCallbackCount: nonNegativeInteger,
       previewCameraDidDropCallbackCount: nonNegativeInteger,
       previewCameraFrameStorePublications: nonNegativeInteger,

--- a/apps/desktop/src/shared/backend.ts
+++ b/apps/desktop/src/shared/backend.ts
@@ -2306,29 +2306,29 @@ export interface DiagnosticStats {
   /** Completed-command boundaries that flushed the CoreVideo Metal texture cache. */
   compositorSourceTextureCacheFlushes: number
   /** Cached capture-source CVMetalTexture/IOSurface imports retained process-wide. */
-  compositorMetalCachedCaptureSourceImportsLiveCount?: number
+  compositorMetalCachedCaptureSourceImportsLiveCount?: number | null
   /** Peak cached capture-source imports retained process-wide. */
-  compositorMetalCachedCaptureSourceImportsPeakCount?: number
+  compositorMetalCachedCaptureSourceImportsPeakCount?: number | null
   /** Peak bounded capture-source cache capacity observed process-wide. */
-  compositorMetalCachedCaptureSourceImportsCeiling?: number
+  compositorMetalCachedCaptureSourceImportsCeiling?: number | null
   /** IOSurface-backed Metal target-ring slots currently retained process-wide. */
-  compositorMetalTargetRingSlotsLiveCount?: number
+  compositorMetalTargetRingSlotsLiveCount?: number | null
   /** Peak IOSurface-backed Metal target-ring slots retained process-wide. */
-  compositorMetalTargetRingSlotsPeakCount?: number
+  compositorMetalTargetRingSlotsPeakCount?: number | null
   /** Peak target-ring capacity; each compositor contributes the actual hard maximum of five. */
-  compositorMetalTargetRingSlotsCeiling?: number
+  compositorMetalTargetRingSlotsCeiling?: number | null
   /** Encoder guards currently retaining compositor target frames. */
-  encoderBridgeMetalTargetRefsInFlightLiveCount?: number
+  encoderBridgeMetalTargetRefsInFlightLiveCount?: number | null
   /** Peak encoder guards retaining compositor target frames. */
-  encoderBridgeMetalTargetRefsInFlightPeakCount?: number
+  encoderBridgeMetalTargetRefsInFlightPeakCount?: number | null
   /** Peak bounded in-flight capacity derived from the target-ring authorities. */
-  encoderBridgeMetalTargetRefsInFlightCeiling?: number
+  encoderBridgeMetalTargetRefsInFlightCeiling?: number | null
   /** Native-presenter cached IOSurface imports currently retained. */
-  nativePreviewIosurfaceImportLiveCount?: number
+  nativePreviewIosurfaceImportLiveCount?: number | null
   /** Peak native-presenter cached IOSurface imports retained. */
-  nativePreviewIosurfaceImportPeakCount?: number
+  nativePreviewIosurfaceImportPeakCount?: number | null
   /** Hard cached-IOSurface import bound reported by the active presenter. */
-  nativePreviewIosurfaceImportCeiling?: number
+  nativePreviewIosurfaceImportCeiling?: number | null
   /** Cumulative live-source zero-copy import attempts that fell back to byte upload. */
   compositorSourceImportFailures: number
   /** Cumulative camera frames imported from IOSurface storage into Metal. */

--- a/docs/releases/release-runbook.md
+++ b/docs/releases/release-runbook.md
@@ -560,8 +560,18 @@ eight-subject directory, the isolated GitHub attestation, and all six
 independently downloaded public byte strings against the accepted seal and
 receipt mappings. The satisfied record retains the complete embedded
 attestation bundle, not only its digest. Commit that satisfied record. Later
-macOS releases must descend from the exact first publication and still run the
-recurring 60-minute idle and 15-minute recording synthetic gates. The
+macOS releases must descend from the exact first publication and must not change
+native capture, retention, recovery, diagnostics, dependencies, or the D3 gate
+definitions without collecting and publishing fresh D3 evidence. Committed
+edits, deletions, and both sides of renames are checked from the first
+publication commit. Release documentation and a reviewed, named allowlist of
+unrelated paths (UI surfaces, account/provider/chat integrations, updater and
+import helpers, and the two cfg-gated Windows-only backend capture modules)
+stay allowed; any other production path fails closed until it is deliberately
+added to that allowlist or fresh D3 evidence is collected. Case-variant paths
+that collide with guarded files on a case-insensitive filesystem classify as
+sensitive. Later releases still run the recurring 60-minute idle and
+15-minute recording synthetic gates. The
 acceptance record stores hashes and bounded summaries, not twelve hours of raw
 media; retain the immutable raw evidence, seal receipt, publication receipt,
 exact subject directory, public downloads, and attestation bundle in protected

--- a/scripts/lib/capture-decay-publication-git.mjs
+++ b/scripts/lib/capture-decay-publication-git.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
+import { isDeepStrictEqual, promisify } from 'node:util'
 
 import {
   assertCaptureDecayD3AcceptanceRecord,
@@ -10,6 +10,7 @@ import {
 const execFileAsync = promisify(execFile)
 const DEFAULT_BRANCH = 'main'
 const DEFAULT_REPOSITORY = 'TheOrcDev/videorc'
+const DESKTOP_PACKAGE_PATH = 'apps/desktop/package.json'
 
 export class CaptureDecayPublicationRefError extends Error {
   constructor(code, message, options) {
@@ -76,34 +77,9 @@ export async function assertCaptureDecayD3PublicationGate({
   const record = assertCaptureDecayD3AcceptanceRecord(
     await readCaptureDecayD3AcceptanceRecord(recordPath)
   )
-  const headCommit = await gitText(repoRoot, ['rev-parse', 'HEAD'])
-  if (record.status === 'accepted') {
-    const candidateCommit = record.candidate.sourceCommit
-    const candidateIsAncestor = await gitIsAncestor(repoRoot, candidateCommit, headCommit)
-    const changedPaths = await gitLines(repoRoot, [
-      'diff',
-      '--name-only',
-      '--diff-filter=ACDMRTUXB',
-      `${candidateCommit}..${headCommit}`,
-      '--'
-    ])
-    assertCaptureDecayD3PublicationSourceState(record, {
-      candidateIsAncestor,
-      changedPaths,
-      publicationSourceIsAncestor: false
-    })
-  } else {
-    const publicationSourceCommit = record.publicationReceipt.publicationSourceCommit
-    assertCaptureDecayD3PublicationSourceState(record, {
-      candidateIsAncestor: false,
-      changedPaths: [],
-      publicationSourceIsAncestor: await gitIsAncestor(
-        repoRoot,
-        publicationSourceCommit,
-        headCommit
-      )
-    })
-  }
+  const sourceState = await captureDecayD3PublicationSourceState({ record, repoRoot })
+  assertCaptureDecayD3PublicationSourceState(record, sourceState)
+  const { headCommit } = sourceState
   return { headCommit, protectedRef, record }
 }
 
@@ -353,25 +329,69 @@ export async function captureDecayD3PublicationSourceState({ record, repoRoot })
     return {
       headCommit,
       candidateIsAncestor: await gitIsAncestor(repoRoot, candidateCommit, headCommit),
-      changedPaths: await gitLines(repoRoot, [
-        'diff',
-        '--name-only',
-        '--diff-filter=ACDMRTUXB',
-        `${candidateCommit}..${headCommit}`,
-        '--'
-      ]),
+      changedPaths: await captureDecayD3CommittedChangedPaths({
+        fromCommit: candidateCommit,
+        repoRoot,
+        toCommit: headCommit
+      }),
       publicationSourceIsAncestor: false
     }
   }
+  const publicationSourceCommit = valid.publicationReceipt.publicationSourceCommit
+  const changedPaths = await captureDecayD3CommittedChangedPaths({
+    fromCommit: publicationSourceCommit,
+    repoRoot,
+    toCommit: headCommit
+  })
   return {
     headCommit,
     candidateIsAncestor: false,
-    changedPaths: [],
-    publicationSourceIsAncestor: await gitIsAncestor(
-      repoRoot,
-      valid.publicationReceipt.publicationSourceCommit,
-      headCommit
-    )
+    changedPaths,
+    desktopPackageVersionOnlyChange:
+      changedPaths.includes(DESKTOP_PACKAGE_PATH) &&
+      (await captureDecayD3DesktopPackageVersionOnlyChange({
+        fromCommit: publicationSourceCommit,
+        repoRoot,
+        toCommit: headCommit
+      })),
+    publicationSourceIsAncestor: await gitIsAncestor(repoRoot, publicationSourceCommit, headCommit)
+  }
+}
+
+export async function captureDecayD3CommittedChangedPaths({
+  fromCommit,
+  repoRoot,
+  toCommit = 'HEAD'
+}) {
+  return await gitNulFields(repoRoot, [
+    'diff',
+    '--name-only',
+    '-z',
+    '--no-renames',
+    '--diff-filter=ACDMRTUXB',
+    `${fromCommit}..${toCommit}`,
+    '--'
+  ])
+}
+
+export async function captureDecayD3DesktopPackageVersionOnlyChange({
+  fromCommit,
+  repoRoot,
+  toCommit = 'HEAD'
+}) {
+  try {
+    const [before, after] = await Promise.all([
+      gitJsonAtCommit(repoRoot, fromCommit, DESKTOP_PACKAGE_PATH),
+      gitJsonAtCommit(repoRoot, toCommit, DESKTOP_PACKAGE_PATH)
+    ])
+    if (typeof before.version !== 'string' || typeof after.version !== 'string') return false
+    const beforeWithoutVersion = { ...before }
+    const afterWithoutVersion = { ...after }
+    delete beforeWithoutVersion.version
+    delete afterWithoutVersion.version
+    return isDeepStrictEqual(beforeWithoutVersion, afterWithoutVersion)
+  } catch {
+    return false
   }
 }
 
@@ -385,6 +405,15 @@ async function gitIsAncestor(repoRoot, ancestor, descendant) {
     if (error?.code === 1) return false
     throw error
   }
+}
+
+async function gitJsonAtCommit(repoRoot, commit, path) {
+  const text = await gitText(repoRoot, ['show', `${commit}:${path}`])
+  const document = JSON.parse(text)
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    throw new Error(`Git JSON object is invalid: ${path}.`)
+  }
+  return document
 }
 
 async function resolvePublicationRef(repoRoot, ref, code) {
@@ -439,6 +468,15 @@ function publicationRefError(code, message, cause) {
 async function gitLines(repoRoot, args) {
   const text = await gitText(repoRoot, args)
   return text.length > 0 ? text.split('\n') : []
+}
+
+async function gitNulFields(repoRoot, args) {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024
+  })
+  return stdout.split('\0').filter((value) => value.length > 0)
 }
 
 async function gitText(repoRoot, args) {

--- a/scripts/lib/capture-decay-publication-git.test.mjs
+++ b/scripts/lib/capture-decay-publication-git.test.mjs
@@ -1,13 +1,19 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
 import { promisify } from 'node:util'
 
 import {
+  assertCaptureDecayD3SatisfiedSourceState,
+  captureDecayD3SensitiveChangedPaths
+} from './capture-decay-release-acceptance.mjs'
+import {
   assertCaptureDecayCurrentProtectedMain,
+  captureDecayD3CommittedChangedPaths,
+  captureDecayD3DesktopPackageVersionOnlyChange,
   assertCaptureDecayD3PublicationMode,
   assertCaptureDecayD3PublicationTrackedTreeClean,
   assertCaptureDecayProtectedPublicationRef,
@@ -91,6 +97,137 @@ describe('capture-decay publication tracked source boundary', () => {
       await assert.rejects(
         assertCaptureDecayD3PublicationTrackedTreeClean({ repoRoot: repository }),
         /tracked source changes/
+      )
+    })
+  })
+})
+
+describe('satisfied capture-decay committed drift boundary', () => {
+  it('reports committed edits, deletes, and both sides of renames without UI/docs noise loss', async () => {
+    await withGitRepository(async (repository) => {
+      const backendDir = join(repository, 'crates/videorc-backend/src')
+      const scriptDir = join(repository, 'scripts')
+      const uiDir = join(repository, 'apps/desktop/src/renderer/src/components/ui')
+      const docsDir = join(repository, 'docs/releases')
+      await Promise.all(
+        [backendDir, scriptDir, uiDir, docsDir].map((directory) =>
+          mkdir(directory, { recursive: true })
+        )
+      )
+      const recoveryPath = join(backendDir, 'capture_recovery.rs')
+      const gatePath = join(scriptDir, 'smoke-capture-decay-soak.mjs')
+      const uiPath = join(uiDir, 'button.tsx')
+      const runbookPath = join(docsDir, 'release-runbook.md')
+      await writeFile(recoveryPath, 'pub fn recover() {}\n')
+      await writeFile(gatePath, 'export const gate = true\n')
+      await writeFile(uiPath, 'export const AboutTab = null\n')
+      await writeFile(runbookPath, '# Release\n')
+      await execFileAsync('git', ['add', '.'], { cwd: repository })
+      await execFileAsync('git', ['commit', '--quiet', '-m', 'published D3 source'], {
+        cwd: repository
+      })
+      const publicationSourceCommit = await gitHead(repository)
+
+      const renamedPath = join(docsDir, 'capture-recovery-history.rs')
+      await rename(recoveryPath, renamedPath)
+      await rm(gatePath)
+      await writeFile(uiPath, 'export const AboutTab = "updated"\n')
+      await writeFile(runbookPath, '# Release\n\nUpdated after D3.\n')
+      await execFileAsync('git', ['add', '-A'], { cwd: repository })
+      await execFileAsync('git', ['commit', '--quiet', '-m', 'later release'], {
+        cwd: repository
+      })
+
+      const changedPaths = await captureDecayD3CommittedChangedPaths({
+        fromCommit: publicationSourceCommit,
+        repoRoot: repository
+      })
+      assert.deepEqual(changedPaths.sort(), [
+        'apps/desktop/src/renderer/src/components/ui/button.tsx',
+        'crates/videorc-backend/src/capture_recovery.rs',
+        'docs/releases/capture-recovery-history.rs',
+        'docs/releases/release-runbook.md',
+        'scripts/smoke-capture-decay-soak.mjs'
+      ])
+      assert.deepEqual(captureDecayD3SensitiveChangedPaths(changedPaths), [
+        'crates/videorc-backend/src/capture_recovery.rs',
+        'scripts/smoke-capture-decay-soak.mjs'
+      ])
+      assert.throws(
+        () =>
+          assertCaptureDecayD3SatisfiedSourceState({
+            changedPaths,
+            publicationSourceIsAncestor: true
+          }),
+        (error) => error?.code === 'satisfied-sensitive-source-diff'
+      )
+    })
+  })
+
+  it('allows only the desktop package version field to change after D3 publication', async () => {
+    await withGitRepository(async (repository) => {
+      const desktopDirectory = join(repository, 'apps/desktop')
+      const packagePath = join(desktopDirectory, 'package.json')
+      await mkdir(desktopDirectory, { recursive: true })
+      await writeFile(
+        packagePath,
+        `${JSON.stringify({ name: '@videorc/desktop', version: '1.0.0', scripts: { build: 'vite' } }, null, 2)}\n`
+      )
+      await execFileAsync('git', ['add', '.'], { cwd: repository })
+      await execFileAsync('git', ['commit', '--quiet', '-m', 'published D3 package'], {
+        cwd: repository
+      })
+      const publicationSourceCommit = await gitHead(repository)
+
+      await writeFile(
+        packagePath,
+        `${JSON.stringify({ name: '@videorc/desktop', version: '1.0.1', scripts: { build: 'vite' } }, null, 2)}\n`
+      )
+      await execFileAsync('git', ['add', '.'], { cwd: repository })
+      await execFileAsync('git', ['commit', '--quiet', '-m', 'bump release version'], {
+        cwd: repository
+      })
+      assert.equal(
+        await captureDecayD3DesktopPackageVersionOnlyChange({
+          fromCommit: publicationSourceCommit,
+          repoRoot: repository
+        }),
+        true
+      )
+      const versionChangedPaths = await captureDecayD3CommittedChangedPaths({
+        fromCommit: publicationSourceCommit,
+        repoRoot: repository
+      })
+      assert.deepEqual(
+        captureDecayD3SensitiveChangedPaths(versionChangedPaths, {
+          desktopPackageVersionOnlyChange: true
+        }),
+        []
+      )
+
+      await writeFile(
+        packagePath,
+        `${JSON.stringify({ name: '@videorc/desktop', version: '1.0.2', scripts: { build: 'vite --mode changed' } }, null, 2)}\n`
+      )
+      await execFileAsync('git', ['add', '.'], { cwd: repository })
+      await execFileAsync('git', ['commit', '--quiet', '-m', 'change build behavior'], {
+        cwd: repository
+      })
+      assert.equal(
+        await captureDecayD3DesktopPackageVersionOnlyChange({
+          fromCommit: publicationSourceCommit,
+          repoRoot: repository
+        }),
+        false
+      )
+      assert.deepEqual(
+        captureDecayD3SensitiveChangedPaths(
+          await captureDecayD3CommittedChangedPaths({
+            fromCommit: publicationSourceCommit,
+            repoRoot: repository
+          })
+        ),
+        ['apps/desktop/package.json']
       )
     })
   })

--- a/scripts/lib/capture-decay-release-acceptance.mjs
+++ b/scripts/lib/capture-decay-release-acceptance.mjs
@@ -58,6 +58,140 @@ export const CAPTURE_DECAY_D3_MAX_RECOVERY_DELAY_MS = 30 * 60 * 1_000
 export const CAPTURE_DECAY_D3_MAX_ATTESTATION_DELAY_MS = 5 * 60 * 1_000
 export const CAPTURE_DECAY_D3_ACCEPTANCE_RECORD_PATH = 'docs/acceptance/macos-capture-decay-d3.json'
 
+const CAPTURE_DECAY_D3_SENSITIVE_EXACT_PATHS = new Set([
+  '.npmrc',
+  'Cargo.lock',
+  'Cargo.toml',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'rust-toolchain',
+  'rust-toolchain.toml',
+  'apps/desktop/package.json',
+  'apps/desktop/scripts/release-upload.mjs',
+  'apps/desktop/build-resources/entitlements.mac.plist',
+  'apps/desktop/electron-builder.yml',
+  'apps/desktop/electron.vite.config.ts',
+  'apps/desktop/tsconfig.json',
+  'apps/desktop/tsconfig.node.json',
+  'apps/desktop/tsconfig.web.json',
+  'apps/desktop/src/renderer/index.html',
+  'apps/desktop/src/renderer/theme-bootstrap.js',
+  '.github/workflows/promote-macos-capture-decay-d3.yml',
+  '.github/workflows/release-macos.yml',
+  'scripts/build-ffmpeg-macos.sh'
+])
+const CAPTURE_DECAY_D3_SENSITIVE_PREFIXES = Object.freeze([
+  'crates/videorc-native-preview-addon/',
+  'patches/'
+])
+const CAPTURE_DECAY_D3_PRODUCTION_PREFIXES = Object.freeze([
+  'apps/desktop/src/main/',
+  'apps/desktop/src/preload/',
+  'apps/desktop/src/shared/',
+  'apps/desktop/src/renderer/',
+  'crates/videorc-backend/'
+])
+const CAPTURE_DECAY_D3_SAFE_PRODUCTION_PATHS = Object.freeze([
+  /^apps\/desktop\/src\/main\/(?:account-refresh-broker|account-sign-in-transactions|avatar-cache|comments-command-broker|comments-history-cache|global-shortcut-lifecycle|obs-import|provider-oauth-callbacks|updater|updater-install|updater-status|windows-pilot-update)(?:\.test)?\.ts$/,
+  /^apps\/desktop\/src\/shared\/(?:comments-command-timing|comments-send-operation|comments-snapshot-delta|oauth-callback-policy|windows-live-audio-smoke)(?:\.test)?\.ts$/,
+  /^apps\/desktop\/src\/renderer\/src\/assets\/videorc-logo\.png$/,
+  /^apps\/desktop\/src\/renderer\/src\/components\/ui\//,
+  /^apps\/desktop\/src\/renderer\/src\/components\/(?:account-menu|chat-platform-icon|cohost-flag-row|cohost-nudge|cohost-pane|cohost-question-row|cohost-settings-section|cohost-status|comment-row|comments-destination-status|comments-reader|live-chat-panel|theme-toggle|whats-new-dialog|workspace-nav)(?:\.test)?\.tsx?$/,
+  /^apps\/desktop\/src\/renderer\/src\/hooks\/(?:use-account|use-modifier-held|use-reduced-motion|use-theme-toggle|use-updater|use-whats-new)(?:\.test)?\.tsx?$/,
+  /^apps\/desktop\/src\/renderer\/src\/lib\/(?:account(?:-callback-retry|-ready-refresh|-snapshot-policy)?|ai-readiness|ai-workflow-status|chat-avatar|chat-send|cohost-presence|cohost-view|library-view|live-chat-view|noise-cleanup-view|obs-import-apply|obs-import-map|obs-import-nudge|obs-import-read-authority|platform|premium-upgrade|provider-oauth-retry|stream-key-format|update-ui|utils|videorc-web-links|viewer-count-view|whats-new|youtube-channels|youtube-transition)(?:\.test)?\.tsx?$/,
+  // format.ts owns isActiveRecordingState/findDevice/mergeStreamHealth: capture-facing, so NOT safe.
+  /^crates\/videorc-backend\/src\/(?:account|ai|cohost|live_chat|live_chat_persistence|oauth|publish_clips|secrets|twitch|twitch_chat|videorc_api|viewer_stats|x_chat|x_live|x_oauth1|youtube|youtube_chat)\.rs$/,
+  // Only these two backend Windows modules are #[cfg(target_os = "windows")]-gated at their mod
+  // declarations; every windows_d3d11_* module compiles into (and partly runs inside) the macOS
+  // backend, so those stay sensitive.
+  /^crates\/videorc-backend\/src\/(?:windows_graphics_capture|windows_media_foundation_encoder)\.rs$/,
+  /^crates\/videorc-backend\/tests\/content_length_wire\.rs$/
+])
+export const CAPTURE_DECAY_D3_SCRIPT_DEPENDENCY_PATHS = Object.freeze([
+  'apps/desktop/scripts/staple-dmg.mjs',
+  'scripts/check-real-source-evidence.mjs',
+  'scripts/build-native-preview-addon.mjs',
+  'scripts/generate-macos-beta-manifest.mjs',
+  'scripts/preflight-macos-package.mjs',
+  'scripts/preflight-macos-release-upload.mjs',
+  'scripts/preflight-macos-release.mjs',
+  'scripts/real-source-baseline-app.mjs',
+  'scripts/run-with-env.mjs',
+  'scripts/smoke-noise-cleanup.mjs',
+  'scripts/smoke-recording-session-decay.mjs',
+  'scripts/smoke-recording-session.mjs',
+  'scripts/upload-macos-beta-release.mjs',
+  'scripts/validate-macos-release-artifact.mjs',
+  'scripts/lib/acceptance-gate.mjs',
+  'scripts/lib/app-launcher.mjs',
+  'scripts/lib/av-sync-stimulus.mjs',
+  'scripts/lib/beta-release-manifest.mjs',
+  'scripts/lib/changelog.mjs',
+  'scripts/lib/ffmpeg-sibling-paths.mjs',
+  'scripts/lib/final-recording-path.mjs',
+  'scripts/lib/frame-cadence.mjs',
+  'scripts/lib/macos-release-artifact-validation.mjs',
+  'scripts/lib/macos-release-preflight.mjs',
+  'scripts/lib/media-quality-mode.mjs',
+  'scripts/lib/native-preview-claim.mjs',
+  'scripts/lib/native-preview-addon-build.mjs',
+  'scripts/lib/noise-cleanup-artifact.mjs',
+  'scripts/lib/notes-overlay-artifact-gate.mjs',
+  'scripts/lib/obs-parity-evidence.mjs',
+  'scripts/lib/performance-budget.mjs',
+  'scripts/lib/performance-contract.mjs',
+  'scripts/lib/performance-sampling-schedule.mjs',
+  'scripts/lib/process-census.mjs',
+  'scripts/lib/process-endurance.mjs',
+  'scripts/lib/process-memory-gate.mjs',
+  'scripts/lib/real-source-evidence-gates.mjs',
+  'scripts/lib/recording-analyzer.mjs',
+  'scripts/lib/recording-duration-gate.mjs',
+  'scripts/lib/recording-smoke-guards.mjs',
+  'scripts/lib/repair-encoder-capabilities.mjs',
+  'scripts/lib/release-upload-https-transport.mjs',
+  'scripts/lib/release-upload-s3.mjs',
+  'scripts/lib/required-source-blockers.mjs',
+  'scripts/lib/run-with-env.mjs',
+  'scripts/lib/screen-motion-stimulus.mjs',
+  'scripts/lib/session-decay-gates.mjs',
+  'scripts/lib/smoke-command-client.mjs',
+  'scripts/lib/smoke-output-guards.mjs',
+  'scripts/lib/source-preflight.mjs',
+  'scripts/lib/source-selection.mjs',
+  'scripts/lib/startup-resolution-analyzer.mjs',
+  'scripts/lib/windows-alpha-release.mjs',
+  'scripts/lib/windows-release-publication.mjs'
+])
+const CAPTURE_DECAY_D3_SENSITIVE_SCRIPT_PATHS = new Set(CAPTURE_DECAY_D3_SCRIPT_DEPENDENCY_PATHS)
+const CAPTURE_DECAY_D3_NAMED_SCRIPT_PATH =
+  /^scripts\/(?:lib\/)?(?:[^/]*capture-decay[^/]*|[^/]*macos-d3[^/]*)\.mjs$/
+const CAPTURE_DECAY_D3_MANIFEST_PATH =
+  /^(?:apps\/desktop|crates\/videorc-backend|crates\/videorc-native-preview-addon)\/(?:[^/]+\/)*(?:Cargo\.toml|package\.json|tsconfig[^/]*\.json)$/
+const CAPTURE_DECAY_D3_VITE_CONFIG_PATH =
+  /^apps\/desktop\/electron\.vite\.config(?:\.[^/]+)?\.(?:mjs|ts)$/
+// Case-insensitive shadows of every sensitivity trigger: on case-insensitive release
+// filesystems (APFS), a committed case-variant path clobbers the genuine guarded file,
+// so any collision with a guarded root classifies sensitive.
+const CAPTURE_DECAY_D3_FOLDED_GUARDED_EXACT_PATHS = new Set(
+  [...CAPTURE_DECAY_D3_SENSITIVE_EXACT_PATHS, ...CAPTURE_DECAY_D3_SCRIPT_DEPENDENCY_PATHS].map(
+    (guardedPath) => guardedPath.toLowerCase()
+  )
+)
+const CAPTURE_DECAY_D3_FOLDED_GUARDED_PREFIXES = Object.freeze(
+  [...CAPTURE_DECAY_D3_SENSITIVE_PREFIXES, ...CAPTURE_DECAY_D3_PRODUCTION_PREFIXES].map((prefix) =>
+    prefix.toLowerCase()
+  )
+)
+const CAPTURE_DECAY_D3_FOLDED_GUARDED_PATTERNS = Object.freeze(
+  [
+    CAPTURE_DECAY_D3_MANIFEST_PATH,
+    CAPTURE_DECAY_D3_VITE_CONFIG_PATH,
+    CAPTURE_DECAY_D3_NAMED_SCRIPT_PATH
+  ].map((pattern) => new RegExp(pattern.source, 'i'))
+)
+
 const CAPTURE_DECAY_D3_PUBLICATION_RESERVATION_PROFILE =
   'capture-decay-d3-publication-reservation-v3'
 const CAPTURE_DECAY_D3_EXACT_PROMOTION_MODE = 'exact-sealed-candidate'
@@ -1285,7 +1419,12 @@ export function buildSatisfiedCaptureDecayD3Record(
 
 export function assertCaptureDecayD3PublicationSourceState(
   record,
-  { candidateIsAncestor, changedPaths = [], publicationSourceIsAncestor }
+  {
+    candidateIsAncestor,
+    changedPaths,
+    desktopPackageVersionOnlyChange = false,
+    publicationSourceIsAncestor
+  }
 ) {
   const valid = assertCaptureDecayD3AcceptanceRecord(record)
   if (valid.status === 'accepted') {
@@ -1301,13 +1440,76 @@ export function assertCaptureDecayD3PublicationSourceState(
         'Accepted D3 publication permits only the committed acceptance-record change after the tested commit.'
       )
     }
-  } else if (publicationSourceIsAncestor !== true) {
+  } else {
+    assertCaptureDecayD3SatisfiedSourceState({
+      changedPaths,
+      desktopPackageVersionOnlyChange,
+      publicationSourceIsAncestor
+    })
+  }
+  return valid
+}
+
+export function assertCaptureDecayD3SatisfiedSourceState({
+  changedPaths,
+  desktopPackageVersionOnlyChange = false,
+  publicationSourceIsAncestor
+}) {
+  if (publicationSourceIsAncestor !== true) {
     throw acceptanceError(
       'satisfied-publication-ancestry',
       'The validated first D3 publication is not an ancestor of this later release.'
     )
   }
-  return valid
+  const sensitivePaths = captureDecayD3SensitiveChangedPaths(changedPaths, {
+    desktopPackageVersionOnlyChange
+  })
+  if (sensitivePaths.length > 0) {
+    throw acceptanceError(
+      'satisfied-sensitive-source-diff',
+      `Later macOS release changes invalidate satisfied D3 evidence: ${sensitivePaths.join(', ')}.`
+    )
+  }
+  return sensitivePaths
+}
+
+export function captureDecayD3SensitiveChangedPaths(
+  changedPaths,
+  { desktopPackageVersionOnlyChange = false } = {}
+) {
+  if (!Array.isArray(changedPaths)) {
+    throw acceptanceError(
+      'satisfied-source-diff-invalid',
+      'Later macOS release changed paths must be an array.'
+    )
+  }
+  return changedPaths.filter((path) =>
+    isCaptureDecayD3SensitivePath(path, { desktopPackageVersionOnlyChange })
+  )
+}
+
+function isCaptureDecayD3SensitivePath(path, { desktopPackageVersionOnlyChange }) {
+  if (typeof path !== 'string' || path.length === 0 || path.includes('\\')) return true
+  if (path.split('/').some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    return true
+  }
+  if (path === 'apps/desktop/package.json' && desktopPackageVersionOnlyChange === true) {
+    return false
+  }
+  if (CAPTURE_DECAY_D3_SENSITIVE_EXACT_PATHS.has(path)) return true
+  if (CAPTURE_DECAY_D3_SENSITIVE_PREFIXES.some((prefix) => path.startsWith(prefix))) return true
+  if (CAPTURE_DECAY_D3_MANIFEST_PATH.test(path)) return true
+  if (CAPTURE_DECAY_D3_VITE_CONFIG_PATH.test(path)) return true
+  if (CAPTURE_DECAY_D3_SENSITIVE_SCRIPT_PATHS.has(path)) return true
+  if (CAPTURE_DECAY_D3_NAMED_SCRIPT_PATH.test(path)) return true
+  if (CAPTURE_DECAY_D3_SAFE_PRODUCTION_PATHS.some((pattern) => pattern.test(path))) return false
+  if (CAPTURE_DECAY_D3_PRODUCTION_PREFIXES.some((prefix) => path.startsWith(prefix))) return true
+  const folded = path.toLowerCase()
+  return (
+    CAPTURE_DECAY_D3_FOLDED_GUARDED_EXACT_PATHS.has(folded) ||
+    CAPTURE_DECAY_D3_FOLDED_GUARDED_PREFIXES.some((prefix) => folded.startsWith(prefix)) ||
+    CAPTURE_DECAY_D3_FOLDED_GUARDED_PATTERNS.some((pattern) => pattern.test(folded))
+  )
 }
 
 export function assertCaptureDecayD3AcceptanceRecord(record) {

--- a/scripts/lib/capture-decay-release-acceptance.test.mjs
+++ b/scripts/lib/capture-decay-release-acceptance.test.mjs
@@ -3,7 +3,7 @@ import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
 import { describe, it } from 'node:test'
 import { promisify } from 'node:util'
 
@@ -33,6 +33,7 @@ import {
   CAPTURE_DECAY_D3_ACCEPTANCE_RECORD_PATH,
   CAPTURE_DECAY_D3_EVIDENCE_PROFILE,
   CAPTURE_DECAY_D3_PUBLICATION_RECEIPT_PROFILE,
+  CAPTURE_DECAY_D3_SCRIPT_DEPENDENCY_PATHS,
   CAPTURE_DECAY_DEBUG_RUNNER_PROVENANCE_PROFILE,
   CAPTURE_DECAY_REAL_RELEASE_RATE_FRACTION,
   CAPTURE_DECAY_REAL_RELEASE_SOAK_MINUTES,
@@ -47,6 +48,7 @@ import {
   buildCaptureDecayRunAttestation,
   buildSatisfiedCaptureDecayD3Record,
   captureDecayCanonicalJsonSha256,
+  captureDecayD3SensitiveChangedPaths,
   captureDecayD3PublicationAttestationSubjectSha256s,
   captureDecayRunCoordinates,
   loadAndValidateCaptureDecayD3Evidence,
@@ -1425,6 +1427,33 @@ describe('pending -> accepted -> satisfied publication state', () => {
     }
   })
 
+  it('classifies every transitive D3 gate script dependency as sensitive', async () => {
+    const repositoryRoot = resolve(import.meta.dirname, '..', '..')
+    for (const dependencyPath of CAPTURE_DECAY_D3_SCRIPT_DEPENDENCY_PATHS) {
+      await assert.doesNotReject(
+        readFile(join(repositoryRoot, ...dependencyPath.split('/'))),
+        `missing declared D3 script dependency ${dependencyPath}`
+      )
+    }
+    const gatePaths = await captureDecayD3GateScriptClosure()
+    for (const expectedPath of [
+      'apps/desktop/scripts/staple-dmg.mjs',
+      'scripts/smoke-capture-decay-soak.mjs',
+      'scripts/smoke-noise-cleanup.mjs',
+      'scripts/smoke-recording-session-decay.mjs',
+      'scripts/upload-macos-beta-release.mjs',
+      'scripts/validate-macos-release-artifact.mjs',
+      'scripts/lib/capture-decay-release-acceptance.mjs',
+      'scripts/lib/release-upload-s3.mjs'
+    ]) {
+      assert.ok(gatePaths.includes(expectedPath), `missing D3 gate dependency ${expectedPath}`)
+    }
+    assert.deepEqual(
+      gatePaths.filter((path) => captureDecayD3SensitiveChangedPaths([path]).length !== 1),
+      []
+    )
+  })
+
   it('derives satisfied only from the exact accepted record and verified published release', () => {
     const accepted = buildAccepted(validate(validEvidence()))
     const publication = publicationFixture(accepted)
@@ -1469,7 +1498,15 @@ describe('pending -> accepted -> satisfied publication state', () => {
     assert.equal(
       assertCaptureDecayD3PublicationSourceState(satisfied, {
         candidateIsAncestor: false,
-        changedPaths: [],
+        changedPaths: [
+          'apps/desktop/package.json',
+          'apps/desktop/src/renderer/src/components/account-menu.tsx',
+          'apps/desktop/src/renderer/src/components/ui/button.tsx',
+          'apps/desktop/src/renderer/src/lib/update-ui.ts',
+          'crates/videorc-backend/src/youtube_chat.rs',
+          'docs/releases/release-runbook.md'
+        ],
+        desktopPackageVersionOnlyChange: true,
         publicationSourceIsAncestor: true
       }),
       satisfied
@@ -1483,6 +1520,159 @@ describe('pending -> accepted -> satisfied publication state', () => {
         }),
       hasCode('satisfied-publication-ancestry')
     )
+    const sensitiveChanges = [
+      '.github/workflows/release-macos.yml',
+      '.npmrc',
+      'Cargo.lock',
+      'apps/desktop/package.json',
+      'apps/desktop/electron.vite.config.1787864947110.mjs',
+      'apps/desktop/scripts/release-upload.mjs',
+      'apps/desktop/scripts/staple-dmg.mjs',
+      'apps/desktop/config/tsconfig.renderer.json',
+      'apps/desktop/tsconfig.web.json',
+      'apps/desktop/src/main/backend-bootstrap.ts',
+      'apps/desktop/src/main/future-capture-owner.ts',
+      'apps/desktop/src/preload/index.ts',
+      'apps/desktop/src/shared/backend-rpc-contract.ts',
+      'apps/desktop/src/shared/background-import.test.ts',
+      'apps/desktop/src/shared/background-import.ts',
+      'apps/desktop/src/shared/electron-ipc-contract.ts',
+      'apps/desktop/src/shared/future-runtime-owner.ts',
+      'apps/desktop/src/shared/renderer-security-policy.ts',
+      'apps/desktop/src/shared/runtime-schema.ts',
+      'apps/desktop/src/renderer/captions.html',
+      'apps/desktop/src/renderer/captions/main.tsx',
+      'apps/desktop/src/renderer/comments.html',
+      'apps/desktop/src/renderer/comments/main.tsx',
+      'apps/desktop/src/renderer/src/App.tsx',
+      'apps/desktop/src/renderer/index.html',
+      'apps/desktop/src/renderer/theme-bootstrap.js',
+      'apps/desktop/src/renderer/src/backendClient.ts',
+      'apps/desktop/src/renderer/src/assets/backgrounds/tutorial.webp',
+      'apps/desktop/src/renderer/src/assets/replacement.ts',
+      'apps/desktop/src/renderer/src/components/preview-stage.tsx',
+      'apps/desktop/src/renderer/src/components/source-select.tsx',
+      'apps/desktop/src/renderer/src/components/studio/quick-settings.tsx',
+      'apps/desktop/src/renderer/src/components/video-preset-select-items.tsx',
+      'apps/desktop/src/renderer/src/future-entry.tsx',
+      'apps/desktop/src/renderer/src/hooks/use-studio.tsx',
+      'apps/desktop/src/renderer/src/hooks/use-background-assets.test.tsx',
+      'apps/desktop/src/renderer/src/hooks/use-background-assets.tsx',
+      'apps/desktop/src/renderer/src/lib/background-assets.ts',
+      'apps/desktop/src/renderer/src/lib/caption-overlay.ts',
+      'apps/desktop/src/renderer/src/lib/captions-ui.test.ts',
+      'apps/desktop/src/renderer/src/lib/captions-ui.ts',
+      'apps/desktop/src/renderer/src/lib/captions-preflight.ts',
+      'apps/desktop/src/renderer/src/lib/capture.ts',
+      'apps/desktop/src/renderer/src/lib/comment-highlight.ts',
+      'apps/desktop/src/renderer/src/lib/format.test.ts',
+      'apps/desktop/src/renderer/src/lib/format.ts',
+      'apps/desktop/src/renderer/src/lib/entitlement-ui.ts',
+      'apps/desktop/src/renderer/src/lib/entitlements.ts',
+      'apps/desktop/src/renderer/src/lib/session-params.ts',
+      'apps/desktop/src/renderer/src/lib/session-runtime-recovery.ts',
+      'crates/videorc-backend/src/capture_recovery.rs',
+      'crates/videorc-backend/src/comment_highlight.rs',
+      'crates/videorc-backend/src/windows_d3d11_capture.rs',
+      'crates/videorc-backend/src/windows_d3d11_device.rs',
+      'crates/videorc-backend/src/windows_d3d11_shaders.hlsl',
+      'crates/videorc-backend/src/entitlements.rs',
+      'crates/videorc-backend/src/future_capture_owner.rs',
+      'crates/videorc-backend/src/posters.rs',
+      'crates/videorc-backend/vendor/helper/Cargo.toml',
+      'crates/videorc-native-preview-addon/vendor/helper/Cargo.toml',
+      'crates/videorc-native-preview-addon/src/lib.rs',
+      'scripts/build-ffmpeg-macos.sh',
+      'scripts/build-native-preview-addon.mjs',
+      'scripts/lib/native-preview-addon-build.mjs',
+      'scripts/lib/noise-cleanup-artifact.mjs',
+      'scripts/smoke-capture-decay-soak.mjs',
+      'scripts/smoke-noise-cleanup.mjs',
+      'scripts/validate-macos-release-artifact.mjs',
+      // Case-variant collisions with guarded roots clobber the genuine file on APFS.
+      'Apps/desktop/src/main/index.ts',
+      'Crates/videorc-backend/src/screen_capture.rs',
+      'CARGO.toml',
+      'cargo.toml',
+      'PNPM-LOCK.YAML',
+      'apps/Desktop/package.json',
+      'apps/desktop/TSCONFIG.json',
+      'Scripts/lib/capture-decay-release-acceptance.mjs',
+      'scripts/LIB/Macos-D3-sealed-candidate.mjs'
+    ]
+    assert.deepEqual(captureDecayD3SensitiveChangedPaths(sensitiveChanges), sensitiveChanges)
+    const safeChanges = [
+      '.github/workflows/windows.yml',
+      'apps/streamdeck-plugin/package.json',
+      'apps/streamdeck-plugin/tsconfig.json',
+      'apps/desktop/src/main/provider-oauth-callbacks.ts',
+      'apps/desktop/src/renderer/src/components/chat-platform-icon.tsx',
+      'apps/desktop/src/renderer/src/components/theme-toggle.tsx',
+      'apps/desktop/src/renderer/src/components/ui/button.tsx',
+      'apps/desktop/src/renderer/src/components/workspace-nav.test.ts',
+      'apps/desktop/src/renderer/src/components/workspace-nav.tsx',
+      'apps/desktop/src/renderer/src/assets/videorc-logo.png',
+      'apps/desktop/src/renderer/src/lib/chat-send.ts',
+      'apps/desktop/src/shared/comments-send-operation.ts',
+      'crates/videorc-backend/src/twitch_chat.rs',
+      'crates/videorc-backend/src/windows_graphics_capture.rs',
+      'crates/videorc-backend/src/windows_media_foundation_encoder.rs',
+      'crates/unrelated/Cargo.toml',
+      'docs/acceptance/macos-capture-decay-d3.json',
+      'docs/releases/release-runbook.md',
+      'examples/demo/tsconfig.json',
+      'packages/unrelated/package.json',
+      'scripts/smoke-platform-lifecycle.mjs'
+    ]
+    assert.deepEqual(captureDecayD3SensitiveChangedPaths(safeChanges), [])
+    assert.deepEqual(
+      captureDecayD3SensitiveChangedPaths(['apps/desktop/package.json'], {
+        desktopPackageVersionOnlyChange: true
+      }),
+      []
+    )
+    assert.deepEqual(
+      captureDecayD3SensitiveChangedPaths([
+        '',
+        '/absolute.ts',
+        '../escape.ts',
+        'mixed\\path.ts',
+        './crates/videorc-backend/src/state.rs',
+        'crates//videorc-backend/src/state.rs',
+        'crates/videorc-backend/src/./state.rs',
+        'docs/trailing/'
+      ]),
+      [
+        '',
+        '/absolute.ts',
+        '../escape.ts',
+        'mixed\\path.ts',
+        './crates/videorc-backend/src/state.rs',
+        'crates//videorc-backend/src/state.rs',
+        'crates/videorc-backend/src/./state.rs',
+        'docs/trailing/'
+      ]
+    )
+    assert.throws(
+      () =>
+        assertCaptureDecayD3PublicationSourceState(satisfied, {
+          candidateIsAncestor: false,
+          publicationSourceIsAncestor: true
+        }),
+      hasCode('satisfied-source-diff-invalid')
+    )
+    for (const changedPath of sensitiveChanges) {
+      assert.throws(
+        () =>
+          assertCaptureDecayD3PublicationSourceState(satisfied, {
+            candidateIsAncestor: false,
+            changedPaths: [changedPath],
+            publicationSourceIsAncestor: true
+          }),
+        hasCode('satisfied-sensitive-source-diff'),
+        changedPath
+      )
+    }
   })
 
   it('rejects premature/manual-looking satisfaction and wrong receipt/release/artifact chains', () => {
@@ -2895,6 +3085,164 @@ function publicationTlsPolicyFixture() {
     allowedIssuerOrganizations: ['Cloudflare, Inc.'],
     allowedSpkiSha256: ['a'.repeat(64)]
   }
+}
+
+async function captureDecayD3GateScriptClosure() {
+  const repositoryRoot = resolve(import.meta.dirname, '..', '..')
+  const packageDocument = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8'))
+  const desktopPackageDocument = JSON.parse(
+    await readFile(join(repositoryRoot, 'apps', 'desktop', 'package.json'), 'utf8')
+  )
+  const packageScopes = new Map([
+    ['root', { basePath: '', scripts: packageDocument.scripts ?? {} }],
+    ['desktop', { basePath: 'apps/desktop', scripts: desktopPackageDocument.scripts ?? {} }]
+  ])
+  const spawnedScriptEdges = new Map([
+    [
+      'scripts/create-capture-decay-debug-runner-provenance.mjs',
+      ['scripts/build-capture-decay-debug-runner.mjs']
+    ],
+    ['scripts/run-capture-decay-real-release.mjs', ['scripts/smoke-capture-decay-soak.mjs']],
+    [
+      'scripts/smoke-capture-decay-long-recording.mjs',
+      ['scripts/smoke-recording-session-decay.mjs']
+    ],
+    ['scripts/preflight-macos-package.mjs', ['scripts/smoke-noise-cleanup.mjs']],
+    ['scripts/lib/macos-d3-sealed-candidate.mjs', ['scripts/validate-macos-release-artifact.mjs']]
+  ])
+  const queuedPackageScripts = []
+  const visitedPackageScripts = new Set()
+  const queuedPaths = new Set()
+
+  const collectCommandReferences = (
+    command,
+    { basePath = '', followPackageScripts = false, scope = 'root' } = {}
+  ) => {
+    const currentScripts = packageScopes.get(scope)?.scripts ?? {}
+    for (const match of command.matchAll(/\bscripts\/[a-zA-Z0-9_./-]+\.(?:cjs|js|mjs|sh)\b/g)) {
+      queuedPaths.add([basePath, match[0]].filter(Boolean).join('/'))
+    }
+    if (!followPackageScripts) return
+    for (const match of command.matchAll(
+      /\bpnpm\s+--filter\s+@videorc\/desktop\s+([a-zA-Z0-9:_-]+)/g
+    )) {
+      if (typeof packageScopes.get('desktop').scripts[match[1]] === 'string') {
+        queuedPackageScripts.push({ name: match[1], scope: 'desktop' })
+      }
+    }
+    for (const match of command.matchAll(/\bpnpm(?:\s+--silent)?\s+([a-zA-Z0-9:_-]+)/g)) {
+      if (typeof currentScripts[match[1]] === 'string') {
+        queuedPackageScripts.push({ name: match[1], scope })
+      }
+    }
+  }
+
+  const rootPackageScripts = packageScopes.get('root').scripts
+  for (const name of Object.keys(rootPackageScripts)) {
+    if (/(?:capture-decay|macos-d3)/.test(name)) {
+      queuedPackageScripts.push({ name, scope: 'root' })
+    }
+  }
+  for (const name of [
+    'dist:desktop:release',
+    'release:upload:macos',
+    'release:upload:preflight:macos',
+    'release:validate:macos'
+  ]) {
+    queuedPackageScripts.push({ name, scope: 'root' })
+  }
+  for (const workflowPath of [
+    '.github/workflows/promote-macos-capture-decay-d3.yml',
+    '.github/workflows/release-macos.yml'
+  ]) {
+    collectCommandReferences(await readFile(join(repositoryRoot, workflowPath), 'utf8'))
+  }
+  while (queuedPackageScripts.length > 0) {
+    const { name, scope } = queuedPackageScripts.shift()
+    const identity = `${scope}:${name}`
+    if (visitedPackageScripts.has(identity)) continue
+    visitedPackageScripts.add(identity)
+    const packageScope = packageScopes.get(scope)
+    collectCommandReferences(packageScope.scripts[name], {
+      basePath: packageScope.basePath,
+      followPackageScripts: true,
+      scope
+    })
+  }
+
+  const closure = new Set()
+  const pendingPaths = [...queuedPaths]
+  while (pendingPaths.length > 0) {
+    const repositoryPath = pendingPaths.shift()
+    if (closure.has(repositoryPath)) continue
+    const absolutePath = join(repositoryRoot, ...repositoryPath.split('/'))
+    try {
+      const source = await readFile(absolutePath, 'utf8')
+      closure.add(repositoryPath)
+      for (const specifier of localStaticModuleSpecifiers(source)) {
+        const dependencyPath = await resolveLocalModulePath({
+          importerPath: absolutePath,
+          repositoryRoot,
+          specifier
+        })
+        if (!closure.has(dependencyPath)) pendingPaths.push(dependencyPath)
+      }
+      for (const spawnedPath of spawnedScriptEdges.get(repositoryPath) ?? []) {
+        assert.ok(
+          source.includes(basename(spawnedPath)),
+          `declared D3 spawn edge is absent: ${repositoryPath} -> ${spawnedPath}`
+        )
+        if (!closure.has(spawnedPath)) pendingPaths.push(spawnedPath)
+      }
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        assert.fail(`missing D3 gate dependency ${repositoryPath}`)
+      }
+      throw error
+    }
+  }
+  return [...closure].sort()
+}
+
+function localStaticModuleSpecifiers(source) {
+  const specifiers = new Set()
+  for (const pattern of [
+    /\b(?:import|export)\s+(?:[^'";]*?\s+from\s+)?['"]([^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g
+  ]) {
+    for (const match of source.matchAll(pattern)) {
+      if (match[1].startsWith('.')) specifiers.add(match[1])
+    }
+  }
+  return specifiers
+}
+
+async function resolveLocalModulePath({ importerPath, repositoryRoot, specifier }) {
+  const unresolved = resolve(dirname(importerPath), specifier)
+  const candidates = extname(unresolved)
+    ? [unresolved]
+    : [
+        unresolved,
+        ...['.cjs', '.js', '.json', '.mjs', '.ts', '.tsx'].map(
+          (extension) => `${unresolved}${extension}`
+        ),
+        ...['index.cjs', 'index.js', 'index.json', 'index.mjs', 'index.ts', 'index.tsx'].map(
+          (filename) => join(unresolved, filename)
+        )
+      ]
+  for (const candidatePath of candidates) {
+    try {
+      await readFile(candidatePath)
+      const repositoryPath = relative(repositoryRoot, candidatePath).split(sep).join('/')
+      if (repositoryPath === '..' || repositoryPath.startsWith('../')) {
+        assert.fail(`D3 gate dependency escapes the repository: ${specifier}`)
+      }
+      return repositoryPath
+    } catch (error) {
+      if (error?.code !== 'ENOENT' && error?.code !== 'EISDIR') throw error
+    }
+  }
+  assert.fail(`missing local D3 gate import ${specifier} from ${importerPath}`)
 }
 
 function canonical(value) {

--- a/scripts/smoke-platform-lifecycle.mjs
+++ b/scripts/smoke-platform-lifecycle.mjs
@@ -68,7 +68,7 @@ try {
   )
   assert.deepEqual(
     preparedYouTubeCompletionTargets(streaming).map((item) => item.id),
-    ['youtube-ready']
+    ['youtube-ready', 'youtube-no-stream', 'youtube-disabled']
   )
   assert.deepEqual(readyStreamTargetLabels(streaming), [
     'youtube-ready',


### PR DESCRIPTION
## Summary

Follow-up to #320 closing the remaining D3 release-safety gaps:

- **Diagnostics contract null-tolerance**: the 12 optional macOS Metal/IOSurface retention counters (`compositorMetalCachedCaptureSourceImports*`, `compositorMetalTargetRingSlots*`, `encoderBridgeMetalTargetRefsInFlight*`, `nativePreviewIosurfaceImport*`) may legitimately be `null` on the Rust wire. Runtime schemas and TS types now accept `null`, still reject negative values, and tests cover both RPC results and events.
- **Platform-lifecycle smoke**: the YouTube completion expectation now includes ready, no-stream, and disabled targets, matching the intentional merged behavior and existing unit tests.
- **Permanent D3 satisfied-release drift guard**: once a satisfied D3 acceptance record exists, later macOS releases in that lineage fail closed on any committed change to capture/runtime/dependency/build-sensitive paths without fresh D3 evidence.
  - NUL-delimited git paths with `--no-renames` so edits, deletions, and both sides of renames are all caught.
  - `apps/desktop/package.json` is safe only when its sole semantic change is the top-level `version`; scripts, dependencies, and build metadata stay sensitive.
  - Only the canonical accepted → satisfied record transition is permitted.
  - The Mac D3/build/release dependency closure (package scripts, workflows, static local imports, spawned-script edges) is classified sensitive, including Mac packaging helpers, FFmpeg/native-addon build inputs, entitlements, renderer entrypoints, scene backgrounds, caption/highlight overlay code, noise-cleanup artifact checks, and backend highlight compositing.
  - Manifest sensitivity is scoped to the desktop/backend/native-addon closure so unrelated workspace packages stay safe; unrelated paths pass via a reviewed, named allowlist, and any unlisted production path fails closed.
  - Adversarial review hardening: only the two `#[cfg(target_os = "windows")]`-gated backend modules are Windows-safe (all `windows_d3d11_*` compile into the macOS backend and are sensitive); `renderer/src/lib/format.ts` (owns `isActiveRecordingState`/`findDevice`/`mergeStreamHealth`) is sensitive; legacy `apps/desktop/scripts/release-upload.mjs` is sensitive; the path guard rejects `''`/`.`/`..` segments and classifies case-variant collisions with guarded roots as sensitive (APFS clobber protection).
- **Runbook**: documents the recurring-release drift rule, matching the fail-closed classifier behavior exactly.

## Verification

- `node --test scripts/lib/capture-decay-release-acceptance.test.mjs scripts/lib/capture-decay-publication-git.test.mjs` — 53/53
- `pnpm test:scripts` — full suite green
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `git diff --check` — green
- Desktop unit tests (169 files, 1,664 passed / 1 skipped), `pnpm build`, Rust fmt/tests/clippy, dependency audits — green on this tree
- Real-device smokes on the installed 0.9.84 baseline: `smoke:screen-recording-real`, `smoke:notes-window-invisible`, `smoke:recording-studio:devices` (31/31 stages), and `smoke:local-gates` incl. the 14/14 recording matrix, 3/3 session-decay passes, a 60-minute synthetic soak (1,795 samples), and a 15-minute hard-content recording
- Fresh adversarial review of the full 9-file diff surfaced 2 confirmed + 3 plausible findings (all fixed above); the re-review of the remediated diff reported no actionable findings, including a full-tree sweep (1,327 tracked files) showing the case-collision guard misfires on zero genuine paths

## Notes

This PR does not ship a release. The exact signed 0.9.85 candidate and the physical D3 acceptance ceremony (3×240-minute real-source 4K30 soaks + dual-source recovery + sealed evidence publication) remain separate, still-pending work blocked on signing identities, D3 candidate storage credentials, and the protected `macos-d3-release` environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic telemetry now accepts explicit `null` values for applicable capture, retention, and preview metrics.
  * Updated lifecycle smoke-test expectations to recognize additional completed YouTube states.

* **Release Validation**
  * Strengthened macOS release checks to detect sensitive source changes, renames, deletions, and case-insensitive path conflicts.
  * Version-only desktop package changes remain permitted without requiring new evidence.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->