### PR TITLE
release: 0.9.86-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.85",
+  "version": "0.9.86",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.86-beta.1.md
+++ b/changelog/0.9.86-beta.1.md
@@ -1,6 +1,6 @@
 ---
-version: 0.9.85-beta.1
-date: 2026-08-28
+version: 0.9.86-beta.1
+date: 2026-08-29
 channel: beta
 platforms:
   - macos
@@ -31,3 +31,7 @@ highlights:
   ownership, and preview-driver lifecycle edge cases found during the
   capture-decay investigation are closed, so recovery work can never race a
   session ending or leave orphaned capture state behind.
+- **Diagnostics hardening.** Retention diagnostics tolerate absent values
+  end to end, closing another door on the startup-stall defect class that
+  bit 0.9.68 and 0.9.79, and the release process guards its own acceptance
+  records against drift.


### PR DESCRIPTION
Bump + changelog for #320+#322. Supersedes never-published 0.9.85 (build was fully gated but held behind the record 3h TLS interception; #322 merged meanwhile). The withdrawn 0.9.85 entry never reached the published changelog. Long sentinels (60m idle PASS, 15m recording PASS) ran on `19b5d952`, whose `crates/` tree is byte-identical to this PR's base — #322 touched TS contract + scripts only; fast gates re-run on the merged tree before upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention diagnostics handling when values are unavailable.
  * Further reduced the risk of startup stalls related to diagnostics processing.

* **Chores**
  * Updated the desktop application to version 0.9.86.
  * Added release notes for version 0.9.86-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->