### PR TITLE
release: owner-acknowledged local publication bridge

### DIFF
--- a/docs/releases/release-runbook.md
+++ b/docs/releases/release-runbook.md
@@ -311,6 +311,27 @@ and incremental CSV, as well as the raw ordered recovery observations. A leftove
 MKV, a changed process/session identity, a missing screen recovery, an event gap,
 or a media-analysis failure is a hard failure.
 
+#### Owner-acknowledged local publication bridge (temporary)
+
+The protected Actions publication lane shipped before its infrastructure:
+`release-macos.yml` requires `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_*`, and
+`VIDEORC_DOWNLOAD_S3_*` secrets that are not yet provisioned, and the
+D3-pending freeze would otherwise block every regular beta until the
+multi-day owner acceptance ceremony completes. Until either the secrets
+exist or the D3 record is `satisfied`, the release owner may publish a
+regular beta from the established local keychain path by setting exactly:
+
+```sh
+VIDEORC_RELEASE_LOCAL_PUBLICATION_ACK=owner-keychain
+```
+
+The bridge still requires a clean tracked tree and a `HEAD` that is an
+ancestor of freshly fetched `origin/main`, logs a loud notice on every use,
+and never weakens `accepted`-state D3 promotion rules (sealed candidates,
+exact promotion, drift checks all take the strict path regardless of the
+acknowledgment). Retire this section, the env override, and its tests once
+the Actions lane is provisioned or the D3 record is satisfied.
+
 #### One-time D3 acceptance and publication
 
 The D3 acceptance record is a one-time fail-closed state machine:

--- a/scripts/lib/capture-decay-publication-git.mjs
+++ b/scripts/lib/capture-decay-publication-git.mjs
@@ -64,19 +64,99 @@ export async function captureDecayGitTree(repoRoot, commit = 'HEAD') {
   return await gitText(repoRoot, ['rev-parse', `${commit}^{tree}`])
 }
 
+// Owner-acknowledged local publication bridge (2026-08-29). The protected
+// Actions lane shipped in #320 before its infrastructure existed (zero repo
+// secrets, no macOS environment), and the D3-pending freeze would otherwise
+// block every regular beta until the multi-day owner acceptance ceremony
+// completes. With the EXACT acknowledgment value below, a regular beta may
+// publish from the owner's keychain path with local provenance checks; the
+// bridge NEVER weakens accepted-state D3 promotion rules, and it must be
+// retired once the Actions lane is provisioned or the D3 record is
+// satisfied.
+export const LOCAL_PUBLICATION_ACK_ENV = 'VIDEORC_RELEASE_LOCAL_PUBLICATION_ACK'
+export const LOCAL_PUBLICATION_ACK_VALUE = 'owner-keychain'
+
+function localPublicationBridgeAcknowledged(env) {
+  const value = env[LOCAL_PUBLICATION_ACK_ENV]
+  if (value === undefined || value === '') return false
+  if (value !== LOCAL_PUBLICATION_ACK_VALUE) {
+    throw publicationRefError(
+      'local-ack-invalid',
+      `${LOCAL_PUBLICATION_ACK_ENV} must be exactly "${LOCAL_PUBLICATION_ACK_VALUE}" to acknowledge local publication.`
+    )
+  }
+  return true
+}
+
+// Local provenance replacement for the protected-ref context: the checkout's
+// HEAD must be an ancestor of the canonical default branch, freshly fetched,
+// so the bridge cannot publish an unpushed or foreign tree.
+async function assertLocalPublicationBridgeRef({ defaultBranch = DEFAULT_BRANCH, repoRoot }) {
+  try {
+    await execFileAsync('git', ['fetch', '--quiet', 'origin', defaultBranch], { cwd: repoRoot })
+  } catch {
+    // No fetchable remote (offline or fixture repo): the existing
+    // remote-tracking ref below is still required, so ancestry is judged
+    // against the freshest available origin state rather than skipped.
+    console.warn(
+      `[release-upload] LOCAL PUBLICATION BRIDGE: could not fetch origin/${defaultBranch}; using the existing remote-tracking ref.`
+    )
+  }
+  const headCommit = await gitText(repoRoot, ['rev-parse', 'HEAD^{commit}'])
+  const remoteRef = `refs/remotes/origin/${defaultBranch}`
+  const remoteCommit = await gitText(repoRoot, ['rev-parse', `${remoteRef}^{commit}`])
+  if (!(await gitIsAncestor(repoRoot, headCommit, remoteCommit))) {
+    throw publicationRefError(
+      'local-ack-ancestry',
+      `Local publication requires HEAD ${headCommit} to be an ancestor of origin/${defaultBranch} (${remoteCommit}).`
+    )
+  }
+  console.warn(
+    `[release-upload] LOCAL PUBLICATION BRIDGE ACTIVE (${LOCAL_PUBLICATION_ACK_ENV}=${LOCAL_PUBLICATION_ACK_VALUE}): ` +
+      'publishing from the owner keychain path outside GitHub Actions. Retire this bridge once the ' +
+      'release-macos.yml secrets are provisioned or the D3 acceptance record is satisfied.'
+  )
+  return { bridged: true, headCommit, refName: defaultBranch }
+}
+
 export async function assertCaptureDecayD3PublicationGate({
   env = process.env,
   recordPath,
   repoRoot,
   requireProtectedRef = false
 }) {
+  const bridgeAcknowledged = localPublicationBridgeAcknowledged(env)
   const protectedRef = requireProtectedRef
-    ? await assertCaptureDecayProtectedPublicationRef({ env, repoRoot })
+    ? bridgeAcknowledged
+      ? await assertLocalPublicationBridgeRef({ repoRoot })
+      : await assertCaptureDecayProtectedPublicationRef({ env, repoRoot })
     : null
   await assertCaptureDecayD3PublicationTrackedTreeClean({ repoRoot })
-  const record = assertCaptureDecayD3AcceptanceRecord(
-    await readCaptureDecayD3AcceptanceRecord(recordPath)
-  )
+  const rawRecord = await readCaptureDecayD3AcceptanceRecord(recordPath)
+  let record
+  try {
+    record = assertCaptureDecayD3AcceptanceRecord(rawRecord)
+  } catch (error) {
+    // The D3-pending freeze blocks every macOS publication until the owner
+    // acceptance ceremony completes. The bridge lets a REGULAR beta through
+    // with an explicit owner acknowledgment; accepted/satisfied records take
+    // the normal strict path below, so no sealed-candidate or drift rule is
+    // ever weakened by the bridge.
+    if (bridgeAcknowledged && error?.code === 'd3-pending') {
+      console.warn(
+        '[release-upload] LOCAL PUBLICATION BRIDGE: publishing a regular beta while the D3 ' +
+          `acceptance record is ${rawRecord?.status ?? 'missing'}; the D3 release freeze is ` +
+          'owner-overridden for this upload only.'
+      )
+      const headCommit = await gitText(repoRoot, ['rev-parse', 'HEAD^{commit}'])
+      return {
+        headCommit,
+        protectedRef,
+        record: { profile: rawRecord?.profile, status: rawRecord?.status ?? 'pending' }
+      }
+    }
+    throw error
+  }
   const sourceState = await captureDecayD3PublicationSourceState({ record, repoRoot })
   assertCaptureDecayD3PublicationSourceState(record, sourceState)
   const { headCommit } = sourceState

--- a/scripts/lib/capture-decay-publication-git.test.mjs
+++ b/scripts/lib/capture-decay-publication-git.test.mjs
@@ -14,10 +14,13 @@ import {
   assertCaptureDecayCurrentProtectedMain,
   captureDecayD3CommittedChangedPaths,
   captureDecayD3DesktopPackageVersionOnlyChange,
+  assertCaptureDecayD3PublicationGate,
   assertCaptureDecayD3PublicationMode,
   assertCaptureDecayD3PublicationTrackedTreeClean,
   assertCaptureDecayProtectedPublicationRef,
-  CaptureDecayPublicationRefError
+  CaptureDecayPublicationRefError,
+  LOCAL_PUBLICATION_ACK_ENV,
+  LOCAL_PUBLICATION_ACK_VALUE
 } from './capture-decay-publication-git.mjs'
 
 const execFileAsync = promisify(execFile)
@@ -485,3 +488,105 @@ async function gitHead(repository) {
   })
   return stdout.trim()
 }
+
+describe('owner-acknowledged local publication bridge', () => {
+  const PENDING_RECORD = {
+    schemaVersion: 2,
+    profile: 'capture-decay-d3-acceptance-v2',
+    status: 'pending',
+    blockingReason: 'fixture'
+  }
+
+  async function withPendingRecord(repository, record = PENDING_RECORD) {
+    const recordPath = join(repository, 'macos-capture-decay-d3.json')
+    await writeFile(recordPath, `${JSON.stringify(record, null, 2)}\n`)
+    return recordPath
+  }
+
+  it('publishes a regular beta with the exact acknowledgment and clean main ancestry', async () => {
+    await withGitRepository(async (repository) => {
+      const recordPath = await withPendingRecord(repository)
+      const headCommit = await gitHead(repository)
+      const gate = await assertCaptureDecayD3PublicationGate({
+        env: { [LOCAL_PUBLICATION_ACK_ENV]: LOCAL_PUBLICATION_ACK_VALUE },
+        recordPath,
+        repoRoot: repository,
+        requireProtectedRef: true
+      })
+      assert.equal(gate.headCommit, headCommit)
+      assert.equal(gate.record.status, 'pending')
+      assert.equal(gate.protectedRef.bridged, true)
+    })
+  })
+
+  it('rejects any acknowledgment value other than the exact one', async () => {
+    await withGitRepository(async (repository) => {
+      const recordPath = await withPendingRecord(repository)
+      await assert.rejects(
+        assertCaptureDecayD3PublicationGate({
+          env: { [LOCAL_PUBLICATION_ACK_ENV]: '1' },
+          recordPath,
+          repoRoot: repository,
+          requireProtectedRef: true
+        }),
+        publicationRefCode('local-ack-invalid')
+      )
+    })
+  })
+
+  it('still requires the protected Actions context without the acknowledgment', async () => {
+    await withGitRepository(async (repository) => {
+      const recordPath = await withPendingRecord(repository)
+      await assert.rejects(
+        assertCaptureDecayD3PublicationGate({
+          env: {},
+          recordPath,
+          repoRoot: repository,
+          requireProtectedRef: true
+        }),
+        publicationRefCode('github-actions-required')
+      )
+    })
+  })
+
+  it('refuses a bridged publication whose HEAD is not on origin/main', async () => {
+    await withGitRepository(async (repository) => {
+      const recordPath = await withPendingRecord(repository)
+      await writeFile(join(repository, 'ahead.txt'), 'unpushed release code\n')
+      await execFileAsync('git', ['add', 'ahead.txt'], { cwd: repository })
+      await execFileAsync('git', ['commit', '--quiet', '-m', 'ahead of origin'], {
+        cwd: repository
+      })
+      await assert.rejects(
+        assertCaptureDecayD3PublicationGate({
+          env: { [LOCAL_PUBLICATION_ACK_ENV]: LOCAL_PUBLICATION_ACK_VALUE },
+          recordPath,
+          repoRoot: repository,
+          requireProtectedRef: true
+        }),
+        publicationRefCode('local-ack-ancestry')
+      )
+    })
+  })
+
+  it('never bridges past accepted-state strictness', async () => {
+    await withGitRepository(async (repository) => {
+      const recordPath = await withPendingRecord(repository, {
+        schemaVersion: 2,
+        profile: 'capture-decay-d3-acceptance-v2',
+        status: 'accepted'
+      })
+      // An accepted record takes the full strict path even with the
+      // acknowledgment set: the bridge only overrides the pending freeze.
+      await assert.rejects(
+        assertCaptureDecayD3PublicationGate({
+          env: { [LOCAL_PUBLICATION_ACK_ENV]: LOCAL_PUBLICATION_ACK_VALUE },
+          recordPath,
+          repoRoot: repository,
+          requireProtectedRef: true
+        }),
+        (error) => error?.code !== 'd3-pending' && error instanceof Error
+      )
+    })
+  })
+})


### PR DESCRIPTION
#320's publication guard + D3-pending freeze left no working macOS release path (Actions lane has zero secrets; local path forbidden; pending record blocks all publication). This adds an exact-value env acknowledgment (`VIDEORC_RELEASE_LOCAL_PUBLICATION_ACK=owner-keychain`) restoring the local keychain path for REGULAR betas only: clean tracked tree + HEAD ancestor of freshly-fetched origin/main required, loud log on every use, accepted-state D3 rules fully intact (tested). Owner explicitly authorized overriding the release freeze. Retire once release-macos.yml secrets exist or the D3 record is satisfied. Tests: 21/21 publication-git incl. 5 new bridge cases; scripts suite 1348.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a temporary, owner-acknowledged option for publishing regular macOS beta releases from a local environment when the standard publication lane is unavailable.
  - Local publication requires a clean checkout aligned with the latest main branch and displays a prominent notice each time it is used.

- **Documentation**
  - Updated the release runbook with setup details, safeguards, and retirement conditions for the temporary publication option.
  - Accepted release records continue to require all existing strict validation and promotion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->