### PR TITLE
docs: 0.9.86 release record

### DIFF
--- a/docs/releases/0.9.86.md
+++ b/docs/releases/0.9.86.md
@@ -1,0 +1,49 @@
+# Videorc 0.9.86 Beta 1 (macOS)
+
+The capture-recovery system ships (#320 + #322), through the
+owner-acknowledged local publication bridge (#324).
+
+## Scope (PRs #320, #322, #323, #324)
+
+- **Capture recovery system (#320):** staged restart → verify → recover for
+  BOTH camera and screen sources with observable phase/attempt/outcome
+  status; session start/stop lifecycle, teardown, and process-ownership
+  hardening; a new release-gate regime (60-minute idle soak + analyzed
+  15-minute recording, both mandatory) and the one-time D3 acceptance
+  ceremony machinery (sealed candidates, evidence manifests, fail-closed
+  state machine — record remains `pending`).
+- **#322:** D3 satisfied-release drift guard + nullable retention
+  diagnostics (TS contract; serde-trap defense-in-depth). No Rust changes.
+- **Supersedes the never-published 0.9.85:** its build was fully gated and
+  signed but held behind the record ~3-hour Packetland TLS interception
+  (4th occurrence); #322 merged meanwhile; the unpublished entry was
+  withdrawn before any disclosure (#323).
+- **#324 — owner-acknowledged local publication bridge:** #320 shipped the
+  protected-Actions publication guard before its infrastructure (zero repo
+  secrets, no macOS environment) and the D3-pending freeze blocked every
+  publication path. The owner explicitly chose "override" after being shown
+  the freeze; the bridge requires the exact env acknowledgment, a clean
+  tracked tree, HEAD ancestry against freshly fetched origin/main, logs
+  loudly on every use, and leaves accepted-state D3 promotion rules fully
+  intact (5 dedicated tests). Retire once release-macos.yml secrets exist
+  or the D3 record is satisfied.
+
+## Ship record
+
+- Gates on `1f4eb330` (#323): 60m idle sentinel PASS (1795 samples, flat
+  surfaces, clean teardown; carried from byte-identical `crates/` at
+  `19b5d952`), 15m recording sentinel PASS (29.94fps, 0.1% degraded bridge;
+  1 flaky failure of the stop path under an unresponsive stream endpoint —
+  task filed), contract 42, quick soak, desktop 1664/169, scripts
+  1343→1348, cargo 2036+80, clippy/fmt/typecheck/lint/format, build.
+- Artifacts built and signed/notarized/stapled from `1f4eb330`; published
+  under the bridge at main `564fd676` (delta = the bridge itself,
+  scripts/docs only). TLS issuer guard clean at upload. All objects
+  verified; `latest-mac.yml` serves 0.9.86, zip 206; Discord announced
+  2026-08-29.
+- Owner acceptance: normal recording/streaming; `[capture-health]` and
+  `capture.recovery.status` evidence accumulates toward D3c and the
+  acceptance ceremony.
+- OPEN: provision release-macos.yml secrets (owner: .p12 export) OR
+  complete the D3 ceremony, then retire the bridge. Windows alpha
+  (≥0.9.86-alpha.1) one dispatch away.


### PR DESCRIPTION
Release record for macOS 0.9.86-beta.1: capture-recovery system, superseded 0.9.85, and the owner-authorized publication bridge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for the Videorc 0.9.86 Beta 1 macOS release.
  * Documented capture recovery, release validation, acceptance results, and signed/notarized artifacts.
  * Recorded publication details, owner acceptance evidence, and remaining release actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->