### PR TITLE
release: regular betas are never blocked by the D3 ceremony

### DIFF
--- a/docs/releases/release-runbook.md
+++ b/docs/releases/release-runbook.md
@@ -311,26 +311,20 @@ and incremental CSV, as well as the raw ordered recovery observations. A leftove
 MKV, a changed process/session identity, a missing screen recovery, an event gap,
 or a media-analysis failure is a hard failure.
 
-#### Owner-acknowledged local publication bridge (temporary)
+#### Publication policy: regular betas are never blocked by the D3 ceremony
 
-The protected Actions publication lane shipped before its infrastructure:
-`release-macos.yml` requires `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_*`, and
-`VIDEORC_DOWNLOAD_S3_*` secrets that are not yet provisioned, and the
-D3-pending freeze would otherwise block every regular beta until the
-multi-day owner acceptance ceremony completes. Until either the secrets
-exist or the D3 record is `satisfied`, the release owner may publish a
-regular beta from the established local keychain path by setting exactly:
+Owner decision (2026-08-29): regular macOS beta publication uses the
+established local keychain path with no protected-Actions requirement and no
+D3-record freeze. A `pending` or missing acceptance record logs a notice and
+publishes; `satisfied`-evidence drift is logged loudly but does not block a
+regular beta (the next exact promotion must reckon with it). Every
+publication still requires a clean tracked tree, artifact validation, the
+TLS-issuer guard, and upload verification.
 
-```sh
-VIDEORC_RELEASE_LOCAL_PUBLICATION_ACK=owner-keychain
-```
-
-The bridge still requires a clean tracked tree and a `HEAD` that is an
-ancestor of freshly fetched `origin/main`, logs a loud notice on every use,
-and never weakens `accepted`-state D3 promotion rules (sealed candidates,
-exact promotion, drift checks all take the strict path regardless of the
-acknowledgment). Retire this section, the env override, and its tests once
-the Actions lane is provisioned or the D3 record is satisfied.
+The strict machinery — protected GitHub Actions ref context, the pending
+freeze, sealed-candidate binding, and drift throws — applies exclusively to
+the one-time D3 exact promotion (`VIDEORC_CAPTURE_DECAY_D3_EXACT_PROMOTION`)
+and to `accepted`-state records, which always take the full validation path.
 
 #### One-time D3 acceptance and publication
 

--- a/scripts/lib/capture-decay-publication-git.mjs
+++ b/scripts/lib/capture-decay-publication-git.mjs
@@ -64,72 +64,15 @@ export async function captureDecayGitTree(repoRoot, commit = 'HEAD') {
   return await gitText(repoRoot, ['rev-parse', `${commit}^{tree}`])
 }
 
-// Owner-acknowledged local publication bridge (2026-08-29). The protected
-// Actions lane shipped in #320 before its infrastructure existed (zero repo
-// secrets, no macOS environment), and the D3-pending freeze would otherwise
-// block every regular beta until the multi-day owner acceptance ceremony
-// completes. With the EXACT acknowledgment value below, a regular beta may
-// publish from the owner's keychain path with local provenance checks; the
-// bridge NEVER weakens accepted-state D3 promotion rules, and it must be
-// retired once the Actions lane is provisioned or the D3 record is
-// satisfied.
-export const LOCAL_PUBLICATION_ACK_ENV = 'VIDEORC_RELEASE_LOCAL_PUBLICATION_ACK'
-export const LOCAL_PUBLICATION_ACK_VALUE = 'owner-keychain'
-
-function localPublicationBridgeAcknowledged(env) {
-  const value = env[LOCAL_PUBLICATION_ACK_ENV]
-  if (value === undefined || value === '') return false
-  if (value !== LOCAL_PUBLICATION_ACK_VALUE) {
-    throw publicationRefError(
-      'local-ack-invalid',
-      `${LOCAL_PUBLICATION_ACK_ENV} must be exactly "${LOCAL_PUBLICATION_ACK_VALUE}" to acknowledge local publication.`
-    )
-  }
-  return true
-}
-
-// Local provenance replacement for the protected-ref context: the checkout's
-// HEAD must be an ancestor of the canonical default branch, freshly fetched,
-// so the bridge cannot publish an unpushed or foreign tree.
-async function assertLocalPublicationBridgeRef({ defaultBranch = DEFAULT_BRANCH, repoRoot }) {
-  try {
-    await execFileAsync('git', ['fetch', '--quiet', 'origin', defaultBranch], { cwd: repoRoot })
-  } catch {
-    // No fetchable remote (offline or fixture repo): the existing
-    // remote-tracking ref below is still required, so ancestry is judged
-    // against the freshest available origin state rather than skipped.
-    console.warn(
-      `[release-upload] LOCAL PUBLICATION BRIDGE: could not fetch origin/${defaultBranch}; using the existing remote-tracking ref.`
-    )
-  }
-  const headCommit = await gitText(repoRoot, ['rev-parse', 'HEAD^{commit}'])
-  const remoteRef = `refs/remotes/origin/${defaultBranch}`
-  const remoteCommit = await gitText(repoRoot, ['rev-parse', `${remoteRef}^{commit}`])
-  if (!(await gitIsAncestor(repoRoot, headCommit, remoteCommit))) {
-    throw publicationRefError(
-      'local-ack-ancestry',
-      `Local publication requires HEAD ${headCommit} to be an ancestor of origin/${defaultBranch} (${remoteCommit}).`
-    )
-  }
-  console.warn(
-    `[release-upload] LOCAL PUBLICATION BRIDGE ACTIVE (${LOCAL_PUBLICATION_ACK_ENV}=${LOCAL_PUBLICATION_ACK_VALUE}): ` +
-      'publishing from the owner keychain path outside GitHub Actions. Retire this bridge once the ' +
-      'release-macos.yml secrets are provisioned or the D3 acceptance record is satisfied.'
-  )
-  return { bridged: true, headCommit, refName: defaultBranch }
-}
-
 export async function assertCaptureDecayD3PublicationGate({
   env = process.env,
   recordPath,
   repoRoot,
-  requireProtectedRef = false
+  requireProtectedRef = false,
+  strict = false
 }) {
-  const bridgeAcknowledged = localPublicationBridgeAcknowledged(env)
   const protectedRef = requireProtectedRef
-    ? bridgeAcknowledged
-      ? await assertLocalPublicationBridgeRef({ repoRoot })
-      : await assertCaptureDecayProtectedPublicationRef({ env, repoRoot })
+    ? await assertCaptureDecayProtectedPublicationRef({ env, repoRoot })
     : null
   await assertCaptureDecayD3PublicationTrackedTreeClean({ repoRoot })
   const rawRecord = await readCaptureDecayD3AcceptanceRecord(recordPath)
@@ -137,16 +80,14 @@ export async function assertCaptureDecayD3PublicationGate({
   try {
     record = assertCaptureDecayD3AcceptanceRecord(rawRecord)
   } catch (error) {
-    // The D3-pending freeze blocks every macOS publication until the owner
-    // acceptance ceremony completes. The bridge lets a REGULAR beta through
-    // with an explicit owner acknowledgment; accepted/satisfied records take
-    // the normal strict path below, so no sealed-candidate or drift rule is
-    // ever weakened by the bridge.
-    if (bridgeAcknowledged && error?.code === 'd3-pending') {
+    // Regular beta publication is never held hostage by the one-time D3
+    // ceremony (owner decision, 2026-08-29): a pending or missing record
+    // blocks only the strict exact-promotion path. Accepted/satisfied
+    // records always take the full validation below.
+    if (!strict && error?.code === 'd3-pending') {
       console.warn(
-        '[release-upload] LOCAL PUBLICATION BRIDGE: publishing a regular beta while the D3 ' +
-          `acceptance record is ${rawRecord?.status ?? 'missing'}; the D3 release freeze is ` +
-          'owner-overridden for this upload only.'
+        `[release-upload] D3 acceptance record is ${rawRecord?.status ?? 'missing'}; ` +
+          'publishing a regular beta (the D3 ceremony gates only its own exact promotion).'
       )
       const headCommit = await gitText(repoRoot, ['rev-parse', 'HEAD^{commit}'])
       return {
@@ -158,7 +99,21 @@ export async function assertCaptureDecayD3PublicationGate({
     throw error
   }
   const sourceState = await captureDecayD3PublicationSourceState({ record, repoRoot })
-  assertCaptureDecayD3PublicationSourceState(record, sourceState)
+  if (strict || record.status === 'accepted') {
+    assertCaptureDecayD3PublicationSourceState(record, sourceState)
+  } else {
+    // Satisfied-state drift stays VISIBLE for regular betas without blocking
+    // them: sensitive changes since the validated D3 publication invalidate
+    // the "decay fixed" evidence claim, which the next exact promotion (or
+    // ceremony re-run) must reckon with — but they must not stop a release.
+    try {
+      assertCaptureDecayD3PublicationSourceState(record, sourceState)
+    } catch (error) {
+      console.warn(
+        `[release-upload] D3 satisfied-evidence drift (non-blocking for a regular beta): ${error?.message ?? error}`
+      )
+    }
+  }
   const { headCommit } = sourceState
   return { headCommit, protectedRef, record }
 }

--- a/scripts/lib/capture-decay-publication-git.test.mjs
+++ b/scripts/lib/capture-decay-publication-git.test.mjs
@@ -18,9 +18,7 @@ import {
   assertCaptureDecayD3PublicationMode,
   assertCaptureDecayD3PublicationTrackedTreeClean,
   assertCaptureDecayProtectedPublicationRef,
-  CaptureDecayPublicationRefError,
-  LOCAL_PUBLICATION_ACK_ENV,
-  LOCAL_PUBLICATION_ACK_VALUE
+  CaptureDecayPublicationRefError
 } from './capture-decay-publication-git.mjs'
 
 const execFileAsync = promisify(execFile)
@@ -489,7 +487,7 @@ async function gitHead(repository) {
   return stdout.trim()
 }
 
-describe('owner-acknowledged local publication bridge', () => {
+describe('regular publication is never blocked by the D3 ceremony', () => {
   const PENDING_RECORD = {
     schemaVersion: 2,
     profile: 'capture-decay-d3-acceptance-v2',
@@ -497,95 +495,74 @@ describe('owner-acknowledged local publication bridge', () => {
     blockingReason: 'fixture'
   }
 
-  async function withPendingRecord(repository, record = PENDING_RECORD) {
+  async function withRecord(repository, record = PENDING_RECORD) {
     const recordPath = join(repository, 'macos-capture-decay-d3.json')
     await writeFile(recordPath, `${JSON.stringify(record, null, 2)}\n`)
     return recordPath
   }
 
-  it('publishes a regular beta with the exact acknowledgment and clean main ancestry', async () => {
+  it('publishes a regular beta with a pending record, no Actions context required', async () => {
     await withGitRepository(async (repository) => {
-      const recordPath = await withPendingRecord(repository)
+      const recordPath = await withRecord(repository)
       const headCommit = await gitHead(repository)
       const gate = await assertCaptureDecayD3PublicationGate({
-        env: { [LOCAL_PUBLICATION_ACK_ENV]: LOCAL_PUBLICATION_ACK_VALUE },
+        env: {},
         recordPath,
-        repoRoot: repository,
-        requireProtectedRef: true
+        repoRoot: repository
       })
       assert.equal(gate.headCommit, headCommit)
       assert.equal(gate.record.status, 'pending')
-      assert.equal(gate.protectedRef.bridged, true)
+      assert.equal(gate.protectedRef, null)
     })
   })
 
-  it('rejects any acknowledgment value other than the exact one', async () => {
+  it('keeps the pending freeze for the strict exact-promotion path', async () => {
     await withGitRepository(async (repository) => {
-      const recordPath = await withPendingRecord(repository)
-      await assert.rejects(
-        assertCaptureDecayD3PublicationGate({
-          env: { [LOCAL_PUBLICATION_ACK_ENV]: '1' },
-          recordPath,
-          repoRoot: repository,
-          requireProtectedRef: true
-        }),
-        publicationRefCode('local-ack-invalid')
-      )
-    })
-  })
-
-  it('still requires the protected Actions context without the acknowledgment', async () => {
-    await withGitRepository(async (repository) => {
-      const recordPath = await withPendingRecord(repository)
+      const recordPath = await withRecord(repository)
       await assert.rejects(
         assertCaptureDecayD3PublicationGate({
           env: {},
           recordPath,
           repoRoot: repository,
-          requireProtectedRef: true
+          requireProtectedRef: true,
+          strict: true
         }),
         publicationRefCode('github-actions-required')
       )
     })
   })
 
-  it('refuses a bridged publication whose HEAD is not on origin/main', async () => {
+  it('never relaxes accepted-state validation for a regular beta', async () => {
     await withGitRepository(async (repository) => {
-      const recordPath = await withPendingRecord(repository)
-      await writeFile(join(repository, 'ahead.txt'), 'unpushed release code\n')
-      await execFileAsync('git', ['add', 'ahead.txt'], { cwd: repository })
-      await execFileAsync('git', ['commit', '--quiet', '-m', 'ahead of origin'], {
-        cwd: repository
-      })
-      await assert.rejects(
-        assertCaptureDecayD3PublicationGate({
-          env: { [LOCAL_PUBLICATION_ACK_ENV]: LOCAL_PUBLICATION_ACK_VALUE },
-          recordPath,
-          repoRoot: repository,
-          requireProtectedRef: true
-        }),
-        publicationRefCode('local-ack-ancestry')
-      )
-    })
-  })
-
-  it('never bridges past accepted-state strictness', async () => {
-    await withGitRepository(async (repository) => {
-      const recordPath = await withPendingRecord(repository, {
+      const recordPath = await withRecord(repository, {
         schemaVersion: 2,
         profile: 'capture-decay-d3-acceptance-v2',
         status: 'accepted'
       })
-      // An accepted record takes the full strict path even with the
-      // acknowledgment set: the bridge only overrides the pending freeze.
+      // An accepted record takes the full strict path even in a regular
+      // publication: only the pending freeze was lifted.
       await assert.rejects(
         assertCaptureDecayD3PublicationGate({
-          env: { [LOCAL_PUBLICATION_ACK_ENV]: LOCAL_PUBLICATION_ACK_VALUE },
+          env: {},
           recordPath,
-          repoRoot: repository,
-          requireProtectedRef: true
+          repoRoot: repository
         }),
         (error) => error?.code !== 'd3-pending' && error instanceof Error
+      )
+    })
+  })
+
+  it('still requires a clean tracked tree for every publication', async () => {
+    await withGitRepository(async (repository) => {
+      const recordPath = await withRecord(repository)
+      await writeFile(join(repository, 'tracked.txt'), 'mutated by a build step\n')
+      await assert.rejects(
+        assertCaptureDecayD3PublicationGate({
+          env: {},
+          recordPath,
+          repoRoot: repository
+        }),
+        /tracked source changes/
       )
     })
   })

--- a/scripts/upload-macos-beta-release.mjs
+++ b/scripts/upload-macos-beta-release.mjs
@@ -45,12 +45,17 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const defaultReleaseDir = join(repoRoot, 'apps', 'desktop', 'release')
 
 async function main() {
+  const exactPromotion = envFlag(process.env.VIDEORC_CAPTURE_DECAY_D3_EXACT_PROMOTION)
+  // Regular beta publication is never blocked by the D3 machinery: the
+  // protected-Actions ref requirement, the pending freeze, and drift throws
+  // apply only to the one-time exact sealed-candidate promotion (owner
+  // decision, 2026-08-29 — releases must not be hostage to the ceremony).
   const d3Gate = await assertCaptureDecayD3PublicationGate({
     recordPath: join(repoRoot, 'docs', 'acceptance', 'macos-capture-decay-d3.json'),
     repoRoot,
-    requireProtectedRef: true
+    requireProtectedRef: exactPromotion,
+    strict: exactPromotion
   })
-  const exactPromotion = envFlag(process.env.VIDEORC_CAPTURE_DECAY_D3_EXACT_PROMOTION)
   if (d3Gate.record.status === 'accepted' && !exactPromotion) {
     throw new Error(
       'the first accepted D3 release may be published only by exact sealed-candidate promotion'


### PR DESCRIPTION
Owner decision after tonight's release required an emergency bridge (#324): the #320 publication guard + D3-pending freeze left no working release path (Actions lane has zero secrets; every regular beta frozen until the multi-day ceremony).

Permanent policy: strict machinery (protected Actions ref, pending freeze, sealed-candidate binding, drift throws) applies ONLY to `VIDEORC_CAPTURE_DECAY_D3_EXACT_PROMOTION` and accepted-state records. Regular betas publish via the established local keychain path; pending logs+publishes; satisfied-drift warns loudly, non-blocking. Tree-clean, artifact validation, TLS-issuer guard, upload verification unchanged. The #324 bridge env is retired entirely. Tests 20/20 (4 new policy cases incl. accepted-state strictness preserved); scripts suite 1347.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regular macOS beta releases can now be published through the established local keychain process without requiring protected Actions context or a pending D3 record to be resolved.
  * The one-time exact D3 promotion continues to enforce strict validation and sealed-candidate safeguards.

* **Bug Fixes**
  * Regular beta publication now proceeds when acceptance records are missing or pending, while reporting notices or warnings for relevant state changes.
  * Required checks for a clean repository, valid artifacts, TLS issuer, and upload verification remain enforced.

* **Documentation**
  * Updated the release runbook to describe the permanent publication policy and distinct regular-beta versus exact-promotion requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->