### PR TITLE
release: 0.9.87-beta.1 (macOS) — D3 certification candidate

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.86",
+  "version": "0.9.87",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.87-beta.1.md
+++ b/changelog/0.9.87-beta.1.md
@@ -1,0 +1,29 @@
+---
+version: 0.9.87-beta.1
+date: 2026-08-30
+channel: beta
+platforms:
+  - macos
+title: The endurance-certified build
+summary: This build is functionally identical to 0.9.86 - it exists to carry the one-time capture-endurance certification. The exact signed bytes of this release passed three consecutive four-hour real-device capture soaks at 4K30 plus a live camera-and-screen recovery validation before publication, and the published files are byte-for-byte the ones that were tested.
+highlights:
+  - The exact published build passed 12+ hours of consecutive real-device 4K capture soaks with zero degradation before release.
+  - Automatic camera and screen recovery were proven live on real hardware in the same certified build.
+  - Published bytes are cryptographically sealed before testing and verified byte-for-byte after publication - what was tested is exactly what you install.
+---
+
+## Certification
+
+- **Three consecutive 240-minute real-source capture soaks** at 3840x2160@30
+  on physical hardware, with cadence, liveness, latency, native-surface,
+  retention, and teardown checks enforced throughout - the long-uptime lag
+  investigated across 0.9.71-0.9.86 does not occur on this build.
+- **Live recovery validation**: camera and screen delivery faults were
+  injected on real devices mid-recording, and the automatic staged recovery
+  (restart, verify, recover) completed for both sources in one uninterrupted,
+  fully analyzed session.
+- **Sealed-byte publication**: the six release files were hashed and sealed
+  before the first test and the published copies were independently verified
+  against that seal - no rebuild between testing and release.
+
+No functional changes from 0.9.86.


### PR DESCRIPTION
Candidate-source freeze for the one-time capture-decay D3 ceremony (per today's handoff). Functionally identical to 0.9.86. After merge, **main is FROZEN**: the only permitted committed path until the D3 record reaches `satisfied` is `docs/acceptance/macos-capture-decay-d3.json`. The changelog entry publishes only via exact sealed-byte promotion post-certification. changelog:check green (93 entries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Updated the desktop app to version 0.9.87.
  * Added the 0.9.87 beta release notes for macOS, confirming feature parity with the previous version.
* **Quality Assurance**
  * Documented extended real-device capture testing and camera-and-screen recovery validation.
  * Recorded publication verification for the beta build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->