### PR TITLE
release: 0.9.88-beta.1 (macOS)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.87",
+  "version": "0.9.88",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.88-beta.1.md
+++ b/changelog/0.9.88-beta.1.md
@@ -1,0 +1,43 @@
+---
+version: 0.9.88-beta.1
+date: 2026-08-31
+channel: beta
+platforms:
+  - macos
+title: The lag investigation lands - no more mid-session repair noise
+summary: The camera lag investigation reached its root - under heavy overall system load, macOS itself delivers camera frames below full rate, and restarting the camera cannot fix that. Videorc now tells the difference - a camera that genuinely froze is restarted silently, a camera that is merely slowed by system pressure is left alone and logged quietly, and no warnings interrupt your session either way. Camera capture also gets a priority boost so macOS sheds other work before your camera under load.
+highlights:
+  - No more mid-session warnings or repair attempts while you record - a slowed camera is recognized as system pressure and handled silently.
+  - Camera capture now runs at elevated priority, so under load macOS deprioritizes other work before your camera frames.
+  - A genuinely frozen camera still self-heals silently in the background - two failures before you are ever notified.
+  - Every diagnostic line now reports Videorc's own CPU share, so slowdowns can be attributed at a glance.
+---
+
+## Fixed
+
+- **No repair theater.** The live investigation proved that when overall
+  system load is high, macOS's own camera pipeline delivers frames below
+  full rate - and restarting the camera cannot help, because the bottleneck
+  is upstream of Videorc. A slowed-but-flowing camera is now logged quietly
+  and left alone: no restarts, no warnings, no interruption. Only a camera
+  that has genuinely stopped delivering frames is restarted, silently.
+- **Camera priority under load.** The camera delivery path now runs at
+  user-initiated priority, so when your Mac is busy, other background work
+  yields before your camera frames do.
+
+## Added
+
+- **Self-attribution in diagnostics.** Capture diagnostics now include
+  Videorc's own CPU share, so "is Videorc the load?" is answered in every
+  line without external tooling.
+- An expert flag (VIDEORC_CAMERA_NATIVE_FORMAT=1) to capture in the
+  camera's native format, reducing the per-frame cost inside macOS's camera
+  pipeline; this becomes the default after field validation.
+
+## Practical note
+
+If your whole system is under pressure - many heavy apps, weeks of uptime -
+camera delivery can still slow down at the source. Closing heavyweight
+background apps while recording (and the occasional reboot) remains the
+single biggest lever; Videorc now stays honest and quiet about it instead
+of fighting the operating system.


### PR DESCRIPTION
Bump + changelog for the camera root-fix batch (#328). Supersedes the abandoned 0.9.87 D3 candidate (never sealed/published).