### PR TITLE
release: 0.9.89-beta.1 (macOS) — 0.9.88 crash-loop hotfix

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.88",
+  "version": "0.9.89",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.89-beta.1.md
+++ b/changelog/0.9.89-beta.1.md
@@ -1,0 +1,28 @@
+---
+version: 0.9.89-beta.1
+date: 2026-08-31
+channel: beta
+platforms:
+  - macos
+title: Hotfix - 0.9.88 could crash the backend at camera start
+summary: 0.9.88's camera priority boost used a system call in a way macOS forbids, which could crash and restart the recording engine in a loop the moment the app started with a camera configured. Same priority boost, correct mechanism, no crash. Update immediately if you are on 0.9.88. The "Coming from OBS?" banner in the Studio is also gone - the import lives in Settings.
+highlights:
+  - Fixes the 0.9.88 backend crash loop at camera start - update immediately.
+  - The camera priority boost from 0.9.88 is preserved, implemented the way macOS requires.
+  - The OBS import banner no longer appears in the Studio; import stays available in Settings -> Import.
+---
+
+## Fixed
+
+- **0.9.88 crash loop at camera start.** The camera priority boost set a
+  queue property after the queue was already active, which macOS treats as
+  a client bug and stops the process - crashing the recording engine in a
+  restart loop as soon as a camera was configured. The priority is now
+  conferred at creation, the supported way. All 0.9.88 users should update
+  immediately.
+
+## Changed
+
+- **OBS import banner removed.** The dismissible "Coming from OBS?" row in
+  the Studio is gone; importing from OBS remains available in
+  Settings -> Import.


### PR DESCRIPTION
Hotfix bump for #330 (camera-start crash loop) + OBS nudge removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a macOS crash loop that could occur when starting the camera.
  * Preserved camera priority improvements for more reliable startup.

* **Improvements**
  * Removed the OBS import banner from Studio while keeping OBS import available in Settings.

* **Release**
  * Updated the desktop app to version 0.9.89 beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->