### PR TITLE
Adaptive camera format step-down for USB delivery shortfall

### DIFF
--- a/crates/videorc-backend/src/camera_capture.rs
+++ b/crates/videorc-backend/src/camera_capture.rs
@@ -1,6 +1,87 @@
 use crate::protocol::{Device, DeviceKind, DeviceStatus};
 
 const NATIVE_CAMERA_PREFIX: &str = "camera:avfoundation-native:";
+
+/// Adaptive camera step-down (2026-08-31, Cam Link 4K field diagnosis): true
+/// 2160p over USB 3.0 is at the wire's physical ceiling (~497 MB/s
+/// uncompressed 4:2:2 at 29.97fps) and collapses to a stable ~6fps fraction
+/// under any bus variance — on a CLEAN machine (owner repro: fresh reboot,
+/// nothing running, backend at 8% CPU). A same-format restart is useless; a
+/// renegotiation ONE tier down (1080p) returns inside comfortable bandwidth.
+/// The registry holds, per camera id, the negotiated dimensions of the last
+/// start and an armed ceiling the next (re)start's format chooser honors.
+pub const CAMERA_STEP_DOWN_CEILING: (u32, u32) = (1920, 1080);
+
+#[derive(Debug, Default, Clone, Copy)]
+struct CameraFormatAdaptiveState {
+    negotiated: Option<(u32, u32)>,
+    ceiling: Option<(u32, u32)>,
+}
+
+fn camera_adaptive_registry()
+-> &'static std::sync::Mutex<std::collections::HashMap<String, CameraFormatAdaptiveState>> {
+    static REGISTRY: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<String, CameraFormatAdaptiveState>>,
+    > = std::sync::OnceLock::new();
+    REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Record what a camera start actually negotiated (called on every start).
+pub fn record_negotiated_camera_format(camera_id: &str, width: u32, height: u32) {
+    let mut registry = camera_adaptive_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry
+        .entry(camera_id.to_string())
+        .or_default()
+        .negotiated = Some((width, height));
+}
+
+/// The ceiling the format chooser must respect for this camera, if armed.
+pub fn camera_format_ceiling(camera_id: &str) -> Option<(u32, u32)> {
+    camera_adaptive_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(camera_id)
+        .and_then(|state| state.ceiling)
+}
+
+/// Arm a one-tier step-down for this camera. Returns true only when the
+/// camera's negotiated format exceeds the ceiling AND no ceiling was armed
+/// yet — the caller restarts the camera exactly once on a true return; a
+/// false return means a step-down is unavailable or already applied, so no
+/// restart is warranted (restart-for-slowness stays banned).
+pub fn arm_camera_step_down(camera_id: &str) -> bool {
+    let mut registry = camera_adaptive_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let state = registry.entry(camera_id.to_string()).or_default();
+    if state.ceiling.is_some() {
+        return false;
+    }
+    let Some((width, height)) = state.negotiated else {
+        return false;
+    };
+    let (ceiling_width, ceiling_height) = CAMERA_STEP_DOWN_CEILING;
+    if width <= ceiling_width && height <= ceiling_height {
+        return false;
+    }
+    state.ceiling = Some(CAMERA_STEP_DOWN_CEILING);
+    true
+}
+
+/// Clear an armed ceiling (a future explicit quality setting or camera swap).
+/// Test-only: production never forgets a ceiling — the bus shortfall is a
+/// property of the device+port, not of one session.
+#[cfg(test)]
+pub fn clear_camera_step_down(camera_id: &str) {
+    let mut registry = camera_adaptive_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(state) = registry.get_mut(camera_id) {
+        state.ceiling = None;
+    }
+}
 const WINDOWS_DSHOW_CAMERA_PREFIX: &str = "camera:windows-dshow:";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1131,5 +1212,25 @@ mod tests {
         // Junk ranges never panic and never resolve below the sane floor.
         let junk = super::resolve_camera_frame_rate(30, &[(-5.0, -1.0)]).unwrap();
         assert!(junk.effective_fps > 0.0);
+    }
+    #[test]
+    fn camera_step_down_arms_once_and_only_above_the_ceiling() {
+        let id = "camera:avfoundation-native:test-step-down";
+        super::clear_camera_step_down(id);
+        // No negotiation recorded yet: nothing to step down from.
+        assert!(!super::arm_camera_step_down(id));
+        // Already at/below the ceiling: no step-down.
+        super::record_negotiated_camera_format(id, 1920, 1080);
+        assert!(!super::arm_camera_step_down(id));
+        // Above the ceiling: arms exactly once.
+        super::record_negotiated_camera_format(id, 3840, 2160);
+        assert!(super::arm_camera_step_down(id));
+        assert_eq!(
+            super::camera_format_ceiling(id),
+            Some(super::CAMERA_STEP_DOWN_CEILING)
+        );
+        assert!(!super::arm_camera_step_down(id), "second arm is a no-op");
+        super::clear_camera_step_down(id);
+        assert_eq!(super::camera_format_ceiling(id), None);
     }
 }

--- a/crates/videorc-backend/src/capture_health.rs
+++ b/crates/videorc-backend/src/capture_health.rs
@@ -35,6 +35,9 @@ pub const DEGRADED_RATE_FRACTION: f64 = 0.6;
 /// changed nothing. Restarting for slowness is repair theater; slowness is
 /// logged silently, stalls are healed silently.
 pub const PRODUCER_STALL_FLOOR_FPS: f64 = 1.0;
+/// Consecutive slow-camera windows before an adaptive format step-down is
+/// attempted (2s windows → ~10s of sustained shortfall).
+pub const CAMERA_STEP_DOWN_WINDOW_THRESHOLD: u32 = 5;
 
 /// Our own process CPU (% of one core) over the sampled window, from
 /// getrusage deltas. Answers "are WE the load?" inside every capture-health
@@ -243,6 +246,14 @@ pub struct CaptureHealthMonitor {
     /// Edge-latch for the slow-but-flowing delivery log so a sustained
     /// pressure episode writes one line, not one per window.
     slow_delivery_log_active: bool,
+    /// Consecutive slow-camera windows; drives the one-shot adaptive
+    /// step-down (reset by health, stall, or a camera epoch change).
+    slow_camera_streak: u32,
+    /// Latched once a step-down is armed: keeps presenting camera-delivery
+    /// as the degraded stage across the declare threshold so the recovery
+    /// machinery actually runs the renegotiating restart. Cleared by the
+    /// epoch rearm the restart itself causes.
+    camera_step_down_pending: bool,
     last_process_cpu_seconds: Option<f64>,
 }
 
@@ -259,6 +270,8 @@ impl CaptureHealthMonitor {
     fn reset_camera_epoch_state(&mut self, epoch: Option<CaptureHealthCameraEpoch>) {
         self.last_camera_fresh = None;
         self.last_camera_callbacks = None;
+        self.slow_camera_streak = 0;
+        self.camera_step_down_pending = false;
         self.last_camera_publications = None;
         self.last_camera_did_drop_callbacks = None;
         self.last_camera_out_of_buffers = None;
@@ -527,8 +540,39 @@ impl CaptureHealthMonitor {
                             if callbacks < floor && publications < floor
                     )
             });
+        // Adaptive step-down (Cam Link-class USB shortfall): a camera that
+        // sustains slow-but-flowing delivery for CAMERA_STEP_DOWN_WINDOW_THRESHOLD
+        // windows, whose negotiated format sits above the step-down ceiling,
+        // is worth exactly ONE purposeful restart — renegotiating a tier down
+        // returns inside the bus budget. arm_camera_step_down is the one-shot
+        // guard: once armed (or when no step-down exists), slowness never
+        // restarts anything again.
+        if producer_camera_slow && consumer_camera_starved {
+            self.slow_camera_streak = self.slow_camera_streak.saturating_add(1);
+            if self.slow_camera_streak >= CAMERA_STEP_DOWN_WINDOW_THRESHOLD
+                && !self.camera_step_down_pending
+                && let Some(epoch) = sample_camera_epoch.as_ref()
+                && crate::camera_capture::arm_camera_step_down(&epoch.source_key.id)
+            {
+                tracing::warn!(
+                    "[capture-health] stepping the camera down one format tier after {} sustained slow windows (USB/bus delivery shortfall at the negotiated resolution); restarting the camera once to renegotiate",
+                    self.slow_camera_streak
+                );
+                self.camera_step_down_pending = true;
+            }
+        } else {
+            self.slow_camera_streak = 0;
+        }
+        // The latch presents camera-delivery to the normal declare machinery
+        // until the renegotiating restart replaces the epoch (which rearms
+        // and clears it).
+        let step_down_stage = self
+            .camera_step_down_pending
+            .then_some(CaptureStage::CameraDelivery);
         let degraded_stage = if consumer_camera_starved && producer_camera_stalled {
             Some(CaptureStage::CameraDelivery)
+        } else if step_down_stage.is_some() {
+            step_down_stage
         } else if consumer_screen_starved && producer_screen_stalled {
             Some(CaptureStage::ScreenDelivery)
         } else if sample.render_fps < render_floor {
@@ -866,6 +910,80 @@ mod tests {
             other => panic!("expected a camera-delivery degradation, got {other:?}"),
         }
         assert_eq!(monitor.degraded_stage(), Some(CaptureStage::CameraDelivery));
+    }
+
+    /// The Cam Link shape: slow-but-flowing delivery from a camera whose
+    /// negotiated format sits above the step-down ceiling earns exactly ONE
+    /// renegotiating restart. The latch must hold camera-delivery across the
+    /// declare threshold (a single edge window would otherwise never satisfy
+    /// DEGRADED_WINDOW_THRESHOLD), and the restart's new generation must
+    /// rearm the monitor without re-declaring.
+    #[test]
+    fn sustained_slow_camera_above_ceiling_steps_down_exactly_once() {
+        let camera_id = "camera:avfoundation-native:step-down-monitor";
+        crate::camera_capture::clear_camera_step_down(camera_id);
+        crate::camera_capture::record_negotiated_camera_format(camera_id, 3840, 2160);
+
+        let sample = |camera_fresh: u64, generation: u64| {
+            let mut sample = healthy_sample(camera_fresh, 0);
+            sample.screen_present = false;
+            let producer = sample.camera_producer.as_mut().unwrap();
+            producer.epoch = CaptureHealthCameraEpoch {
+                source_key: SourceKey::camera(camera_id),
+                generation,
+            };
+            sample
+        };
+
+        let mut monitor = CaptureHealthMonitor::new();
+        let mut camera = 0_u64;
+        for _ in 0..4 {
+            camera += 60;
+            assert_eq!(monitor.observe(sample(camera, 1)), None);
+        }
+        // Slow-but-flowing windows: nothing declared until the streak arms
+        // the step-down, then the latch carries the declare threshold.
+        let mut transitions = Vec::new();
+        for _ in 0..(CAMERA_STEP_DOWN_WINDOW_THRESHOLD + DEGRADED_WINDOW_THRESHOLD) {
+            camera += 13; // ~6.5fps: starved consumer, flowing producer
+            transitions.extend(monitor.observe(sample(camera, 1)));
+        }
+        match transitions.as_slice() {
+            [CaptureHealthTransition::Degraded { stage, .. }] => {
+                assert_eq!(*stage, CaptureStage::CameraDelivery);
+            }
+            other => panic!("expected exactly one step-down degradation, got {other:?}"),
+        }
+        assert_eq!(
+            crate::camera_capture::camera_format_ceiling(camera_id),
+            Some(crate::camera_capture::CAMERA_STEP_DOWN_CEILING),
+            "the arm must have recorded the renegotiation ceiling"
+        );
+
+        // The renegotiating restart brings generation 2: the epoch rearm
+        // clears the declared stage and the latch (verified recovery is the
+        // recovery supervisor's job, not the monitor's), and renewed slowness
+        // at the now ceiling-bound format never earns a second restart.
+        camera += 60;
+        assert_eq!(monitor.observe(sample(camera, 2)), None);
+        assert_eq!(
+            monitor.degraded_stage(),
+            None,
+            "the new generation is a fresh incident boundary"
+        );
+        for _ in 0..4 {
+            camera += 60;
+            assert_eq!(monitor.observe(sample(camera, 2)), None);
+        }
+        for _ in 0..(CAMERA_STEP_DOWN_WINDOW_THRESHOLD * 3) {
+            camera += 13;
+            assert_eq!(
+                monitor.observe(sample(camera, 2)),
+                None,
+                "an armed camera must never step down (or degrade) again"
+            );
+        }
+        crate::camera_capture::clear_camera_step_down(camera_id);
     }
 
     #[test]

--- a/crates/videorc-backend/src/preview_camera.rs
+++ b/crates/videorc-backend/src/preview_camera.rs
@@ -4766,9 +4766,25 @@ mod macos {
         };
 
         let selected =
-            select_camera_format(&device, &config.layout, &config.video).ok_or_else(|| {
-                NativeCameraStartup::Failed("Camera did not report usable formats.".to_string())
-            })?;
+            select_camera_format(&device, &config.camera_id, &config.layout, &config.video)
+                .ok_or_else(|| {
+                    NativeCameraStartup::Failed("Camera did not report usable formats.".to_string())
+                })?;
+        crate::camera_capture::record_negotiated_camera_format(
+            &config.camera_id,
+            selected.format.width,
+            selected.format.height,
+        );
+        tracing::info!(
+            "Camera capture format selected: {}x{}@{:.2} (requested {}x{}@{}, ceiling {:?})",
+            selected.format.width,
+            selected.format.height,
+            selected.format.max_fps,
+            selected.requested_width,
+            selected.requested_height,
+            config.video.fps,
+            crate::camera_capture::camera_format_ceiling(&config.camera_id),
+        );
         let configured_fps = configure_device(&device, &selected, config.video.fps)?;
 
         let input = unsafe { AVCaptureDeviceInput::deviceInputWithDevice_error(&device) }.map_err(
@@ -4915,6 +4931,7 @@ mod macos {
 
     fn select_camera_format(
         camera: &AVCaptureDevice,
+        camera_id: &str,
         layout: &LayoutSettings,
         video: &VideoSettings,
     ) -> Option<NativeCameraFormatSelection> {
@@ -4944,7 +4961,16 @@ mod macos {
             .iter()
             .map(|(summary, _)| summary.clone())
             .collect::<Vec<_>>();
-        let (target_width, target_height) = camera_capture_target_dimensions(layout, video);
+        let (mut target_width, mut target_height) = camera_capture_target_dimensions(layout, video);
+        // An armed adaptive ceiling (Cam Link-class USB bandwidth shortfall)
+        // caps the requested capture box; the chooser then prefers the
+        // highest format inside it (1080p60 on the Cam Link 4K).
+        if let Some((ceiling_width, ceiling_height)) =
+            crate::camera_capture::camera_format_ceiling(camera_id)
+        {
+            target_width = target_width.min(ceiling_width);
+            target_height = target_height.min(ceiling_height);
+        }
         let choice = choose_camera_format(&summaries, target_width, target_height, video.fps)?;
         let selected_entry = entries
             .into_iter()


### PR DESCRIPTION
## Root cause this closes

Cam Link 4K at true 2160p@29.97 uncompressed 4:2:2 ≈ 497 MB/s ≈ the USB 3.0 physical ceiling. Any bus variance collapses delivery to a stable ~6fps — the clean-machine lag in the owner's recording. Pre-0.9.77 the chooser's zero-tolerance fps match rejected 29.97 and captured 1080p-upscaled, which is why "three weeks ago it was perfect."

## The fix

- `camera_capture.rs`: per-camera adaptive registry — negotiated format recorded at selection; `arm_camera_step_down` is a one-shot that installs a 1920×1080 ceiling only when the negotiated format sits above it.
- `preview_camera.rs`: `select_camera_format` honors the ceiling during renegotiation and records/logs the negotiated format.
- `capture_health.rs`: 5 consecutive slow-but-flowing windows (~10s) with a starved consumer arm the step-down; a latch presents camera-delivery across the declare threshold so the existing declare→restart→verify recovery machinery performs exactly ONE renegotiating restart. The new source generation rearms the monitor; the one-shot guard returns further slowness to log-only. Ceiling persists for the backend lifetime (device+port property).

## Gates

- `cargo test -p videorc-backend`: 2120 green, incl. new `camera_step_down_arms_once_and_only_above_the_ceiling` and `sustained_slow_camera_above_ceiling_steps_down_exactly_once`
- `cargo clippy -p videorc-backend -- -D warnings`: clean
- `cargo fmt --check --all`: clean

Physical Cam Link acceptance happens on the owner's box after release (agent camera testing is TCC-blind).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive camera quality reduction when sustained slow delivery is detected.
  * Camera capture can now automatically retry with a maximum resolution of 1920×1080.
  * Added tracking of negotiated camera formats to support smarter format selection.
* **Bug Fixes**
  * Improved recovery from prolonged camera performance degradation while preserving video flow.
  * Ensured the quality reduction triggers only once per recovery cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->