### PR TITLE
release: 0.9.90-beta.1 (macOS) — adaptive USB capture-card format step-down

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.89",
+  "version": "0.9.90",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.90-beta.1.md
+++ b/changelog/0.9.90-beta.1.md
@@ -1,0 +1,26 @@
+---
+version: 0.9.90-beta.1
+date: 2026-08-31
+channel: beta
+platforms:
+  - macos
+title: Smooth camera on USB capture cards - automatic format step-down
+summary: Capture cards like the Elgato Cam Link 4K advertise full 4K, but at true 4K they sit at the physical limit of a USB 3.0 port - any bus pressure collapses delivery to a choppy ~6fps, which is the laggy preview and recording some of you have seen since 0.9.77 started selecting the card's real 4K format. Videorc now notices within about ten seconds that the camera cannot sustain its negotiated resolution and steps it down one tier to 1080p60 with a single quick restart. You get 4K when your USB bus delivers it, and automatic smoothness when it cannot.
+highlights:
+  - Laggy Cam Link / USB capture card video fixes itself within ~10 seconds - one automatic step-down to 1080p60.
+  - The step-down happens once per camera and is remembered, so the session stays stable afterwards.
+  - Nothing changes for cameras whose USB bandwidth keeps up - they keep their full negotiated format.
+---
+
+## Fixed
+
+- **Choppy video from USB capture cards at 4K.** A Cam Link 4K negotiated
+  at true 2160p sits at the USB 3.0 wire ceiling (~497 MB/s uncompressed),
+  and any bus variance collapses it to a stable ~6fps - the lag reported
+  since 0.9.77 began honoring the card's real 4K format. When camera
+  delivery stays below its negotiated rate for about ten seconds while
+  frames are still flowing, Videorc now performs one purposeful restart
+  that renegotiates the camera one tier down (1080p at up to 60fps),
+  bringing it back inside the USB budget. The step-down is one-shot and
+  per-camera: it never loops, and cameras that can sustain their format
+  are never touched.


### PR DESCRIPTION
Version bump + changelog for the adaptive Cam Link step-down shipped in #332. macOS beta channel.