### PR TITLE
release: 0.9.91-beta.1 (macOS) — silent capture repair, Studio UI removed

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videorc/desktop",
-  "version": "0.9.90",
+  "version": "0.9.91",
   "private": true,
   "main": "./out/main/index.js",
   "description": "Videorc desktop app.",

--- a/changelog/0.9.91-beta.1.md
+++ b/changelog/0.9.91-beta.1.md
@@ -1,0 +1,23 @@
+---
+version: 0.9.91-beta.1
+date: 2026-08-31
+channel: beta
+platforms:
+  - macos
+title: Quieter Studio - capture repair now works silently
+summary: When a capture source hiccups, Videorc quietly fixes it in the background - the same self-healing as before, minus the red alert, the "Repairing capture" chip, and the Restart capture button that used to take over the Studio while you were working. Your session keeps running, the preview keeps moving, and the Studio stays about your content. The technical details remain available in the Diagnostics tab for anyone who wants to look under the hood.
+highlights:
+  - The red capture alert and Restart capture button are gone from the Studio - recovery happens silently in the background.
+  - The "Repairing capture" status chip no longer appears next to your session badge.
+  - Diagnostics keeps the full technical picture, including recovery activity, for troubleshooting.
+---
+
+## Changed
+
+- **Capture repair is now invisible.** The Studio no longer shows the
+  destructive capture alert, the Restart capture button, or the
+  repairing/recovered status chip. The underlying self-healing is
+  unchanged - stalled sources still restart automatically and the
+  adaptive camera step-down from 0.9.90 still protects sessions - it
+  simply happens without interrupting your work. The Diagnostics tab
+  keeps the technical summary.


### PR DESCRIPTION
Version bump + changelog for the Studio repair-UI removal (#334). macOS beta channel.