### PR TITLE
docs: 0.9.91-alpha.1 Windows changelog — Intel hardware encoding + quieter Studio

### DIFF
--- a/changelog/0.9.91-alpha.1.md
+++ b/changelog/0.9.91-alpha.1.md
@@ -1,0 +1,48 @@
+---
+version: 0.9.91-alpha.1
+date: 2026-08-31
+channel: alpha
+platforms:
+  - windows
+title: Intel laptops encode in hardware again, and a quieter Studio
+summary: On Intel integrated graphics, Videorc was falling back to software encoding and working the CPU harder than it needed to; hardware H.264 encoding now starts correctly on those machines, including the Iris Xe startup failures at higher bitrates. The Studio also stops showing capture-repair alerts and the OBS import banner, the controls stay responsive when the preview is struggling, and the post-recording quality check no longer gives up early on long or 4K recordings.
+highlights:
+  - Intel integrated GPUs (Iris Xe and similar) now use hardware H.264 encoding instead of falling back to the CPU.
+  - The red capture alert, Restart capture button, and repairing status chip are gone from the Studio - recovery happens silently in the background.
+  - Studio controls answer quickly even when the preview surface is struggling, instead of blocking for 30+ seconds.
+  - The post-recording quality check completes on longer and 4K recordings instead of timing out.
+---
+
+## Fixed
+
+- **Intel integrated graphics can hardware-encode again.** On Intel iGPU
+  systems the hardware H.264 encoder asked to renegotiate its output format
+  during startup, and Videorc treated that request as a fatal error. It now
+  completes the renegotiation and keeps hardware encoding. Iris Xe systems
+  that then failed the encoder probe at higher constant bitrates fall back
+  through a ladder of probe settings until one starts. NVIDIA systems were
+  never affected.
+- **Controls no longer jam behind a struggling preview.** Preview-surface
+  operations now answer quickly and retry in the background instead of
+  holding up every other command for 30+ seconds.
+- **Quality checks finish on long recordings.** The post-recording file check
+  scales its time budget with the recording's length and resolution instead
+  of giving up early.
+
+## Changed
+
+- **Capture repair is now invisible.** The Studio no longer shows the
+  destructive capture alert, the Restart capture button, or the
+  repairing/recovered status chip. The Diagnostics tab keeps the technical
+  summary.
+- **OBS import banner removed.** The dismissible "Coming from OBS?" row in
+  the Studio is gone; importing from OBS remains available in
+  Settings -> Import.
+
+## Known limitations on Windows
+
+Unchanged from 0.9.80: this candidate has not yet been verified on physical
+Windows hardware, and Windows DirectShow still lacks the native microphone
+source-loss monitor, so a clean end-of-stream raises no
+`microphone-input-lost` warning and a fatal driver error can still end the
+capture process.


### PR DESCRIPTION
Windows Alpha entry for the current numeric version (0.9.91, no bump). Carries the unshipped Intel iGPU encoder fixes (#305, #307) plus the cross-platform Studio changes since 0.9.80-alpha.1. Claims limited to what physical acceptance can prove.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hardware H.264 encoding on Intel integrated graphics, including higher-bitrate recordings.
  - Studio controls remain responsive when the preview surface is struggling.
  - Post-recording quality checks now allocate time based on recording length and resolution.

- **Changes**
  - Removed capture-repair alerts, the Restart capture button, and the repairing status indicator from Studio. Technical details remain available in Diagnostics.
  - Removed the “Coming from OBS?” banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->