### PR TITLE
docs: 0.9.90/0.9.91 release record

### DIFF
--- a/docs/releases/0.9.91.md
+++ b/docs/releases/0.9.91.md
@@ -1,0 +1,42 @@
+# Videorc 0.9.91 Beta 1 (macOS) + 0.9.91-alpha.1 (Windows pilot)
+
+The Studio stops showing capture-repair machinery; Windows additionally
+receives the Intel integrated-graphics hardware-encoding fixes that never
+shipped (their 0.9.81 alpha was burned). Same day as 0.9.90 (macOS-only),
+which introduced the adaptive camera format step-down.
+
+## Scope
+
+- macOS 0.9.90-beta.1 (#332 + bump #333): adaptive one-shot camera format
+  step-down for USB capture cards that cannot sustain their negotiated
+  resolution (Cam Link 4K at 2160p sits at the USB 3.0 wire ceiling). Proved
+  itself in the owner's first field session; the delivery shortfall was later
+  confirmed as degraded Cam Link hardware (reproduced in OBS).
+- 0.9.91 (#334 + bump #335): the destructive capture alert, Restart capture
+  button and repairing/recovered status chip are removed from the Studio.
+  Backend recovery keeps healing silently; Diagnostics keeps the summary; the
+  compositor CPU-fallback parity alert stays.
+- Windows-only in this alpha: Intel iGPU encoder renegotiation (#305) and the
+  Iris Xe probe fallback ladder (#307), plus every cross-platform change since
+  0.9.80-alpha.1 (command-lane responsiveness under preview pressure,
+  duration-scaled recording quality checks, OBS banner removal).
+
+## Ship record
+
+- macOS 0.9.90-beta.1 built from `9eca7552`, and 0.9.91-beta.1 from
+  `60f479d7`; both signed/notarized (Developer ID Uros Miric C2PA37RB58),
+  uploaded and feed-verified (`latest-mac.yml` → version, zip 206), Discord
+  announced 2026-08-31. Built via the local keychain path with
+  `DEVELOPER_DIR=/Library/Developer/CommandLineTools` (Xcode licence pending).
+- Windows 0.9.91-alpha.1 pilot: changelog #336 (`5b394de3`), candidate run
+  33961856772 (unsigned gates + sign job green, sign approved per owner
+  directive), identity
+  `windows:0.9.91-alpha.1:5b394de3ab62d62ca450b31c18409a737cfe7c52:sha256:7d1f3d0a83abd6adfe9f6f368c705697c5d94762b451005278ec47d1bc964866`,
+  publisher `Uros Miric`, prefix
+  `candidates/windows/0.9.91-alpha.1/5b394de3ab62d62ca450b31c18409a737cfe7c52/`.
+  Pilot promotion 33964017367 (success, upload PASS, every pilot object
+  SHA-256 verified). Production pilot route verified: `latest.yml` → 0.9.91
+  with the operator bearer, installer 206, tokenless 401. Discord announced.
+- Public Windows promotion remains pending a physical Windows 11 acceptance
+  record (runbook §3); the DirectShow microphone source-loss monitor is still
+  absent (unchanged since 0.9.78).


### PR DESCRIPTION
Release record for the macOS 0.9.90/0.9.91 betas and the Windows 0.9.91-alpha.1 pilot (candidate 33961856772, promotion 33964017367).